### PR TITLE
Merge steps and containerTemplate during Task validation

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/merge"
 	"github.com/tektoncd/pipeline/pkg/templating"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -46,7 +47,15 @@ func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 	if err := ValidateVolumes(ts.Volumes).ViaField("volumes"); err != nil {
 		return err
 	}
-	if err := validateSteps(ts.Steps).ViaField("steps"); err != nil {
+	mergedSteps, err := merge.CombineStepsWithContainerTemplate(ts.ContainerTemplate, ts.Steps)
+	if err != nil {
+		return &apis.FieldError{
+			Message: fmt.Sprintf("error merging container template and steps: %s", err),
+			Paths:   []string{"containerTemplate"},
+		}
+	}
+
+	if err := validateSteps(mergedSteps).ViaField("steps"); err != nil {
 		return err
 	}
 

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -43,9 +43,10 @@ var invalidBuildSteps = []corev1.Container{{
 
 func TestTaskSpecValidate(t *testing.T) {
 	type fields struct {
-		Inputs     *Inputs
-		Outputs    *Outputs
-		BuildSteps []corev1.Container
+		Inputs            *Inputs
+		Outputs           *Outputs
+		BuildSteps        []corev1.Container
+		ContainerTemplate *corev1.Container
 	}
 	tests := []struct {
 		name   string
@@ -108,13 +109,26 @@ func TestTaskSpecValidate(t *testing.T) {
 				WorkingDir: "/foo/bar/${outputs.resources.source}",
 			}},
 		},
+	}, {
+		name: "container template included in validation",
+		fields: fields{
+			BuildSteps: []corev1.Container{{
+				Name:    "astep",
+				Command: []string{"echo"},
+				Args:    []string{"hello"},
+			}},
+			ContainerTemplate: &corev1.Container{
+				Image: "some-image",
+			},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := &TaskSpec{
-				Inputs:  tt.fields.Inputs,
-				Outputs: tt.fields.Outputs,
-				Steps:   tt.fields.BuildSteps,
+				Inputs:            tt.fields.Inputs,
+				Outputs:           tt.fields.Outputs,
+				Steps:             tt.fields.BuildSteps,
+				ContainerTemplate: tt.fields.ContainerTemplate,
 			}
 			if err := ts.Validate(context.Background()); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)


### PR DESCRIPTION
# Changes

We actually care about what the Task steps will look like *after*
they've been merged with the containerTemplate, if it exists, so we
should be merging them together in validation, not just in runtime.

fixes #824 

/assign @vdemeester 
/assign @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

n/a