### PR TITLE
Fix the broken link

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -64,10 +64,10 @@ developing and running Pipelines. Your Kubernetes version must be 1.11 or later.
 
 To setup a cluster with GKE:
 
-1. [Install required tools and setup GCP project](https://github.com/knative/docs/blob/master/install/Knative-with-GKE.md#before-you-begin)
+1. [Install required tools and setup GCP project](https://github.com/knative/docs/blob/master/docs/install/Knative-with-GKE.md#before-you-begin)
    (You may find it useful to save the ID of the project in an environment
    variable (e.g. `PROJECT_ID`).
-1. [Create a GKE cluster](https://github.com/knative/docs/blob/master/install/Knative-with-GKE.md#creating-a-kubernetes-cluster)
+1. [Create a GKE cluster](https://github.com/knative/docs/blob/master/docs/install/Knative-with-GKE.md#creating-a-kubernetes-cluster)
 
 Note that
 [the `--scopes` argument to `gcloud container cluster create`](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--scopes)

--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -41,8 +41,8 @@ expected to be written in certain locations by a resulting pod)._
 ## `Build` and `BuildTemplate`
 
 The CRD types
-[`Build`](https://github.com/knative/docs/blob/master/build/builds.md) and
-[`BuildTemplate`](https://github.com/knative/docs/blob/master/build/build-templates.md)
+[`Build`](https://github.com/knative/docs/blob/master/docs/build/builds.md) and
+[`BuildTemplate`](https://github.com/knative/docs/blob/master/docs/build/build-templates.md)
 should be considered frozen at beta and only additive changes should be allowed.
 
 Support will continue for the `Build` type for the foreseeable future,


### PR DESCRIPTION
Link to setting up cluster in GKE in DEVELOPMENT.md is updated to fix the broken links.
Fixes #660 
