### PR TITLE
Don't call `t.Fatal` from a goroutine 💀 & pin `prow-tests` 📌

### DIFF
--- a/infra/prow/config.yaml
+++ b/infra/prow/config.yaml
@@ -49,7 +49,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-build-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests@sha256:39296f6df4f29812689b41c47c78bdb00fbbec5ee63407fcbfefec0f48f5b6b1
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -84,7 +84,7 @@ presubmits:
     trigger: "(?m)^/test (all|tekton-pipeline-unit-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests@sha256:39296f6df4f29812689b41c47c78bdb00fbbec5ee63407fcbfefec0f48f5b6b1
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"
@@ -119,7 +119,7 @@ presubmits:
     trigger: "(?m)^/test (all|pull-tekton-pipeline-integration-tests),?(\\s+|$)"
     spec:
       containers:
-      - image: gcr.io/knative-tests/test-infra/prow-tests:stable
+      - image: gcr.io/knative-tests/test-infra/prow-tests@sha256:39296f6df4f29812689b41c47c78bdb00fbbec5ee63407fcbfefec0f48f5b6b1
         imagePullPolicy: Always
         args:
         - "--scenario=kubernetes_execute_bazel"

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -56,17 +56,20 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 			defer wg.Done()
 
 			if err := WaitForTaskRunState(c, taskrunName, TaskRunSucceed(taskrunName), "TaskRunDuplicatePodTaskRunFailed"); err != nil {
-				t.Fatalf("Error waiting for TaskRun to finish: %s", err)
+				t.Errorf("Error waiting for TaskRun to finish: %s", err)
+				return
 			}
 
 			pods, err := c.KubeClient.Kube.CoreV1().Pods(namespace).List(metav1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s=%s", pipeline.GroupName+pipeline.TaskRunLabelKey, taskrunName),
 			})
 			if err != nil {
-				t.Fatalf("Error getting TaskRun pod list: %v", err)
+				t.Errorf("Error getting TaskRun pod list: %v", err)
+				return
 			}
 			if n := len(pods.Items); n != 1 {
-				t.Fatalf("Error matching the number of build pods: expecting 1 pod, got %d", n)
+				t.Errorf("Error matching the number of build pods: expecting 1 pod, got %d", n)
+				return
 			}
 		}(t)
 	}


### PR DESCRIPTION
# Changes

## First issue

It turns out that calling `t.Fatal` (and other functions that end tests,
see https://tip.golang.org/pkg/testing/#T) is only safe from the
goroutine running the Test function, so when this test started to fail
(root cause still TBD) (e.g. in
https://github.com/tektoncd/pipeline/pull/654) we started to see race
condition failures, kinda masking whatever was actually going wrong.

I think I caught all the instances of this but not 100% sure - note that
using it in sub tests (https://blog.golang.org/subtests) is a-ok :D

## Second issue

We were using `stable` and `stable` was suddenly updated to install `ko`
from https://github.com/google/ko but unfortunately that version of `ko`
didn't include google/go-containerregistry#380
which was the critical change from building binaries at `/ko-app` to
building them at `/ko-app/my-pkg` <- which we built some of our
functionality around.

Now we'll try to pin the image so we aren't caught by surprise by
changes again and can decide for ourselves when we want to consume them.
(Hopefully old images don't get deleted too often.. 🙏 Or at least not
before #267 😛)

I'm gonna manually apply this right now 🤞🤞🤞 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes
```
n/a
```
