### PR TITLE
wip: e2e: safer timeout test (less flakey 🙏)

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -284,7 +284,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 		}
 	} else {
 		// Pod is not present, create pod.
-		go c.timeoutHandler.WaitTaskRun(tr)
 		pod, err = c.createPod(tr, rtr.TaskSpec, rtr.TaskName)
 		if err != nil {
 			// This Run has failed, so we need to mark it as failed and stop reconciling it
@@ -304,7 +303,9 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 			c.Logger.Errorf("Failed to create build pod for task %q :%v", err, tr.Name)
 			return nil
 		}
-		go c.timeoutHandler.WaitTaskRun(tr)
+		started := make(chan struct{})
+		go c.timeoutHandler.WaitTaskRun(tr, started)
+		<-started
 	}
 	if err := c.tracker.Track(tr.GetBuildPodRef(), tr); err != nil {
 		c.Logger.Errorf("Failed to create tracker for build pod %q for taskrun %q: %v", tr.Name, tr.Name, err)

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -180,7 +180,6 @@ func TestPipelineRunTimeout(t *testing.T) {
 
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
-	t.Skip("Flakey test, tracked in https://github.com/tektoncd/pipeline/issues/731")
 	c, namespace := setup(t)
 	t.Parallel()
 


### PR DESCRIPTION
# Changes

- Do not start two go routines sweat, my bad, I messed up a rebase on my
  part brought an additional timeout goroutine bowing_man (https://github.com/tektoncd/pipeline/commit/23af2de43a049d6c6395a1a8be19c764b71bf63e).
- Use a channel (started) to make sure we start the timeout timer in
  time at the time we issue the `go …` call.

  When using the `go` keyword to start a goroutines, there is no
  guarantee the code inside the go routine will start right away. The
  scheduler might (and most likely will) wait for the main
  goroutine (or the caller goroutine) to have a waiting/sleeping time,
  to start working in the issued go routine.

  This means, that before that fix, we have no guarantee we started
  the timer at the right time — especially if the controller is very
  busy.

  Passing a channel and waiting for it to be closed just after the `go
  …` call forces the scheduler to sleep and run the goroutine's
  code. Which, in our case, that we started the timeout timer at the
  right time.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix timeout handling : in the case of a busy controller, it was possible that the timeout timer wouldn't start at the right time — this should be fixed now
```
