### PR TITLE
Specify `Command` field for internal containers (creds-init, …)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,7 +49,12 @@ You must install these tools:
 1. [`dep`](https://github.com/golang/dep): For managing external Go
    dependencies. - Please Install dep v0.5.0 or greater.
 1. [`ko`](https://github.com/google/go-containerregistry/tree/master/cmd/ko):
-   For development.
+   For development. A recent version of `ko` (after the 23th of
+   February, see
+   [google/go-containerregistry#380](https://github.com/google/go-containerregistry/pull/380))
+   is required for `pipeline` to work correctly.
+   
+   won't work).
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    interacting with your kube cluster
 

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -82,14 +82,16 @@ func (b *ArtifactBucket) GetCopyFromContainerSpec(name, sourcePath, destinationP
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts("bucket", secretVolumeMountPath, b.Secrets)
 
 	return []corev1.Container{{
-		Name:  names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-dest-mkdir-%s", name)),
-		Image: *bashNoopImage,
+		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-dest-mkdir-%s", name)),
+		Image:   *bashNoopImage,
+		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " "),
 		},
 	}, {
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-copy-from-%s", name)),
 		Image:        *gsutilImage,
+		Command:      []string{"/ko-app/gsutil"},
 		Args:         args,
 		Env:          envVars,
 		VolumeMounts: secretVolumeMount,
@@ -105,6 +107,7 @@ func (b *ArtifactBucket) GetCopyToContainerSpec(name, sourcePath, destinationPat
 	return []corev1.Container{{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-copy-to-%s", name)),
 		Image:        *gsutilImage,
+		Command:      []string{"/ko-app/gsutil"},
 		Args:         args,
 		Env:          envVars,
 		VolumeMounts: secretVolumeMount,

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
@@ -35,12 +35,14 @@ func TestBucketGetCopyFromContainerSpec(t *testing.T) {
 		}},
 	}
 	want := []corev1.Container{{
-		Name:  "artifact-dest-mkdir-workspace-9l9zj",
-		Image: "override-with-bash-noop:latest",
-		Args:  []string{"-args", "mkdir -p /workspace/destination"},
+		Name:    "artifact-dest-mkdir-workspace-9l9zj",
+		Image:   "override-with-bash-noop:latest",
+		Command: []string{"/ko-app/bash"},
+		Args:    []string{"-args", "mkdir -p /workspace/destination"},
 	}, {
 		Name:         "artifact-copy-from-workspace-mz4c7",
 		Image:        "override-with-gsutil-image:latest",
+		Command:      []string{"/ko-app/gsutil"},
 		Args:         []string{"-args", "cp -r gs://fake-bucket/src-path/* /workspace/destination"},
 		Env:          []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/bucketsecret/secret1/serviceaccount"}},
 		VolumeMounts: []corev1.VolumeMount{{Name: "volume-bucket-secret1", MountPath: "/var/bucketsecret/secret1"}},
@@ -65,6 +67,7 @@ func TestBucketGetCopyToContainerSpec(t *testing.T) {
 	want := []corev1.Container{{
 		Name:         "artifact-copy-to-workspace-9l9zj",
 		Image:        "override-with-gsutil-image:latest",
+		Command:      []string{"/ko-app/gsutil"},
 		Args:         []string{"-args", "cp -r src-path gs://fake-bucket/workspace/destination"},
 		Env:          []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/bucketsecret/secret1/serviceaccount"}},
 		VolumeMounts: []corev1.VolumeMount{{Name: "volume-bucket-secret1", MountPath: "/var/bucketsecret/secret1"}},

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
@@ -49,24 +49,28 @@ func (p *ArtifactPVC) StorageBasePath(pr *PipelineRun) string {
 // GetCopyFromContainerSpec returns a container used to download artifacts from temporary storage
 func (p *ArtifactPVC) GetCopyFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	return []corev1.Container{{
-		Name:  names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
-		Image: *bashNoopImage,
-		Args:  []string{"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " ")},
+		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
+		Image:   *bashNoopImage,
+		Command: []string{"/ko-app/bash"},
+		Args:    []string{"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " ")},
 	}}
 }
 
 // GetCopyToContainerSpec returns a container used to upload artifacts for temporary storage
 func (p *ArtifactPVC) GetCopyToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	return []corev1.Container{{
-		Name:  names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-mkdir-%s", name)),
-		Image: *bashNoopImage,
+		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-mkdir-%s", name)),
+		Image:   *bashNoopImage,
+		Command: []string{"/ko-app/bash"},
 		Args: []string{
+
 			"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " "),
 		},
 		VolumeMounts: []corev1.VolumeMount{getPvcMount(p.Name)},
 	}, {
-		Name:  names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
-		Image: *bashNoopImage,
+		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
+		Image:   *bashNoopImage,
+		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " "),
 		},
@@ -84,9 +88,10 @@ func getPvcMount(name string) corev1.VolumeMount {
 // CreateDirContainer returns a container step to create a dir
 func CreateDirContainer(name, destinationPath string) corev1.Container {
 	return corev1.Container{
-		Name:  names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("create-dir-%s", name)),
-		Image: *bashNoopImage,
-		Args:  []string{"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " ")},
+		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("create-dir-%s", name)),
+		Image:   *bashNoopImage,
+		Command: []string{"/ko-app/bash"},
+		Args:    []string{"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " ")},
 	}
 }
 

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
@@ -32,9 +32,10 @@ func TestPVCGetCopyFromContainerSpec(t *testing.T) {
 		Name: "pipelinerun-pvc",
 	}
 	want := []corev1.Container{{
-		Name:  "source-copy-workspace-9l9zj",
-		Image: "override-with-bash-noop:latest",
-		Args:  []string{"-args", "cp -r src-path/. /workspace/destination"},
+		Name:    "source-copy-workspace-9l9zj",
+		Image:   "override-with-bash-noop:latest",
+		Command: []string{"/ko-app/bash"},
+		Args:    []string{"-args", "cp -r src-path/. /workspace/destination"},
 	}}
 
 	got := pvc.GetCopyFromContainerSpec("workspace", "src-path", "/workspace/destination")
@@ -52,11 +53,13 @@ func TestPVCGetCopyToContainerSpec(t *testing.T) {
 	want := []corev1.Container{{
 		Name:         "source-mkdir-workspace-9l9zj",
 		Image:        "override-with-bash-noop:latest",
+		Command:      []string{"/ko-app/bash"},
 		Args:         []string{"-args", "mkdir -p /workspace/destination"},
 		VolumeMounts: []corev1.VolumeMount{{MountPath: "/pvc", Name: "pipelinerun-pvc"}},
 	}, {
 		Name:         "source-copy-workspace-mz4c7",
 		Image:        "override-with-bash-noop:latest",
+		Command:      []string{"/ko-app/bash"},
 		Args:         []string{"-args", "cp -r src-path/. /workspace/destination"},
 		VolumeMounts: []corev1.VolumeMount{{MountPath: "/pvc", Name: "pipelinerun-pvc"}},
 	}}
@@ -71,9 +74,10 @@ func TestPVCGetMakeDirContainerSpec(t *testing.T) {
 	names.TestingSeed()
 
 	want := corev1.Container{
-		Name:  "create-dir-workspace-9l9zj",
-		Image: "override-with-bash-noop:latest",
-		Args:  []string{"-args", "mkdir -p /workspace/destination"},
+		Name:    "create-dir-workspace-9l9zj",
+		Image:   "override-with-bash-noop:latest",
+		Command: []string{"/ko-app/bash"},
+		Args:    []string{"-args", "mkdir -p /workspace/destination"},
 	}
 	got := CreateDirContainer("workspace", "/workspace/destination")
 	if d := cmp.Diff(got, want); d != "" {

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -222,9 +222,10 @@ func Test_BuildGCSGetDownloadContainerSpec(t *testing.T) {
 			ArtifactType:   "Archive",
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "create-dir-gcs-valid-9l9zj",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "mkdir -p /workspace"},
+			Name:    "create-dir-gcs-valid-9l9zj",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "mkdir -p /workspace"},
 		}, {
 			Name:  "storage-fetch-gcs-valid-mz4c7",
 			Image: "gcr.io/cloud-builders/gcs-fetcher:latest",

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -168,8 +168,9 @@ func (s *ClusterResource) GetDownloadContainerSpec() ([]corev1.Container, error)
 	}
 
 	clusterContainer := corev1.Container{
-		Name:  names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("kubeconfig"),
-		Image: *kubeconfigWriterImage,
+		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("kubeconfig"),
+		Image:   *kubeconfigWriterImage,
+		Command: []string{"/ko-app/kubeconfigwriter"},
 		Args: []string{
 			"-clusterConfig", s.String(),
 		},

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -198,9 +198,10 @@ func Test_ClusterResource_GetDownloadContainerSpec(t *testing.T) {
 			}},
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "kubeconfig-9l9zj",
-			Image: "override-with-kubeconfig-writer:latest",
-			Args:  []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
+			Name:    "kubeconfig-9l9zj",
+			Image:   "override-with-kubeconfig-writer:latest",
+			Command: []string{"/ko-app/kubeconfigwriter"},
+			Args:    []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
 			Env: []corev1.EnvVar{{
 				Name: "CADATA",
 				ValueFrom: &corev1.EnvVarSource{

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -121,6 +121,7 @@ func (s *GCSResource) GetUploadContainerSpec() ([]corev1.Container, error) {
 	return []corev1.Container{{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("upload-%s", s.Name)),
 		Image:        *gsutilImage,
+		Command:      []string{"/ko-app/gsutil"},
 		Args:         args,
 		VolumeMounts: secretVolumeMount,
 		Env:          envVars,
@@ -144,6 +145,7 @@ func (s *GCSResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 		CreateDirContainer(s.Name, s.DestinationDir), {
 			Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("fetch-%s", s.Name)),
 			Image:        *gsutilImage,
+			Command:      []string{"/ko-app/gsutil"},
 			Args:         args,
 			Env:          envVars,
 			VolumeMounts: secretVolumeMount,

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -230,13 +230,15 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			}},
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "create-dir-gcs-valid-9l9zj",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "mkdir -p /workspace"},
+			Name:    "create-dir-gcs-valid-9l9zj",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "mkdir -p /workspace"},
 		}, {
-			Name:  "fetch-gcs-valid-mz4c7",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp -r gs://some-bucket/* /workspace"},
+			Name:    "fetch-gcs-valid-mz4c7",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r gs://some-bucket/* /workspace"},
 			Env: []corev1.EnvVar{{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 				Value: "/var/secret/secretName/key.json",
@@ -263,13 +265,15 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			}},
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "create-dir-gcs-valid-mssqb",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "mkdir -p /workspace"},
+			Name:    "create-dir-gcs-valid-mssqb",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "mkdir -p /workspace"},
 		}, {
-			Name:  "fetch-gcs-valid-78c5n",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp gs://some-bucket /workspace"},
+			Name:    "fetch-gcs-valid-78c5n",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp gs://some-bucket /workspace"},
 			Env: []corev1.EnvVar{{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 				Value: "/var/secret/secretName/key.json",
@@ -322,10 +326,11 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			}},
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "upload-gcs-valid-9l9zj",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp -r /workspace/* gs://some-bucket"},
-			Env:   []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"}},
+			Name:    "upload-gcs-valid-9l9zj",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/* gs://some-bucket"},
+			Env:     []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",
 				MountPath: "/var/secret/secretName",
@@ -348,9 +353,10 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			}},
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "upload-gcs-valid-mz4c7",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp /workspace/* gs://some-bucket"},
+			Name:    "upload-gcs-valid-mz4c7",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp /workspace/* gs://some-bucket"},
 			Env: []corev1.EnvVar{
 				{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"},
 			},
@@ -368,9 +374,10 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			TypeDir:        false,
 		},
 		wantContainers: []corev1.Container{{
-			Name:  "upload-gcs-valid-mssqb",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp /workspace/* gs://some-bucket"},
+			Name:    "upload-gcs-valid-mssqb",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp /workspace/* gs://some-bucket"},
 		}},
 	}, {
 		name: "invalid upload with no source directory path",

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -115,6 +115,7 @@ func (s *GitResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 	return []corev1.Container{{
 		Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(gitSource + "-" + s.Name),
 		Image:      *gitImage,
+		Command:    []string{"/ko-app/git-init"},
 		Args:       args,
 		WorkingDir: workspaceDir,
 	}}, nil

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -276,6 +276,7 @@ func TestAddResourceToBuild(t *testing.T) {
 			Steps: []corev1.Container{{
 				Name:       "git-source-the-git-9l9zj",
 				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "master", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
 			}},
@@ -308,6 +309,7 @@ func TestAddResourceToBuild(t *testing.T) {
 			Steps: []corev1.Container{{
 				Name:       "git-source-the-git-with-branch-9l9zj",
 				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
 			}},
@@ -345,11 +347,13 @@ func TestAddResourceToBuild(t *testing.T) {
 			Steps: []corev1.Container{{
 				Name:       "git-source-the-git-with-branch-mz4c7",
 				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/git-duplicate-space"},
 				WorkingDir: "/workspace",
 			}, {
 				Name:       "git-source-the-git-with-branch-9l9zj",
 				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
 			}},
@@ -382,6 +386,7 @@ func TestAddResourceToBuild(t *testing.T) {
 			Steps: []corev1.Container{{
 				Name:       "git-source-the-git-9l9zj",
 				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "master", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
 			}},
@@ -414,6 +419,7 @@ func TestAddResourceToBuild(t *testing.T) {
 			Steps: []corev1.Container{{
 				Name:       "git-source-the-git-with-branch-9l9zj",
 				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
 			}},
@@ -446,12 +452,14 @@ func TestAddResourceToBuild(t *testing.T) {
 		wantErr: false,
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "create-dir-gitspace-mz4c7",
-				Image: "override-with-bash-noop:latest",
-				Args:  []string{"-args", "mkdir -p /workspace/gitspace"},
+				Name:    "create-dir-gitspace-mz4c7",
+				Image:   "override-with-bash-noop:latest",
+				Command: []string{"/ko-app/bash"},
+				Args:    []string{"-args", "mkdir -p /workspace/gitspace"},
 			}, {
 				Name:         "source-copy-gitspace-9l9zj",
 				Image:        "override-with-bash-noop:latest",
+				Command:      []string{"/ko-app/bash"},
 				Args:         []string{"-args", "cp -r prev-task-path/. /workspace/gitspace"},
 				VolumeMounts: []corev1.VolumeMount{{MountPath: "/pvc", Name: "pipelinerun-pvc"}},
 			}},
@@ -485,13 +493,15 @@ func TestAddResourceToBuild(t *testing.T) {
 		wantErr: false,
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "create-dir-storage1-9l9zj",
-				Image: "override-with-bash-noop:latest",
-				Args:  []string{"-args", "mkdir -p /workspace/gcs-dir"},
+				Name:    "create-dir-storage1-9l9zj",
+				Image:   "override-with-bash-noop:latest",
+				Command: []string{"/ko-app/bash"},
+				Args:    []string{"-args", "mkdir -p /workspace/gcs-dir"},
 			}, {
-				Name:  "fetch-storage1-mz4c7",
-				Image: "override-with-gsutil-image:latest",
-				Args:  []string{"-args", "cp gs://fake-bucket/rules.zip /workspace/gcs-dir"},
+				Name:    "fetch-storage1-mz4c7",
+				Image:   "override-with-gsutil-image:latest",
+				Command: []string{"/ko-app/gsutil"},
+				Args:    []string{"-args", "cp gs://fake-bucket/rules.zip /workspace/gcs-dir"},
 			}},
 		},
 	}, {
@@ -522,12 +532,14 @@ func TestAddResourceToBuild(t *testing.T) {
 		wantErr: false,
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "create-dir-workspace-mz4c7",
-				Image: "override-with-bash-noop:latest",
-				Args:  []string{"-args", "mkdir -p /workspace/gcs-dir"},
+				Name:    "create-dir-workspace-mz4c7",
+				Image:   "override-with-bash-noop:latest",
+				Command: []string{"/ko-app/bash"},
+				Args:    []string{"-args", "mkdir -p /workspace/gcs-dir"},
 			}, {
 				Name:         "source-copy-workspace-9l9zj",
 				Image:        "override-with-bash-noop:latest",
+				Command:      []string{"/ko-app/bash"},
 				Args:         []string{"-args", "cp -r prev-task-path/. /workspace/gcs-dir"},
 				VolumeMounts: []corev1.VolumeMount{{MountPath: "/pvc", Name: "pipelinerun-pvc"}},
 			}},
@@ -638,8 +650,9 @@ func TestAddResourceToBuild(t *testing.T) {
 		wantErr: false,
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "kubeconfig-9l9zj",
-				Image: "override-with-kubeconfig-writer:latest",
+				Name:    "kubeconfig-9l9zj",
+				Image:   "override-with-kubeconfig-writer:latest",
+				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args: []string{
 					"-clusterConfig", `{"name":"cluster3","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":"bXktY2EtY2VydAo=","secrets":null}`,
 				},
@@ -684,8 +697,9 @@ func TestAddResourceToBuild(t *testing.T) {
 		wantErr: false,
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "kubeconfig-9l9zj",
-				Image: "override-with-kubeconfig-writer:latest",
+				Name:    "kubeconfig-9l9zj",
+				Image:   "override-with-kubeconfig-writer:latest",
+				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args: []string{
 					"-clusterConfig", `{"name":"cluster2","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`,
 				},
@@ -843,13 +857,15 @@ func Test_StorageInputResource(t *testing.T) {
 			},
 			Spec: buildv1alpha1.BuildSpec{
 				Steps: []corev1.Container{{
-					Name:  "create-dir-gcs-input-resource-9l9zj",
-					Image: "override-with-bash-noop:latest",
-					Args:  []string{"-args", "mkdir -p /workspace/gcs-input-resource"},
+					Name:    "create-dir-gcs-input-resource-9l9zj",
+					Image:   "override-with-bash-noop:latest",
+					Command: []string{"/ko-app/bash"},
+					Args:    []string{"-args", "mkdir -p /workspace/gcs-input-resource"},
 				}, {
-					Name:  "fetch-gcs-input-resource-mz4c7",
-					Image: "override-with-gsutil-image:latest",
-					Args:  []string{"-args", "cp gs://fake-bucket/rules.zip /workspace/gcs-input-resource"},
+					Name:    "fetch-gcs-input-resource-mz4c7",
+					Image:   "override-with-gsutil-image:latest",
+					Command: []string{"/ko-app/gsutil"},
+					Args:    []string{"-args", "cp gs://fake-bucket/rules.zip /workspace/gcs-input-resource"},
 				}},
 			},
 		},
@@ -920,13 +936,15 @@ func Test_StorageInputResource(t *testing.T) {
 			},
 			Spec: buildv1alpha1.BuildSpec{
 				Steps: []corev1.Container{{
-					Name:  "create-dir-storage-gcs-keys-9l9zj",
-					Image: "override-with-bash-noop:latest",
-					Args:  []string{"-args", "mkdir -p /workspace/gcs-input-resource"},
+					Name:    "create-dir-storage-gcs-keys-9l9zj",
+					Image:   "override-with-bash-noop:latest",
+					Command: []string{"/ko-app/bash"},
+					Args:    []string{"-args", "mkdir -p /workspace/gcs-input-resource"},
 				}, {
-					Name:  "fetch-storage-gcs-keys-mz4c7",
-					Image: "override-with-gsutil-image:latest",
-					Args:  []string{"-args", "cp -r gs://fake-bucket/rules.zip/* /workspace/gcs-input-resource"},
+					Name:    "fetch-storage-gcs-keys-mz4c7",
+					Image:   "override-with-gsutil-image:latest",
+					Command: []string{"/ko-app/gsutil"},
+					Args:    []string{"-args", "cp -r gs://fake-bucket/rules.zip/* /workspace/gcs-input-resource"},
 					VolumeMounts: []corev1.VolumeMount{
 						{Name: "volume-storage-gcs-keys-secret-name", MountPath: "/var/secret/secret-name"},
 					},
@@ -1023,13 +1041,15 @@ func TestAddStepsToBuild_WithBucketFromConfigMap(t *testing.T) {
 		build: build(),
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "artifact-dest-mkdir-gitspace-mssqb",
-				Image: "override-with-bash-noop:latest",
-				Args:  []string{"-args", "mkdir -p /workspace/gitspace"},
+				Name:    "artifact-dest-mkdir-gitspace-mssqb",
+				Image:   "override-with-bash-noop:latest",
+				Command: []string{"/ko-app/bash"},
+				Args:    []string{"-args", "mkdir -p /workspace/gitspace"},
 			}, {
-				Name:  "artifact-copy-from-gitspace-78c5n",
-				Image: "override-with-gsutil-image:latest",
-				Args:  []string{"-args", "cp -r gs://fake-bucket/prev-task-path/* /workspace/gitspace"},
+				Name:    "artifact-copy-from-gitspace-78c5n",
+				Image:   "override-with-gsutil-image:latest",
+				Command: []string{"/ko-app/gsutil"},
+				Args:    []string{"-args", "cp -r gs://fake-bucket/prev-task-path/* /workspace/gitspace"},
 			}},
 		},
 	}, {
@@ -1059,13 +1079,15 @@ func TestAddStepsToBuild_WithBucketFromConfigMap(t *testing.T) {
 		build: build(),
 		want: buildv1alpha1.BuildSpec{
 			Steps: []corev1.Container{{
-				Name:  "artifact-dest-mkdir-workspace-6nl7g",
-				Image: "override-with-bash-noop:latest",
-				Args:  []string{"-args", "mkdir -p /workspace/gcs-dir"},
+				Name:    "artifact-dest-mkdir-workspace-6nl7g",
+				Image:   "override-with-bash-noop:latest",
+				Command: []string{"/ko-app/bash"},
+				Args:    []string{"-args", "mkdir -p /workspace/gcs-dir"},
 			}, {
-				Name:  "artifact-copy-from-workspace-j2tds",
-				Image: "override-with-gsutil-image:latest",
-				Args:  []string{"-args", "cp -r gs://fake-bucket/prev-task-path/* /workspace/gcs-dir"},
+				Name:    "artifact-copy-from-workspace-j2tds",
+				Image:   "override-with-gsutil-image:latest",
+				Command: []string{"/ko-app/gsutil"},
+				Args:    []string{"-args", "cp -r gs://fake-bucket/prev-task-path/* /workspace/gcs-dir"},
 			}},
 		},
 	}} {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -25,6 +25,7 @@ import (
 	fakeclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,7 @@ var (
 )
 
 func outputResourceSetup() {
+	logger, _ = logging.NewLogger("", "")
 	fakeClient := fakeclientset.NewSimpleClientset()
 	sharedInfomer := informers.NewSharedInformerFactory(fakeClient, 0)
 	pipelineResourceInformer := sharedInfomer.Tekton().V1alpha1().PipelineResources()
@@ -164,17 +166,19 @@ func Test_Valid_OutputResources(t *testing.T) {
 			},
 		},
 		wantSteps: []corev1.Container{{
-			Name:  "source-mkdir-source-git-9l9zj",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "mkdir -p pipeline-task-name"},
+			Name:    "source-mkdir-source-git-9l9zj",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "mkdir -p pipeline-task-name"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "pipelinerun-pvc",
 				MountPath: "/pvc",
 			}},
 		}, {
-			Name:  "source-copy-source-git-mz4c7",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "cp -r /workspace/source-workspace/. pipeline-task-name"},
+			Name:    "source-copy-source-git-mz4c7",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "cp -r /workspace/source-workspace/. pipeline-task-name"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "pipelinerun-pvc",
 				MountPath: "/pvc",
@@ -220,17 +224,19 @@ func Test_Valid_OutputResources(t *testing.T) {
 			},
 		},
 		wantSteps: []corev1.Container{{
-			Name:  "source-mkdir-source-git-9l9zj",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "mkdir -p pipeline-task-name"},
+			Name:    "source-mkdir-source-git-9l9zj",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "mkdir -p pipeline-task-name"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "pipelinerun-pvc",
 				MountPath: "/pvc",
 			}},
 		}, {
-			Name:  "source-copy-source-git-mz4c7",
-			Image: "override-with-bash-noop:latest",
-			Args:  []string{"-args", "cp -r /workspace/output/source-workspace/. pipeline-task-name"},
+			Name:    "source-copy-source-git-mz4c7",
+			Image:   "override-with-bash-noop:latest",
+			Command: []string{"/ko-app/bash"},
+			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/. pipeline-task-name"},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "pipelinerun-pvc",
 				MountPath: "/pvc",
@@ -372,18 +378,21 @@ func Test_Valid_OutputResources(t *testing.T) {
 				Name:      "volume-source-gcs-sname",
 				MountPath: "/var/secret/sname",
 			}},
-			Args: []string{"-args", "cp -r /workspace/faraway-disk/* gs://some-bucket"},
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/faraway-disk/* gs://some-bucket"},
 			Env: []corev1.EnvVar{{
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 		}, {
 			Name:         "source-mkdir-source-gcs-mz4c7",
 			Image:        "override-with-bash-noop:latest",
+			Command:      []string{"/ko-app/bash"},
 			Args:         []string{"-args", "mkdir -p pipeline-task-path"},
 			VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-parent-pvc", MountPath: "/pvc"}},
 		}, {
 			Name:         "source-copy-source-gcs-mssqb",
 			Image:        "override-with-bash-noop:latest",
+			Command:      []string{"/ko-app/bash"},
 			Args:         []string{"-args", "cp -r /workspace/faraway-disk/. pipeline-task-path"},
 			VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-parent-pvc", MountPath: "/pvc"}},
 		}},
@@ -441,15 +450,18 @@ func Test_Valid_OutputResources(t *testing.T) {
 			Env: []corev1.EnvVar{{
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
-			Args: []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
 		}, {
 			Name:         "source-mkdir-source-gcs-mz4c7",
 			Image:        "override-with-bash-noop:latest",
+			Command:      []string{"/ko-app/bash"},
 			Args:         []string{"-args", "mkdir -p pipeline-task-path"},
 			VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-pvc", MountPath: "/pvc"}},
 		}, {
 			Name:         "source-copy-source-gcs-mssqb",
 			Image:        "override-with-bash-noop:latest",
+			Command:      []string{"/ko-app/bash"},
 			Args:         []string{"-args", "cp -r /workspace/output/source-workspace/. pipeline-task-path"},
 			VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-pvc", MountPath: "/pvc"}},
 		}},
@@ -503,7 +515,8 @@ func Test_Valid_OutputResources(t *testing.T) {
 			Env: []corev1.EnvVar{{
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
-			Args: []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
 		}},
 		build: build(),
 		wantVolumes: []corev1.Volume{{
@@ -554,7 +567,8 @@ func Test_Valid_OutputResources(t *testing.T) {
 			Env: []corev1.EnvVar{{
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
-			Args: []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
 		}},
 		build: &buildv1alpha1.Build{
 			TypeMeta: metav1.TypeMeta{
@@ -760,9 +774,10 @@ func Test_Valid_OutputResources_WithBucketStorage(t *testing.T) {
 			},
 		},
 		wantSteps: []corev1.Container{{
-			Name:  "artifact-copy-to-source-git-9l9zj",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp -r /workspace/source-workspace gs://fake-bucket/pipeline-task-name"},
+			Name:    "artifact-copy-to-source-git-9l9zj",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/source-workspace gs://fake-bucket/pipeline-task-name"},
 		}},
 		build: build(),
 	}, {
@@ -804,9 +819,10 @@ func Test_Valid_OutputResources_WithBucketStorage(t *testing.T) {
 			},
 		},
 		wantSteps: []corev1.Container{{
-			Name:  "artifact-copy-to-source-git-9l9zj",
-			Image: "override-with-gsutil-image:latest",
-			Args:  []string{"-args", "cp -r /workspace/output/source-workspace gs://fake-bucket/pipeline-task-name"},
+			Name:    "artifact-copy-to-source-git-9l9zj",
+			Image:   "override-with-gsutil-image:latest",
+			Command: []string{"/ko-app/gsutil"},
+			Args:    []string{"-args", "cp -r /workspace/output/source-workspace gs://fake-bucket/pipeline-task-name"},
 		}},
 		build: build(),
 	}, {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -203,6 +203,7 @@ func makeCredentialInitializer(build *v1alpha1.Build, kubeclient kubernetes.Inte
 	return &corev1.Container{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(containerPrefix + credsInit),
 		Image:        *credsImage,
+		Command:      []string{"/ko-app/creds-init"},
 		Args:         args,
 		VolumeMounts: volumeMounts,
 		Env:          implicitEnvVars,
@@ -296,7 +297,7 @@ func MakePod(build *v1alpha1.Build, kubeclient kubernetes.Interface) (*corev1.Po
 	}
 	gibberish := hex.EncodeToString(b)
 
-	podContainers = append(podContainers, corev1.Container{Name: "nop", Image: *nopImage})
+	podContainers = append(podContainers, corev1.Container{Name: "nop", Image: *nopImage, Command: []string{"/ko-app/nop"}})
 
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -40,8 +40,9 @@ var (
 	ignoreVolatileTime          = cmp.Comparer(func(_, _ apis.VolatileTime) bool { return true })
 	ignoreVolatileTimePtr       = cmp.Comparer(func(_, _ *apis.VolatileTime) bool { return true })
 	nopContainer                = corev1.Container{
-		Name:  "nop",
-		Image: *nopImage,
+		Name:    "nop",
+		Image:   *nopImage,
+		Command: []string{"/ko-app/nop"},
 	}
 )
 
@@ -95,6 +96,7 @@ func TestMakePod(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
 				Image:        *credsImage,
+				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
@@ -128,6 +130,7 @@ func TestMakePod(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
 				Image:        *credsImage,
+				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts, // without subpath
@@ -158,8 +161,9 @@ func TestMakePod(t *testing.T) {
 			ServiceAccountName: "service-account",
 			RestartPolicy:      corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:  containerPrefix + credsInit + "-mz4c7",
-				Image: *credsImage,
+				Name:    containerPrefix + credsInit + "-mz4c7",
+				Image:   *credsImage,
+				Command: []string{"/ko-app/creds-init"},
 				Args: []string{
 					"-basic-docker=multi-creds=https://docker.io",
 					"-basic-docker=multi-creds=https://us.gcr.io",
@@ -197,6 +201,7 @@ func TestMakePod(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
 				Image:        *credsImage,
+				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
@@ -229,6 +234,7 @@ func TestMakePod(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
 				Image:        *credsImage,
+				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -130,6 +130,7 @@ var (
 
 	getCredentialsInitContainer = func(suffix string) tb.PodSpecOp {
 		return tb.PodInitContainer("build-step-credential-initializer-"+suffix, "override-with-creds:latest",
+			tb.Command("/ko-app/creds-init"),
 			tb.WorkingDir(workspaceDir),
 			tb.EnvVar("HOME", "/builder/home"),
 			tb.VolumeMount("workspace", workspaceDir),
@@ -306,7 +307,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -333,7 +334,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -358,7 +359,7 @@ func TestReconcile(t *testing.T) {
 				placeToolsInitContainer,
 				tb.PodContainer("build-step-git-source-git-resource-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
 						"-url", "https://foo.git", "-revision", "master", "-path", "/workspace/workspace"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -387,7 +388,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -414,7 +415,7 @@ func TestReconcile(t *testing.T) {
 				placeToolsInitContainer,
 				tb.PodContainer("build-step-create-dir-another-git-resource-78c5n", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "mkdir -p /workspace/another-git-resource"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -424,7 +425,7 @@ func TestReconcile(t *testing.T) {
 				),
 				tb.PodContainer("build-step-source-copy-another-git-resource-mssqb", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "cp -r source-folder/. /workspace/another-git-resource"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -435,7 +436,7 @@ func TestReconcile(t *testing.T) {
 				),
 				tb.PodContainer("build-step-create-dir-git-resource-mz4c7", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "mkdir -p /workspace/git-resource"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -445,7 +446,7 @@ func TestReconcile(t *testing.T) {
 				),
 				tb.PodContainer("build-step-source-copy-git-resource-9l9zj", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "/builder/tools/2", "-post_file", "/builder/tools/3", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "/builder/tools/2", "-post_file", "/builder/tools/3", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "cp -r source-folder/. /workspace/git-resource"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -465,7 +466,7 @@ func TestReconcile(t *testing.T) {
 				),
 				tb.PodContainer("build-step-source-mkdir-git-resource-6nl7g", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "/builder/tools/4", "-post_file", "/builder/tools/5", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "/builder/tools/4", "-post_file", "/builder/tools/5", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "mkdir -p output-folder"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -476,7 +477,7 @@ func TestReconcile(t *testing.T) {
 				),
 				tb.PodContainer("build-step-source-copy-git-resource-j2tds", "override-with-bash-noop:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "/builder/tools/5", "-post_file", "/builder/tools/6", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "/builder/tools/5", "-post_file", "/builder/tools/6", "-entrypoint", "/ko-app/bash", "--",
 						"-args", "cp -r /workspace/git-resource/. output-folder"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -485,7 +486,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -502,7 +503,7 @@ func TestReconcile(t *testing.T) {
 				getCredentialsInitContainer("mz4c7"),
 				tb.PodContainer("build-step-git-source-git-resource-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
 						"-url", "https://foo.git", "-revision", "master", "-path", "/workspace/workspace"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/builder/home"),
@@ -521,7 +522,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -547,7 +548,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -565,7 +566,7 @@ func TestReconcile(t *testing.T) {
 				placeToolsInitContainer,
 				tb.PodContainer("build-step-git-source-workspace-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
-					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app", "--",
+					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
 						"-url", "github.com/build-pipeline.git", "-revision", "rel-can", "-path",
 						"/workspace/workspace"),
 					tb.WorkingDir(workspaceDir),
@@ -583,7 +584,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	}, {
@@ -610,7 +611,7 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest"),
+				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
 			),
 		),
 	},
@@ -631,8 +632,8 @@ func TestReconcile(t *testing.T) {
 				},
 			})
 
-			entrypoint.AddToEntrypointCache(entrypointCache, "override-with-git:latest", []string{"/ko-app"})
-			entrypoint.AddToEntrypointCache(entrypointCache, "override-with-bash-noop:latest", []string{"/ko-app"})
+			entrypoint.AddToEntrypointCache(entrypointCache, "override-with-git:latest", []string{"/ko-app/git-init"})
+			entrypoint.AddToEntrypointCache(entrypointCache, "override-with-bash-noop:latest", []string{"/ko-app/bash"})
 
 			if err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun)); err != nil {
 				t.Errorf("expected no error. Got error %v", err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `entrypoint` package will try to talk to the remotes for
containers that do not specify `Command` (aka `Entrypoint` in
image-spec).

- This should not be required for internal containers as we are the
  one maintaining it. It should remove so registry call that aren't
  required.
- It fails in some development mode (when using
  `KO_DOCKER_REPO=ko.local`), as the registry might not
  exists (`ko.local`) or not available from the
  cluster (`localhost:5000`, …)

This is a partial fix for #591 :sweat_smile: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] <del>Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)</del>
- [ ] <del>Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
