### PR TITLE
Skip some tests if KO_DOCKER_REPO is missing…

### DIFF
--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -18,7 +18,6 @@ package test
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -51,6 +50,7 @@ var (
 // TestHelmDeployPipelineRun is an integration test that will verify a pipeline build an image
 // and then using helm to deploy it
 func TestHelmDeployPipelineRun(t *testing.T) {
+	repo := ensureDockerRepo(t)
 	c, namespace := setup(t)
 	setupClusterBindingForHelm(c, t, namespace)
 	t.Parallel()
@@ -64,7 +64,7 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Image PipelineResource %s", sourceImageName)
-	if _, err := c.PipelineResourceClient.Create(getHelmImageResource(t, namespace)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getHelmImageResource(namespace, repo)); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceImageName, err)
 	}
 
@@ -150,14 +150,7 @@ func getGoHelloworldGitResource(namespace string) *v1alpha1.PipelineResource {
 	))
 }
 
-func getHelmImageResource(t *testing.T, namespace string) *v1alpha1.PipelineResource {
-	// according to knative/test-infra readme (https://github.com/knative/test-infra/blob/13055d769cc5e1756e605fcb3bcc1c25376699f1/scripts/README.md)
-	// the KO_DOCKER_REPO will be set with according to the project where the cluster is created
-	// it is used here to dynamically get the docker registry to push the image to
-	dockerRepo := os.Getenv("KO_DOCKER_REPO")
-	if dockerRepo == "" {
-		t.Fatalf("KO_DOCKER_REPO env variable is required")
-	}
+func getHelmImageResource(namespace, dockerRepo string) *v1alpha1.PipelineResource {
 	imageName := fmt.Sprintf("%s/%s", dockerRepo, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(sourceImageName))
 
 	return tb.PipelineResource(sourceImageName, namespace, tb.PipelineResourceSpec(

--- a/test/ko_test.go
+++ b/test/ko_test.go
@@ -1,0 +1,50 @@
+// +build e2e
+
+/*
+Copyright 2019 Knative Authors LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var (
+	// Wether missing KO_DOCKER_REPO environment variable should be fatal or not
+	missingKoFatal = "true"
+)
+
+func ensureDockerRepo(t *testing.T) string {
+	fmt.Println("missingKoFatal", missingKoFatal)
+	repo, err := getDockerRepo()
+	if err != nil {
+		if missingKoFatal == "false" {
+			t.Skip("KO_DOCKER_REPO env variable is required")
+		}
+		t.Fatal("KO_DOCKER_REPO env variable is required")
+	}
+	return repo
+}
+
+func getDockerRepo() (string, error) {
+	// according to knative/test-infra readme (https://github.com/knative/test-infra/blob/13055d769cc5e1756e605fcb3bcc1c25376699f1/scripts/README.md)
+	// the KO_DOCKER_REPO will be set with according to the project where the cluster is created
+	// it is used here to dynamically get the docker registry to push the image to
+	dockerRepo := os.Getenv("KO_DOCKER_REPO")
+	if dockerRepo == "" {
+		return "", fmt.Errorf("KO_DOCKER_REPO env variable is required")
+	}
+	return fmt.Sprintf("%s/kanikotasktest", dockerRepo), nil
+}


### PR DESCRIPTION
# Changes

… instead of "hard" failing, we could just skip it as it doesn't meet
the requirements. Impacted tests :

- TestHelmDeployPipelineRun
- TestKanikoTaskRun

To skip those tests instead of failing, you need to provide the following arguments to go test command :
`-ldflags '-X github.com/tektoncd/pipeline/test.missingKoFatal=false'`

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
