### PR TITLE
Add t.Parallel() to some more e2e tests.

### DIFF
--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -50,6 +50,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -42,6 +42,7 @@ import (
 func TestDAGPipelineRun(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)

--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -66,6 +66,7 @@ func getEmbeddedTaskRun(namespace string) *v1alpha1.TaskRun {
 func TestTaskRun_EmbeddedResource(t *testing.T) {
 	logger := logging.GetContextLogger(t.Name())
 	c, namespace := setup(t, logger)
+	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, logger, c, namespace) }, logger)
 	defer tearDown(t, logger, c, namespace)


### PR DESCRIPTION
This will speed up prow runs. We should figure out a way to ensure
these get added automatically in the future.
