### PR TITLE
Read step status from Container Statuses instead of InitContainer's

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -327,7 +327,8 @@ func TestBuildStatusFromPod(t *testing.T) {
 		podStatus: corev1.PodStatus{
 			InitContainerStatuses: []corev1.ContainerStatus{{
 				// creds-init; ignored
-			}, {
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
 				Name: "state-name",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
@@ -354,7 +355,8 @@ func TestBuildStatusFromPod(t *testing.T) {
 				// creds-init; ignored.
 			}, {
 				// git-init; ignored.
-			}, {
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
 				Name: "state-name",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
@@ -388,7 +390,8 @@ func TestBuildStatusFromPod(t *testing.T) {
 				// first git-init; ignored.
 			}, {
 				// second git-init; ignored.
-			}, {
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
 				Name: "state-name",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
@@ -440,10 +443,11 @@ func TestBuildStatusFromPod(t *testing.T) {
 	}, {
 		desc: "failure-terminated",
 		podStatus: corev1.PodStatus{
-			Phase: corev1.PodFailed,
+			Phase:                 corev1.PodFailed,
 			InitContainerStatuses: []corev1.ContainerStatus{{
 				// creds-init status; ignored
-			}, {
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
 				Name:    "status-name",
 				ImageID: "image-id",
 				State: corev1.ContainerState{
@@ -492,10 +496,11 @@ func TestBuildStatusFromPod(t *testing.T) {
 	}, {
 		desc: "pending-waiting-message",
 		podStatus: corev1.PodStatus{
-			Phase: corev1.PodPending,
+			Phase:                 corev1.PodPending,
 			InitContainerStatuses: []corev1.ContainerStatus{{
 				// creds-init status; ignored
-			}, {
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
 				Name: "status-name",
 				State: corev1.ContainerState{
 					Waiting: &corev1.ContainerStateWaiting{

--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -39,7 +39,7 @@ func getEmbeddedTask(namespace string, args []string) *v1alpha1.Task {
 			tb.TaskInputs(tb.InputsResource("docs", v1alpha1.PipelineResourceTypeGit)),
 			tb.Step("read", "ubuntu",
 				tb.Command("/bin/bash"),
-				tb.Args("-c", "cat /workspace/docs/README.md"),
+				tb.Args("-c", "cat /workspace/docs/LICENSE"),
 			),
 			tb.Step("helloworld-busybox", "busybox", tb.Command(args...)),
 		))
@@ -50,7 +50,7 @@ func getEmbeddedTaskRun(namespace string) *v1alpha1.TaskRun {
 		Type: v1alpha1.PipelineResourceTypeGit,
 		Params: []v1alpha1.Param{{
 			Name:  "URL",
-			Value: "http://github.com/knative/docs",
+			Value: "https://github.com/knative/docs",
 		}},
 	}
 	return tb.TaskRun(embedTaskRunName, namespace,


### PR DESCRIPTION
# Changes
When moving away from init containers, the steps are now in containers
inside the pods. This means we need to look at container's statuses
instead of init container's statuses for getting their state.

Fixes #630 

/cc @bobcatfish @pivotal-nader-ziada 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
