### PR TITLE
e2e test: fix test panic in case of KO_DOCKER_REPO not present

### DIFF
--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -64,12 +64,12 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Image PipelineResource %s", sourceImageName)
-	if _, err := c.PipelineResourceClient.Create(getHelmImageResource(namespace)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getHelmImageResource(t, namespace)); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceImageName, err)
 	}
 
 	t.Logf("Creating Task %s", createImageTaskName)
-	if _, err := c.TaskClient.Create(getCreateImageTask(namespace, t)); err != nil {
+	if _, err := c.TaskClient.Create(getCreateImageTask(namespace)); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", createImageTaskName, err)
 	}
 
@@ -150,7 +150,7 @@ func getGoHelloworldGitResource(namespace string) *v1alpha1.PipelineResource {
 	))
 }
 
-func getHelmImageResource(namespace string) *v1alpha1.PipelineResource {
+func getHelmImageResource(t *testing.T, namespace string) *v1alpha1.PipelineResource {
 	// according to knative/test-infra readme (https://github.com/knative/test-infra/blob/13055d769cc5e1756e605fcb3bcc1c25376699f1/scripts/README.md)
 	// the KO_DOCKER_REPO will be set with according to the project where the cluster is created
 	// it is used here to dynamically get the docker registry to push the image to
@@ -166,7 +166,7 @@ func getHelmImageResource(namespace string) *v1alpha1.PipelineResource {
 	))
 }
 
-func getCreateImageTask(namespace string, t *testing.T) *v1alpha1.Task {
+func getCreateImageTask(namespace string) *v1alpha1.Task {
 	return tb.Task(createImageTaskName, namespace, tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit)),
 		tb.TaskOutputs(tb.OutputsResource("builtimage", v1alpha1.PipelineResourceTypeImage)),

--- a/test/wait_example_test.go
+++ b/test/wait_example_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -28,9 +27,13 @@ var (
 	// Golang Example functions do not take `t *testing.T` as argument, so we "fake"
 	// it so that examples still compiles (`go test` tries to compile those) and look
 	// nice in the go documentation.
-	t *testing.T
+	t testingT
 	c *clients
 )
+
+type testingT interface {
+	Errorf(string, ...interface{})
+}
 
 func ExampleWaitForTaskRunState() {
 	// […] setup the test, get clients


### PR DESCRIPTION
# Changes

In `TestHelmDeployPipelineRun`, we call `t.Fatalf` is `KO_DOCKER_REPO`
is empty. But `t` is not passed as an argument, so it refers a *hacky*
t from `wait_example_test.go`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
