### PR TITLE
Allow controller to watch specified namespace only

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -49,6 +50,7 @@ const (
 var (
 	masterURL  string
 	kubeconfig string
+	namespace  string
 )
 
 func main() {
@@ -100,8 +102,8 @@ func main() {
 		Logger:            logger,
 	}
 
-	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, opt.ResyncPeriod)
-	pipelineInformerFactory := pipelineinformers.NewSharedInformerFactory(pipelineClient, opt.ResyncPeriod)
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, opt.ResyncPeriod, kubeinformers.WithNamespace(namespace))
+	pipelineInformerFactory := pipelineinformers.NewSharedInformerFactoryWithOptions(pipelineClient, opt.ResyncPeriod, pipelineinformers.WithNamespace(namespace))
 
 	taskInformer := pipelineInformerFactory.Tekton().V1alpha1().Tasks()
 	clusterTaskInformer := pipelineInformerFactory.Tekton().V1alpha1().ClusterTasks()
@@ -182,4 +184,5 @@ func main() {
 func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&namespace, "namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
 }


### PR DESCRIPTION
# Changes

Add a command line option to the controller for specifying a single
namespace to watch, rather than watching all namespaces. Still
defaults to watching all namespaces, but this should be an improvement
for multitenant usage.

Fixes #751 

Note - not sure how to test this, so any pointers on that front would be appreciated!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes


```
Add a command line option to the controller for specifying a single namespace to watch, rather than watching all namespaces.
```
