### PR TITLE
Create our test clusters in us-central1 🌍

### DIFF
--- a/infra/prow/config.yaml
+++ b/infra/prow/config.yaml
@@ -71,7 +71,7 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-west1
+          value: us-central1
       volumes:
       - name: test-account
         secret:
@@ -106,7 +106,7 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-west1
+          value: us-central1
       volumes:
       - name: test-account
         secret:
@@ -141,7 +141,7 @@ presubmits:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/test-account/service-account.json
         - name: E2E_CLUSTER_REGION
-          value: us-west1
+          value: us-central1
       volumes:
       - name: test-account
         secret:


### PR DESCRIPTION
# Changes

In https://github.com/tektoncd/pipeline/pull/632 I've been running into
`ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS` errors saying `us-west1-c`
doesn't have enough resources for our test clusters. It seems like this
is outside of our control (and even tho we are using a regional
`us-west1` cluster, the setup stubbornly insists on trying to use
`us-west1-c`.

So instead let's try `us-central` for these very scientific reasons:

1. It's the only region with 4 zones at https://cloud.google.com/compute/docs/regions-zones/
2. Knative is using it and seems fine XD

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing) <-- we should probably add some docs on how to update this in prow tho 🤔 
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
n/a
```
