### PR TITLE
Add the step name in taskrun status

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -162,6 +162,7 @@ func (tr *TaskRunStatus) SetCondition(newCond *apis.Condition) {
 // StepState reports the results of running a step in the Task.
 type StepState struct {
 	corev1.ContainerState
+	Name string `json:"name,omitempty"`
 }
 
 // +genclient

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
@@ -310,4 +311,9 @@ func findMaxResourceRequest(containers []corev1.Container, resourceNames ...core
 		}
 	}
 	return maxIdxs
+}
+
+// TrimContainerNamePrefix trim the container name prefix to get the corresponding step name
+func TrimContainerNamePrefix(containerName string) string {
+	return strings.TrimPrefix(containerName, containerPrefix)
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -344,6 +344,7 @@ func updateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 	for _, s := range pod.Status.ContainerStatuses {
 		taskRun.Status.Steps = append(taskRun.Status.Steps, v1alpha1.StepState{
 			ContainerState: *s.State.DeepCopy(),
+			Name:           resources.TrimContainerNamePrefix(s.Name),
 		})
 	}
 
@@ -413,7 +414,7 @@ func getFailureMessage(pod *corev1.Pod) string {
 	for _, status := range pod.Status.ContainerStatuses {
 		term := status.State.Terminated
 		if term != nil && term.ExitCode != 0 {
-			return fmt.Sprintf("build step %q exited with code %d (image: %q); for logs run: kubectl -n %s logs %s -c %s",
+			return fmt.Sprintf("%q exited with code %d (image: %q); for logs run: kubectl -n %s logs %s -c %s",
 				status.Name, term.ExitCode, status.ImageID,
 				pod.Namespace, pod.Name, status.Name)
 		}

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -78,6 +78,7 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Error",
 			},
 		},
+		Name: "exit",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -85,6 +86,7 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Completed",
 			},
 		},
+		Name: "hello",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -92,6 +94,7 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Completed",
 			},
 		},
+		Name: "world",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -99,6 +102,7 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Completed",
 			},
 		},
+		Name: "nop",
 	}}
 	ignoreFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreFields); d != "" {


### PR DESCRIPTION
# Changes

refer to #549

Add a step name to `taskrun` status to help user to trace their steps status

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Test

apply the following `task`

```
...
kind: Task
...
spec:
  steps:
    - name: step1
      image: ubuntu
      command:
        - echo
      args:
        - "hello world 1"
    - name: step2
      image: ubuntu
      command:
        - echo
      args:
        - "hello world 2"
```

Then apply a `taskrun` to trigger this `task`, we can watch the each step status, like:

```
...

status:
  conditions:
  - lastTransitionTime: 2019-03-22T08:53:26Z
    status: "True"
    type: Succeeded
  podName: steps-task-run-pod-354cda
  startTime: 2019-03-22T08:52:58Z
  steps:
  - name: step1
    terminated:
      containerID: docker://85f1c1df656df87a3eb15bf68a9ff0776ee0b399a9a6e41abcebcc459e981282
      exitCode: 0
      finishedAt: 2019-03-22T08:53:03Z
      reason: Completed
      startedAt: 2019-03-22T08:53:03Z
  - name: step2
    terminated:
      containerID: docker://2b70e22616b43cf0cf407d95180bc3bfb69fd1d29809beee1e27a7e3e000574b
      exitCode: 0
      finishedAt: 2019-03-22T08:53:05Z
      reason: Completed
      startedAt: 2019-03-22T08:53:05Z
  - name: nop
    terminated:
      containerID: docker://b7af1e688c434489535a43772e5ed3608c4e3a0ce7580c0b460dda38517d2689
      exitCode: 0
      finishedAt: 2019-03-22T08:53:05Z
      reason: Completed
      startedAt: 2019-03-22T08:53:05Z
```