### PR TITLE
Use gsutil rsync instead of cp for buckets

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -111,7 +111,7 @@ func (s *GCSResource) GetUploadContainerSpec() ([]corev1.Container, error) {
 	}
 	var args []string
 	if s.TypeDir {
-		args = []string{"-args", fmt.Sprintf("cp -r %s %s", filepath.Join(s.DestinationDir, "*"), s.Location)}
+		args = []string{"-args", fmt.Sprintf("rsync -d -r %s %s", s.DestinationDir, s.Location)}
 	} else {
 		args = []string{"-args", fmt.Sprintf("cp %s %s", filepath.Join(s.DestinationDir, "*"), s.Location)}
 	}
@@ -135,7 +135,7 @@ func (s *GCSResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 	}
 	var args []string
 	if s.TypeDir {
-		args = []string{"-args", fmt.Sprintf("cp -r %s %s", fmt.Sprintf("%s/*", s.Location), s.DestinationDir)}
+		args = []string{"-args", fmt.Sprintf("rsync -d -r %s %s", s.Location, s.DestinationDir)}
 	} else {
 		args = []string{"-args", fmt.Sprintf("cp %s %s", s.Location, s.DestinationDir)}
 	}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -238,7 +238,7 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 			Name:    "fetch-gcs-valid-mz4c7",
 			Image:   "override-with-gsutil-image:latest",
 			Command: []string{"/ko-app/gsutil"},
-			Args:    []string{"-args", "cp -r gs://some-bucket/* /workspace"},
+			Args:    []string{"-args", "rsync -d -r gs://some-bucket /workspace"},
 			Env: []corev1.EnvVar{{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 				Value: "/var/secret/secretName/key.json",
@@ -329,7 +329,7 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			Name:    "upload-gcs-valid-9l9zj",
 			Image:   "override-with-gsutil-image:latest",
 			Command: []string{"/ko-app/gsutil"},
-			Args:    []string{"-args", "cp -r /workspace/* gs://some-bucket"},
+			Args:    []string{"-args", "rsync -d -r /workspace/ gs://some-bucket"},
 			Env:     []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -882,7 +882,7 @@ func TestStorageInputResource(t *testing.T) {
 				Name:    "fetch-storage-gcs-keys-mz4c7",
 				Image:   "override-with-gsutil-image:latest",
 				Command: []string{"/ko-app/gsutil"},
-				Args:    []string{"-args", "cp -r gs://fake-bucket/rules.zip/* /workspace/gcs-input-resource"},
+				Args:    []string{"-args", "rsync -d -r gs://fake-bucket/rules.zip /workspace/gcs-input-resource"},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "volume-storage-gcs-keys-secret-name", MountPath: "/var/secret/secret-name"},
 				},

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -373,7 +373,7 @@ func TestValidOutputResources(t *testing.T) {
 				MountPath: "/var/secret/sname",
 			}},
 			Command: []string{"/ko-app/gsutil"},
-			Args:    []string{"-args", "cp -r /workspace/faraway-disk/* gs://some-bucket"},
+			Args:    []string{"-args", "rsync -d -r /workspace/faraway-disk gs://some-bucket"},
 			Env: []corev1.EnvVar{{
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
@@ -444,7 +444,7 @@ func TestValidOutputResources(t *testing.T) {
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 			Command: []string{"/ko-app/gsutil"},
-			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
+			Args:    []string{"-args", "rsync -d -r /workspace/output/source-workspace gs://some-bucket"},
 		}, {
 			Name:         "source-mkdir-source-gcs-mz4c7",
 			Image:        "override-with-bash-noop:latest",
@@ -508,7 +508,7 @@ func TestValidOutputResources(t *testing.T) {
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 			Command: []string{"/ko-app/gsutil"},
-			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
+			Args:    []string{"-args", "rsync -d -r /workspace/output/source-workspace gs://some-bucket"},
 		}},
 		wantVolumes: []corev1.Volume{{
 			Name: "volume-source-gcs-sname",
@@ -559,7 +559,7 @@ func TestValidOutputResources(t *testing.T) {
 				Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/sname/key.json",
 			}},
 			Command: []string{"/ko-app/gsutil"},
-			Args:    []string{"-args", "cp -r /workspace/output/source-workspace/* gs://some-bucket"},
+			Args:    []string{"-args", "rsync -d -r /workspace/output/source-workspace gs://some-bucket"},
 		}},
 		wantVolumes: []corev1.Volume{{
 			Name: "volume-source-gcs-sname",


### PR DESCRIPTION

# Changes

Fixes #646 

Use `gsutil rsync` instead of `cp` for buckets to handle the case when the bucket is empty 

`cp` has an a bug where it will fail, but `rsync` works fine

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [yeah ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [no ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [ yeah, i think so] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes



```
Use gsutil rsync instead of cp for updating storage resource.
```
