### PR TITLE
Add additionalPrinterColumns to taskrun CRD

### DIFF
--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -25,6 +25,21 @@ spec:
     - knative
     - tekton-pipelines
   scope: Namespaced
+  additionalPrinterColumns:
+    - name: Type
+      type: string
+      description: The cron spec defining the interval a CronJob is run
+      JSONPath: .status.conditions[0].type
+    - name: Status
+      type: string
+      description: The number of jobs launched by the CronJob
+      JSONPath: .status.conditions[0].status
+    - name: StartTime
+      type: date
+      JSONPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      JSONPath: .status.conditions[0].lastTransitionTime
   # Opt into the status subresource so metadata.generation
   # starts to increment
   subresources:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Added type, status, startTime and CompletionTime as additional
printer columns in taskrun.
This will show the above fields when someone does `kubectl get taskruns`.

Fixes https://github.com/tektoncd/pipeline/issues/615
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes? **yes**

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

-  `kubectl get taskruns` now gives more information like `Type`, `Status`, `StartTime`,`CompletionTime`

