### PR TITLE
Decouple TaskRun startTime from pod start time ⌚

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -153,12 +153,13 @@ func (pr *PipelineRunStatus) GetCondition(t apis.ConditionType) *apis.Condition 
 }
 
 // InitializeConditions will set all conditions in pipelineRunCondSet to unknown for the PipelineRun
+// and set the started time to the current time
 func (pr *PipelineRunStatus) InitializeConditions() {
 	if pr.TaskRuns == nil {
 		pr.TaskRuns = make(map[string]*PipelineRunTaskRunStatus)
 	}
 	if pr.StartTime.IsZero() {
-		pr.StartTime = &metav1.Time{time.Now()}
+		pr.StartTime = &metav1.Time{Time: time.Now()}
 	}
 	pipelineRunCondSet.Manage(pr).InitializeConditions()
 }

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -136,7 +136,7 @@ func TestPipelineRunHasStarted(t *testing.T) {
 	}, {
 		name: "prWithStartTime",
 		prStatus: PipelineRunStatus{
-			StartTime: &metav1.Time{time.Now()},
+			StartTime: &metav1.Time{Time: time.Now()},
 		},
 		expectedValue: true,
 	}, {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -144,9 +144,12 @@ type TaskRunStatus struct {
 func (tr *TaskRunStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 	return taskRunCondSet.Manage(tr).GetCondition(t)
 }
+
+// InitializeConditions will set all conditions in taskRunCondSet to unknown for the TaskRun
+// and set the started time to the current time
 func (tr *TaskRunStatus) InitializeConditions() {
 	if tr.StartTime.IsZero() {
-		tr.StartTime = &metav1.Time{time.Now()}
+		tr.StartTime = &metav1.Time{Time: time.Now()}
 	}
 	taskRunCondSet.Manage(tr).InitializeConditions()
 }
@@ -213,7 +216,7 @@ func (tr *TaskRun) GetPipelineRunPVCName() string {
 	return ""
 }
 
-// HasPipeluneRunOwnerReference returns true of TaskRun has
+// HasPipelineRunOwnerReference returns true of TaskRun has
 // owner reference of type PipelineRun
 func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 	for _, ref := range tr.GetOwnerReferences() {
@@ -227,6 +230,11 @@ func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 // IsDone returns true if the TaskRun's status indicates that it is done.
 func (tr *TaskRun) IsDone() bool {
 	return !tr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
+}
+
+// HasStarted function check whether taskrun has valid start time set in its status
+func (tr *TaskRun) HasStarted() bool {
+	return tr.Status.StartTime != nil && !tr.Status.StartTime.IsZero()
 }
 
 // IsCancelled returns true if the TaskRun's spec status is set to Cancelled state

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
@@ -161,5 +162,43 @@ func TestTaskRunKey(t *testing.T) {
 	expectedKey := "TaskRun/testns/taskrunname"
 	if tr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, tr.GetRunKey())
+	}
+}
+
+func TestTaskRunHasStarted(t *testing.T) {
+	params := []struct {
+		name          string
+		trStatus      TaskRunStatus
+		expectedValue bool
+	}{{
+		name:          "trWithNoStartTime",
+		trStatus:      TaskRunStatus{},
+		expectedValue: false,
+	}, {
+		name: "trWithStartTime",
+		trStatus: TaskRunStatus{
+			StartTime: &metav1.Time{Time: time.Now()},
+		},
+		expectedValue: true,
+	}, {
+		name: "trWithZeroStartTime",
+		trStatus: TaskRunStatus{
+			StartTime: &metav1.Time{},
+		},
+		expectedValue: false,
+	}}
+	for _, tc := range params {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "prunname",
+					Namespace: "testns",
+				},
+				Status: tc.trStatus,
+			}
+			if tr.HasStarted() != tc.expectedValue {
+				t.Fatalf("Expected taskrun HasStarted() to return %t but got %t", tc.expectedValue, tr.HasStarted())
+			}
+		})
 	}
 }

--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -93,23 +93,6 @@ func (t *TimeoutSet) getOrCreateFinishedChan(runObj StatusKey) chan bool {
 	return finished
 }
 
-// StatusLock function acquires lock for taskrun/pipelinerun status key
-func (t *TimeoutSet) StatusLock(runObj StatusKey) {
-	m, _ := t.statusMap.LoadOrStore(runObj.GetRunKey(), &sync.Mutex{})
-	mut := m.(*sync.Mutex)
-	mut.Lock()
-}
-
-// StatusUnlock function releases lock for taskrun/pipelinerun status key
-func (t *TimeoutSet) StatusUnlock(runObj StatusKey) {
-	m, ok := t.statusMap.Load(runObj.GetRunKey())
-	if !ok {
-		return
-	}
-	mut := m.(*sync.Mutex)
-	mut.Unlock()
-}
-
 func getTimeout(d *metav1.Duration) time.Duration {
 	timeout := defaultTimeout
 	if d != nil {

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -114,7 +114,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 				}
 				return true, nil
 			}); err != nil {
-				t.Fatalf("Expected %s callback to be %t but got callback to be %#v", tc.name, tc.expectCallback, gotCallback)
+				t.Fatalf("Expected %s callback to be %t but got error: %s", tc.name, tc.expectCallback, err)
 			}
 		})
 	}
