### PR TITLE
Fix docs/tasks.md wrong apiVersion 📖

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -81,7 +81,7 @@ The following example is a non-working sample where most of the possible
 configuration fields are used:
 
 ```yaml
-apiVersion: build.knative.dev/v1alpha1
+apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
   name: example-task-name


### PR DESCRIPTION
# Changes

There was a wrong `apiVersion` in one of the example :sweat_smile: 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- <del>[ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)</del>
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

