### PR TITLE
Add `latest` tag to most recently released images 🔖

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -118,8 +118,6 @@ spec:
       mkdir -p /workspace/bucket/previous/${inputs.params.versionTag}/
       cp /workspace/bucket/latest/release.yaml /workspace/bucket/previous/${inputs.params.versionTag}/release.yaml
 
-  # TODO(#216) Hopefully once we can avoid doing this parsing; on the other hand, `ko` doesn't
-  # really fit super well into our declarative model
   - name: tag-images
     image: google/cloud-sdk
     command:
@@ -149,6 +147,9 @@ spec:
         for REGION in "${REGIONS[@]}"
         do
           IMAGE_WITHOUT_SHA=${IMAGE%%@*}
-          gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:${inputs.params.versionTag}
+          for TAG in "latest" ${inputs.params.versionTag}
+          do
+            gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:$TAG
+          done
         done
       done


### PR DESCRIPTION
# Changes

Looking again at the knative/test-infra release scripts, it looks like
they now tag `latest` on the most recently released images, which makes
sense for us as well (otherwise you can't pull without an explicit tag).

It also looks like the knative release process has changed such that the
process is to copy the most recent nightly-build, but we can decide if
that's the route we want to go down later.

Remove a comment about parsing and `ko`'s declarative model - in #631 we
can decide what we want to do about using `ko` for releasing in the
future.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
n/a
```
