### PR TITLE
Updating some tests to not require the docker socket

### DIFF
--- a/examples/taskruns/private-taskrun.yaml
+++ b/examples/taskruns/private-taskrun.yaml
@@ -46,15 +46,8 @@ spec:
     steps:
     - name: pull
       # Private image is just Ubuntu
-      image: gcr.io/cloud-builders/docker
-      args: ["pull", "gcr.io/build-crd-testing/secret-sauce"]
-      volumeMounts:
-      - name: docker-socket
-        mountPath: /var/run/docker.sock
-    volumes:
-    - name: docker-socket
-      hostPath:
-        path: /var/run/docker.sock
-        type: Socket
+      image: quay.io/rhpipeline/skopeo:alpine
+      command: ["skopeo"]
+      args: ["copy", "docker://gcr.io/build-crd-testing/secret-sauce", "dir:///tmp/"]
   trigger:
     type: manual

--- a/examples/taskruns/taskrun-docker-basic.yaml
+++ b/examples/taskruns/taskrun-docker-basic.yaml
@@ -38,14 +38,7 @@ spec:
   taskSpec:
     steps:
     - name: test
-      image: gcr.io/cloud-builders/docker
+      image: quay.io/rhpipeline/skopeo:alpine
       # Test pulling a private builder container.
-      args: ["pull", "gcr.io/build-crd-testing/secret-sauce"]
-      volumeMounts:
-      - name: docker-socket
-        mountPath: /var/run/docker.sock
-    volumes:
-    - name: docker-socket
-      hostPath:
-        path: /var/run/docker.sock
-        type: Socket
+      command: ["skopeo"]
+      args: ["copy", "docker://gcr.io/build-crd-testing/secret-sauce", "dir:///tmp/"]

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -93,17 +93,10 @@ func TestPipelineRun(t *testing.T) {
 
 			task := tb.Task(getName(taskName, index), namespace, tb.TaskSpec(
 				// Reference build: https://github.com/knative/build/tree/master/test/docker-basic
-				tb.Step("config-docker", "gcr.io/cloud-builders/docker",
-					tb.Command("docker"),
-					tb.Args("pull", "gcr.io/build-crd-testing/secret-sauce"),
-					tb.VolumeMount("docker-socket", "/var/run/docker.sock"),
+				tb.Step("config-docker", "quay.io/rhpipeline/skopeo:alpine",
+					tb.Command("skopeo"),
+					tb.Args("copy", "docker://gcr.io/build-crd-testing/secret-sauce", "dir:///tmp/"),
 				),
-				tb.TaskVolume("docker-socket", tb.VolumeSource(corev1.VolumeSource{
-					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/var/run/docker.sock",
-						Type: newHostPathType(string(corev1.HostPathSocket)),
-					},
-				})),
 			))
 			if _, err := c.TaskClient.Create(task); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", getName(taskName, index), err)


### PR DESCRIPTION
# Changes

We should try to avoid, as much as possible, to assume that there will
be a docker socket available on the node. If the runtime used by
Kubernetes is not Docker, this fails.

This affects : TestPipelineRun and private-taskrun and
taskrun-docker-basic examples.

- [x] `quay.io/rhpipeline/buildah` is not completely optimized (we may want a lighter image) — using `skopeo` it's lighter and easier to run in userspace.
- [x] I am ok to use something else here — just something that doesn't need the docker socket volume :angel: :pray: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- <del>[ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)</del>
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
