### PR TITLE
fixes task's document

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -86,7 +86,6 @@ kind: Task
 metadata:
   name: example-task-name
 spec:
-  serviceAccountName: task-auth-example
   inputs:
     resources:
       - name: workspace
@@ -104,7 +103,8 @@ spec:
       image: ubuntu
       args: ["ubuntu-build-example", "SECRETS-example.md"]
     - image: gcr.io/example-builders/build-example
-      args: ["echo", "${inputs.resources.params.pathToDockerFile}"]
+      command: ["echo"]
+      args: ["${inputs.resources.params.pathToDockerFile}"]
     - name: dockerfile-pushexample
       image: gcr.io/example-builders/push-example
       args: ["push", "${outputs.resources.builtImage.url}"]


### PR DESCRIPTION
# Changes
One of the [example](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md#syntax) in the `task.md` shows `serviceAccountName`
field at `Task` specification which is not valid for now.
This patch updates the task's document with correct spec fields.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
