### PR TITLE
Require `ko` >= 0.1 and simplify entrypoint copy container args

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,10 +48,8 @@ You must install these tools:
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
 1. [`dep`](https://github.com/golang/dep): For managing external Go
    dependencies. - Please Install dep v0.5.0 or greater.
-1. [`ko`](https://github.com/google/ko): For development. A recent version of
-   `ko` (after the 23th of February, see
-   [google/go-containerregistry#380](https://github.com/google/go-containerregistry/pull/380))
-   is required for `pipeline` to work correctly.
+1. [`ko`](https://github.com/google/ko): For development. `ko`
+   version v0.1 or higher is required for `pipeline` to work correctly.
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    interacting with your kube cluster
 

--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint.go
@@ -95,7 +95,7 @@ func AddCopyStep(spec *v1alpha1.TaskSpec) {
 		Image:   *entrypointImage,
 		Command: []string{"/bin/sh"},
 		// based on the ko version, the binary could be in one of two different locations
-		Args:         []string{"-c", fmt.Sprintf("if [[ -d /ko-app ]]; then cp /ko-app/entrypoint %s; else cp /ko-app %s;  fi;", BinaryLocation, BinaryLocation)},
+		Args:         []string{"-c", fmt.Sprintf("cp /ko-app/entrypoint %s", BinaryLocation)},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 	spec.Steps = append([]corev1.Container{cp}, spec.Steps...)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -141,7 +141,7 @@ var (
 
 	placeToolsInitContainer = tb.PodInitContainer("build-step-place-tools", "override-with-entrypoint:latest",
 		tb.Command("/bin/sh"),
-		tb.Args("-c", fmt.Sprintf("if [[ -d /ko-app ]]; then cp /ko-app/entrypoint %s; else cp /ko-app %s;  fi;", entrypointLocation, entrypointLocation)),
+		tb.Args("-c", fmt.Sprintf("cp /ko-app/entrypoint %s", entrypointLocation)),
 		tb.WorkingDir(workspaceDir),
 		tb.EnvVar("HOME", "/builder/home"),
 		tb.VolumeMount("tools", "/builder/tools"),


### PR DESCRIPTION
# Changes

In #605, we required that `ko` was recent enough to be *guaranteed* to
have `/ko-app/{app}` (see google/go-containerregistry#380). As we now
point to `google/ko` and as we have a `ko` release (v0.1), we can
require this version for development.

Given the requirement above, we can simplify the `entrypoint` copy
container `args`.

cc @pivotal-nader-ziada 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- <del>[ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)</del>
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
