### PR TITLE
[WIP] Upload code coverage reports to codecov.io

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -24,6 +24,15 @@ go test ./...
 By default `go test` will not run [the end to end tests](#end-to-end-tests),
 which need `-tags=e2e` to be enabled.
 
+### Code coverage
+
+Coverage information is reported to [codecov.io](https://codecov.io) by:
+
+* Running `go test` with `-covermode=atomic` and `-coverprofile=coverage.txt`
+* Injecting the `codecov` token via `pull-tekton-pipeline-unit-tests` in
+  [the prow job configuration](https://github.com/tektoncd/plumbing/blob/master/prow/config.yaml)
+* Invoking [codecov-bash](`https://github.com/codecov/codecov-bash`) to upload the results
+
 ### Unit testing Controllers
 
 Kubernetes [client-go](https://godoc.org/k8s.io/client-go) provides a number of

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -25,8 +25,20 @@
 # in a net-negative contributor experience.
 export DISABLE_MD_LINTING=1
 
+# I probably shouldn't hardcode this here, but only viable alternatives at the moment are
+# to hardcode it in tektoncd/plumbing, which doesn't seem much better, or to put it into
+# a secret in the Prow cluster, which we could do later if this becomes a problem
+export CODECOV_TOKEN="ccdc8320-3d8d-4e0c-b88c-ee54ec95d25d"
+
 source $(dirname $0)/../vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
 
-# We use the default build, unit and integration test runners.
+# Override the default unit test runner so we can add arguments to produce coverage
+# reporting and report it to codecov.io
+function unit_tests() {
+  report_go_test -coverprofile=coverage.txt -covermode=atomic ./...
+  bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+}
+
+# We use the default build, integration test runners.
 
 main $@


### PR DESCRIPTION
# Changes

The token is currently hardcoded which is probably terrible but
only viable alternatives I can think of are
to hardcode it in tektoncd/plumbing, which doesn't seem much better, or to put it into
a secret in the Prow cluster, which we could do later if this becomes a problem

I am not 100% sure if this will work with the existing knative bash
scripts, really looking forward to https://github.com/tektoncd/pipeline/issues/532

These commands worked when run locally, except the generated deepcopy
file was included in the coverage reporting. No matter what I did to try
to exclude it (https://docs.codecov.io/docs/ignoring-paths) I couldn't
make it work, so putting that aside for now (and continuing to try to
chip away at it in https://github.com/tektoncd/pipeline/pull/834)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._