### PR TITLE
Minor style nits affecting YAML output

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -23,9 +23,9 @@ import (
 
 // PipelineSpec defines the desired state of PipeLine.
 type PipelineSpec struct {
-	Resources []PipelineDeclaredResource `json:"resources"`
-	Tasks     []PipelineTask             `json:"tasks"`
-	Params    []PipelineParam            `json:"params"`
+	Resources []PipelineDeclaredResource `json:"resources,omitempty"`
+	Tasks     []PipelineTask             `json:"tasks,omitempty"`
+	Params    []PipelineParam            `json:"params,omitempty"`
 }
 
 // PipelineStatus does not contain anything because Pipelines on their own
@@ -61,16 +61,16 @@ type Pipeline struct {
 
 	// Spec holds the desired state of the Pipeline from the client
 	// +optional
-	Spec PipelineSpec `json:"spec,omitempty"`
+	Spec PipelineSpec `json:"spec"`
 	// Status communicates the observed state of the Pipeline form the controller
 	// +optional
-	Status PipelineStatus `json:"status,omitempty"`
+	Status PipelineStatus `json:"status"`
 }
 
 // PipelineTask defines a task in a Pipeline, passing inputs from both
 // Params and from the output of previous tasks.
 type PipelineTask struct {
-	Name    string  `json:"name"`
+	Name    string  `json:"name,omitempty"`
 	TaskRef TaskRef `json:"taskRef"`
 
 	// RunAfter is the list of PipelineTask names that should be executed before
@@ -118,10 +118,10 @@ type PipelineDeclaredResource struct {
 type PipelineTaskResources struct {
 	// Inputs holds the mapping from the PipelineResources declared in
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
-	Inputs []PipelineTaskInputResource `json:"inputs"`
+	Inputs []PipelineTaskInputResource `json:"inputs,omitempty"`
 	// Outputs holds the mapping from the PipelineResources declared in
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
-	Outputs []PipelineTaskOutputResource `json:"outputs"`
+	Outputs []PipelineTaskOutputResource `json:"outputs,omitempty"`
 }
 
 // PipelineTaskInputResource maps the name of a declared PipelineResource input
@@ -152,7 +152,7 @@ type PipelineTaskOutputResource struct {
 // Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64
 type TaskRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// TaskKind inficates the kind of the task, namespaced or cluster scoped.
 	Kind TaskKind `json:"kind,omitempty"`
 	// API version of the referent

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -44,16 +44,16 @@ type PipelineRunSpec struct {
 	// Resources is a list of bindings specifying which actual instances of
 	// PipelineResources to use for the resources the Pipeline has declared
 	// it needs.
-	Resources []PipelineResourceBinding `json:"resources"`
+	Resources []PipelineResourceBinding `json:"resources,omitempty"`
 	// Params is a list of parameter names and values.
-	Params []Param `json:"params"`
+	Params []Param `json:"params,omitempty"`
 	// +optional
 	ServiceAccount string `json:"serviceAccount"`
 	// +optional
 	Results *Results `json:"results,omitempty"`
 	// Used for cancelling a pipelinerun (and maybe more later on)
 	// +optional
-	Status PipelineRunSpecStatus
+	Status PipelineRunSpecStatus `json:"status,omitempty"`
 	// Time after which the Pipeline times out. Defaults to never.
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
@@ -83,7 +83,7 @@ const (
 // PipelineResourceRef can be used to refer to a specific instance of a Resource
 type PipelineResourceRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
@@ -93,7 +93,7 @@ type PipelineResourceRef struct {
 // Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64
 type PipelineRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
@@ -110,7 +110,7 @@ const (
 // PipelineTrigger describes what triggered this Pipeline to run. It could be triggered manually,
 // or it could have been some kind of external event (not yet designed).
 type PipelineTrigger struct {
-	Type PipelineTriggerType `json:"type"`
+	Type PipelineTriggerType `json:"type,omitempty"`
 	// +optional
 	Name string `json:"name,omitempty"`
 }
@@ -138,8 +138,8 @@ type PipelineRunStatus struct {
 
 // PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun's Status
 type PipelineRunTaskRunStatus struct {
-	// PipelineTaskName is the name of the PipelineTask
-	PipelineTaskName string `json:"pipelineTaskName"`
+	// PipelineTaskName is the name of the PipelineTask.
+	PipelineTaskName string `json:"pipelineTaskName,omitempty"`
 	// Status is the TaskRunStatus for the corresponding TaskRun
 	// +optional
 	Status *TaskRunStatus `json:"status,omitempty"`
@@ -195,14 +195,14 @@ type PipelineRunList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []PipelineRun `json:"items"`
+	Items           []PipelineRun `json:"items,omitempty"`
 }
 
 // PipelineTaskRun reports the results of running a step in the Task. Each
 // task has the potential to succeed or fail (based on the exit code)
 // and produces logs.
 type PipelineTaskRun struct {
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 // GetTaskRunRef for pipelinerun

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -119,10 +119,10 @@ type PipelineResource struct {
 // with a PipelineResource dependency that the Pipeline has declared
 type PipelineResourceBinding struct {
 	// Name is the name of the PipelineResource in the Pipeline's declaration
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 	// ResourceRef is a reference to the instance of the actual PipelineResource
 	// that should be used
-	ResourceRef PipelineResourceRef `json:"resourceRef"`
+	ResourceRef PipelineResourceRef `json:"resourceRef,omitempty"`
 }
 
 // TaskResourceBinding points to the PipelineResource that
@@ -133,11 +133,11 @@ type TaskResourceBinding struct {
 	Name string `json:"name"`
 	// no more than one of the ResourceRef and ResourceSpec may be specified.
 	// +optional
-	ResourceRef PipelineResourceRef `json:"resourceRef"`
+	ResourceRef PipelineResourceRef `json:"resourceRef,omitempty"`
 	// +optional
-	ResourceSpec *PipelineResourceSpec `json:"resourceSpec"`
+	ResourceSpec *PipelineResourceSpec `json:"resourceSpec,omitempty"`
 	// +optional
-	Paths []string `json:"paths"`
+	Paths []string `json:"paths,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -68,11 +68,11 @@ var _ apis.Defaultable = (*Task)(nil)
 type Task struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.ObjectMeta `json:"metadata"`
 
 	// Spec holds the desired state of the Task from the client
 	// +optional
-	Spec TaskSpec `json:"spec,omitempty"`
+	Spec TaskSpec `json:"spec"`
 }
 
 // Inputs are the requirements that a task needs to run a Build.

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -32,7 +32,7 @@ var _ apis.Defaultable = (*TaskRun)(nil)
 
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {
-	Trigger TaskTrigger `json:"trigger"`
+	Trigger TaskTrigger `json:"trigger,omitempty"`
 	// +optional
 	Inputs TaskRunInputs `json:"inputs,omitempty"`
 	// +optional
@@ -48,7 +48,7 @@ type TaskRunSpec struct {
 	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 	// Used for cancelling a taskrun (and maybe more later on)
 	// +optional
-	Status TaskRunSpecStatus
+	Status TaskRunSpecStatus `json:"status,omitempty"`
 	// Time after which the build times out. Defaults to 10 minutes.
 	// Specified build timeout should be less than 24h.
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
@@ -111,7 +111,7 @@ const (
 type TaskTrigger struct {
 	Type TaskTriggerType `json:"type"`
 	// +optional
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty,omitempty"`
 }
 
 var taskRunCondSet = apis.NewBatchConditionSet()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Address some minor styling nits affecting YAML output.

* Add `omitempty` for string, slice, map or pointer fields that can be omitted.
* Remove `omitempty` from non-pointer struct fields, where `omitempty` doesn't do anything.

From [`encoding/json`](https://golang.org/pkg/encoding/json/#Marshal):
> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.

In addition to this change, some fields that are structs could be changed to pointers, to allow them to be omitted from YAML output as well, when not specified.

For example, `TaskRunSpec`'s `Outputs` field is an `Outputs` struct, which means the field is always present in YAML output, but is `outputs: {}` when none are specified. If the field was a `*Outputs` with `json:"outputs,omitempty`, it could be omitted from YAML if none are specified. Same with `TaskRunSpec`'s `Inputs` and `Trigger` fields, and some in `PipelineRunSpec`, etc.

It's possible that `outputs: {}` is preferrable to just omitting it, but it's unclear whether that was an explicit decision or not. 🤷‍♂️ 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ 🙅‍♂️] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ 🙅‍♂️] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ 🙅‍♂️] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

N/A