### PR TITLE
Hide e2e test's example_test under a build tag

### DIFF
--- a/test/wait_example_test.go
+++ b/test/wait_example_test.go
@@ -1,3 +1,5 @@
+// +build examples
+
 /*
 Copyright 2018 The Knative Authors.
 


### PR DESCRIPTION
# Changes

This removes the global `t` variable from the e2e test builds. Bonus : it stills appears in `godoc` :dancer: 

It's a follow-up of #702 cc @bobcatfish @abayer 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
