### PR TITLE
Initialize working dirs inside workspace dir

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"crypto/rand"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -314,6 +315,52 @@ func TestMakePod(t *testing.T) {
 			},
 			Volumes: implicitVolumes,
 		},
+	}, {
+		desc: "working-dir-in-workspace-dir",
+		ts: v1alpha1.TaskSpec{
+			Steps: []corev1.Container{{
+				Name:       "name",
+				Image:      "image",
+				WorkingDir: filepath.Join(workspaceDir, "test"),
+			}},
+		},
+		want: &corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{{
+				Name:         containerPrefix + credsInit + "-9l9zj",
+				Image:        *credsImage,
+				Command:      []string{"/ko-app/creds-init"},
+				Args:         []string{},
+				Env:          implicitEnvVars,
+				VolumeMounts: implicitVolumeMounts,
+				WorkingDir:   workspaceDir,
+			}, {
+				Name:         containerPrefix + workingDirInit + "-mz4c7",
+				Image:        *bashWorkingDirImage,
+				Command:      []string{"/ko-app/bash"},
+				Args:         []string{"-args", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
+				Env:          implicitEnvVars,
+				VolumeMounts: implicitVolumeMounts,
+				WorkingDir:   workspaceDir,
+			}},
+			Containers: []corev1.Container{{
+				Name:         "build-step-name",
+				Image:        "image",
+				Env:          implicitEnvVars,
+				VolumeMounts: implicitVolumeMounts,
+				WorkingDir:   filepath.Join(workspaceDir, "test"),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceMemory:           resource.MustParse("0"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+					},
+				},
+			},
+				nopContainer,
+			},
+			Volumes: implicitVolumes,
+		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
@@ -370,6 +417,32 @@ func TestMakePod(t *testing.T) {
 			}
 			if d := cmp.Diff(got.Annotations, wantAnnotations); d != "" {
 				t.Errorf("Diff annotations:\n%s", d)
+			}
+		})
+	}
+}
+
+func TestMakeWorkingDirScript(t *testing.T) {
+	for _, c := range []struct {
+		desc        string
+		workingDirs map[string]bool
+		want        string
+	}{{
+		desc:        "default",
+		workingDirs: map[string]bool{"/workspace": true},
+		want:        "",
+	}, {
+		desc:        "simple",
+		workingDirs: map[string]bool{"/workspace/foo": true, "/workspace/bar": true, "/baz": true},
+		want:        "mkdir -p /workspace/foo /workspace/bar",
+	}, {
+		desc:        "empty",
+		workingDirs: map[string]bool{"/workspace": true, "": true, "/baz": true, "/workspacedir": true},
+		want:        "",
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			if script := makeWorkingDirScript(c.workingDirs); script != c.want {
+				t.Errorf("Expected `%v`, got `%v`", c.want, script)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In order to allow steps to define workingDirs that are subdirectories of the workspace directory we need to make sure they have been created first since they will not exist on startup.

Fixes #725

Note: this PR does not solve the general problem of ensuring all valid combinations of workingDir + volumes + volume mounts will not fail, instead opting to keep things simple and solve the most common case as a first pass - setting the working directory to the cloned git repository (or other input resource folder). We also do not check that the `workingDir` path actually refers to the implicit workspace volume (as opposed to a user defined one that they've mounted at the same path) because it keeps the logic simple and the worst case is we have an additional empty directory in the implicit workspace volume.

Adds an additional parameter to the controller config for the image to use for this container. We could have reused the other bash image parameter, but it makes for a nice extension point to tekton to keep them separate IMO since it allows overriding specific bits of functionality should the user desire.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Fix setting workingDirs that are subdirectories of the default workspace directory
```
