### PR TITLE
Recreate pod on TaskRun's pod deletion

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -29,6 +29,7 @@ import (
 
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -158,6 +159,23 @@ func makeCredentialInitializer(serviceAccountName, namespace string, kubeclient 
 		Env:          implicitEnvVars,
 		WorkingDir:   workspaceDir,
 	}, volumes, nil
+}
+
+// GetPod returns the Pod for the given pod name
+type GetPod func(string, metav1.GetOptions) (*corev1.Pod, error)
+
+// TryGetPod fetches the TaskRun's pod, returning nil if it has not been created or it does not exist.
+func TryGetPod(taskRunStatus v1alpha1.TaskRunStatus, gp GetPod) (*corev1.Pod, error) {
+	if taskRunStatus.PodName == "" {
+		return nil, nil
+	}
+
+	pod, err := gp(taskRunStatus.PodName, metav1.GetOptions{})
+	if err == nil || errors.IsNotFound(err) {
+		return pod, nil
+	}
+
+	return nil, err
 }
 
 // MakePod converts TaskRun and TaskSpec objects to a Pod which implements the taskrun specified


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

A TaskRun's pod may be deleted either manually by the user or due to system constraints (e.g. node recreation). This change adds modifies the TaskRun reconciliation logic to recreate pods which are not found.

Fixes https://github.com/tektoncd/pipeline/issues/618

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Recreate TaskRun pods on deletion.
```
