### PR TITLE
Refactor the git-init container code so the logic can be exposed as a…

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -16,15 +16,10 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
 	"flag"
-	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/knative/pkg/logging"
-	homedir "github.com/mitchellh/go-homedir"
-	"go.uber.org/zap"
+	"github.com/tektoncd/pipeline/pkg/git"
 )
 
 var (
@@ -33,75 +28,12 @@ var (
 	path     = flag.String("path", "", "Path of directory under which git repository will be copied")
 )
 
-func run(logger *zap.SugaredLogger, cmd string, args ...string) error {
-	c := exec.Command(cmd, args...)
-	var output bytes.Buffer
-	c.Stderr = &output
-	c.Stdout = &output
-	if err := c.Run(); err != nil {
-		logger.Errorf("Error running %v %v: %v\n%v", cmd, args, err, output.String())
-		return err
-	}
-	return nil
-}
-
-func runOrFail(logger *zap.SugaredLogger, cmd string, args ...string) {
-	c := exec.Command(cmd, args...)
-	var output bytes.Buffer
-	c.Stderr = &output
-	c.Stdout = &output
-
-	if err := c.Run(); err != nil {
-		logger.Fatalf("Unexpected error running %v %v: %v\n%v", cmd, args, err, output.String())
-	}
-}
-
 func main() {
 	flag.Parse()
 	logger, _ := logging.NewLogger("", "git-init")
 	defer logger.Sync()
 
-	// HACK: This is to get git+ssh to work since ssh doesn't respect the HOME
-	// env variable.
-	homepath, err := homedir.Dir()
-	if err != nil {
-		logger.Fatalf("Unexpected error: getting the user home directory: %v", err)
+	if err := git.Fetch(logger, *revision, *path, *url); err != nil {
+		logger.Fatalf("Error fetching git repository: %s", err)
 	}
-	homeenv := os.Getenv("HOME")
-	if homeenv != "" && homeenv != homepath {
-		if _, err := os.Stat(homepath + "/.ssh"); os.IsNotExist(err) {
-			err = os.Symlink(homeenv+"/.ssh", homepath+"/.ssh")
-			if err != nil {
-				// Only do a warning, in case we don't have a real home
-				// directory writable in our image
-				logger.Warnf("Unexpected error: creating symlink: %v", err)
-			}
-		}
-	}
-
-	if *revision == "" {
-		*revision = "master"
-	}
-	if *path != "" {
-		runOrFail(logger, "git", "init", *path)
-		if err := os.Chdir(*path); err != nil {
-			logger.Fatalf("Failed to change directory with path %s; err %v", path, err)
-		}
-	} else {
-		runOrFail(logger, "git", "init")
-	}
-	trimmedURL := strings.TrimSpace(*url)
-	runOrFail(logger, "git", "remote", "add", "origin", trimmedURL)
-	if err := run(logger, "git", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", *revision); err != nil {
-		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error
-		// as no guarantee that the same error is returned by all git servers gitlab, github etc...
-		if err := run(logger, "git", "pull", "--recurse-submodules=yes", "origin"); err != nil {
-			logger.Warnf("Failed to pull origin : %s", err)
-		}
-		runOrFail(logger, "git", "checkout", *revision)
-	} else {
-		runOrFail(logger, "git", "reset", "--hard", "FETCH_HEAD")
-	}
-
-	logger.Infof("Successfully cloned %q @ %q in path %q", trimmedURL, *revision, *path)
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package git
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"go.uber.org/zap"
+)
+
+func run(logger *zap.SugaredLogger, cmd string, args ...string) error {
+	c := exec.Command(cmd, args...)
+	var output bytes.Buffer
+	c.Stderr = &output
+	c.Stdout = &output
+	if err := c.Run(); err != nil {
+		logger.Errorf("Error running %v %v: %v\n%v", cmd, args, err, output.String())
+		return err
+	}
+	return nil
+}
+
+// Fetch fetches the specified git repository at the revision into path.
+func Fetch(logger *zap.SugaredLogger, revision, path, url string) error {
+	// HACK: This is to get git+ssh to work since ssh doesn't respect the HOME
+	// env variable.
+	homepath, err := homedir.Dir()
+	if err != nil {
+		logger.Errorf("Unexpected error: getting the user home directory: %v", err)
+		return err
+	}
+	homeenv := os.Getenv("HOME")
+	if homeenv != "" && homeenv != homepath {
+		if _, err := os.Stat(homepath + "/.ssh"); os.IsNotExist(err) {
+			err = os.Symlink(homeenv+"/.ssh", homepath+"/.ssh")
+			if err != nil {
+				// Only do a warning, in case we don't have a real home
+				// directory writable in our image
+				logger.Warnf("Unexpected error: creating symlink: %v", err)
+			}
+		}
+	}
+
+	if revision == "" {
+		revision = "master"
+	}
+	if path != "" {
+		if err := run(logger, "git", "init", path); err != nil {
+			return err
+		}
+		if err := os.Chdir(path); err != nil {
+			return fmt.Errorf("Failed to change directory with path %s; err %v", path, err)
+		}
+	} else {
+		if err := run(logger, "git", "init"); err != nil {
+			return err
+		}
+	}
+	trimmedURL := strings.TrimSpace(url)
+	if err := run(logger, "git", "remote", "add", "origin", trimmedURL); err != nil {
+		return err
+	}
+	if err := run(logger, "git", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", revision); err != nil {
+		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error
+		// as no guarantee that the same error is returned by all git servers gitlab, github etc...
+		if err := run(logger, "git", "pull", "--recurse-submodules=yes", "origin"); err != nil {
+			logger.Warnf("Failed to pull origin : %s", err)
+		}
+		if err := run(logger, "git", "checkout", revision); err != nil {
+			return err
+		}
+	} else {
+		if err := run(logger, "git", "reset", "--hard", "FETCH_HEAD"); err != nil {
+			return err
+		}
+	}
+	logger.Infof("Successfully cloned %s @ %s in path %s", trimmedURL, revision, path)
+	return nil
+}


### PR DESCRIPTION
… function.

I'm experimenting with adding richer SCM interactions to Tasks, and cloning a repo is
a prereq for most other interactions. It would be useful to be able to use this logic
from other code.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing)
- [x ] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)
