### PR TITLE
Format markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,8 @@ You can see more details (including a burndown, issues in epics, etc.) on our
 [zenhub board](https://app.zenhub.com/workspaces/pipelines-5bc61a054b5806bc2bed4fb2/boards?repos=146641150).
 To see this board, you must:
 
-- Ask [an OWNER](OWNERS) via [slack](https://knative.slack.com) for an invitation
+- Ask [an OWNER](OWNERS) via [slack](https://knative.slack.com) for an
+  invitation
 - Add [the zenhub browser extension](https://www.zenhub.com/extension) to see
   new info via GitHub (or just use zenhub.com directly)
 
@@ -118,8 +119,8 @@ Before a PR can be merged, it must have both `/lgtm` AND `/approve`:
 - `/approve` can be added only by
   [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
 
-[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
-automatically get `/approve` but still will need an `/lgtm` to merge.
+[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) automatically
+get `/approve` but still will need an `/lgtm` to merge.
 
 The merge will happen automatically once the PR has both `/lgtm` and `/approve`,
 and all tests pass. If you don't want this to happen you should

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -49,10 +49,9 @@ You must install these tools:
 1. [`dep`](https://github.com/golang/dep): For managing external Go
    dependencies. - Please Install dep v0.5.0 or greater.
 1. [`ko`](https://github.com/google/go-containerregistry/tree/master/cmd/ko):
-   For development. A recent version of `ko` (after the 23th of
-   February, see
+   For development. A recent version of `ko` (after the 23th of February, see
    [google/go-containerregistry#380](https://github.com/google/go-containerregistry/pull/380))
-   is required for `pipeline` to work correctly.   
+   is required for `pipeline` to work correctly.
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    interacting with your kube cluster
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,9 +28,8 @@ To add the Tekton Pipelines component to an existing cluster:
 
 1. Run the
    [`kubectl apply`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#apply)
-   command to install
-   [Tekton Pipelines](https://github.com/tektoncd/pipeline) and its
-   dependencies:
+   command to install [Tekton Pipelines](https://github.com/tektoncd/pipeline)
+   and its dependencies:
 
    ```bash
    kubectl apply --filename https://storage.googleapis.com/knative-releases/build-pipeline/latest/release.yaml

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,11 +1,12 @@
 # Tekton Test Infra
 
-This directory contains configuration and documentation for the test infrastructure for the Tekton Project.
+This directory contains configuration and documentation for the test
+infrastructure for the Tekton Project.
 
 ## Prow
 
-Prow is currently running on GKE in the project `tekton-releases`.
-The cluster name is `prow`.
+Prow is currently running on GKE in the project `tekton-releases`. The cluster
+name is `prow`.
 
 Configuration lives in the `prow` directory here.
 
@@ -17,11 +18,12 @@ It was deployed using `gcloud app deploy .` with no configuration changes.
 
 ## Boskos
 
-Boskos configuration lives in the `boskos` directory here.
-It runs in the `prow` cluster of the `tekton-release` project, in the namespace `test-pods`.
+Boskos configuration lives in the `boskos` directory here. It runs in the `prow`
+cluster of the `tekton-release` project, in the namespace `test-pods`.
 
 ### Adding a project
 
 Projects are created in GCP and added to the `boskos/boskos-config.yaml` file.
 
-Make sure the IAM account: `prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.
+Make sure the IAM account:
+`prow-account@tekton-releases.iam.gserviceaccount.com` has Editor permissions.

--- a/roadmap-2019.md
+++ b/roadmap-2019.md
@@ -4,12 +4,12 @@ This is an incomplete list of work we hope to accomplish in 2019.
 
 Highlights:
 
-* [Version 1.0](#version-10)
-* [Workflow features](#workflow) such as conditional execution
-* [Triggering](#triggering)
-* [Security](#security)
-* [SCM](#scm)
-* [Library of shared Pipelines and Tasks](#community-library)
+- [Version 1.0](#version-10)
+- [Workflow features](#workflow) such as conditional execution
+- [Triggering](#triggering)
+- [Security](#security)
+- [SCM](#scm)
+- [Library of shared Pipelines and Tasks](#community-library)
 
 _For comparison, Build CRD's 2018 roadmap is
 [here](https://github.com/knative/build/blob/master/roadmap-2018.md)._
@@ -23,10 +23,10 @@ where backwards incompatible changes must be made across multiple releases.
 This would also imply that the project is in a state where it is safe for other
 projects to rely on it, for example:
 
-- If users of [`knative/build`](https://github.com/knative/build) want to migrate to
-  [TaskRun](docs/taskruns.md)
-- If [`knative/serving`](https://github.com/knative/serving) would like to take a
-  dependency on this project
+- If users of [`knative/build`](https://github.com/knative/build) want to
+  migrate to [TaskRun](docs/taskruns.md)
+- If [`knative/serving`](https://github.com/knative/serving) would like to take
+  a dependency on this project
 
 ## Workflow
 
@@ -62,8 +62,8 @@ shine.
 
 Security requirements inform much of the overall Tekton pipelines design, but we
 still have lots of work to do. Declarative pipelines should make it possible to
-automatically vet delivery systems for compliance, secure software supply chains,
-auditability and other key features.
+automatically vet delivery systems for compliance, secure software supply
+chains, auditability and other key features.
 
 ## SCM
 
@@ -77,8 +77,8 @@ this is just the beginning. Users expect an SCM system to provide features like:
 - Linting
 - and more!
 
-Tekton should abstract these interactions (and providers!) away so Task authors can
-focus on adding value rather than implementing API wrappers.
+Tekton should abstract these interactions (and providers!) away so Task authors
+can focus on adding value rather than implementing API wrappers.
 
 ## Community library
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`