### PR TITLE
Storage end to end test can run without env var credentials ✨

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -107,24 +107,24 @@ pipelineRunsInformer.Informer().GetIndexer().Add(obj)
 
 ### Setup
 
-Besides the environment variable `KO_DOCKER_REPO`, you may also need the
-permissions inside the TaskRun to run the Kaniko e2e test and GCS taskrun test.
+Environment variables used by end to end tests:
+
+- `KO_DOCKER_REPO` - Set this to an image registry your tests can push images to
+- `GCP_SERVICE_ACCOUNT_KEY_PATH` - Tests that need to interact with GCS buckets
+  will use the json credentials at this path to authenticate with GCS.
 
 - In Kaniko e2e test, setting `GCP_SERVICE_ACCOUNT_KEY_PATH` as the path of the
   GCP service account JSON key which has permissions to push to the registry
   specified in `KO_DOCKER_REPO` will enable Kaniko to use those credentials when
   pushing an image.
 - In GCS taskrun test, GCP service account JSON key file at path
-  `GCP_SERVICE_ACCOUNT_KEY_PATH` is used to generate Kubernetes secret to access
-  GCS bucket. This e2e test requires valid service account configuration json
-  but it does not require any role binding.
-- In Storage artifact bucket, setting the `GCP_SERVICE_ACCOUNT_KEY_PATH` as the
-  path of the GCP service account JSON key which has permissions to
-  create/delete a bucket.
+  `GCP_SERVICE_ACCOUNT_KEY_PATH`, if present, is used to generate Kubernetes
+  secret to access GCS bucket.
+- In Storage artifact bucket test, the `GCP_SERVICE_ACCOUNT_KEY_PATH`
+  JSON key is used to create/delete a bucket which will be used for output to
+  input linking by the `PipelineRun` controller.
 
