### PR TITLE
Move CRD type assertions to a test

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/webhook"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,9 +40,6 @@ func (t *ClusterTask) SetDefaults() {
 // Check that Task may be validated and defaulted.
 var _ apis.Validatable = (*ClusterTask)(nil)
 var _ apis.Defaultable = (*ClusterTask)(nil)
-
-// Assert that Task implements the GenericCRD interface.
-var _ webhook.GenericCRD = (*ClusterTask)(nil)
 
 // +genclient
 // +genclient:noStatus

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"github.com/knative/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -35,8 +34,6 @@ var (
 	}
 )
 
-// Assert that TaskRun implements the GenericCRD interface.
-var _ webhook.GenericCRD = (*TaskRun)(nil)
 
 // PipelineRunSpec defines the desired state of PipelineRun
 type PipelineRunSpec struct {

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -83,9 +82,6 @@ type PipelineResourceStatus struct {
 // Check that PipelineResource may be validated and defaulted.
 var _ apis.Validatable = (*PipelineResource)(nil)
 var _ apis.Defaultable = (*PipelineResource)(nil)
-
-// Assert that PipelineResource implements the GenericCRD interface.
-var _ webhook.GenericCRD = (*PipelineResource)(nil)
 
 // TaskResource defines an input or output Resource declared as a requirement
 // by a Task. The Name field will be used to refer to these Resources within

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/knative/pkg/apis"
-	"github.com/knative/pkg/webhook"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -56,9 +55,6 @@ type TaskSpec struct {
 // Check that Task may be validated and defaulted.
 var _ apis.Validatable = (*Task)(nil)
 var _ apis.Defaultable = (*Task)(nil)
-
-// Assert that Task implements the GenericCRD interface.
-var _ webhook.GenericCRD = (*Task)(nil)
 
 // +genclient
 // +genclient:noStatus

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/knative/pkg/apis"
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
-	"github.com/knative/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,9 +29,6 @@ import (
 // Check that TaskRun may be validated and defaulted.
 var _ apis.Validatable = (*TaskRun)(nil)
 var _ apis.Defaultable = (*TaskRun)(nil)
-
-// Assert that TaskRun implements the GenericCRD interface.
-var _ webhook.GenericCRD = (*TaskRun)(nil)
 
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {

--- a/pkg/apis/pipeline/v1alpha1/types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/types_test.go
@@ -1,0 +1,16 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/knative/pkg/webhook"
+)
+
+func TestTypes(t *testing.T) {
+	// Assert that types satisfy webhook interface.
+	var _ webhook.GenericCRD = (*ClusterTask)(nil)
+	var _ webhook.GenericCRD = (*TaskRun)(nil)
+	var _ webhook.GenericCRD = (*PipelineResource)(nil)
+	var _ webhook.GenericCRD = (*Task)(nil)
+	var _ webhook.GenericCRD = (*TaskRun)(nil)
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Instead of asserting types satisfy interfaces in knative/pkg in top-level vars in code, do it in tests.

The effect is the same; the tests will fail to compile if types are not satisfied. The benefit of this change is that it removes imports from our types packages that are only pulled in for the interface. In some cases these imports pull in much more code than is necessary, which can become a support burden.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [Y] Includes [tests](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [N/A] Includes [docs](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [Y] Commit messages follow [commit message best practices](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#commit-messages)


/assign @bobcatfish 