### PR TITLE
Adds shortname for taskrun and  pipelinerun

### DIFF
--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -23,6 +23,9 @@ spec:
     categories:
     - all
     - tekton-pipelines
+    shortNames:
+    - pr
+    - prs
   scope: Namespaced
   additionalPrinterColumns:
     - name: Type

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -23,6 +23,9 @@ spec:
     categories:
     - all
     - tekton-pipelines
+    shortNames:
+    - tr
+    - trs
   scope: Namespaced
   additionalPrinterColumns:
   - name: Succeeded

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,9 +39,12 @@ test-git-ref      Succeeded   True      2019-02-11T21:21:02Z
 test-git-tag      Succeeded   True      2019-02-11T21:21:02Z
 ```
 
+
 ```shell
 $ kubectl get pipelineruns -o=custom-columns-file=./test/columns.txt
 NAME                  TYPE        STATUS    START
 demo-pipeline-run-1   Succeeded   True      2019-02-11T21:21:03Z
 output-pipeline-run   Succeeded   True      2019-02-11T21:35:43Z
 ```
+
+You can also use `kubectl get tr` or `kubectl get pr` to query all `taskruns` or `pipelineruns` respectively.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
During pipeline development, a developer often queries
`taskruns` and `pipelineruns`. So a user has to type
these names quite often which is kind of mundane.

This patch adds short names to `taskruns` and `pipelineruns` CR's.
So it could improve CLI experience while querying `taskruns` and
`pipelineruns` resources.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Add short names to `taskrun` and `pipelinerun` resources. 
User can use `kubectl <action> tr ...` to deal with `taskruns`
and `kubectl <action> pr ...` to deal with `pipelineruns`. 
```