@@ -218,7 +218,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 				}
 				return true, nil
 			}); err != nil {
-				t.Fatalf("Expected %s callback to be %t but got callback to be %#+v", tc.name, tc.expectCallback, gotCallback)
+				t.Fatalf("Expected %s callback to be %t but got error: %s", tc.name, tc.expectCallback, err)
 			}
 		})
 	}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -167,11 +167,12 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	pr := original.DeepCopy()
 	c.timeoutHandler.StatusLock(pr)
 	if !pr.HasStarted() {
+		pr.Status.InitializeConditions()
 		// start goroutine to track pipelinerun timeout only startTime is not set
-		go c.timeoutHandler.WaitPipelineRun(pr)
+		go c.timeoutHandler.WaitPipelineRun(pr, pr.Status.StartTime)
+	} else {
+		pr.Status.InitializeConditions()
 	}
-	pr.Status.InitializeConditions()
-
 	c.timeoutHandler.StatusUnlock(original)
 
 	if pr.IsDone() {

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -165,7 +165,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 	// Don't modify the informer's copy.
 	pr := original.DeepCopy()
-	c.timeoutHandler.StatusLock(pr)
 	if !pr.HasStarted() {
 		pr.Status.InitializeConditions()
 		// start goroutine to track pipelinerun timeout only startTime is not set
@@ -173,7 +172,6 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	} else {
 		pr.Status.InitializeConditions()
 	}
-	c.timeoutHandler.StatusUnlock(original)
 
 	if pr.IsDone() {
 		c.timeoutHandler.Release(pr)
@@ -373,10 +371,8 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 		}
 	}
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)
-	c.timeoutHandler.StatusLock(pr)
 	after := resources.GetPipelineConditionStatus(pr.Name, pipelineState, c.Logger, pr.Status.StartTime, pr.Spec.Timeout)
 	pr.Status.SetCondition(after)
-	c.timeoutHandler.StatusUnlock(pr)
 	reconciler.EmitEvent(c.Recorder, before, after, pr)
 
 	updateTaskRunsStatus(pr, pipelineState)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -315,9 +315,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 
 	before := tr.Status.GetCondition(apis.ConditionSucceeded)
 
-	c.timeoutHandler.StatusLock(tr)
 	updateStatusFromPod(tr, pod)
-	c.timeoutHandler.StatusUnlock(tr)
 
 	after := tr.Status.GetCondition(apis.ConditionSucceeded)
 

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -180,7 +180,6 @@ func TestPipelineRunTimeout(t *testing.T) {
 
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
-	t.Skip("Flakey test, tracked in https://github.com/tektoncd/pipeline/issues/731")
 	c, namespace := setup(t)
 	t.Parallel()
 


### PR DESCRIPTION
# Changes

Our TaskRun timeout end to end test has been intermittently failing
against PRs. After adding a lot of (terrible) log messages, I found out
that the reason TaskRuns weren't timing out was b/c the go routine
checking for a timeout was considering them timed out several
milliseconds before the reconcile loop would.

So what would happen was:

1. The timeout handler decided the run timed out, and triggered a
   reconcile
2. The reconcile checked if the run timed out, decided the run had a few
   more milliseconds of execution time and let it go
3. And the TaskRun would just keep running

It looks like the root cause is that when the go routine starts,
it uses a `StartTime` that has been set by `TaskRun.InitializeConditions`,
but after that, the pod is started and the `TaskRun.Status` is updated to use _the pod's_
`StartTime` instead - which is what the Reconcile loop will use from
that point forward, causing the slight drift.

This is fixed by no longer tying the start time of the TaskRun to the
pod: the TaskRun will be considered started as soon as the reconciler
starts to act on it, which is probably the functionality the user would
expect anyway (e.g. if the pod was delayed in being started, this delay
should be subtracted from the timeout, and in #734 we are looking to be
more tolerant of pods not immediately scheduling anyway).

This PR also includes some refactoring to make the timeout logic more similar between PipelineRuns and TaskRuns, see the separate commits if you don't want to look at these changes all at once :)

## Verified by

I hacked in my change from #771 to run the timeout test 10 times and:

- Ran it a bunch of times locally - they all passed!
- Ran the 10 test version once in this PR - it passed!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
- Fixes bug where sometimes TaskRun timeouts are dropped and the TaskRun may continue executing indefinitely
- TaskRun startTime is now determined by the start of reconciliation and is not tied to the creation time of the underlying Pod(s)
```
