### PR TITLE
Update TaskRun status even if PipelineRun is done

### DIFF
--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -348,6 +348,13 @@ func PipelineRunStartTime(startTime time.Time) PipelineRunStatusOp {
 	}
 }
 
+// PipelineRunTaskRunsStatus sets the TaskRuns of the PipelineRunStatus.
+func PipelineRunTaskRunsStatus(taskRuns map[string]*v1alpha1.PipelineRunTaskRunStatus) PipelineRunStatusOp {
+	return func(s *v1alpha1.PipelineRunStatus) {
+		s.TaskRuns = taskRuns
+	}
+}
+
 // PipelineResource creates a PipelineResource with default values.
 // Any number of PipelineResource modifier can be passed to transform it.
 func PipelineResource(name, namespace string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Due to the DAG execution model, it's possible for the PipelineRun to error while other TaskRuns are still executing. This change resolves a bug where the status for the other TaskRuns would not propagate to the PipelineRun if it has failed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Fix propagation of concurrent TaskRun status to failed PipelineRuns
```
