### PR TITLE
feat(retries) Design and implement retries

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -10,6 +10,7 @@ This document defines `Pipelines` and their capabilities.
   - [Pipeline Tasks](#pipeline-tasks)
     - [From](#from)
     - [RunAfter](#runafter)
+    - [Retries](#retries)
 - [Ordering](#ordering)
 - [Examples](#examples)
 
@@ -41,6 +42,7 @@ following fields:
       - [`runAfter`](#runAfter) - Used when the [Pipeline Task](#pipeline-task)
         should be executed after another Pipeline Task, but there is no
         [output linking](#from) required
+      - [`retries`](#retries) - Used when the task is wanted to be executed if it fails. Could a network error or a missing dependency. It does not apply to cancellations.      
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -254,6 +256,24 @@ In this `Pipeline`, we want to test the code before we build from it, but there
 is no output from `test-app`, so `build-app` uses `runAfter` to indicate that
 `test-app` should run before it, regardless of the order they appear in the
 spec.
+
+#### retries
+
+Sometimes is needed some policy for retrying tasks for various reasons such as network errors, missing dependencies or upload problems. 
+Any of those issue must be reflected as False (corev1.ConditionFalse) within the TaskRun Status Succeeded Condition. 
+For that reason there is an optional attribute called `retries` which declares how many times that task should be retried in case of failure,
+
+By default and in its absence there are no retries; its value is 0.
+
+```yaml
+tasks:
+  - name: build-the-image
+    retries: 1
+    taskRef:
+      name: build-push
+```
+
+In this example, the task "build-the-image" will be executed and if the first run fails a second one would triggered. But, if that fails no more would triggered: a max of two executions.  
 
 ## Ordering
 

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -73,6 +73,10 @@ type PipelineTask struct {
 	Name    string  `json:"name"`
 	TaskRef TaskRef `json:"taskRef"`
 
+	// Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False
+	// +optional
+	Retries int `json:"retries",omitempty`
+
 	// RunAfter is the list of PipelineTask names that should be executed before
 	// this Task executes. (Used to force a specific ordering in graph execution.)
 	// +optional

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -138,6 +138,10 @@ type TaskRunStatus struct {
 	// Steps describes the state of each build step container.
 	// +optional
 	Steps []StepState `json:"steps,omitempty"`
+	// RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.
+	// All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.
+	// +optional
+	RetriesStatus []TaskRunStatus `json:"retriesStatus,omitempty"`
 }
 
 // GetCondition returns the Condition matching the given type.

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1430,6 +1430,13 @@ func (in *TaskRunStatus) DeepCopyInto(out *TaskRunStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RetriesStatus != nil {
+		in, out := &in.RetriesStatus, &out.RetriesStatus
+		*out = make([]TaskRunStatus, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/v1alpha1/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/taskspec.go
@@ -25,6 +25,7 @@ import (
 
 // GetTask is a function used to retrieve Tasks.
 type GetTask func(string) (v1alpha1.TaskInterface, error)
+type GetTaskRun func(string) (*v1alpha1.TaskRun, error)
 
 // GetClusterTask is a function that will retrieve the Task from name and namespace.
 type GetClusterTask func(name string) (v1alpha1.TaskInterface, error)

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -146,6 +146,12 @@ func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
 	}
 }
 
+func Retries(retries int) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.Retries = retries
+	}
+}
+
 // RunAfter will update the provided Pipeline Task to indicate that it
 // should be run after the provided list of Pipeline Task names.
 func RunAfter(tasks ...string) PipelineTaskOp {

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -303,6 +303,12 @@ func Condition(condition apis.Condition) TaskRunStatusOp {
 	}
 }
 
+func Retry(retry v1alpha1.TaskRunStatus) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.RetriesStatus = append(s.RetriesStatus, retry)
+	}
+}
+
 // StepState adds a StepState to the TaskRunStatus.
 func StepState(ops ...StepStateOp) TaskRunStatusOp {
 	return func(s *v1alpha1.TaskRunStatus) {

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -32,127 +32,154 @@ import (
 // verify that pipelinerun cancel lead to the the correct TaskRun statuses
 // and pod deletions.
 func TestTaskRunPipelineRunCancel(t *testing.T) {
-	c, namespace := setup(t)
+	type tests struct {
+		name    string
+		retries bool
+	}
+
+	tds := []tests{
+		{
+			name:    "With retries",
+			retries: true,
+		}, {
+			name:    "No retries",
+			retries: false,
+		},
+	}
+
 	t.Parallel()
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
-	defer tearDown(t, c, namespace)
+	for _, tdd := range tds {
+		t.Run(tdd.name, func(t *testing.T) {
 
-	t.Logf("Creating Task in namespace %s", namespace)
-	task := tb.Task("banana", namespace, tb.TaskSpec(
-		tb.Step("foo", "ubuntu", tb.Command("/bin/bash"), tb.Args("-c", "sleep 5000")),
-	))
-	if _, err := c.TaskClient.Create(task); err != nil {
-		t.Fatalf("Failed to create Task `banana`: %s", err)
-	}
-
-	t.Logf("Creating Pipeline in namespace %s", namespace)
-	pipeline := tb.Pipeline("tomatoes", namespace,
-		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
-	)
-	if _, err := c.PipelineClient.Create(pipeline); err != nil {
-		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
-	}
-
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
-
-	t.Logf("Creating PipelineRun in namespace %s", namespace)
-	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
-		t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
-	}
-
-	t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", "pear", namespace)
-	if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
-		c := pr.Status.GetCondition(apis.ConditionSucceeded)
-		if c != nil {
-			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
-				return true, fmt.Errorf("pipelineRun %s already finished", "pear")
-			} else if c.Status == corev1.ConditionUnknown && (c.Reason == "Running" || c.Reason == "Pending") {
-				return true, nil
+			var pipelineTask = tb.PipelineTask("foo", "banana")
+			if tdd.retries {
+				pipelineTask = tb.PipelineTask("foo", "banana", tb.Retries(1))
 			}
-		}
-		return false, nil
-	}, "PipelineRunRunning"); err != nil {
-		t.Fatalf("Error waiting for PipelineRun %s to be running: %s", "pear", err)
-	}
 
-	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=pear"})
-	if err != nil {
-		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", "pear", err)
-	}
+			c, namespace := setup(t)
+			t.Parallel()
 
-	var wg sync.WaitGroup
-	t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", "pear", namespace)
-	for _, taskrunItem := range taskrunList.Items {
-		wg.Add(1)
-		go func(name string) {
-			defer wg.Done()
-			err := WaitForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
-				if c := tr.Status.GetCondition(apis.ConditionSucceeded); c != nil {
-					if c.IsTrue() || c.IsFalse() {
-						return true, fmt.Errorf("taskRun %s already finished!", name)
-					} else if c.IsUnknown() && (c.Reason == "Running" || c.Reason == "Pending") {
+			knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+			defer tearDown(t, c, namespace)
+
+			t.Logf("Creating Task in namespace %s", namespace)
+			task := tb.Task("banana", namespace, tb.TaskSpec(
+				tb.Step("foo", "ubuntu", tb.Command("/bin/bash"), tb.Args("-c", "sleep 5000")),
+			))
+			if _, err := c.TaskClient.Create(task); err != nil {
+				t.Fatalf("Failed to create Task `banana`: %s", err)
+			}
+
+			t.Logf("Creating Pipeline in namespace %s", namespace)
+			pipeline := tb.Pipeline("tomatoes", namespace,
+				tb.PipelineSpec(pipelineTask),
+			)
+			if _, err := c.PipelineClient.Create(pipeline); err != nil {
+				t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
+			}
+
+			pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
+
+			t.Logf("Creating PipelineRun in namespace %s", namespace)
+			if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+				t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
+			}
+
+			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", "pear", namespace)
+			if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+				c := pr.Status.GetCondition(apis.ConditionSucceeded)
+				if c != nil {
+					if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
+						return true, fmt.Errorf("pipelineRun %s already finished", "pear")
+					} else if c.Status == corev1.ConditionUnknown && (c.Reason == "Running" || c.Reason == "Pending") {
 						return true, nil
 					}
 				}
 				return false, nil
-			}, "TaskRunRunning")
+			}, "PipelineRunRunning"); err != nil {
+				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", "pear", err)
+			}
+
+			taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=pear"})
 			if err != nil {
-				t.Errorf("Error waiting for TaskRun %s to be running: %v", name, err)
+				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", "pear", err)
 			}
-		}(taskrunItem.Name)
-	}
-	wg.Wait()
 
-	pr, err := c.PipelineRunClient.Get("pear", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get PipelineRun `%s`: %s", "pear", err)
-	}
-
-	pr.Spec.Status = v1alpha1.PipelineRunSpecStatusCancelled
-	if _, err := c.PipelineRunClient.Update(pr); err != nil {
-		t.Fatalf("Failed to cancel PipelineRun `%s`: %s", "pear", err)
-	}
-
-	t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
-	if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
-		if c := pr.Status.GetCondition(apis.ConditionSucceeded); c != nil {
-			if c.IsFalse() {
-				if c.Reason == "PipelineRunCancelled" {
-					return true, nil
-				}
-				return true, fmt.Errorf("pipelineRun %s completed with the wrong reason: %s", "pear", c.Reason)
-			} else if c.IsTrue() {
-				return true, fmt.Errorf("pipelineRun %s completed successfully, should have been cancelled", "pear")
+			var wg sync.WaitGroup
+			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", "pear", namespace)
+			for _, taskrunItem := range taskrunList.Items {
+				wg.Add(1)
+				go func(name string) {
+					defer wg.Done()
+					err := WaitForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
+						if c := tr.Status.GetCondition(apis.ConditionSucceeded); c != nil {
+							if c.IsTrue() || c.IsFalse() {
+								return true, fmt.Errorf("taskRun %s already finished!", name)
+							} else if c.IsUnknown() && (c.Reason == "Running" || c.Reason == "Pending") {
+								return true, nil
+							}
+						}
+						return false, nil
+					}, "TaskRunRunning")
+					if err != nil {
+						t.Errorf("Error waiting for TaskRun %s to be running: %v", name, err)
+					}
+				}(taskrunItem.Name)
 			}
-		}
-		return false, nil
-	}, "PipelineRunCancelled"); err != nil {
-		t.Errorf("Error waiting for PipelineRun `pear` to finished: %s", err)
-	}
+			wg.Wait()
 
-	t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
-	for _, taskrunItem := range taskrunList.Items {
-		wg.Add(1)
-		go func(name string) {
-			defer wg.Done()
-			err := WaitForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
-				if c := tr.Status.GetCondition(apis.ConditionSucceeded); c != nil {
+			pr, err := c.PipelineRunClient.Get("pear", metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get PipelineRun `%s`: %s", "pear", err)
+			}
+
+			pr.Spec.Status = v1alpha1.PipelineRunSpecStatusCancelled
+			if _, err := c.PipelineRunClient.Update(pr); err != nil {
+				t.Fatalf("Failed to cancel PipelineRun `%s`: %s", "pear", err)
+			}
+
+			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
+			if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+				if c := pr.Status.GetCondition(apis.ConditionSucceeded); c != nil {
 					if c.IsFalse() {
-						if c.Reason == "TaskRunCancelled" {
+						if c.Reason == "PipelineRunCancelled" {
 							return true, nil
 						}
-						return true, fmt.Errorf("taskRun %s completed with the wrong reason: %s", name, c.Reason)
+						return true, fmt.Errorf("pipelineRun %s completed with the wrong reason: %s", "pear", c.Reason)
 					} else if c.IsTrue() {
-						return true, fmt.Errorf("taskRun %s completed successfully, should have been cancelled", name)
+						return true, fmt.Errorf("pipelineRun %s completed successfully, should have been cancelled", "pear")
 					}
 				}
 				return false, nil
-			}, "TaskRunCancelled")
-			if err != nil {
-				t.Errorf("Error waiting for TaskRun %s to be finished: %v", name, err)
+			}, "PipelineRunCancelled"); err != nil {
+				t.Errorf("Error waiting for PipelineRun `pear` to finished: %s", err)
 			}
-		}(taskrunItem.Name)
+
+			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
+			for _, taskrunItem := range taskrunList.Items {
+				wg.Add(1)
+				go func(name string) {
+					defer wg.Done()
+					err := WaitForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
+						if c := tr.Status.GetCondition(apis.ConditionSucceeded); c != nil {
+							if c.IsFalse() {
+								if c.Reason == "TaskRunCancelled" {
+									return true, nil
+								}
+								return true, fmt.Errorf("taskRun %s completed with the wrong reason: %s", name, c.Reason)
+							} else if c.IsTrue() {
+								return true, fmt.Errorf("taskRun %s completed successfully, should have been cancelled", name)
+							}
+						}
+						return false, nil
+					}, "TaskRunCancelled")
+					if err != nil {
+						t.Errorf("Error waiting for TaskRun %s to be finished: %v", name, err)
+					}
+				}(taskrunItem.Name)
+			}
+			wg.Wait()
+		})
 	}
