### PR TITLE
Port duplicate pod test from knative/build 🏗

### DIFF
--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -1,0 +1,74 @@
+// +build e2e
+
+/*
+Copyright 2018 Knative Authors LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	knativetest "github.com/knative/pkg/test"
+	"github.com/knative/pkg/test/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	tb "github.com/tektoncd/pipeline/test/builder"
+)
+
+// TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
+func TestDuplicatePodTaskRun(t *testing.T) {
+	logger := logging.GetContextLogger(t.Name())
+	c, namespace := setup(t, logger)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
+	defer tearDown(t, logger, c, namespace)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(1)
+		taskrunName := fmt.Sprintf("duplicate-pod-taskrun-%d", i)
+		logger.Infof("Creating taskrun %q.", taskrunName)
+
+		taskrun := tb.TaskRun(taskrunName, namespace, tb.TaskRunSpec(
+			tb.TaskRunTaskSpec(tb.Step("echo", "busybox",
+				tb.Command("/bin/echo"),
+				tb.Args("simple"),
+			)),
+		))
+		if _, err := c.TaskRunClient.Create(taskrun); err != nil {
+			t.Fatalf("Error creating taskrun: %v", err)
+		}
+		go func(t *testing.T) {
+			defer wg.Done()
+
+			if err := WaitForTaskRunState(c, taskrunName, TaskRunSucceed(taskrunName), "TaskRunDuplicatePodTaskRunFailed"); err != nil {
+				t.Fatalf("Error waiting for TaskRun to finish: %s", err)
+			}
+
+			pods, err := c.KubeClient.Kube.CoreV1().Pods(namespace).List(metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=%s", pipeline.GroupName+pipeline.TaskRunLabelKey, taskrunName),
+			})
+			if err != nil {
+				t.Fatalf("Error getting TaskRun pod list: %v", err)
+			}
+			if n := len(pods.Items); n != 1 {
+				t.Fatalf("Error matching the number of build pods: expecting 1 pod, got %d", n)
+			}
+		}(t)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

knative/build had a bug where duplicate pods can be created. This was
cause by a possible race condition between pod creation and start ; if
a `reconcile` run starts in this time, it would create duplicate pods.

This port the knative/build fixes (knative/build#519 and
knative/build#562) to tektoncd/build-pipeline with the test.

Closes #594 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] <del>Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

I did some run and I can't manage to get duplicate pods with the test on master, so I need to dig deeper to see if the code changes are even required (the test is :angel:)

/cc @abayer @pivotal-nader-ziada @bobcatfish 
