### PR TITLE
Format markdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,11 @@ _See also
 
 ## Contact
 
-This work is being done by the Tekton Pipeline working group.
-If you are interested please join our meetings
+This work is being done by the Tekton Pipeline working group. If you are
+interested please join our meetings
 [at 9am PST on Tuesdays](https://calendar.google.com/event?action=TEMPLATE&tmeid=amZyNTljOWpkZWdibmpsY3JlazNodDU5NWdfMjAxOTAzMjZUMTYwMDAwWiBnb29nbGUuY29tX2Qzb3Zjdm8xcDMyMTloOTg5NTczdjk4Zm5zQGc&tmsrc=google.com_d3ovcvo1p3219h989573v98fns%40group.calendar.google.com&scp=ALL)
-and or in slack at [`#build-pipeline`](https://knative.slack.com/messages/build-pipeline)!
+and or in slack at
+[`#build-pipeline`](https://knative.slack.com/messages/build-pipeline)!
 
 All docs shared with this group are made visible to members of
 [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev), please join
@@ -57,8 +58,8 @@ This means that most PRs should include both:
 
 ## Proposing features
 
-If you have an idea for a feature, or if you have a solution for an existing issue
-that involves an API change (i.e. changes
+If you have an idea for a feature, or if you have a solution for an existing
+issue that involves an API change (i.e. changes
 [the structure of a CRD](api_compatibility_policy.md#what-does-compatibility-mean-here)),
 we highly suggest that you propose the changes before implementing them.
 
@@ -70,18 +71,21 @@ This is for two main reasons:
 
 Some suggestions for how to do this:
 
-1. Write up a design doc and share it with [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev)
-2. Bring your design/ideas to [our working group meetings](#contact) for discussion
+1. Write up a design doc and share it with
+   [tekton-dev@](https://groups.google.com/forum/#!forum/tekton-dev)
+2. Bring your design/ideas to [our working group meetings](#contact) for
+   discussion
 
 A great proposal will include:
 
-* **The use case(s) it solves** Who needs this and why?
-* **Requirements** What needs to be true about the solution?
-* **2+ alternative proposals** Even if alternatives aren't obvious, forcing yourself to
-  brainstorm a couple more approaches may give you new ideas or make clear that your
-  initial proposal is the best one
+- **The use case(s) it solves** Who needs this and why?
+- **Requirements** What needs to be true about the solution?
+- **2+ alternative proposals** Even if alternatives aren't obvious, forcing
+  yourself to brainstorm a couple more approaches may give you new ideas or make
+  clear that your initial proposal is the best one
 
-Also feel free to reach out to us on [slack](#contact) if you want any help/guidance.
+Also feel free to reach out to us on [slack](#contact) if you want any
+help/guidance.
 
 Thanks so much!!
 

--- a/hack/release.md
+++ b/hack/release.md
@@ -1,6 +1,7 @@
 # Creating a new Tekton Pipeline release
 
-**Note: we are transitioning to a Pipelines based test and release process, see [tekton/README.md](../tekton/README.md).**
+**Note: we are transitioning to a Pipelines based test and release process, see
+[tekton/README.md](../tekton/README.md).**
 
 The `release.sh` script automates the creation of Tekton Pipeline releases,
 either nightly or versioned ones.

--- a/infra/README.md
+++ b/infra/README.md
@@ -3,20 +3,20 @@
 This directory contains configuration and documentation for the test
 infrastructure for the Tekton Project.
 
-* [Access](#access)
-* [Support](#support)
-* [Prow](#prow)
-* [Ingress](#ingress)
-* [Gubernator](#guberator)
-* [Boskos](#boskos)
+- [Access](#access)
+- [Support](#support)
+- [Prow](#prow)
+- [Ingress](#ingress)
+- [Gubernator](#guberator)
+- [Boskos](#boskos)
 
 ## Access
 
 Currently users have been manually added by @dlorenc to have access to
 [the Prow GCP project](#prow) and [the Boskos projects](#boskos).
 
-TODO(dlorenc, bobcatfish): Create a role/group that has access to these clusters and
-guidelines about who should be added.
+TODO(dlorenc, bobcatfish): Create a role/group that has access to these clusters
+and guidelines about who should be added.
 
 ## Support
 
@@ -26,21 +26,27 @@ TODO(dlorenc, bobcatfish): Create support guidelines, add monitoring
 
 ## Prow
 
-* Prow runs in [the GCP project `tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
-* Prow runs in [the GKE cluster `prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
-* Prow uses the service account `prow-account@tekton-releases.iam.gserviceaccount.com`
-  * Secrets for this account are configured in [Prow's config.yaml](prow/config.yaml) via `gcs_credentials_secret: "test-account"`
-* Prow configuration is in [infra/prow](./prow)
+- Prow runs in
+  [the GCP project `tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
+- Prow runs in
+  [the GKE cluster `prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
+- Prow uses the service account
+  `prow-account@tekton-releases.iam.gserviceaccount.com`
+  - Secrets for this account are configured in
+    [Prow's config.yaml](prow/config.yaml) via
+    `gcs_credentials_secret: "test-account"`
+- Prow configuration is in [infra/prow](./prow)
 
 _[Prow docs](https://github.com/kubernetes/test-infra/tree/master/prow)._
-_[See the CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-process) for more on Prow and the PR process._
+_[See the CONTRIBUTING.md](../CONTRIBUTING.md#pull-request-process) for more on
+Prow and the PR process._
 
 ### Updating Prow
 
 TODO(#652) Apply config.yaml changes automatically
 
-Changes to [config.yaml](./prow/config.yaml) are not automatically reflected in the Prow
-cluster and must be manually applied.
+Changes to [config.yaml](./prow/config.yaml) are not automatically reflected in
+the Prow cluster and must be manually applied.
 
 ```bash
 # Step 1: Configure kubectl to use the cluster, doesn't have to be via gcloud but gcloud makes it easy
@@ -55,15 +61,17 @@ gcloud beta container clusters get-credentials ...
 
 ## Ingress
 
-* Ingress for prow is configured using [cert-manager](https://github.com/jetstack/cert-manager/).
-* `cert-manager` was installed via `Helm` using this [guide](https://docs.cert-manager.io/en/latest/getting-started/)
-* `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
-* https://prow.tekton.dev is pointed at the Cluster ingress address.
+- Ingress for prow is configured using
+  [cert-manager](https://github.com/jetstack/cert-manager/).
+- `cert-manager` was installed via `Helm` using this
+  [guide](https://docs.cert-manager.io/en/latest/getting-started/)
+- `prow.tekton.dev` is configured as a host on the prow `Ingress` resource.
+- https://prow.tekton.dev is pointed at the Cluster ingress address.
 
 ## Gubernator
 
-* Gubernator is configured on App Engine in the project `tekton-releases`.
-* It was deployed using `gcloud app deploy .` with no configuration changes.
+- Gubernator is configured on App Engine in the project `tekton-releases`.
+- It was deployed using `gcloud app deploy .` with no configuration changes.
 
 _[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernator)._
 
@@ -71,8 +79,9 @@ _[Gubernator docs](https://github.com/kubernetes/test-infra/tree/master/gubernat
 
 We use Boskos to manage GCP projects which end to end tests are run against.
 
-* Boskos configuration lives [in the `boskos` directory](./boskos)
-* It runs [in the `prow` cluster of the `tekton-releases` project](#prow), in the namespace `test-pods`
+- Boskos configuration lives [in the `boskos` directory](./boskos)
+- It runs [in the `prow` cluster of the `tekton-releases` project](#prow), in
+  the namespace `test-pods`
 
 _[Boskos docs](https://github.com/kubernetes/test-infra/tree/master/boskos)._
 

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -1,49 +1,62 @@
 # Tekton Repo CI/CD
 
-We dogfood our project by using Tekton Pipelines to build, test and release Tekton Pipelines!
+We dogfood our project by using Tekton Pipelines to build, test and release
+Tekton Pipelines!
 
-This directory contains the [`Tasks`](https://github.com/knative/build-pipeline/blob/master/docs/tasks.md)
-and [`Pipelines`](https://github.com/knative/build-pipeline/blob/master/docs/pipelines.md) that we (will)
-use.
+This directory contains the
+[`Tasks`](https://github.com/knative/build-pipeline/blob/master/docs/tasks.md)
+and
+[`Pipelines`](https://github.com/knative/build-pipeline/blob/master/docs/pipelines.md)
+that we (will) use.
 
-TODO(#538): In #538 or #537 we will update [Prow](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#pull-request-process)
-to invoke these `Pipelines` automatically, but for now we will have to invoke them manually.
+TODO(#538): In #538 or #537 we will update
+[Prow](https://github.com/knative/build-pipeline/blob/master/CONTRIBUTING.md#pull-request-process)
+to invoke these `Pipelines` automatically, but for now we will have to invoke
+them manually.
 
 ## Release Pipeline
 
 The `Tasks` which make up our release `Pipeline` are:
 
-* [`ci-images.yaml`](ci-images.yaml) - This `Task` uses [`kaniko`](https://github.com/GoogleContainerTools/kaniko)
-  to build and publish [images for the CI itself](#supporting-images), which can then be used as `steps` in
-  downstream `Tasks`
-* [`publish.yaml`](publish.yaml) - This `Task` uses [`kaniko`](https://github.com/GoogleContainerTools/kaniko)
-  to build and publish base images, and uses [`ko`](https://github.com/google/go-containerregistry/tree/master/cmd/ko)
-  to build all of the container images we release and generate the `release.yaml`
+- [`ci-images.yaml`](ci-images.yaml) - This `Task` uses
+  [`kaniko`](https://github.com/GoogleContainerTools/kaniko) to build and
+  publish [images for the CI itself](#supporting-images), which can then be used
+  as `steps` in downstream `Tasks`
+- [`publish.yaml`](publish.yaml) - This `Task` uses
+  [`kaniko`](https://github.com/GoogleContainerTools/kaniko) to build and
+  publish base images, and uses
+  [`ko`](https://github.com/google/go-containerregistry/tree/master/cmd/ko) to
+  build all of the container images we release and generate the `release.yaml`
 
 ### Running
 
-To run these `Pipelines` and `Tasks`, you must have Tekton Pipelines installed, either via
+To run these `Pipelines` and `Tasks`, you must have Tekton Pipelines installed,
+either via
 [an official release](https://github.com/knative/build-pipeline/blob/master/docs/install.md)
-or [from `HEAD`](https://github.com/knative/build-pipeline/blob/master/DEVELOPMENT.md#install-pipeline).
+or
+[from `HEAD`](https://github.com/knative/build-pipeline/blob/master/DEVELOPMENT.md#install-pipeline).
 
-TODO(#531): Add the Pipeline, for now all we have are `Tasks` which we can invoke individually
-by creating [`TaskRuns`](https://github.com/knative/build-pipeline/blob/master/docs/taskruns.md)
-and [`PipelineResources`](https://github.com/knative/build-pipeline/blob/master/docs/resources.md).
+TODO(#531): Add the Pipeline, for now all we have are `Tasks` which we can
+invoke individually by creating
+[`TaskRuns`](https://github.com/knative/build-pipeline/blob/master/docs/taskruns.md)
+and
+[`PipelineResources`](https://github.com/knative/build-pipeline/blob/master/docs/resources.md).
 
-TODO(#569): Normally we'd use the image `PipelineResources` to control which image registry the images are pushed to.
-However since we have so many images, all going to the same registry, we are cheating and using a parameter
-for the image registry instead.
+TODO(#569): Normally we'd use the image `PipelineResources` to control which
+image registry the images are pushed to. However since we have so many images,
+all going to the same registry, we are cheating and using a parameter for the
+image registry instead.
 
-* [`ciimages-run.yaml`](ci-images-run.yaml) - This example `TaskRun` and `PipelineResources` demonstrate
-  how to invoke `ci-images.yaml`:
+- [`ciimages-run.yaml`](ci-images-run.yaml) - This example `TaskRun` and
+  `PipelineResources` demonstrate how to invoke `ci-images.yaml`:
 
   ```bash
   kubectl apply -f tekton/ci-images.yaml
   kubectl apply -f tekton/ci-images-run.yaml
   ```
 
-* [`publish-run.yaml`](publish-run.yaml) - This example `TaskRun` and `PipelineResources` demonstrate
-  how to invoke `publish.yaml`:
+- [`publish-run.yaml`](publish-run.yaml) - This example `TaskRun` and
+  `PipelineResources` demonstrate how to invoke `publish.yaml`:
 
   ```bash
   kubectl apply -f tekton/publish.yaml
@@ -54,49 +67,54 @@ for the image registry instead.
 
 Users executing the publish task must be able to:
 
-* Push to the image registry (production registry is `gcr.io/tekton-releases`)
-* Write to the GCS bucket (production bucket is `gs://tekton-releases`)
+- Push to the image registry (production registry is `gcr.io/tekton-releases`)
+- Write to the GCS bucket (production bucket is `gs://tekton-releases`)
 
-To be able to publish images via `kaniko` or `ko`, you must be able to push to your image registry.
-At the moment, the publish `Task` will try to use your default service account in the namespace where
-you create the `TaskRun`. If that default service account is able to push to your image registry,
-you are good to go. Otherwise, you need to use [a secret annotated with your docker registry
-credentials](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker).
+To be able to publish images via `kaniko` or `ko`, you must be able to push to
+your image registry. At the moment, the publish `Task` will try to use your
+default service account in the namespace where you create the `TaskRun`. If that
+default service account is able to push to your image registry, you are good to
+go. Otherwise, you need to use
+[a secret annotated with your docker registry credentials](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#basic-authentication-docker).
 
-TODO(#631) Ensure that we are supporting folks using credentials other than the cluster defaults; not
-sure how this will play out with publishing to our prod registry!
+TODO(#631) Ensure that we are supporting folks using credentials other than the
+cluster defaults; not sure how this will play out with publishing to our prod
+registry!
 
 #### Production credentials
 
-TODO(dlorenc, bobcatfish): We need to setup a group which users can be added to, as well as guidelines
-around who should be added to this group.
+TODO(dlorenc, bobcatfish): We need to setup a group which users can be added to,
+as well as guidelines around who should be added to this group.
 
-For now, users who need access to our production registry (`gcr.io/tekton-releases`) and production
-GCS bucket (`gs://tekton-releases`) should ping @bobcatfish or @dlorenc to get added to the authorized
-users.
+For now, users who need access to our production registry
+(`gcr.io/tekton-releases`) and production GCS bucket (`gs://tekton-releases`)
+should ping @bobcatfish or @dlorenc to get added to the authorized users.
 
 ## Supporting scripts
 
 Some supporting scripts have been written using Python 2.7:
 
-* [koparse](./koparse) - Contains logic for parsing `release.yaml` files created by `ko`
+- [koparse](./koparse) - Contains logic for parsing `release.yaml` files created
+  by `ko`
 
 ## Supporting images
 
-TODO(#639) Ensure we are using the images that are published by the `Pipeline` itself.
+TODO(#639) Ensure we are using the images that are published by the `Pipeline`
+itself.
 
 These images are built and published to be used by the release Pipeline itself.
 
 ### ko image
 
-In order to run `ko`, and to be able to use a cluster's default credentials, we need an image which
-contains:
+In order to run `ko`, and to be able to use a cluster's default credentials, we
+need an image which contains:
 
-* `ko`
-* `golang` - Required by `ko` to build
-* `gcloud` - Required to auth with default namespace credentials
+- `ko`
+- `golang` - Required by `ko` to build
+- `gcloud` - Required to auth with default namespace credentials
 
-The image which we use for this is built from [tekton/ko/Dockerfile](./ko/Dockerfile).
+The image which we use for this is built from
+[tekton/ko/Dockerfile](./ko/Dockerfile).
 
-_[go-containerregistry#383](https://github.com/google/go-containerregistry/issues/383) is about publishing
-a `ko` image, which hopefully we'll be able to move it._
+_[go-containerregistry#383](https://github.com/google/go-containerregistry/issues/383)
+is about publishing a `ko` image, which hopefully we'll be able to move it._


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`