### PR TITLE
Format markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,8 @@ Before a PR can be merged, it must have both `/lgtm` AND `/approve`:
 - `/approve` can be added only by
   [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
 
-[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
-automatically get `/approve` but still will need an `/lgtm` to merge.
+[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) automatically
+get `/approve` but still will need an `/lgtm` to merge.
 
 The merge will happen automatically once the PR has both `/lgtm` and `/approve`,
 and all tests pass. If you don't want this to happen you should

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,9 +28,8 @@ To add the Tekton Pipelines component to an existing cluster:
 
 1. Run the
    [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)
-   command to install
-   [Tekton Pipelines](https://github.com/tektoncd/pipeline) and its
-   dependencies:
+   command to install [Tekton Pipelines](https://github.com/tektoncd/pipeline)
+   and its dependencies:
 
    ```bash
    kubectl apply --filename https://storage.googleapis.com/knative-releases/build-pipeline/latest/release.yaml

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,11 +1,12 @@
 # Tekton Test Infra
 
-This directory contains configuration and documentation for the test infrastructure for the Tekton Project.
+This directory contains configuration and documentation for the test
+infrastructure for the Tekton Project.
 
 ## Prow
 
-Prow is currently running on GKE in the project `tekton-releases`.
-The cluster name is `prow`.
+Prow is currently running on GKE in the project `tekton-releases`. The cluster
+name is `prow`.
 
 Configuration lives in the `prow` directory here.
 
@@ -17,11 +18,12 @@ It was deployed using `gcloud app deploy .` with no configuration changes.
 
 ## Boskos
 
-Boskos configuration lives in the `boskos` directory here.
-It runs in the `prow` cluster of the `tekton-release` project, in the namespace `test-pods`.
+Boskos configuration lives in the `boskos` directory here. It runs in the `prow`
+cluster of the `tekton-release` project, in the namespace `test-pods`.
 
 ### Adding a project
 
 Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
 
-Make sure the IAM account: `prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
+Make sure the IAM account:
+`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`