### PR TITLE
Update taskrun/pipelinerun timeout logic to not rely on resync behavior

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -43,6 +43,7 @@ import (
 
 const (
 	threadsPerController = 2
+	resyncPeriod         = 10 * time.Hour
 )
 
 var (
@@ -95,7 +96,7 @@ func main() {
 		SharedClientSet:   sharedClient,
 		PipelineClientSet: pipelineClient,
 		ConfigMapWatcher:  configMapWatcher,
-		ResyncPeriod:      time.Second * 30,
+		ResyncPeriod:      resyncPeriod,
 		Logger:            logger,
 	}
 
@@ -110,26 +111,35 @@ func main() {
 
 	pipelineInformer := pipelineInformerFactory.Tekton().V1alpha1().Pipelines()
 	pipelineRunInformer := pipelineInformerFactory.Tekton().V1alpha1().PipelineRuns()
+	timeoutHandler := reconciler.NewTimeoutHandler(kubeClient, pipelineClient, stopCh, logger)
+
+	trc := taskrun.NewController(opt,
+		taskRunInformer,
+		taskInformer,
+		clusterTaskInformer,
+		resourceInformer,
+		podInformer,
+		nil, //entrypoint cache will be initialized by controller if not provided
+		timeoutHandler,
+	)
+	prc := pipelinerun.NewController(opt,
+		pipelineRunInformer,
+		pipelineInformer,
+		taskInformer,
+		clusterTaskInformer,
+		taskRunInformer,
+		resourceInformer,
+		timeoutHandler,
+	)
 	// Build all of our controllers, with the clients constructed above.
 	controllers := []*controller.Impl{
 		// Pipeline Controllers
-		taskrun.NewController(opt,
-			taskRunInformer,
-			taskInformer,
-			clusterTaskInformer,
-			resourceInformer,
-			podInformer,
-			nil, //entrypoint cache will be initialized by controller if not provided
-		),
-		pipelinerun.NewController(opt,
-			pipelineRunInformer,
-			pipelineInformer,
-			taskInformer,
-			clusterTaskInformer,
-			taskRunInformer,
-			resourceInformer,
-		),
+		trc,
+		prc,
 	}
+	timeoutHandler.SetTaskRunCallbackFunc(trc.Enqueue)
+	timeoutHandler.SetPipelineRunCallbackFunc(prc.Enqueue)
+	timeoutHandler.CheckTimeouts()
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher.Watch(logging.ConfigName, logging.UpdateLevelFromConfigMap(logger, atomicLevel, logging.ControllerLogKey))

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -222,3 +222,18 @@ func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 	}
 	return false
 }
+
+// IsDone returns true if the TaskRun's status indicates that it is done.
+func (tr *TaskRun) IsDone() bool {
+	return !tr.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsUnknown()
+}
+
+// IsCancelled returns true if the TaskRun's spec status is set to Cancelled state
+func (tr *TaskRun) IsCancelled() bool {
+	return tr.Spec.Status == TaskRunSpecStatusCancelled
+}
+
+// GetRunKey return the taskrun key for timeout handler map
+func (tr *TaskRun) GetRunKey() string {
+	return fmt.Sprintf("%s/%s/%s", "TaskRun", tr.Namespace, tr.Name)
+}

--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -1,0 +1,232 @@
+package reconciler
+
+import (
+	"sync"
+
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	defaultFunc = func(i interface{}) {}
+)
+
+const (
+	defaultTimeout = 10 * time.Minute
+)
+
+// StatusKey interface to be implemented by Taskrun Pipelinerun types
+type StatusKey interface {
+	GetRunKey() string
+}
+
+// TimeoutSet contains required k8s interfaces to handle build timeouts
+type TimeoutSet struct {
+	logger                  *zap.SugaredLogger
+	kubeclientset           kubernetes.Interface
+	pipelineclientset       clientset.Interface
+	taskRunCallbackFunc     func(interface{})
+	pipelineRunCallbackFunc func(interface{})
+	stopCh                  <-chan struct{}
+	statusMap               *sync.Map
+	done                    map[string]chan bool
+	doneMut                 sync.Mutex
+}
+
+// NewTimeoutHandler returns TimeoutSet filled structure
+func NewTimeoutHandler(
+	kubeclientset kubernetes.Interface,
+	pipelineclientset clientset.Interface,
+	stopCh <-chan struct{},
+	logger *zap.SugaredLogger,
+) *TimeoutSet {
+	return &TimeoutSet{
+		kubeclientset:     kubeclientset,
+		pipelineclientset: pipelineclientset,
+		stopCh:            stopCh,
+		statusMap:         &sync.Map{},
+		done:              make(map[string]chan bool),
+		doneMut:           sync.Mutex{},
+		logger:            logger,
+	}
+}
+
+// SetTaskRunCallbackFunc sets the callback function when timeout occurs for taskrun objects
+func (t *TimeoutSet) SetTaskRunCallbackFunc(f func(interface{})) {
+	t.taskRunCallbackFunc = f
+}
+
+// SetPipelineRunCallbackFunc sets the callback function when timeout occurs for pipelinerun objects
+func (t *TimeoutSet) SetPipelineRunCallbackFunc(f func(interface{})) {
+	t.pipelineRunCallbackFunc = f
+}
+
+// Release function deletes key from timeout map
+func (t *TimeoutSet) Release(runObj StatusKey) {
+	key := runObj.GetRunKey()
+	t.doneMut.Lock()
+	defer t.statusMap.Delete(key)
+	defer t.doneMut.Unlock()
+
+	if finished, ok := t.done[key]; ok {
+		delete(t.done, key)
+		close(finished)
+	}
+}
+
+func (t *TimeoutSet) getOrCreateFinishedChan(runObj StatusKey) chan bool {
+	var finished chan bool
+	key := runObj.GetRunKey()
+	t.doneMut.Lock()
+	defer t.doneMut.Unlock()
+	if existingfinishedChan, ok := t.done[key]; ok {
+		finished = existingfinishedChan
+	} else {
+		finished = make(chan bool)
+	}
+	t.done[key] = finished
+	return finished
+}
+
+// StatusLock function acquires lock for taskrun/pipelinerun status key
+func (t *TimeoutSet) StatusLock(runObj StatusKey) {
+	m, _ := t.statusMap.LoadOrStore(runObj.GetRunKey(), &sync.Mutex{})
+	mut := m.(*sync.Mutex)
+	mut.Lock()
+}
+
+// StatusUnlock function releases lock for taskrun/pipelinerun status key
+func (t *TimeoutSet) StatusUnlock(runObj StatusKey) {
+	m, ok := t.statusMap.Load(runObj.GetRunKey())
+	if !ok {
+		return
+	}
+	mut := m.(*sync.Mutex)
+	mut.Unlock()
+}
+
+func getTimeout(d *metav1.Duration) time.Duration {
+	timeout := defaultTimeout
+	if d != nil {
+		timeout = d.Duration
+	}
+	return timeout
+}
+
+// checkPipelineRunTimeouts function creates goroutines to wait for pipelinerun to
+// finish/timeout in a given namespace
+func (t *TimeoutSet) checkPipelineRunTimeouts(namespace string) {
+	pipelineRuns, err := t.pipelineclientset.TektonV1alpha1().PipelineRuns(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("Can't get taskruns list in namespace %s: %s", namespace, err)
+	}
+	for _, pipelineRun := range pipelineRuns.Items {
+		pipelineRun := pipelineRun
+		if pipelineRun.IsDone() || pipelineRun.IsCancelled() {
+			continue
+		}
+		go t.WaitPipelineRun(&pipelineRun)
+	}
+}
+
+// CheckTimeouts function iterates through all namespaces and calls corresponding
+// taskrun/pipelinerun timeout functions
+func (t *TimeoutSet) CheckTimeouts() {
+	namespaces, err := t.kubeclientset.CoreV1().Namespaces().List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("Can't get namespaces list: %s", err)
+	}
+	for _, namespace := range namespaces.Items {
+		t.checkTaskRunTimeouts(namespace.GetName())
+		t.checkPipelineRunTimeouts(namespace.GetName())
+	}
+}
+
+// checkTaskRunTimeouts function creates goroutines to wait for pipelinerun to
+// finish/timeout in a given namespace
+func (t *TimeoutSet) checkTaskRunTimeouts(namespace string) {
+	taskruns, err := t.pipelineclientset.TektonV1alpha1().TaskRuns(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		t.logger.Errorf("Can't get taskruns list in namespace %s: %s", namespace, err)
+	}
+	for _, taskrun := range taskruns.Items {
+		taskrun := taskrun
+		if taskrun.IsDone() || taskrun.IsCancelled() {
+			continue
+		}
+		go t.WaitTaskRun(&taskrun)
+	}
+}
+
+// WaitTaskRun function creates a blocking function for taskrun to wait for
+// 1. Stop signal, 2. TaskRun to complete or 3. Taskrun to time out
+func (t *TimeoutSet) WaitTaskRun(tr *v1alpha1.TaskRun) {
+	timeout := getTimeout(tr.Spec.Timeout)
+	runtime := time.Duration(0)
+
+	t.StatusLock(tr)
+	if tr.Status.StartTime != nil && !tr.Status.StartTime.Time.IsZero() {
+		runtime = time.Since(tr.Status.StartTime.Time)
+	}
+	t.StatusUnlock(tr)
+	timeout -= runtime
+	finished := t.getOrCreateFinishedChan(tr)
+
+	defer t.Release(tr)
+
+	select {
+	case <-t.stopCh:
+		// we're stopping, give up
+		return
+	case <-finished:
+		// taskrun finished, we can stop watching
+		return
+	case <-time.After(timeout):
+		t.StatusLock(tr)
+		defer t.StatusUnlock(tr)
+		if t.taskRunCallbackFunc != nil {
+			t.taskRunCallbackFunc(tr)
+		} else {
+			defaultFunc(tr)
+		}
+	}
+}
+
+// WaitPipelineRun function creates a blocking function for pipelinerun to wait for
+// 1. Stop signal, 2. pipelinerun to complete or 3. pipelinerun to time out
+func (t *TimeoutSet) WaitPipelineRun(pr *v1alpha1.PipelineRun) {
+	timeout := getTimeout(pr.Spec.Timeout)
+
+	runtime := time.Duration(0)
+	t.StatusLock(pr)
+	if pr.Status.StartTime != nil && !pr.Status.StartTime.Time.IsZero() {
+		runtime = time.Since(pr.Status.StartTime.Time)
+	}
+	t.StatusUnlock(pr)
+	timeout -= runtime
+	finished := t.getOrCreateFinishedChan(pr)
+
+	defer t.Release(pr)
+
+	select {
+	case <-t.stopCh:
+		// we're stopping, give up
+		return
+	case <-finished:
+		// taskrun finished, we can stop watching
+		return
+	case <-time.After(timeout):
+		t.StatusLock(pr)
+		defer t.StatusUnlock(pr)
+		if t.pipelineRunCallbackFunc != nil {
+			t.pipelineRunCallbackFunc(pr)
+		} else {
+			defaultFunc(pr)
+		}
+	}
+}

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -1,0 +1,263 @@
+package reconciler
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	testNs     = "foo"
+	simpleStep = tb.Step("simple-step", testNs, tb.Command("/mycmd"))
+	simpleTask = tb.Task("test-task", testNs, tb.TaskSpec(simpleStep))
+)
+
+func TestTaskRunCheckTimeouts(t *testing.T) {
+	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+		tb.TaskRunTimeout(1*time.Second),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
+	))
+
+	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now()),
+	))
+
+	taskRunDone := tb.TaskRun("test-taskrun-completed", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionTrue}),
+	))
+
+	taskRunCancelled := tb.TaskRun("test-taskrun-run-cancelled", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name),
+		tb.TaskRunCancelled,
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+	))
+
+	d := test.Data{
+		TaskRuns: []*v1alpha1.TaskRun{taskRunTimedout, taskRunRunning, taskRunDone, taskRunCancelled},
+		Tasks:    []*v1alpha1.Task{simpleTask},
+		Namespaces: []*corev1.Namespace{&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNs,
+			},
+		}},
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c, _ := test.SeedTestData(d)
+	observer, _ := observer.New(zap.InfoLevel)
+	th := NewTimeoutHandler(c.Kube, c.Pipeline, stopCh, zap.New(observer).Sugar())
+	gotCallback := sync.Map{}
+	f := func(tr interface{}) {
+		trNew := tr.(*v1alpha1.TaskRun)
+		gotCallback.Store(trNew.Name, struct{}{})
+	}
+
+	th.SetTaskRunCallbackFunc(f)
+	th.CheckTimeouts()
+
+	for _, tc := range []struct {
+		name           string
+		taskRun        *v1alpha1.TaskRun
+		expectCallback bool
+	}{{
+		name:           "timedout",
+		taskRun:        taskRunTimedout,
+		expectCallback: true,
+	}, {
+		name:           "running",
+		taskRun:        taskRunRunning,
+		expectCallback: false,
+	}, {
+		name:           "completed",
+		taskRun:        taskRunDone,
+		expectCallback: false,
+	}, {
+		name:           "cancelled",
+		taskRun:        taskRunCancelled,
+		expectCallback: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := wait.PollImmediate(100*time.Millisecond, 3*time.Second, func() (bool, error) {
+				if tc.expectCallback {
+					if _, ok := gotCallback.Load(tc.taskRun.Name); ok {
+						return true, nil
+					}
+					return false, nil
+				}
+				// not expecting callback
+				if _, ok := gotCallback.Load(tc.taskRun.Name); ok {
+					return false, fmt.Errorf("did not expect call back for %s why", tc.taskRun.Name)
+				}
+				return true, nil
+			}); err != nil {
+				t.Fatalf("Expected %s callback to be %t but got callback to be %#v", tc.name, tc.expectCallback, gotCallback)
+			}
+		})
+	}
+
+}
+
+func TestPipelinRunCheckTimeouts(t *testing.T) {
+	simplePipeline := tb.Pipeline("test-pipeline", testNs, tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hello-world"),
+	))
+	prTimeout := tb.PipelineRun("test-pipeline-run-with-timeout", testNs,
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccount("test-sa"),
+			tb.PipelineRunTimeout(&metav1.Duration{Duration: 1 * time.Second}),
+		),
+		tb.PipelineRunStatus(
+			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
+	)
+	ts := tb.Task("hello-world", testNs)
+
+	prRunning := tb.PipelineRun("test-pipeline-running", testNs,
+		tb.PipelineRunSpec("test-pipeline"),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionUnknown}),
+			tb.PipelineRunStartTime(time.Now()),
+		),
+	)
+	prDone := tb.PipelineRun("test-pipeline-done", testNs,
+		tb.PipelineRunSpec("test-pipeline"),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionTrue}),
+		),
+	)
+	prCancelled := tb.PipelineRun("test-pipeline-cancel", testNs,
+		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccount("test-sa"),
+			tb.PipelineRunCancelled,
+		),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(duckv1alpha1.Condition{
+			Type:   duckv1alpha1.ConditionSucceeded,
+			Status: corev1.ConditionUnknown}),
+		),
+	)
+	d := test.Data{
+		PipelineRuns: []*v1alpha1.PipelineRun{prTimeout, prRunning, prDone, prCancelled},
+		Pipelines:    []*v1alpha1.Pipeline{simplePipeline},
+		Tasks:        []*v1alpha1.Task{ts},
+		Namespaces: []*corev1.Namespace{&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNs,
+			},
+		}},
+	}
+	c, _ := test.SeedTestData(d)
+	stopCh := make(chan struct{})
+	observer, _ := observer.New(zap.InfoLevel)
+	th := NewTimeoutHandler(c.Kube, c.Pipeline, stopCh, zap.New(observer).Sugar())
+	defer close(stopCh)
+
+	gotCallback := sync.Map{}
+	f := func(pr interface{}) {
+		prNew := pr.(*v1alpha1.PipelineRun)
+		gotCallback.Store(prNew.Name, struct{}{})
+	}
+
+	th.SetPipelineRunCallbackFunc(f)
+	th.CheckTimeouts()
+	for _, tc := range []struct {
+		name           string
+		pr             *v1alpha1.PipelineRun
+		expectCallback bool
+	}{{
+		name:           "pr-running",
+		pr:             prRunning,
+		expectCallback: false,
+	}, {
+		name:           "pr-timedout",
+		pr:             prTimeout,
+		expectCallback: true,
+	}, {
+		name:           "pr-completed",
+		pr:             prDone,
+		expectCallback: false,
+	}, {
+		name:           "pr-cancel",
+		pr:             prCancelled,
+		expectCallback: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
+				if tc.expectCallback {
+					if _, ok := gotCallback.Load(tc.pr.Name); ok {
+						return true, nil
+					}
+					return false, nil
+				}
+				// not expecting callback
+				if _, ok := gotCallback.Load(tc.pr.Name); ok {
+					return false, fmt.Errorf("did not expect call back for %s why", tc.pr.Name)
+				}
+				return true, nil
+			}); err != nil {
+				t.Fatalf("Expected %s callback to be %t but got callback to be %#+v", tc.name, tc.expectCallback, gotCallback)
+			}
+		})
+	}
+}
+
+// TestWithNoFunc does not set taskrun/pipelinerun function and verifies that code does not panic
+func TestWithNoFunc(t *testing.T) {
+	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+		tb.TaskRunTimeout(2*time.Second),
+	), tb.TaskRunStatus(tb.Condition(duckv1alpha1.Condition{
+		Type:   duckv1alpha1.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
+	))
+
+	d := test.Data{
+		TaskRuns: []*v1alpha1.TaskRun{taskRunRunning},
+		Tasks:    []*v1alpha1.Task{simpleTask},
+		Namespaces: []*corev1.Namespace{&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNs,
+			},
+		}},
+	}
+	stopCh := make(chan struct{})
+	c, _ := test.SeedTestData(d)
+	observer, _ := observer.New(zap.InfoLevel)
+	testHandler := NewTimeoutHandler(c.Kube, c.Pipeline, stopCh, zap.New(observer).Sugar())
+	defer func() {
+		// this delay will ensure there is no race condition between stopCh/ timeout channel getting triggered
+		time.Sleep(10 * time.Millisecond)
+		close(stopCh)
+		if r := recover(); r != nil {
+			t.Fatal("Expected CheckTimeouts function not to panic")
+		}
+	}()
+	testHandler.CheckTimeouts()
+
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
@@ -27,11 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// isCancelled returns true if the PipelineRun's spec indicates it is cancelled
-func isCancelled(spec v1alpha1.PipelineRunSpec) bool {
-	return spec.Status == v1alpha1.PipelineRunSpecStatusCancelled
-}
-
 // cancelPipelineRun makrs the PipelineRun as cancelled and any resolved taskrun too.
 func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask, clientSet clientset.Interface) error {
 	pr.Status.SetCondition(&duckv1alpha1.Condition{

--- a/pkg/reconciler/v1alpha1/taskrun/cancel.go
+++ b/pkg/reconciler/v1alpha1/taskrun/cancel.go
@@ -31,11 +31,6 @@ type logger interface {
 	Warnf(template string, args ...interface{})
 }
 
-// isCancelled returns true if the TaskRun's' spec indicates it is cancelled
-func isCancelled(spec v1alpha1.TaskRunSpec) bool {
-	return spec.Status == v1alpha1.TaskRunSpecStatusCancelled
-}
-
 // cancelTaskRun marks the TaskRun as cancelled and delete pods linked to it.
 func cancelTaskRun(tr *v1alpha1.TaskRun, clientSet kubernetes.Interface, logger logger) error {
 	logger.Warn("task run %q has been cancelled", tr.Name)

--- a/test/controller.go
+++ b/test/controller.go
@@ -46,6 +46,7 @@ type Data struct {
 	ClusterTasks      []*v1alpha1.ClusterTask
 	PipelineResources []*v1alpha1.PipelineResource
 	Pods              []*corev1.Pod
+	Namespaces        []*corev1.Namespace
 }
 
 // Clients holds references to clients which are useful for reconciler tests.
@@ -99,6 +100,9 @@ func SeedTestData(d Data) (Clients, Informers) {
 	kubeObjs := []runtime.Object{}
 	for _, p := range d.Pods {
 		kubeObjs = append(kubeObjs, p)
+	}
+	for _, n := range d.Namespaces {
+		kubeObjs = append(kubeObjs, n)
 	}
 	c := Clients{
 		Pipeline: fakepipelineclientset.NewSimpleClientset(objs...),

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -193,11 +193,13 @@ func TestTaskRunTimeout(t *testing.T) {
 
 	logger.Infof("Creating Task and TaskRun in namespace %s", namespace)
 	if _, err := c.TaskClient.Create(tb.Task("giraffe", namespace,
-		tb.TaskSpec(tb.Step("amazing-busybox", "busybox", tb.Command("/bin/sh"), tb.Args("-c", "sleep 300"))))); err != nil {
+		tb.TaskSpec(tb.Step("amazing-busybox", "busybox", tb.Command("/bin/sh"), tb.Args("-c", "sleep 3000"))))); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", "giraffe", err)
 	}
 	if _, err := c.TaskRunClient.Create(tb.TaskRun("run-giraffe", namespace, tb.TaskRunSpec(tb.TaskRunTaskRef("giraffe"),
-		tb.TaskRunTimeout(10*time.Second)))); err != nil {
+		// Do not reduce this timeout. Taskrun e2e test is also verifying
+		// if reconcile is triggered from timeout handler and not by pod informers
+		tb.TaskRunTimeout(30*time.Second)))); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", "run-giraffe", err)
 	}
 


### PR DESCRIPTION
# Changes

In this PR each new taskrun/pipelinerun starts goroutine that waits for either
stop signal, finish or timeout to occur. Once run times out handler adds
the object into respective controller queues.
When run controllers are restarted new goroutines are being created to
track existing timeouts. Mutexes added to safely update statuses.
Same timeout handler is used for pipelinerun / taskrun so mutex has
prefix "TaskRun" and "PipelineRun" to differentiate the keys.

why: As the number of taskruns and pipelineruns increase the controllers
cannot handle the number of reconciliations triggered. One of the
solutios to tackle this problems is to increase the resync period to 10h
instead of 30sec. This solution manifests a problem for
taskrun/pipelinerun timeouts because this implementation relied on the
resync behavior to update run status to "Timeout".

I drew inspiration from @tzununbekov PR in knative/build. Credit to
@pivotal-nader-ziada @dprotaso for suggesting level based reconciliation.

Fixes: https://github.com/tektoncd/pipeline/issues/456
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

## Additional info
- In previous PR I ran into e2e test error that I could not resolve. I spent couple of days and went nowhere with the debugging error. I started fresh again in this PR. @vdemeester I have taken your feedback from previous PR and addressed them. Please review again and let me know your thoughts.

I apologize for multiple PRs 
3rd times the charm 🎆 