### PR TITLE
Changes logging for _timeout_handler_ in order to use Infof when has …

### DIFF
--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -181,13 +181,13 @@ func (t *TimeoutSet) waitRun(runObj StatusKey, timeout time.Duration, startTime 
 
 	select {
 	case <-t.stopCh:
-		t.logger.Info("Stopping timeout timer for %s", runObj.GetRunKey())
+		t.logger.Infof("Stopping timeout timer for %s", runObj.GetRunKey())
 		return
 	case <-finished:
-		t.logger.Info("%s finished, stopping the timeout timer", runObj.GetRunKey())
+		t.logger.Infof("%s finished, stopping the timeout timer", runObj.GetRunKey())
 		return
 	case <-time.After(timeout - runtime):
-		t.logger.Info("Timeout timer for %s has timed out (started at %s, timeout is %s, running for %s", runObj.GetRunKey(), startTime, timeout, time.Since(startTime.Time))
+		t.logger.Infof("Timeout timer for %s has timed out (started at %s, timeout is %s, running for %s", runObj.GetRunKey(), startTime, timeout, time.Since(startTime.Time))
 		if callback != nil {
 			callback(runObj)
 		} else {


### PR DESCRIPTION
…params.

# Changes

Changes from *Info* to *Infof* in _timeout_handler_

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._