### PR TITLE
Remove redundant error check

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -91,9 +91,7 @@ func main() {
 		},
 		Logger: logger,
 	}
-	if err != nil {
-		logger.Fatal("Failed to create the admission controller", zap.Error(err))
-	}
+
 	if err := controller.Run(stopCh); err != nil {
 		logger.Fatal("Error running admission controller", zap.Error(err))
 	}


### PR DESCRIPTION
# Changes

There is no new err being set since `configMapWatcher.Start`.
So there is no way this condition could be true here.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

This PR doesn't contain any user-facing changes.