-	wg.Wait()
 }

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -410,11 +410,15 @@ func checkLabelPropagation(t *testing.T, c *clients, namespace string, pipelineR
 	}
 	assertLabelsMatch(t, labels, tr.ObjectMeta.Labels)
 
-	// Check label propagation to Pods.
-	pod := getPodForTaskRun(t, c.KubeClient, namespace, tr)
+	// PodName is "" iff a retry happened and pod is deleted
 	// This label is added to every Pod by the TaskRun controller
-	labels[pipeline.GroupName+pipeline.TaskRunLabelKey] = tr.Name
-	assertLabelsMatch(t, labels, pod.ObjectMeta.Labels)
+	if tr.Status.PodName != "" {
+		// Check label propagation to Pods.
+		pod := getPodForTaskRun(t, c.KubeClient, namespace, tr)
+		// This label is added to every Pod by the TaskRun controller
+		labels[pipeline.GroupName+pipeline.TaskRunLabelKey] = tr.Name
+		assertLabelsMatch(t, labels, pod.ObjectMeta.Labels)
+	}
 }
 
 func getPodForTaskRun(t *testing.T, kubeClient *knativetest.KubeClient, namespace string, tr *v1alpha1.TaskRun) *corev1.Pod {

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -178,6 +178,58 @@ func TestPipelineRunTimeout(t *testing.T) {
 	}
 }
 
