### PR TITLE
Format markdown

### DIFF
--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -14,11 +14,11 @@ When `command` is not explicitly set, the controller will attempt to lookup the
 entrypoint from the remote registry. If the image is a private registry, the
 service account should include an
 [ImagePullSecret](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account).
-The Tekton controller will use the `ImagePullSecret` of the service
-account, and if service account is empty, `default` is assumed. Next is falling
-back to docker config added in a `.docker/config.json` at
-`$HOME/.docker/config.json`. If none of these credentials are available the
-controller will try to lookup the image anonymously.
+The Tekton controller will use the `ImagePullSecret` of the service account, and
+if service account is empty, `default` is assumed. Next is falling back to
+docker config added in a `.docker/config.json` at `$HOME/.docker/config.json`.
+If none of these credentials are available the controller will try to lookup the
+image anonymously.
 
 For example, in the following Task with the images,
 `gcr.io/cloud-builders/gcloud` and `gcr.io/cloud-builders/docker`, the

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,17 +61,22 @@ You are now ready to create and run Tekton Pipelines:
 
 ### Installing Tekton Pipelines on OpenShift
 
-The `tekton-pipelines-controller` service account needs the `anyuid` security context constraint in order to run the webhook pod.
+The `tekton-pipelines-controller` service account needs the `anyuid` security
+context constraint in order to run the webhook pod.
 
-_See [Security Context Constraints](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html) for more information_
+_See
+[Security Context Constraints](https://docs.openshift.com/container-platform/3.11/admin_guide/manage_scc.html)
+for more information_
 
-1. First, login as a user with `cluster-admin` privileges.  The following example uses the default `system:admin` user:
+1. First, login as a user with `cluster-admin` privileges. The following example
+   uses the default `system:admin` user:
 
    ```bash
    oc login -u system:admin
    ```
 
-1. Run the following commands to set up the project/namespace, and to install Tekton Pipelines:
+1. Run the following commands to set up the project/namespace, and to install
+   Tekton Pipelines:
 
    ```bash
    oc new project tekton-pipelines
@@ -79,10 +84,12 @@ _See [Security Context Constraints](https://docs.openshift.com/container-platfor
    oc apply --filename https://storage.googleapis.com/tekton-releases/latest/release.yaml
    ```
 
-   _See [here](https://docs.openshift.com/container-platform/3.11/cli_reference/get_started_cli.html) for an overview of the `oc` command-line tool for OpenShift._
+   _See
+   [here](https://docs.openshift.com/container-platform/3.11/cli_reference/get_started_cli.html)
+   for an overview of the `oc` command-line tool for OpenShift._
 
-1. Run the `oc get` command to monitor the Tekton Pipelines components until all of the
-   components show a `STATUS` of `Running`:
+1. Run the `oc get` command to monitor the Tekton Pipelines components until all
+   of the components show a `STATUS` of `Running`:
 
    ```bash
    oc get pods --namespace tekton-pipelines --watch

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -4,8 +4,7 @@ We dogfood our project by using Tekton Pipelines to build, test and release
 Tekton Pipelines!
 
 This directory contains the
-[`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md)
-and
+[`Tasks`](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md) and
 [`Pipelines`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelines.md)
 that we (will) use.
 

--- a/test/README.md
+++ b/test/README.md
@@ -230,7 +230,8 @@ be used to run only [the unit tests](#unit-tests), i.e.:
 #### Create Tekton objects
 
 To create Tekton objects (e.g. `Task`, `Pipeline`, …), you can use the
-[`github.com/tektoncd/pipeline/test/builder`](./builder) package to reduce noise:
+[`github.com/tektoncd/pipeline/test/builder`](./builder) package to reduce
+noise:
 
 ```go
 import tb "github.com/tektoncd/pipeline/test/builder"


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`