### PR TITLE
fix issue, docker push in kaniko failed since permission error

### DIFF
--- a/examples/taskruns/taskrun.yaml
+++ b/examples/taskruns/taskrun.yaml
@@ -66,6 +66,9 @@ spec:
     - --dockerfile=${inputs.params.pathToDockerFile}
     - --destination=${outputs.resources.builtImage.url}
     - --context=${inputs.params.pathToContext}
+    env:
+      - name: "DOCKER_CONFIG"
+        value: "/builder/home/.docker/"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
I tried this example, at the step of "build-push-kaniko", it try to push image to docker.hub,
then hit permission error, seems it's not authorized to do that.
As we know, the "taskrun" will launch a "init container" to do that for us after set the "service account".

After some search, I find in "kaniko", it use a env parameter: DOCKER_CONFIG which point to ".docker/config.json". by default, the value is "/kaniko/.docker/".
As we know, the "taskrun" will put the docker authentication file at "/builder/home/.docker/"

So, to make the example work, need add additional config to rewrite the " DOCKER_CONFIG"
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist
examples/taskruns/taskrun.yaml
These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
