### PR TITLE
Correct the output path in the Developer docs

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -93,7 +93,7 @@ expected in directory path `/workspace/output/resource_name`.
 
   - If resource is declared both in input and output for task without custom
     target directory then copy step includes resource being copied to PVC to
-    path `/pvc/task_name/resource_name` from `/workspace/random-space/` like the
+    path `/pvc/task_name/resource_name` from `/workspace/resource_name/` like the
     following example.
 
   ```yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The path is not correct. 
If there is no `TargetPath` defined in input resource, the copy from path should be:
`/workspace/resource_name/` rather than `/workspace/random-space/`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

