### PR TITLE
Make generated pods only request the maximum necessary resources

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -129,6 +129,12 @@ or container images that you define:
   the configuration file.
 - Each container image runs until completion or until the first failure is
   detected.
+- The CPU, memory, and ephemeral storage resource requests will be set to zero
+  if the container image does not have the largest resource request out of all
+  container images in the Task. This ensures that the Pod that executes the Task
+  will only request the resources necessary to execute any single container
+  image in the Task, rather than requesting the sum of all of the container
+  image's resource requests.
 
 ### Inputs
 

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +33,10 @@ import (
 )
 
 var (
-	ignorePrivateResourceFields = cmpopts.IgnoreUnexported(resource.Quantity{})
-	nopContainer                = corev1.Container{
+	resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
+		return x.Cmp(y) == 0
+	})
+	nopContainer = corev1.Container{
 		Name:    "nop",
 		Image:   *nopImage,
 		Command: []string{"/builder/tools/entrypoint"},
@@ -110,6 +111,13 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
 				WorkingDir:   workspaceDir,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceMemory:           resource.MustParse("0"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+					},
+				},
 			},
 				nopContainer,
 			},
@@ -149,6 +157,13 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
 				WorkingDir:   workspaceDir,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceMemory:           resource.MustParse("0"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+					},
+				},
 			},
 				nopContainer,
 			},
@@ -182,6 +197,13 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
 				WorkingDir:   workspaceDir,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceMemory:           resource.MustParse("0"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+					},
+				},
 			},
 				nopContainer,
 			},
@@ -215,6 +237,13 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
 				WorkingDir:   workspaceDir,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceMemory:           resource.MustParse("0"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+					},
+				},
 			},
 				nopContainer,
 			},
@@ -264,7 +293,7 @@ func TestMakePod(t *testing.T) {
 				t.Errorf("Pod name got %q, want %q", got.Name, wantName)
 			}
 
-			if d := cmp.Diff(&got.Spec, c.want, ignorePrivateResourceFields); d != "" {
+			if d := cmp.Diff(&got.Spec, c.want, resourceQuantityCmp); d != "" {
 				t.Errorf("Diff spec:\n%s", d)
 			}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Before this change, if CPU, memory, or ephemeral storage resource requests were set in a Task's steps (which are Containers), the generated Pod would require the sum of all of the steps' requests to be scheduled on a Node. However, because Tekton overwrites Container entrypoints in Tasks to make the Containers logically execute one at a time, we want to make Pods generated by the TaskRun only request the maximum resources that will be necessary for any single Container rather than the sum of all resource requests.
    
To make this happen, when generating a Pod for a Task, we find the Step with largest resource requests among all Steps, and set the resource requests for all other steps to 0 for the respective resource. If no Step has an explicit resource request, all requests are set to 0. If we unset resource requests instead of setting them to 0 explicitly, then the limits would be used for the requests, which would defeat the purpose of unsetting the requested values (and could end up making the Pod request more memory than it did in the first place).

I did not add any e2e tests, but would be happy to do so if desired by reviewers. I think the tests would need to look up `Nodes` in the cluster to find the maximum allowed resources and then create some tasks dynamically that would have been unschedulable before this change but work after the change.

CC @bbrowning, @abayer

Fixes #598

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Set CPU, memory, and ephemeral storage resource requests for each
step in a Task to zero if the step does not have the largest resource
request out of all steps in the Task. This ensures that the Pod that
executes the Task will only request the resources necessary to
execute any single step in the Task, rather than requesting the sum
of all of the step's resource requests, and is safe because Tekton
executes steps sequentially rather than all at once.
```
