### PR TITLE
Artifact bucket storage volume name should be consistent with mounts

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -75,8 +75,8 @@ func (b *ArtifactBucket) StorageBasePath(pr *PipelineRun) string {
 	return fmt.Sprintf("%s-%s-bucket", pr.Name, pr.Namespace)
 }
 
-// GetCopyFromContainerSpec returns a container used to download artifacts from temporary storage
-func (b *ArtifactBucket) GetCopyFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
+// GetCopyFromStorageToContainerSpec returns a container used to download artifacts from temporary storage
+func (b *ArtifactBucket) GetCopyFromStorageToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	args := []string{"-args", fmt.Sprintf("cp -r %s %s", fmt.Sprintf("%s/%s/*", b.Location, sourcePath), destinationPath)}
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts("bucket", secretVolumeMountPath, b.Secrets)
@@ -98,8 +98,8 @@ func (b *ArtifactBucket) GetCopyFromContainerSpec(name, sourcePath, destinationP
 	}}
 }
 
-// GetCopyToContainerSpec returns a container used to upload artifacts for temporary storage
-func (b *ArtifactBucket) GetCopyToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
+// GetCopyToStorageFromContainerSpec returns a container used to upload artifacts for temporary storage
+func (b *ArtifactBucket) GetCopyToStorageFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	args := []string{"-args", fmt.Sprintf("cp -r %s %s", sourcePath, fmt.Sprintf("%s/%s", b.Location, destinationPath))}
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts("bucket", secretVolumeMountPath, b.Secrets)
@@ -120,7 +120,7 @@ func (b *ArtifactBucket) GetSecretsVolumes() []corev1.Volume {
 	volumes := []corev1.Volume{}
 	for _, sec := range b.Secrets {
 		volumes = append(volumes, corev1.Volume{
-			Name: names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("bucket-secret-%s", sec.SecretName)),
+			Name: fmt.Sprintf("volume-bucket-%s", sec.SecretName),
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: sec.SecretName,

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
@@ -46,8 +46,8 @@ func (p *ArtifactPVC) StorageBasePath(pr *PipelineRun) string {
 	return pvcDir
 }
 
-// GetCopyFromContainerSpec returns a container used to download artifacts from temporary storage
-func (p *ArtifactPVC) GetCopyFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
+// GetCopyFromStorageToContainerSpec returns a container used to download artifacts from temporary storage
+func (p *ArtifactPVC) GetCopyFromStorageToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	return []corev1.Container{{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
 		Image:   *bashNoopImage,
@@ -56,8 +56,8 @@ func (p *ArtifactPVC) GetCopyFromContainerSpec(name, sourcePath, destinationPath
 	}}
 }
 
-// GetCopyToContainerSpec returns a container used to upload artifacts for temporary storage
-func (p *ArtifactPVC) GetCopyToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
+// GetCopyToStorageFromContainerSpec returns a container used to upload artifacts for temporary storage
+func (p *ArtifactPVC) GetCopyToStorageFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	return []corev1.Container{{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-mkdir-%s", name)),
 		Image:   *bashNoopImage,

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
@@ -38,7 +38,7 @@ func TestPVCGetCopyFromContainerSpec(t *testing.T) {
 		Args:    []string{"-args", "cp -r src-path/. /workspace/destination"},
 	}}
 
-	got := pvc.GetCopyFromContainerSpec("workspace", "src-path", "/workspace/destination")
+	got := pvc.GetCopyFromStorageToContainerSpec("workspace", "src-path", "/workspace/destination")
 	if d := cmp.Diff(got, want); d != "" {
 		t.Errorf("Diff:\n%s", d)
 	}
@@ -64,7 +64,7 @@ func TestPVCGetCopyToContainerSpec(t *testing.T) {
 		VolumeMounts: []corev1.VolumeMount{{MountPath: "/pvc", Name: "pipelinerun-pvc"}},
 	}}
 
-	got := pvc.GetCopyToContainerSpec("workspace", "src-path", "/workspace/destination")
+	got := pvc.GetCopyToStorageFromContainerSpec("workspace", "src-path", "/workspace/destination")
 	if d := cmp.Diff(got, want); d != "" {
 		t.Errorf("Diff:\n%s", d)
 	}

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -33,8 +33,8 @@ import (
 // ArtifactStorageInterface is an interface to define the steps to copy
 // an pipeline artifact to/from temporary storage
 type ArtifactStorageInterface interface {
-	GetCopyToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container
-	GetCopyFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container
+	GetCopyToStorageFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container
+	GetCopyFromStorageToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container
 	GetSecretsVolumes() []corev1.Volume
 	GetType() string
 	StorageBasePath(pr *v1alpha1.PipelineRun) string

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -91,7 +91,7 @@ func AddInputResource(
 		// to the desired destination directory, as long as the resource exports output to be copied
 		if allowedOutputResources[resource.Spec.Type] && taskRun.HasPipelineRunOwnerReference() {
 			for _, path := range boundResource.Paths {
-				cpContainers := as.GetCopyFromContainerSpec(boundResource.Name, path, dPath)
+				cpContainers := as.GetCopyFromStorageToContainerSpec(boundResource.Name, path, dPath)
 				if as.GetType() == v1alpha1.ArtifactStoragePVCType {
 
 					mountPVC = true

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -132,7 +132,7 @@ func AddOutputResources(
 		if allowedOutputResources[resource.Spec.Type] && taskRun.HasPipelineRunOwnerReference() {
 			var newSteps []corev1.Container
 			for _, dPath := range boundResource.Paths {
-				containers := as.GetCopyToContainerSpec(resource.GetName(), sourcePath, dPath)
+				containers := as.GetCopyToStorageFromContainerSpec(resource.GetName(), sourcePath, dPath)
 				newSteps = append(newSteps, containers...)
 			}
 			resourceContainers = append(resourceContainers, newSteps...)


### PR DESCRIPTION
# Changes

The name of the volume added to the pod spec differed from the name of
the volume referenced in the container volume mount, for...well, no
good reason, as best as I could tell. The volume name used in the pod
spec also was using a generated random suffix, which just made things
more confusing. This change brings the naming in line with how we do
volume naming for GCS storage resource volumes, making the naming
consistent in both the pod spec and volume mount.

I also renamed the copy functions in `ArtifactStorageInterface`
because `GetCopyToContainerSpec` actually meant "copy *from* the
container to storage" and `GetCopyFromContainerSpec` meant "copy *to*
the container from storage", and that just always confused me at a
glance, so more verbose but clear names are nice to have.

And finally, I refactored `artifact_bucket_test.go` to make sure we're
actually testing that the volume name and volume mount name are the
same. Since that was the problem.

Fixes #819 

/assign @vdemeester 
/assign @nader-ziada 
/assign @dwnusbaum 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fixes bug when using GCS storage uploads to link Task inputs + outputs (name of mounted volume was incorrect)
```