### PR TITLE
timeout_handler small fixes

### DIFF
--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -123,7 +123,8 @@ func getTimeout(d *metav1.Duration) time.Duration {
 func (t *TimeoutSet) checkPipelineRunTimeouts(namespace string) {
 	pipelineRuns, err := t.pipelineclientset.TektonV1alpha1().PipelineRuns(namespace).List(metav1.ListOptions{})
 	if err != nil {
-		t.logger.Errorf("Can't get taskruns list in namespace %s: %s", namespace, err)
+		t.logger.Errorf("Can't get pipelinerun list in namespace %s: %s", namespace, err)
+		return
 	}
 	for _, pipelineRun := range pipelineRuns.Items {
 		pipelineRun := pipelineRun
@@ -140,6 +141,7 @@ func (t *TimeoutSet) CheckTimeouts() {
 	namespaces, err := t.kubeclientset.CoreV1().Namespaces().List(metav1.ListOptions{})
 	if err != nil {
 		t.logger.Errorf("Can't get namespaces list: %s", err)
+		return
 	}
 	for _, namespace := range namespaces.Items {
 		t.checkTaskRunTimeouts(namespace.GetName())
@@ -152,7 +154,8 @@ func (t *TimeoutSet) CheckTimeouts() {
 func (t *TimeoutSet) checkTaskRunTimeouts(namespace string) {
 	taskruns, err := t.pipelineclientset.TektonV1alpha1().TaskRuns(namespace).List(metav1.ListOptions{})
 	if err != nil {
-		t.logger.Errorf("Can't get taskruns list in namespace %s: %s", namespace, err)
+		t.logger.Errorf("Can't get taskrun list in namespace %s: %s", namespace, err)
+		return
 	}
 	for _, taskrun := range taskruns.Items {
 		taskrun := taskrun
@@ -218,7 +221,7 @@ func (t *TimeoutSet) WaitPipelineRun(pr *v1alpha1.PipelineRun) {
 		// we're stopping, give up
 		return
 	case <-finished:
-		// taskrun finished, we can stop watching
+		// pipelinerun finished, we can stop watching
 		return
 	case <-time.After(timeout):
 		t.StatusLock(pr)

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -186,7 +186,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	// Reconcile this copy of the task run and then write back any status or label
+	// Reconcile this copy of the pipelinerun and then write back any status or label
 	// updates regardless of whether the reconciliation errored out.
 	if err = c.reconcile(ctx, pr); err != nil {
 		c.Logger.Errorf("Reconcile error: %v", err.Error())


### PR DESCRIPTION
# Changes

- fix typos where it should be pipelinerun instead of taskrun
- return function early to not panic. It's not likely to happen, but
  there is no guarantee to get a non-nil List object in case of an
  error happened

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- <del>[ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)</del>
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
