### PR TITLE
Set TaskRun Completion time in case of Failure or Success 🏁

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -361,6 +361,8 @@ func updateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 			Status:  corev1.ConditionFalse,
 			Message: msg,
 		})
+		// update tr completed time
+		taskRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 	case corev1.PodPending:
 		msg := getWaitingMessage(pod)
 		taskRun.Status.SetCondition(&duckv1alpha1.Condition{
@@ -374,6 +376,8 @@ func updateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 			Type:   duckv1alpha1.ConditionSucceeded,
 			Status: corev1.ConditionTrue,
 		})
+		// update tr completed time
+		taskRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 	}
 }
 


### PR DESCRIPTION
# Changes

Before this change, the completion time of a TaskRun is only set in
case of a timeout, which is not quite right.

While reviewing #718, I discovered that we only update the CompletionTime of a TaskRun in case of a Timeout.

cc @abayer 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [:no_good_man:] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix CompletionTime missing in TaskRun status
```
