### PR TITLE
Make first example of running e2e tests include longer timeout ⏱️

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,7 @@ ko apply -f ./config/
 go test ./...
 
 # Integration tests (against your current kube cluster)
-go test -v -count=1 -tags=e2e ./test
+go test -v -count=1 -tags=e2e -timeout=20m ./test
 ```
 
 ## Unit tests


### PR DESCRIPTION
# Changes

I foolishly tried to use the example at the top of the test README when
I was trying to run the timeout tests (for the #731 investigation) and I
was sad when it failed b/c the default timeout was too short. This is
the timeout we are using when running CI anyway!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
none
```
