### PR TITLE
Fix e2e yaml false success report

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -103,21 +103,17 @@ function run_yaml_tests() {
   done
 
   # Wait for tests to finish.
-  echo ">> Waiting for tests to finish"
-  for test in taskrun pipelinerun; do
-     if validate_run ${test}; then
-      echo "ERROR: tests timed out"
-     fi
-  done
+  echo ">> Waiting for tests to finish for ${test}"
+  if validate_run $1; then
+    echo "ERROR: tests timed out"
+  fi
 
   # Check that tests passed.
-  echo ">> Checking test results"
-  for test in taskrun pipelinerun; do
-    if check_results ${test}; then
-      echo ">> All YAML tests passed"
-      return 0
-    fi
-  done
+  echo ">> Checking test results for ${test}"
+  if check_results $1; then
+    echo ">> All YAML tests passed"
+    return 0
+  fi
 
   return 1
 }

--- a/test/e2e-tests-yaml.sh
+++ b/test/e2e-tests-yaml.sh
@@ -37,9 +37,9 @@ for test in taskrun pipelinerun; do
   header "Running YAML e2e tests for ${test}s"
   if ! run_yaml_tests ${test}; then
     echo "ERROR: one or more YAML tests failed"
-    failed=1
     output_yaml_test_results ${test}
     output_pods_logs ${test}
+    failed=1
   fi
 done
 


### PR DESCRIPTION
# Changes

Even if a `TaskRun`, or a `PipelineRun` fails, the script will return
an exit code 0, which will show in CI as success. This fixes that.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

