### PR TITLE
Update taskrun/pipelinerun timeout logic to not rely on resync behavior

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -213,3 +213,13 @@ func (pr *PipelineRun) GetOwnerReference() []metav1.OwnerReference {
 		*metav1.NewControllerRef(pr, groupVersionKind),
 	}
 }
+
+// IsDone returns true if the PipelineRun's status indicates that it is done.
+func (pr *PipelineRunStatus) IsDone() bool {
+	return !pr.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown()
+}
+
+// IsCancelled returns true if the PipelineRun's spec status is set to Cancelled state
+func (sp PipelineRunSpec) IsCancelled() bool {
+	return sp.Status == PipelineRunSpecStatusCancelled
+}

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -87,3 +87,24 @@ func TestInitializeConditions(t *testing.T) {
 		t.Fatalf("PipelineRun status getting reset")
 	}
 }
+func TestPipelineRunIsDone(t *testing.T) {
+	p := &PipelineRun{}
+	foo := &duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionFalse,
+	}
+	p.Status.SetCondition(foo)
+	if !p.Status.IsDone() {
+		t.Fatal("Expected pipelinerun status to be done")
+	}
+}
+
+func TestPipelineRunIsCancelled(t *testing.T) {
+	ps := PipelineRunSpec{
+		Status: PipelineRunSpecStatusCancelled,
+	}
+
+	if !ps.IsCancelled() {
+		t.Fatal("Expected pipelinerun status to be cancelled")
+	}
+}

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -222,3 +222,13 @@ func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 	}
 	return false
 }
+
+// IsDone returns true if the TaskRun's status indicates that it is done.
+func (st *TaskRunStatus) IsDone() bool {
+	return !st.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown()
+}
+
+// IsCancelled returns true if the TaskRun's spec status is set to Cancelled state
+func (sp TaskRunSpec) IsCancelled() bool {
+	return sp.Status == TaskRunSpecStatusCancelled
+}

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -123,5 +124,26 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 				t.Fatalf("taskrun pipeline run pvc name mismatch: got %s ; expected %t", tt.tr.GetPipelineRunPVCName(), tt.want)
 			}
 		})
+	}
+}
+func TestTaskRunIsDone(t *testing.T) {
+	tr := &TaskRun{}
+	foo := &duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionFalse,
+	}
+	tr.Status.SetCondition(foo)
+	if !tr.Status.IsDone() {
+		t.Fatal("Expected pipelinerun status to be done")
+	}
+}
+
+func TestTaskRunIsCancelled(t *testing.T) {
+	ts := TaskRunSpec{
+		Status: TaskRunSpecStatusCancelled,
+	}
+
+	if !ts.IsCancelled() {
+		t.Fatal("Expected pipelinerun status to be cancelled")
 	}
 }

