### PR TITLE
Wrap nop final step with entrypoint

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -488,7 +488,7 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, ts *v1alpha1.TaskSpec, task
 		return nil, fmt.Errorf("couldnt apply output resource templating: %s", err)
 	}
 
-	pod, err := resources.MakePod(tr, *ts, c.KubeClientSet)
+	pod, err := resources.MakePod(tr, *ts, c.KubeClientSet, c.cache, c.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("translating Build to Pod: %v", err)
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/knative/pkg/configmap"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/taskrun/entrypoint"
 	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/taskrun/resources"
@@ -312,7 +313,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -339,7 +344,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -393,7 +402,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/2", "-post_file", "/builder/tools/3", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -491,7 +504,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/6", "-post_file", "/builder/tools/7", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -506,6 +523,7 @@ func TestReconcile(t *testing.T) {
 				tb.PodVolumes(toolsVolume, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getCredentialsInitContainer("mz4c7"),
+				placeToolsInitContainer,
 				tb.PodContainer("build-step-git-source-git-resource-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "", "-post_file", "/builder/tools/0", "-entrypoint", "/ko-app/git-init", "--",
@@ -516,7 +534,6 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				placeToolsInitContainer,
 				tb.PodContainer("build-step-mycontainer", "myimage",
 					tb.Command(entrypointLocation),
 					tb.WorkingDir(workspaceDir),
@@ -527,7 +544,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -553,7 +574,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -589,7 +614,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/1", "-post_file", "/builder/tools/2", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}, {
@@ -616,7 +645,11 @@ func TestReconcile(t *testing.T) {
 					tb.VolumeMount("workspace", workspaceDir),
 					tb.VolumeMount("home", "/builder/home"),
 				),
-				tb.PodContainer("nop", "override-with-nop:latest", tb.Command("/ko-app/nop")),
+				tb.PodContainer("nop", "override-with-nop:latest",
+					tb.Command("/builder/tools/entrypoint"),
+					tb.Args("-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/nop", "--"),
+					tb.VolumeMount(entrypoint.MountName, entrypoint.MountPoint),
+				),
 			),
 		),
 	}} {
@@ -774,6 +807,8 @@ func TestReconcilePodFetchError(t *testing.T) {
 func TestReconcilePodUpdateStatus(t *testing.T) {
 	taskRun := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(tb.TaskRunTaskRef("test-task")))
 
+	logger, _ := logging.NewLogger("", "")
+	cache, _ := entrypoint.NewCache()
 	// TODO(jasonhall): This avoids a circular dependency where
 	// getTaskRunController takes a test.Data which must be populated with
 	// a pod created from MakePod which requires a (fake) Kube client. When
@@ -786,7 +821,7 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 			Name:      "default",
 			Namespace: taskRun.Namespace,
 		},
-	}))
+	}), cache, logger)
 	if err != nil {
 		t.Fatalf("MakePod: %v", err)
 	}


### PR DESCRIPTION
# Changes

`nop` image/step used to be executed *only* when all the previous step
were done sucessfully. As we are not using init containers anymore,
this is not true, `nop` will always be executed even in case of
previous failure (after the others though). This happens because we
don't use the `entrypoint` wrapper for this final step.

This fixes it by wrapping `nop` with entrypoint — just like other
steps. That way, it will only print `build successful` in case of
actual successful run dancer

Related is https://github.com/tektoncd/pipeline/pull/715, but in the meantime, <del>we may want to print something less misleading</del> we may want to fix that :angel: 

cc @nader-ziada 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [:no_good_man:] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [:no_good_man:] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
