### PR TITLE
Fixing image release task ⛏

### DIFF
--- a/tekton/publish-run.yaml
+++ b/tekton/publish-run.yaml
@@ -144,7 +144,7 @@ spec:
         name: tekton-bucket
     params:
     - name: versionTag
-      value: 0.0.0 # REPLACE with the version you want to release, for nightly releases, we might want to use `vYYYYMMDD-commit`
+      value: v0.0.0 # REPLACE with the version you want to release, for nightly releases, we might want to use `vYYYYMMDD-commit`
     - name: imageRegistry
       value: gcr.io/tekton-releases # REPLACE with your own registry
     - name: pathToProject

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -164,9 +164,11 @@ spec:
       # Tag the images and put them in all the regions
       for IMAGE in "${BUILT_IMAGES[@]}"
       do
+        IMAGE_WITHOUT_SHA=${IMAGE%%@*}
+        gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:latest
+        gcloud -q container images add-tag ${IMAGE} ${IMAGE_WITHOUT_SHA}:${inputs.params.versionTag}
         for REGION in "${REGIONS[@]}"
         do
-          IMAGE_WITHOUT_SHA=${IMAGE%%@*}
           for TAG in "latest" ${inputs.params.versionTag}
           do
             gcloud -q container images add-tag ${IMAGE} ${REGION}.${IMAGE_WITHOUT_SHA}:$TAG


### PR DESCRIPTION
# Changes

There was an issue in the release task where we are tagging images
with `latest` and the version on all region *but* `gcr.io`. This aims
to fix that.

- Use `vX.X.X` for the image tag (example)
- Tag gcr image in addition to regions images

Hopefully this is the right fix :angel: 

/assign @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