--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -1,0 +1,228 @@
+package reconciler
+
+import (
+	"sync"
+
+	"fmt"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	defaultFunc = func(i interface{}, l *zap.SugaredLogger) {}
+)
+
+const (
+	defaultTimeout = 10 * time.Minute
+)
+
+// TimeoutSet contains required k8s interfaces to handle build timeouts
+type TimeoutSet struct {
+	logger                  *zap.SugaredLogger
+	kubeclientset           kubernetes.Interface
+	pipelineclientset       clientset.Interface
+	taskRuncallbackFunc     func(interface{})
+	pipelineruncallbackFunc func(interface{})
+	stopCh                  <-chan struct{}
+	statusMap               *sync.Map
+	done                    map[string]chan bool
+	doneMut                 sync.Mutex
+}
+
+// NewTimeoutHandler returns TimeoutSet filled structure
+func NewTimeoutHandler(
+	logger *zap.SugaredLogger,
+	kubeclientset kubernetes.Interface,
+	pipelineclientset clientset.Interface,
+	stopCh <-chan struct{},
+) *TimeoutSet {
+	return &TimeoutSet{
+		logger:            logger,
+		kubeclientset:     kubeclientset,
+		pipelineclientset: pipelineclientset,
+		stopCh:            stopCh,
+		statusMap:         &sync.Map{},
+		done:              make(map[string]chan bool),
+		doneMut:           sync.Mutex{},
+	}
+}
+
+func (t *TimeoutSet) AddtrCallBackFunc(f func(interface{})) {
+	t.taskRuncallbackFunc = f
+}
+
+func (t *TimeoutSet) AddPrCallBackFunc(f func(interface{})) {
+	t.pipelineruncallbackFunc = f
+}
+
+func (t *TimeoutSet) Release(key string) {
+	t.doneMut.Lock()
+	defer t.doneMut.Unlock()
+	if finished, ok := t.done[key]; ok {
+		delete(t.done, key)
+		close(finished)
+	}
+}
+
+func (t *TimeoutSet) StatusLock(key string) {
+	m, _ := t.statusMap.LoadOrStore(key, &sync.Mutex{})
+	mut := m.(*sync.Mutex)
+	mut.Lock()
+}
+
+func (t *TimeoutSet) StatusUnlock(key string) {
+	m, ok := t.statusMap.Load(key)
+	if !ok {
+		return
+	}
+	mut := m.(*sync.Mutex)
+	mut.Unlock()
+}
+
+func (t *TimeoutSet) ReleaseKey(key string) {
+	t.statusMap.Delete(key)
+}
+
+func getTimeout(d *metav1.Duration) time.Duration {
+	timeout := defaultTimeout
+	if d != nil {
+		timeout = d.Duration
+	}
+	return timeout
+}
+
+// checkPipelineRunTimeouts function creates goroutines to wait for pipelinerun to
+// finish/timeout in a given namespace
+func (t *TimeoutSet) checkPipelineRunTimeouts(namespace string) {
+	pipelineRuns, err := t.pipelineclientset.TektonV1alpha1().PipelineRuns(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("Can't get taskruns list in namespace %s: %s", namespace, err)
+	}
+	for _, pipelineRun := range pipelineRuns.Items {
+		pipelineRun := pipelineRun
+		if pipelineRun.Status.IsDone() {
+			continue
+		}
+		if pipelineRun.Spec.IsCancelled() {
+			continue
+		}
+		go t.WaitPipelineRun(&pipelineRun)
+	}
+}
+
+// CheckTimeouts function iterates through all namespaces and calls corresponding
+// taskrun/pipelinerun timeout functions
+func (t *TimeoutSet) CheckTimeouts() {
+	namespaces, err := t.kubeclientset.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("Can't get namespaces list: %s", err)
+	}
+	for _, namespace := range namespaces.Items {
+		t.checkTaskRunTimeouts(namespace.GetName())
+		t.checkPipelineRunTimeouts(namespace.GetName())
+	}
+}
+
+// checkTaskRunTimeouts function creates goroutines to wait for pipelinerun to
+// finish/timeout in a given namespace
+func (t *TimeoutSet) checkTaskRunTimeouts(namespace string) {
+	taskruns, err := t.pipelineclientset.TektonV1alpha1().TaskRuns(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("Can't get taskruns list in namespace %s: %s", namespace, err)
+	}
+	for _, taskrun := range taskruns.Items {
+		taskrun := taskrun
+		if taskrun.Status.IsDone() {
+			continue
+		}
+		if taskrun.Spec.IsCancelled() {
+			continue
+		}
+		go t.WaitTaskRun(&taskrun)
+	}
+}
+
+// WaitTaskRun function creates a blocking function for taskrun to wait for
+// 1. Stop signal, 2. TaskRun to complete or 3. Taskrun to time out
+func (t *TimeoutSet) WaitTaskRun(tr *v1alpha1.TaskRun) {
+	key := fmt.Sprintf("%s/%s/%s", "TaskRun", tr.Namespace, tr.Name)
+
+	timeout := getTimeout(tr.Spec.Timeout)
+	runtime := time.Duration(0)
+
+	t.StatusLock(key)
+	if tr.Status.StartTime != nil && !tr.Status.StartTime.Time.IsZero() {
+		runtime = time.Since(tr.Status.StartTime.Time)
+	}
+	t.StatusUnlock(key)
+	timeout -= runtime
+
+	var finished chan bool
+	t.doneMut.Lock()
+	if existingfinishedChan, ok := t.done[key]; ok {
+		finished = existingfinishedChan
+	} else {
+		finished = make(chan bool)
+	}
+	t.done[key] = finished
+	t.doneMut.Unlock()
+
+	defer t.Release(key)
+
+	select {
+	case <-t.stopCh:
+	case <-finished:
+	case <-time.After(timeout):
+		t.StatusLock(key)
+		if t.taskRuncallbackFunc == nil {
+			defaultFunc(tr, t.logger)
+		} else {
+			t.taskRuncallbackFunc(tr)
+		}
+		t.StatusUnlock(key)
+	}
+}
+
+// WaitPipelineRun function creates a blocking function for pipelinerun to wait for
+// 1. Stop signal, 2. pipelinerun to complete or 3. pipelinerun to time out
+func (t *TimeoutSet) WaitPipelineRun(pr *v1alpha1.PipelineRun) {
+	key := fmt.Sprintf("%s/%s/%s", "PipelineRun", pr.Namespace, pr.Name)
+	timeout := getTimeout(pr.Spec.Timeout)
+
+	runtime := time.Duration(0)
+	t.StatusLock(key)
+	if pr.Status.StartTime != nil && !pr.Status.StartTime.Time.IsZero() {
+		runtime = time.Since(pr.Status.StartTime.Time)
+	}
+	t.StatusUnlock(key)
+	timeout -= runtime
+
+	var finished chan bool
+	t.doneMut.Lock()
+	if existingfinishedChan, ok := t.done[key]; ok {
+		finished = existingfinishedChan
+	} else {
+		finished = make(chan bool)
+	}
+	t.done[key] = finished
+	t.doneMut.Unlock()
+	defer t.Release(key)
+
+	select {
+	case <-t.stopCh:
+	case <-finished:
+	case <-time.After(timeout):
+		t.StatusLock(key)
+		if t.pipelineruncallbackFunc == nil {
+			defaultFunc(pr, t.logger)
+		} else {
+			t.pipelineruncallbackFunc(pr)
+		}
+		t.StatusUnlock(key)
+	}
+}

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -1,0 +1,247 @@
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/google/go-cmp/cmp"
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testNs     = "foo"
+	simpleStep = tb.Step("simple-step", testNs, tb.Command("/mycmd"))
+	simpleTask = tb.Task("test-task", testNs, tb.TaskSpec(simpleStep))
+)
+
+func setup(d test.Data, stopCh chan struct{}) (*TimeoutSet, test.Clients) {
+	c, _ := test.SeedTestData(d)
+	observer, _ := observer.New(zap.InfoLevel)
+	return NewTimeoutHandler(zap.New(observer).Sugar(), c.Kube, c.Pipeline, stopCh), c
+}
+
+func TestTaskRunCheckTimeouts(t *testing.T) {
+	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+		tb.TaskRunTimeout(1*time.Second),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
+	))
+
+	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+		tb.TaskRunTimeout(2*time.Hour),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now()),
+	))
+
+	taskRunDone := tb.TaskRun("test-taskrun-completed", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionTrue}),
+	))
+
+	taskRunCancelled := tb.TaskRun("test-taskrun-run-cancelled", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name),
+		tb.TaskRunCancelled,
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+	))
+
+	for _, tc := range []struct {
+		name           string
+		taskRun        *v1alpha1.TaskRun
+		expectCallback bool
+	}{{
+		name:           "timedout",
+		taskRun:        taskRunTimedout,
+		expectCallback: true,
+	}, {
+		name:           "running",
+		taskRun:        taskRunRunning,
+		expectCallback: false,
+	}, {
+		name:           "completed",
+		taskRun:        taskRunDone,
+		expectCallback: false,
+	}, {
+		name:           "cancelled",
+		taskRun:        taskRunCancelled,
+		expectCallback: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := test.Data{
+				TaskRuns: []*v1alpha1.TaskRun{tc.taskRun},
+				Tasks:    []*v1alpha1.Task{simpleTask},
+				Namespaces: []*corev1.Namespace{&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNs,
+					},
+				}},
+			}
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			testHandler, _ := setup(d, stopCh)
+			var gotCallback bool
+			f := func(tr interface{}) {
+				gotCallback = true
+			}
+			testHandler.AddtrCallBackFunc(f)
+			testHandler.CheckTimeouts()
+
+			if err := wait.PollImmediate(100*time.Millisecond, 3*time.Second, func() (bool, error) {
+				if !cmp.Equal(gotCallback, tc.expectCallback) {
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Fatalf("Expected %s callback to be %t but got callback to be %t", tc.name, tc.expectCallback, gotCallback)
+			}
+		})
+	}
+
+}
+
+func TestPipelinRunCheckTimeouts(t *testing.T) {
+	simplePipeline := tb.Pipeline("test-pipeline", testNs, tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hello-world"),
+	))
+	prTimeout := tb.PipelineRun("test-pipeline-run-with-timeout", testNs,
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccount("test-sa"),
+			tb.PipelineRunTimeout(&metav1.Duration{Duration: 1 * time.Second}),
+		),
+		tb.PipelineRunStatus(
+			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
+	)
+	ts := tb.Task("hello-world", testNs)
+
+	prRunning := tb.PipelineRun("test-pipeline-running", testNs,
+		tb.PipelineRunSpec("test-pipeline"),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionUnknown}),
+		),
+	)
+	prDone := tb.PipelineRun("test-pipeline-done", testNs,
+		tb.PipelineRunSpec("test-pipeline"),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionTrue}),
+		),
+	)
+	prCancelled := tb.PipelineRun("test-pipeline-cancel", testNs,
+		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccount("test-sa"),
+			tb.PipelineRunCancelled,
+		),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionUnknown}),
+		),
+	)
+
+	for _, tc := range []struct {
+		name           string
+		pr             *v1alpha1.PipelineRun
+		expectCallback bool
+	}{{
+		name:           "pr-timedout",
+		pr:             prTimeout,
+		expectCallback: true,
+	}, {
+		name:           "pr-running",
+		pr:             prRunning,
+		expectCallback: false,
+	}, {
+		name:           "pr-completed",
+		pr:             prDone,
+		expectCallback: false,
+	}, {
+		name:           "pr-cancel",
+		pr:             prCancelled,
+		expectCallback: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := test.Data{
+				PipelineRuns: []*v1alpha1.PipelineRun{tc.pr},
+				Pipelines:    []*v1alpha1.Pipeline{simplePipeline},
+				Tasks:        []*v1alpha1.Task{ts},
+				Namespaces: []*corev1.Namespace{&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: testNs,
+					},
+				}},
+			}
+			stopCh := make(chan struct{})
+			var gotCallback bool
+			f := func(tr interface{}) {
+				gotCallback = true
+			}
+			testHandler, _ := setup(d, stopCh)
+			testHandler.AddPrCallBackFunc(f)
+			testHandler.CheckTimeouts()
+			defer close(stopCh)
+
+			if err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+				if !cmp.Equal(gotCallback, tc.expectCallback) {
+					return false, nil
+				}
+				return true, nil
+			}); err != nil {
+				t.Fatalf("Expected %s callback to be %t but got callback to be %t", tc.name, tc.expectCallback, gotCallback)
+			}
+		})
+	}
+}
+
+// TestWithNoFunc does not set taskrun/pipelinerun function and verifies that code does not panic
+func TestWithNoFunc(t *testing.T) {
+	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+		tb.TaskRunTimeout(2*time.Second),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
+	))
+
+	d := test.Data{
+		TaskRuns: []*v1alpha1.TaskRun{taskRunRunning},
+		Tasks:    []*v1alpha1.Task{simpleTask},
+		Namespaces: []*corev1.Namespace{&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNs,
+			},
+		}},
+	}
+	stopCh := make(chan struct{})
+	testHandler, _ := setup(d, stopCh)
+	defer func() {
+		// this delay will ensure there is no race condition between stopCh/ timeout channel getting triggered
+		time.Sleep(10 * time.Millisecond)
+		close(stopCh)
+		if r := recover(); r != nil {
+			t.Fatal("Expected CheckTimeouts function not to panic")
+		}
+	}()
+	testHandler.CheckTimeouts()
+
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
@@ -27,11 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// isCancelled returns true if the PipelineRun's spec indicates it is cancelled
-func isCancelled(spec v1alpha1.PipelineRunSpec) bool {
-	return spec.Status == v1alpha1.PipelineRunSpecStatusCancelled
-}
-
 // cancelPipelineRun makrs the PipelineRun as cancelled and any resolved taskrun too.
 func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask, clientSet clientset.Interface) error {
 	pr.Status.SetCondition(&duckv1alpha1.Condition{

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -91,6 +91,7 @@ type Reconciler struct {
 	resourceLister    listers.PipelineResourceLister
 	tracker           tracker.Interface
 	configStore       configStore
+	timeoutHandler    *reconciler.TimeoutSet
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -105,6 +106,7 @@ func NewController(
 	clusterTaskInformer informers.ClusterTaskInformer,
 	taskRunInformer informers.TaskRunInformer,
 	resourceInformer informers.PipelineResourceInformer,
+	timeoutHandler *reconciler.TimeoutSet,
 ) *controller.Impl {
 
 	r := &Reconciler{
@@ -115,6 +117,7 @@ func NewController(
 		clusterTaskLister: clusterTaskInformer.Lister(),
 		taskRunLister:     taskRunInformer.Lister(),
 		resourceLister:    resourceInformer.Lister(),
+		timeoutHandler:    timeoutHandler,
 	}
 
 	impl := controller.NewImpl(r, r.Logger, pipelineRunControllerName, reconciler.MustNewStatsReporter(pipelineRunControllerName, r.Logger))
@@ -126,9 +129,10 @@ func NewController(
 		DeleteFunc: impl.Enqueue,
 	})
 
-	r.tracker = tracker.New(impl.EnqueueKey, 30*time.Minute)
+	r.tracker = tracker.New(impl.EnqueueKey, opt.GetTrackerLease())
 	taskRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: controller.PassNew(r.tracker.OnChanged),
+		UpdateFunc: controller.PassNew(impl.EnqueueControllerOf),
+		AddFunc:    impl.EnqueueControllerOf,
 	})
 
 	r.Logger.Info("Setting up ConfigMap receivers")
@@ -164,7 +168,11 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	pr := original.DeepCopy()
 	pr.Status.InitializeConditions()
 
-	if isDone(&pr.Status) {
+	if pr.Status.IsDone() {
+		statusMapKey := fmt.Sprintf("%s/%s", pipelineRunControllerName, key)
+		c.timeoutHandler.Release(statusMapKey)
+		// remove key from status map
+		defer c.timeoutHandler.ReleaseKey(statusMapKey)
 		c.Recorder.Event(pr, corev1.EventTypeNormal, eventReasonSucceeded, "PipelineRun completed successfully.")
 		return nil
 	}
@@ -332,7 +340,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	}
 
 	// If the pipelinerun is cancelled, cancel tasks and update status
-	if isCancelled(pr.Spec) {
+	if pr.Spec.IsCancelled() {
 		return cancelPipelineRun(pr, pipelineState, c.PipelineClientSet)
 	}
 
@@ -357,16 +365,19 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 				return fmt.Errorf("error creating TaskRun called %s for PipelineTask %s from PipelineRun %s: %s", rprt.TaskRunName, rprt.PipelineTask.Name, pr.Name, err)
 			}
 		}
+		go c.timeoutHandler.WaitPipelineRun(pr)
 	}
 
 	before := pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
 	after := resources.GetPipelineConditionStatus(pr.Name, pipelineState, c.Logger, pr.Status.StartTime, pr.Spec.Timeout)
+	statusKey := fmt.Sprintf("%s/%s/%s", pipelineRunControllerName, pr.Namespace, pr.Name)
 
+	c.timeoutHandler.StatusLock(statusKey)
 	pr.Status.SetCondition(after)
+	updateTaskRunsStatus(pr, pipelineState)
+	c.timeoutHandler.StatusUnlock(statusKey)
 
 	reconciler.EmitEvent(c.Recorder, before, after, pr)
-
-	updateTaskRunsStatus(pr, pipelineState)
 
 	c.Logger.Infof("PipelineRun %s status is being set to %s", pr.Name, pr.Status.GetCondition(duckv1alpha1.ConditionSucceeded))
 	return nil
@@ -459,9 +470,4 @@ func (c *Reconciler) updateLabels(pr *v1alpha1.PipelineRun) (*v1alpha1.PipelineR
 		return c.PipelineClientSet.TektonV1alpha1().PipelineRuns(pr.Namespace).Update(newPr)
 	}
 	return newPr, nil
-}
-
-// isDone returns true if the PipelineRun's status indicates the build is done.
-func isDone(status *v1alpha1.PipelineRunStatus) bool {
-	return !status.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown()
 }