+func TestPipelineRunFailedAndRetry(t *testing.T) {
+	numberOfRetries := 2
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	t.Logf("Creating Task in namespace %s", namespace)
+	task := tb.Task("banana", namespace, tb.TaskSpec(
+		tb.Step("foo", "busybox", tb.Command("/bin/sh"), tb.Args("-c", "exit 1")),
+	))
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", "banana", err)
+	}
+
+	pipeline := tb.Pipeline("tomatoes", namespace,
+		tb.PipelineSpec(tb.PipelineTask("foo", "banana", tb.Retries(numberOfRetries))),
+	)
+	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
+	}
+
+	t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+		t.Fatalf("Error waiting for PipelineRun %s to be failed: %s", pipelineRun.Name, err)
+	}
+
+	r, err := c.PipelineRunClient.Get(pipelineRun.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting pipeline %s", pipelineRun.Name)
+	}
+
+	if len(r.Status.TaskRuns) != 1 {
+		t.Fatalf("Only one TaskRun is expected, but got %d", len(r.Status.TaskRuns))
+	}
+
+	for taskRunName := range r.Status.TaskRuns {
+		taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Error getting task run %s", taskRunName)
+		}
+		if len(taskrun.Status.RetriesStatus) != numberOfRetries {
+			t.Fatalf("expected %d retry, but got %d", numberOfRetries, len(r.Status.TaskRuns))
+		}
+	}
+}
+
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
 	c, namespace := setup(t)


### PR DESCRIPTION
closes tektoncd#221

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adding retries to pipeline. Pipeline/Tasks will have retries that will be passed to the subsequent pipeline|task run.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

Adds the possibility to execute automated retries when something fails, could be applied to Pipelines or Tasks.
<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
