### PR TITLE
Delete artifact storage PVCs upon completion of PipelineRun

### DIFF
--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -44,7 +44,7 @@ type ArtifactStorageInterface interface {
 // bucket configured or create a PVC
 func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
-	shouldCreatePVC, err := needsPVC(configMap, err, logger)
+	shouldCreatePVC, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -59,12 +59,31 @@ func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface,
 	return NewArtifactBucketConfigFromConfigMap(configMap)
 }
 
-func needsPVC(configMap *corev1.ConfigMap, err error, logger *zap.SugaredLogger) (bool, error) {
+// CleanupArtifactStorage will delete the PipelineRun's artifact storage PVC if it exists. The PVC is created for using
+// an output workspace or artifacts from one Task to another Task. No other PVCs will be impacted by this cleanup.
+func CleanupArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) error {
+	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
+	shouldCreatePVC, err := NeedsPVC(configMap, err, logger)
+	if err != nil {
+		return err
+	}
+	if shouldCreatePVC {
+		err = deletePVC(pr, c)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NeedsPVC checks if the possibly-nil config map passed to it is configured to use a bucket for artifact storage,
+// returning true if instead a PVC is needed.
+func NeedsPVC(configMap *corev1.ConfigMap, err error, logger *zap.SugaredLogger) (bool, error) {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return true, nil
 		}
-		return false, err
+		return false, fmt.Errorf("couldn't determine if PVC was needed from config map: %s", err)
 	}
 	if configMap == nil {
 		return true, nil
@@ -88,9 +107,9 @@ func needsPVC(configMap *corev1.ConfigMap, err error, logger *zap.SugaredLogger)
 // consumer code to get a container step for copy to/from storage
 func GetArtifactStorage(prName string, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
-	pvc, err := needsPVC(configMap, err, logger)
+	pvc, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("couldn't determine if PVC was needed from config map: %s", err)
 	}
 	if pvc {
 		return &v1alpha1.ArtifactPVC{Name: prName}, nil
@@ -123,9 +142,9 @@ func NewArtifactBucketConfigFromConfigMap(configMap *corev1.ConfigMap) (*v1alpha
 }
 
 func createPVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) error {
-	if _, err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Get(getPVCName(pr), metav1.GetOptions{}); err != nil {
+	if _, err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Get(GetPVCName(pr), metav1.GetOptions{}); err != nil {
 		if errors.IsNotFound(err) {
-			pvc := getPVCSpec(pr)
+			pvc := GetPVCSpec(pr)
 			if _, err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Create(pvc); err != nil {
 				return fmt.Errorf("failed to claim Persistent Volume %q due to error: %s", pr.Name, err)
 			}
@@ -136,13 +155,25 @@ func createPVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) error {
 	return nil
 }
 
-func getPVCSpec(pr *v1alpha1.PipelineRun) *corev1.PersistentVolumeClaim {
+func deletePVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) error {
+	if _, err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Get(GetPVCName(pr), metav1.GetOptions{}); err != nil {
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get Persistent Volume %q due to error: %s", GetPVCName(pr), err)
+		}
+	} else if err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Delete(GetPVCName(pr), &metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete Persistent Volume %q due to error: %s", pr.Name, err)
+	}
+	return nil
+}
+
+// GetPVCSpec returns the PVC to create for a given PipelineRun
+func GetPVCSpec(pr *v1alpha1.PipelineRun) *corev1.PersistentVolumeClaim {
 	// TODO(shashwathi): make this value configurable
 	pvcSizeBytes := int64(5 * 1024 * 1024 * 1024) // 5 GBs
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       pr.Namespace,
-			Name:            getPVCName(pr),
+			Name:            GetPVCName(pr),
 			OwnerReferences: pr.GetOwnerReference(),
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -156,6 +187,7 @@ func getPVCSpec(pr *v1alpha1.PipelineRun) *corev1.PersistentVolumeClaim {
 	}
 }
 
-func getPVCName(pr *v1alpha1.PipelineRun) string {
+// GetPVCName returns the name that should be used for the PVC for a PipelineRun
+func GetPVCName(pr *v1alpha1.PipelineRun) string {
 	return fmt.Sprintf("%s-pvc", pr.Name)
 }

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -157,7 +157,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// If the TaskRun is just starting, this will also set the starttime,
 	// from which the timeout will immediately begin counting down.
 	tr.Status.InitializeConditions()
-        // In case node time was not synchronized, when controller has been scheduled to other nodes.
+	// In case node time was not synchronized, when controller has been scheduled to other nodes.
 	if tr.Status.StartTime.Sub(tr.CreationTimestamp.Time) < 0 {
 		c.Logger.Warnf("TaskRun %s createTimestamp %s is after the taskRun started %s", tr.GetRunKey(), tr.CreationTimestamp, tr.Status.StartTime)
 		tr.Status.StartTime = &tr.CreationTimestamp


### PR DESCRIPTION
# Changes

We currently don't delete artifact storage PVCs until their owner
PipelineRun is deleted. Since PipelineRuns may be kept around for a
very long time, this can result in a giant pile of PVCs sitting around
indefinitely, which is markedly suboptimal. Let's nuke them when the
PipelineRun completes.

Fixes #823 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

n/a