--- a/pkg/reconciler/v1alpha1/taskrun/cancel.go
+++ b/pkg/reconciler/v1alpha1/taskrun/cancel.go
@@ -31,11 +31,6 @@ type logger interface {
 	Warnf(template string, args ...interface{})
 }
 
-// isCancelled returns true if the TaskRun's' spec indicates it is cancelled
-func isCancelled(spec v1alpha1.TaskRunSpec) bool {
-	return spec.Status == v1alpha1.TaskRunSpecStatusCancelled
-}
-
 // cancelTaskRun marks the TaskRun as cancelled and delete pods linked to it.
 func cancelTaskRun(tr *v1alpha1.TaskRun, clientSet kubernetes.Interface, logger logger) error {
 	logger.Warn("task run %q has been cancelled", tr.Name)

--- a/test/controller.go
+++ b/test/controller.go
@@ -46,6 +46,7 @@ type Data struct {
 	ClusterTasks      []*v1alpha1.ClusterTask
 	PipelineResources []*v1alpha1.PipelineResource
 	Pods              []*corev1.Pod
+	Namespaces        []*corev1.Namespace
 }
 
 // Clients holds references to clients which are useful for reconciler tests.
@@ -99,6 +100,9 @@ func SeedTestData(d Data) (Clients, Informers) {
 	kubeObjs := []runtime.Object{}
 	for _, p := range d.Pods {
 		kubeObjs = append(kubeObjs, p)
+	}
+	for _, n := range d.Namespaces {
+		kubeObjs = append(kubeObjs, n)
 	}
 	c := Clients{
 		Pipeline: fakepipelineclientset.NewSimpleClientset(objs...),


### PR DESCRIPTION
# Changes

In this PR each new taskrun/pipelinerun starts goroutine that waits for either
stop signal, finish or timeout to occur. Once run objects times out handler adds
the object into respective controller queues. When run controllers are restarted new goroutines are being created to track existing timeouts. Mutexes added to safely access runtime object status.
Same timeout handler is used for pipelinerun / taskrun so mutex has prefix "TaskRun" and "PipelineRun" to differentiate the keys.

why: As the number of taskruns and pipelineruns increase the controllers cannot handle the number of reconciliations triggered. One of the solutios to tackle this problems is to increase the resync period to 10h instead of 30sec. This solution manifests a problem for taskrun/pipelinerun timeouts because this implementation relied on the resync behavior to update run status to "Timeout".

I drew inspiration from @tzununbekov PR in knative/build. Credit to
@pivotal-nader-ziada @dprotaso for suggesting level based reconciliation.

Fixes: https://github.com/tektoncd/pipeline/issues/456

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

cc @bobcatfish @vdemeester @ImJasonH 