### PR TITLE
fix: incorrect templating not producing error

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -170,6 +170,19 @@ func ResourceFromType(r *PipelineResource) (PipelineResourceInterface, error) {
 func AttributesFromType(prt PipelineResourceType) ([]string, error) {
 	r := &PipelineResource{}
 	r.Spec.Type = prt
+	if prt == PipelineResourceTypeStorage {
+		r.Spec.Params = []Param{
+
+			{
+				Name:  "type",
+				Value: string(PipelineResourceTypeGCS),
+			},
+			{
+				Name:  "Location",
+				Value: "/",
+			},
+		}
+	}
 	resource, err := ResourceFromType(r)
 	if err != nil {
 		return nil, err

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -164,3 +164,19 @@ func ResourceFromType(r *PipelineResource) (PipelineResourceInterface, error) {
 	}
 	return nil, fmt.Errorf("%s is an invalid or unimplemented PipelineResource", r.Spec.Type)
 }
+
+// AttributesFromType returns a list of available attributes that can be replaced
+// through templating.
+func AttributesFromType(prt PipelineResourceType) ([]string, error) {
+	r := &PipelineResource{}
+	r.Spec.Type = prt
+	resource, err := ResourceFromType(r)
+	if err != nil {
+		return nil, err
+	}
+	keys := []string{}
+	for k := range resource.Replacements() {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -170,9 +170,13 @@ func ResourceFromType(r *PipelineResource) (PipelineResourceInterface, error) {
 func AttributesFromType(prt PipelineResourceType) ([]string, error) {
 	r := &PipelineResource{}
 	r.Spec.Type = prt
+	// Todo : The TaskResource struct lacks data to correctly infer the type of
+	// a PipelineResourceTypeStorage. While all the currently implemented types
+	// have the same attributes, this doesn't appear to be an explicit design
+	// choice. Future types could not fit this constraint. So we cannot safely
+	// make any assumptions about the attributes.
 	if prt == PipelineResourceTypeStorage {
 		r.Spec.Params = []Param{
-
 			{
 				Name:  "type",
 				Value: string(PipelineResourceTypeGCS),

--- a/pkg/apis/pipeline/v1alpha1/resource_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAttributesFromType(t *testing.T) {
+	tests := []struct {
+		name         string
+		resourceType PipelineResourceType
+		expectedErr  error
+	}{
+		{
+			name:         "git resource type",
+			resourceType: PipelineResourceTypeGit,
+			expectedErr:  nil,
+		},
+		{
+			name:         "storage resource type",
+			resourceType: PipelineResourceTypeStorage,
+			expectedErr:  nil,
+		},
+		{
+			name:         "image resource type",
+			resourceType: PipelineResourceTypeImage,
+			expectedErr:  nil,
+		},
+		{
+			name:         "cluster resource type",
+			resourceType: PipelineResourceTypeCluster,
+			expectedErr:  nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := AttributesFromType(tc.resourceType)
+			if d := cmp.Diff(err, tc.expectedErr); d != "" {
+				t.Errorf("AttributesFromType error did not match expected error %s", d)
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -137,6 +137,8 @@ func validateInputParameterVariables(steps []corev1.Container, inputs *Inputs) *
 
 func validateResourceVariables(steps []corev1.Container, inputs *Inputs, outputs *Outputs) *apis.FieldError {
 	var err *apis.FieldError
+	// Keep track of input and output resources separately.
+	// This ensures we can validate against appropriate variables set.
 	inputVars := map[string]struct{}{}
 	outputVars := map[string]struct{}{}
 	if inputs != nil {

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -342,7 +342,7 @@ func TestTaskSpec_ValidateError(t *testing.T) {
 		},
 	},
 		{
-			name: "inexistent output param variable",
+			name: "inexistent output resource variable",
 			fields: fields{
 				Inputs: &Inputs{
 					Resources: []TaskResource{{

--- a/pkg/templating/templating.go
+++ b/pkg/templating/templating.go
@@ -47,10 +47,7 @@ func extractVariablesFromString(s, prefix string) ([]string, bool) {
 	vars := make([]string, len(matches))
 	for i, match := range matches {
 		groups := matchGroups(match, re)
-		// foo -> foo
-		// foo.bar -> foo
-		// foo.bar.baz -> foo
-		vars[i] = strings.SplitN(groups["var"], ".", 2)[0]
+		vars[i] = groups["var"]
 	}
 	return vars, true
 }

--- a/pkg/templating/templating_test.go
+++ b/pkg/templating/templating_test.go
@@ -79,6 +79,23 @@ func TestValidateVariables(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			name: "nested variable",
+			args: args{
+				input:         "--flag=${inputs.resources.foo.url}",
+				prefix:        "resources",
+				contextPrefix: "inputs.",
+				locationName:  "step",
+				path:          "taskspec.steps",
+				vars: map[string]struct{}{
+					"foo.name":   {},
+					"foo.type":   {},
+					"foo.url":    {},
+					"foo.digest": {},
+				},
+			},
+			expectedError: nil,
+		},
+		{
 			name: "undefined variable",
 			args: args{
 				input:         "--flag=${inputs.params.baz}",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Fixes issue https://github.com/tektoncd/pipeline/issues/627.

This PR allows tasks to be more properly validated when being created. This allows users to catch templating errors earlier on. 

This PR also addresses an issue where resource variable validation would basically maintain a global list of variables. However, I believe we really want to create 2 list of variables. One list for input resource variables and one list for output resource variables. 

I am still not 100% convinced this is the best way to solve the issue, but it does seem to do the trick. Will sleep on it, but happy to address feedback on this PR or entertain other ideas on how to resolve this issue. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#principles) (if user facing) (note: I didn't write any docs for this, seems unnecessary).
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->
```
Return error to user for incorrect templating of resource variables.
```
