### PR TITLE
Use os.Geteuid instead of user.Current in git-init.

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -49,11 +48,9 @@ func Fetch(logger *zap.SugaredLogger, revision, path, url string) error {
 		return err
 	}
 	homeenv := os.Getenv("HOME")
-	u, err := user.Current()
-	if err != nil {
-		return err
-	}
-	if u.Name == "root" {
+	euid := os.Geteuid()
+	// Special case the root user/directory
+	if euid == 0 {
 		if err := os.Symlink(homeenv+"/.ssh", "/root/.ssh"); err != nil {
 			// Only do a warning, in case we don't have a real home
 			// directory writable in our image


### PR DESCRIPTION
# Changes

user.Current is difficult to use when cross-compiling Go, as it relies on
an environment variable rather than cgo/a syscall. This change
switches to using os.Geteuid, which can be cross compiled correctly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
