### PR TITLE
entrypoint: in case of step command failure, write postfile

### DIFF
--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -1,0 +1,107 @@
+// +build e2e
+
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	knativetest "github.com/knative/pkg/test"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTaskRunFailure(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	taskRunName := "failing-taskrun"
+
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := tb.Task("failing-task", namespace, tb.TaskSpec(
+		tb.Step("hello", "busybox",
+			tb.Command("/bin/sh"), tb.Args("-c", "echo hello"),
+		),
+		tb.Step("exit", "busybox",
+			tb.Command("/bin/sh"), tb.Args("-c", "exit 1"),
+		),
+		tb.Step("world", "busybox",
+			tb.Command("/bin/sh"), tb.Args("-c", "sleep 30s"),
+		),
+	))
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+		tb.TaskRunTaskRef("failing-task"),
+	))
+	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
+	if err := WaitForTaskRunState(c, taskRunName, TaskRunFailed(taskRunName), "TaskRunFailed"); err != nil {
+		t.Errorf("Error waiting for TaskRun to finish: %s", err)
+	}
+
+	taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	expectedStepState := []v1alpha1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 1,
+				Reason:   "Error",
+			},
+		},
+	}, {
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+	}, {
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+	}, {
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+	}}
+	ignoreFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+}


### PR DESCRIPTION
# Changes

The entrypoint package wraps the step commands and execute them. This
allows use to use pods containers with some order. In a step, the
entrypoint binary will wait for the file of the previous step to be
present to execute the actual command.

Before this change, if a command failed (`exit 1` or something),
entrypoint would not write a file, and thus the whole pod would be
stuck running (all the next step would wait forever).

This fixes that by always writing the post-file — and making
the *waiter* a bit smarter :

- it will now look for a `{postfile}.err` to detect if the previous
  step failed or not.
- if the previous steps failed, it will fail too without executing the
  step commands.

Closes #682 

cc @pivotal-nader-ziada 

<del>I need to update `pkg/entrypoint` unit tests though :angel: </del>

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
