### PR TITLE
Fix a couple of small name issues in tutorial pipeline

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -351,20 +351,20 @@ spec:
         - name: pathToDockerFile
           value: Dockerfile
         - name: pathToContext
-          value: /workspace/examples/microservices/leeroy-web #configure: may change according to your source
+          value: /workspace/docker-source/examples/microservices/leeroy-web #configure: may change according to your source
       resources:
         inputs:
-          - name: workspace
+          - name: docker-source
             resource: source-repo
         outputs:
-          - name: image
+          - name: builtImage
             resource: web-image
     - name: deploy-web
       taskRef:
         name: deploy-using-kubectl
       resources:
         inputs:
-          - name: workspace
+          - name: source
             resource: source-repo
           - name: image
             resource: web-image
@@ -372,7 +372,7 @@ spec:
               - build-skaffold-web
       params:
         - name: path
-          value: /workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml #configure: may change according to your source
+          value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml #configure: may change according to your source
         - name: yqArg
           value: "-d1"
         - name: yamlPathToImage
@@ -390,7 +390,7 @@ metadata:
 spec:
   inputs:
     resources:
-      - name: workspace
+      - name: source
         type: git
       - name: image
         type: image


### PR DESCRIPTION
# Changes

- The tutorial pipeline names the input resources "workspace" and
"image" but the build-docker-image-from-git-source task expects
"docker-source" and "builtImage". The `pathToContext` also needed to
be updated to match the path that the git repo will be checked out at.

- The pipeline is configured to use the deploy-using-kubectl task and
provides an input git resource named "workspace" but the
deploy-using-kubectl task expects an input git resource named "source"
and the `path` param needed to be updated to reflect that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

(I've removed tests and docs checkboxes here because I don't think they apply to this change.  lmk if I should do more here).

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)