-To reduce e2e test setup developers can use the same environment variable for
-both Kaniko e2e test and GCS taskrun test. To create a service account usable in
-the e2e tests:
+To create a service account usable in the e2e tests:
 
 ```bash
 PROJECT_ID=your-gcp-project

--- a/test/gcs_taskrun_test.go
+++ b/test/gcs_taskrun_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -34,30 +33,28 @@ import (
 // - places files in expected place
 
 func TestStorageTaskRun(t *testing.T) {
-	configFile := os.Getenv("GCP_SERVICE_ACCOUNT_KEY_PATH")
-	if configFile == "" {
-		t.Skip("GCP_SERVICE_ACCOUNT_KEY_PATH variable is not set.")
-	}
 	t.Parallel()
 
 	c, namespace := setup(t)
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	authSec := createGCSSecret(t, namespace, configFile)
-	if _, err := c.KubeClient.Kube.CoreV1().Secrets(namespace).Create(authSec); err != nil {
-		t.Fatalf("Failed to create secret %s", err)
+	secretName := "auth-secret"
+	_, err := CreateGCPServiceAccountSecret(t, c.KubeClient, namespace, secretName)
+	if err != nil {
+		t.Fatalf("could not create secret %s", err)
 	}
 
 	resName := "gcs-resource"
-	if _, err := c.PipelineResourceClient.Create(getResources(namespace, resName, authSec.Name, filepath.Base(configFile))); err != nil {
+	configFile := os.Getenv("GCP_SERVICE_ACCOUNT_KEY_PATH")
+	if _, err := c.PipelineResourceClient.Create(getResources(namespace, resName, secretName, configFile)); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", resName, err)
 	}
 
 	taskRunName := "gcs-taskrun"
 	t.Logf("Creating Task and TaskRun %s in namespace %s", taskRunName, namespace)
 
-	if _, err := c.TaskClient.Create(getGCSStorageTask(namespace, authSec.Name, filepath.Base(configFile))); err != nil {
+	if _, err := c.TaskClient.Create(getGCSStorageTask(namespace)); err != nil {
 		t.Fatalf("Failed to create Task gcs-file : %s", err)
 	}
 
@@ -73,22 +70,13 @@ func TestStorageTaskRun(t *testing.T) {
 	t.Logf("TaskRun %s succeeded", taskRunName)
 }
 
-func getGCSStorageTask(namespace, secretName, secretKey string) *v1alpha1.Task {
+func getGCSStorageTask(namespace string) *v1alpha1.Task {
 	return tb.Task("gcs-file", namespace, tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("gcsbucket", v1alpha1.PipelineResourceTypeStorage,
 			tb.ResourceTargetPath("gcs-workspace"),
 		)),
 		tb.Step("read-gcs-bucket", "ubuntu", tb.Command("/bin/bash"),
 			tb.Args("-c", "ls -la /workspace/gcs-workspace/rules_docker-master.zip"),
-		),
-		tb.Step("read-secret-env", "ubuntu", tb.Command("/bin/bash"),
-			tb.Args("-c", "ls -la $CREDENTIALS"),
-			tb.VolumeMount(fmt.Sprintf("volume-gcs-resource-%s", secretName),
-				// this build should have volume with
-				// name volume-(resource_name)-(secret_name) because of storage resource(gcs)
-				fmt.Sprintf("/var/secret/%s", secretName),
-			),
-			tb.EnvVar("CREDENTIALS", fmt.Sprintf("/var/secret/%s/%s", secretName, secretKey)),
 		),
 	))
 }
@@ -101,13 +89,17 @@ func getGCSTaskRun(namespace, name, resName string) *v1alpha1.TaskRun {
 			)))
 }
 
-func getResources(namespace, name, secretName, secretKey string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
+func getResources(namespace, name, secretName, configFile string) *v1alpha1.PipelineResource {
+	res := tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("location", "gs://build-crd-tests/rules_docker-master.zip"),
 		tb.PipelineResourceSpecParam("type", "gcs"),
-		tb.PipelineResourceSpecSecretParam("GOOGLE_APPLICATION_CREDENTIALS", secretName, secretKey),
 	))
+	if configFile != "" {
+		jsonKeyFilename := filepath.Base(configFile)
+		tb.PipelineResourceSpecSecretParam("GOOGLE_APPLICATION_CREDENTIALS", secretName, jsonKeyFilename)(&res.Spec)
+	}
+	return res
 }
 
 func createGCSSecret(t *testing.T, namespace, authFilePath string) *corev1.Secret {

--- a/test/secret.go
+++ b/test/secret.go
@@ -1,0 +1,60 @@
+// +build e2e
+
+/*
+Copyright 2019 Tekton Authors LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	knativetest "github.com/knative/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateGCPServiceAccountSecret will create a kube secret called secretName in namespace
+// from the value in the GCP_SERVICE_ACCOUNT_KEY_PATH environment variable. If the env var
+// doesn't exist, no secret will be created. Returns true if the secret was created, false
+// otherwise.
+func CreateGCPServiceAccountSecret(t *testing.T, c *knativetest.KubeClient, namespace string, secretName string) (bool, error) {
+	t.Helper()
+	file := os.Getenv("GCP_SERVICE_ACCOUNT_KEY_PATH")
+	if file == "" {
+		t.Logf("Not creating service account secret, relying on default credentials in namespace %s.", namespace)
+		return false, nil
+	}
+
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+	}
+
+	bs, err := ioutil.ReadFile(file)
+	if err != nil {
+		return false, fmt.Errorf("couldn't read secret json from %s: %v", file, err)
+	}
+
+	sec.Data = map[string][]byte{
+		"config.json": bs,
+	}
+	_, err = c.Kube.CoreV1().Secrets(namespace).Create(sec)
+
+	t.Log("Creating service account secret")
+	return true, err
+}


### PR DESCRIPTION
# Changes

The storage end to end test required that an environment variable be
configured that points to json credentials on disk which can be used to
pull from a private GCS bucket. These are not actually required to run
the test if the defualt credentials in the namespace have the
appropriate permissions - which is the case when the test runs in CI via
Prow!

With this change, the test will now be run in CI. This partially
addresses #821, but TestStorageBucketPipelineRun still requires this env
var to run.

Also removed the `read-secret-env` step from the storage test. If the
credential isn't present, the previous step in the Task would fail. Also
nothing is verifying the output of this step. (Maybe this was for
debugging?)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._