### PR TITLE
Fix some prow configs.

### DIFF
--- a/infra/gubernator/config.yaml
+++ b/infra/gubernator/config.yaml
@@ -15,14 +15,14 @@
 
 default_external_services:
   gcs_pull_prefix: tekton-prow/pr-logs/pull
-  prow_url: tekton.dev
+  prow_url: prow.tekton.dev
 default_org: tektoncd
 default_repo: pipeline
 external_services:
   tektoncd:
     gcs_bucket: tekton-prow/
     gcs_pull_prefix: tekton-prow/pr-logs/pull
-    prow_url: tekton.dev
+    prow_url: prow.tekton.dev
 jobs:
   tekton-prow/pr-logs/directory/:
   - pull-tekton-pipeline-build-tests

--- a/infra/prow/config.yaml
+++ b/infra/prow/config.yaml
@@ -146,3 +146,34 @@ presubmits:
       - name: test-account
         secret:
           secretName: test-account
+  - name: pull-tekton-pipeline-go-coverage
+    agent: kubernetes
+    context: pull-tekton-pipeline-go-coverage
+    always_run: true
+    rerun_command: "/test pull-tekton-pipeline-go-coverage"
+    trigger: "(?m)^/test (all|pull-tekton-pipeline-go-coverage),?(\\s+|$)"
+    optional: true
+    decorate: true
+    clone_uri: "https://github.com/tektoncd/pipeline.git"
+    spec:
+      containers:
+      - image: gcr.io/knative-tests/test-infra/coverage:latest
+        imagePullPolicy: Always
+        command:
+        - "/coverage"
+        args:
+        - "--postsubmit-gcs-bucket=tekton-prow"
+        - "--postsubmit-job-name=pull-tekton-pipeline-go-coverage"
+        - "--artifacts=$(ARTIFACTS)"
+        - "--profile-name=coverage_profile.txt"
+        - "--cov-target=."
+        - "--cov-threshold-percentage=80"
+        - "--github-token=/etc/github-token/oauth"
+        volumeMounts:
+        - name: github-token
+          mountPath: /etc/github-token
+          readOnly: true
+      volumes:
+      - name: github-token
+        secret:
+          secretName: oauth-token


### PR DESCRIPTION
This PR fixes the prow.tekton.dev URL in gubernator (from tekton.dev, which goes to our site),
and also sets up the code coverage job.