### PR TITLE
export SOURCE_DATE_EPOCH env variable to avoid wrong image created time

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export SOURCE_DATE_EPOCH=`date +%s`
+
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/release.sh
 
 # Local generated yaml file


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

refer to issue #642, export `SOURCE_DATE_EPOCH` env variable to avoid wrong image created time to `hack/release.sh`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

# Test result

After build, the image created time is right

```
ko.local/github.com/knative/build-pipeline/build-base             latest                                                             f2d5911df846        About a minute ago   27.6MB
ko.local/github.com/knative/build-pipeline/cmd/controller         573078969e918cca031ed85688872e3810d56309eb772a3778ed929e8c8effa6   fe1f2403e83f        About a minute ago   46MB
ko.local/github.com/knative/build-pipeline/cmd/controller         latest                                                             fe1f2403e83f        About a minute ago   46MB
ko.local/github.com/knative/build-pipeline/cmd/gsutil             1821778c754095f82960eb5b9e1c35294d0b464be07ef11a93da9872a78f37a4   0bbe498275ae        About a minute ago   240MB
ko.local/github.com/knative/build-pipeline/cmd/gsutil             latest                                                             0bbe498275ae        About a minute ago   240MB
ko.local/github.com/knative/build-pipeline/cmd/bash               0e0a4674015642fd2511b9231312429cee8ceec12c05f220a6ebc3d87e89cb66   6adcfce19ef4        About a minute ago   17.4MB
ko.local/github.com/knative/build-pipeline/cmd/bash               latest                                                             6adcfce19ef4        About a minute ago   17.4MB
ko.local/github.com/knative/build-pipeline/cmd/kubeconfigwriter   e2c0459ee4d18c43e730e1f6a170bd5b756c455ed9f0b2387ea606b4a441c40a   89d86f000a62        About a minute ago   33.9MB
ko.local/github.com/knative/build-pipeline/cmd/kubeconfigwriter   latest                                                             89d86f000a62        About a minute ago   33.9MB
ko.local/github.com/knative/build-pipeline/cmd/webhook            82a1c9f7393309f489e80c87cb02df6a5c8e7cc1289de344767eba2ea7514e64   bd09b3b63a9f        About a minute ago   37.5MB
ko.local/github.com/knative/build-pipeline/cmd/webhook            latest                                                             bd09b3b63a9f        About a minute ago   37.5MB
ko.local/github.com/knative/build-pipeline/cmd/git-init           bb1bfb515bb1f26b36964724c94ecc5663650e699e859db0c925b8c5714b44f7   635ef2028593        About a minute ago   43.8MB
ko.local/github.com/knative/build-pipeline/cmd/git-init           latest                                                             635ef2028593        About a minute ago   43.8MB
ko.local/github.com/knative/build-pipeline/cmd/creds-init         bb1d185b4049e365c016c152cf3235fb68c995c7cf524a1df29e4c7e794b3dc4   7083e79535c7        About a minute ago   43.9MB
ko.local/github.com/knative/build-pipeline/cmd/creds-init         latest                                                             7083e79535c7        About a minute ago   43.9MB
ko.local/github.com/knative/build-pipeline/cmd/nop                6d546d560ad1d751dec87a1bba7e46cdb6587b983b5758cabaea2b5a97106f65   c72b76204fbc        About a minute ago   4MB
ko.local/github.com/knative/build-pipeline/cmd/nop                latest                                                             c72b76204fbc        About a minute ago   4MB
ko.local/github.com/knative/build-pipeline/cmd/entrypoint         a25b3ccb42d113c2a51b159e7886f77a75c48ffaef81330996524b5940462b63   416dd647d360        About a minute ago   3.55MB
ko.local/github.com/knative/build-pipeline/cmd/entrypoint         latest                                                             416dd647d360        About a minute ago   3.55MB
```
