### PR TITLE
git-init: trim spaces from url (and remove dead code)

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -84,19 +84,14 @@ func main() {
 	}
 	if *path != "" {
 		runOrFail(logger, "git", "init", *path)
-		if _, err := os.Stat(*path); os.IsNotExist(err) {
-			if err := os.Mkdir(*path, os.ModePerm); err != nil {
-				logger.Debugf("Creating directory at path %s", *path)
-			}
-		}
 		if err := os.Chdir(*path); err != nil {
 			logger.Fatalf("Failed to change directory with path %s; err %v", path, err)
 		}
 	} else {
 		runOrFail(logger, "git", "init")
 	}
-	trimedURL := strings.TrimSpace(*url)
-	runOrFail(logger, "git", "remote", "add", "origin", trimedURL)
+	trimmedURL := strings.TrimSpace(*url)
+	runOrFail(logger, "git", "remote", "add", "origin", trimmedURL)
 	if err := run(logger, "git", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", *revision); err != nil {
 		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error
 		// as no guarantee that the same error is returned by all git servers gitlab, github etc...
@@ -108,5 +103,5 @@ func main() {
 		runOrFail(logger, "git", "reset", "--hard", "FETCH_HEAD")
 	}
 
-	logger.Infof("Successfully cloned %q @ %q in path %q", trimedURL, *revision, *path)
+	logger.Infof("Successfully cloned %q @ %q in path %q", trimmedURL, *revision, *path)
 }

--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/knative/pkg/logging"
 	homedir "github.com/mitchellh/go-homedir"
@@ -94,8 +95,8 @@ func main() {
 	} else {
 		runOrFail(logger, "git", "init")
 	}
-
-	runOrFail(logger, "git", "remote", "add", "origin", *url)
+	trimedURL := strings.TrimSpace(*url)
+	runOrFail(logger, "git", "remote", "add", "origin", trimedURL)
 	if err := run(logger, "git", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", *revision); err != nil {
 		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error
 		// as no guarantee that the same error is returned by all git servers gitlab, github etc...
@@ -107,5 +108,5 @@ func main() {
 		runOrFail(logger, "git", "reset", "--hard", "FETCH_HEAD")
 	}
 
-	logger.Infof("Successfully cloned %q @ %q in path %q", *url, *revision, *path)
+	logger.Infof("Successfully cloned %q @ %q in path %q", trimedURL, *revision, *path)
 }


### PR DESCRIPTION
# Changes

- trim spaces from the url : if the given url contains some spaces (like non-breaking spaces),
`git-init` may fail with `protocol ' https' is not supported`. This
fixes that.
- remove dead code : either `git init` failed and we
left already, *or* `git init` succeeded and the path exists.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [:no_good_man:] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [:no_good_man:] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
