### PR TITLE
Remove first WaitTaskRun call when creating TR pod

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -284,7 +284,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 		}
 	} else {
 		// Pod is not present, create pod.
-		go c.timeoutHandler.WaitTaskRun(tr)
 		pod, err = c.createPod(tr, rtr.TaskSpec, rtr.TaskName)
 		if err != nil {
 			// This Run has failed, so we need to mark it as failed and stop reconciling it


### PR DESCRIPTION
# Changes

This WaitTaskRun call was moved in a commit but then reinstated the
following day. Looks like this being reinstated was an artifact of a
rebase for a separate PR and the removal of the call was the correct
thing to do.

The original change message for this removal is as follows:

> We can save one goroutines per pod creation by waiting for TaskRun only if the pod creation was successful.

This was the original PR with the call removal:
https://github.com/tektoncd/pipeline/pull/674

And then it looks like it was reinstated here: https://github.com/tektoncd/pipeline/pull/648/files#diff-b52b9f382ad878e6aa2a85921bb19065R287

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

Striking out tests and docs here since this is just reinstating a change from a previous commit.  LMK if I should do more here.

- [ ] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
