### PR TITLE
Format markdown

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -39,7 +39,6 @@ test-git-ref      Succeeded   True      2019-02-11T21:21:02Z
 test-git-tag      Succeeded   True      2019-02-11T21:21:02Z
 ```
 
-
 ```shell
 $ kubectl get pipelineruns -o=custom-columns-file=./test/columns.txt
 NAME                  TYPE        STATUS    START
@@ -47,4 +46,5 @@ demo-pipeline-run-1   Succeeded   True      2019-02-11T21:21:03Z
 output-pipeline-run   Succeeded   True      2019-02-11T21:35:43Z
 ```
 
-You can also use `kubectl get tr` or `kubectl get pr` to query all `taskruns` or `pipelineruns` respectively.
+You can also use `kubectl get tr` or `kubectl get pr` to query all `taskruns` or
+`pipelineruns` respectively.


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`