### PR TITLE
Set PipelineRun Completion time in case of Failure or Success 🏁

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel.go
@@ -19,12 +19,14 @@ package pipelinerun
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	duckv1alpha1 "github.com/knative/pkg/apis/duck/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/pipelinerun/resources"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // cancelPipelineRun makrs the PipelineRun as cancelled and any resolved taskrun too.
@@ -35,6 +37,8 @@ func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.Reso
 		Reason:  "PipelineRunCancelled",
 		Message: fmt.Sprintf("PipelineRun %q was cancelled", pr.Name),
 	})
+	// update pr completed time
+	pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
 	errs := []string{}
 	for _, rprt := range pipelineState {
 		if rprt.TaskRun == nil {

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -340,6 +340,10 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			// make sure there is no failed events
 			validateNoEvents(t, fr)
 
+			if tc.pipelineRun.Status.CompletionTime == nil {
+				t.Errorf("Expected a CompletionTime on invalid PipelineRun but was nil")
+			}
+
 			// Since the PipelineRun is invalid, the status should say it has failed
 			condition := tc.pipelineRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
 			if condition == nil || condition.Status != corev1.ConditionFalse {
@@ -561,6 +565,13 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 
 	// Check that the PipelineRun was reconciled correctly
 	reconciledRun, err := clients.Pipeline.Tekton().PipelineRuns("foo").Get("test-pipeline-run-cancelled", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
+	}
+
+	if reconciledRun.Status.CompletionTime == nil {
+		t.Errorf("Expected a CompletionTime on invalid PipelineRun but was nil")
+	}
 
 	// This PipelineRun should still be complete and false, and the status should reflect that
 	if !reconciledRun.Status.GetCondition(duckv1alpha1.ConditionSucceeded).IsFalse() {
@@ -604,6 +615,10 @@ func TestReconcileWithTimeout(t *testing.T) {
 	reconciledRun, err := clients.Pipeline.Tekton().PipelineRuns("foo").Get("test-pipeline-run-with-timeout", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
+	}
+
+	if reconciledRun.Status.CompletionTime == nil {
+		t.Errorf("Expected a CompletionTime on invalid PipelineRun but was nil")
 	}
 
 	// The PipelineRun should be timed out.


### PR DESCRIPTION
# Changes

Before this change, the completion time of a PipelineRun was not set,
which is not quite right.

cc @abayer @nader-ziada 

/hold I want to refactor some stuff because it is messy as is :sweat_smile: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [:no_good_man:] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Fix CompletionTime missing in PipelineRun status
```
