### PR TITLE
Allow user define specific path for output resource

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -67,6 +67,23 @@ expected in directory path `/workspace/output/resource_name`.
         - name: gcs-workspace
           type: storage
   ```
+- If the resource is declared only in output but not in input for task and the resource defined with `TargetPath` then the
+  copy step includes resource being copied to PVC to path
+  `/pvc/task_name/resource_name` from `/workspace/outputstuff` like the
+  following example.
+
+  ```yaml
+  kind: Task
+  metadata:
+    name: get-gcs-task
+    namespace: default
+  spec:
+    outputs:
+      resources:
+        - name: gcs-workspace
+          type: storage
+          targetPath: /workspace/outputstuff
+  ```
 
 - If the resource is declared both in input and output for task the then copy
   step includes resource being copied to PVC to path

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -97,7 +97,11 @@ func AddOutputResources(
 		// To build copy step it needs source path(which is targetpath of input resourcemap) from task input source
 		sourcePath := inputResourceMap[boundResource.Name]
 		if sourcePath == "" {
-			sourcePath = filepath.Join(outputDir, boundResource.Name)
+			if output.TargetPath == "" {
+				sourcePath = filepath.Join(outputDir, boundResource.Name)
+			} else {
+				sourcePath = output.TargetPath
+			}
 		}
 
 		switch resource.Spec.Type {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -606,6 +606,45 @@ func TestValidOutputResources(t *testing.T) {
 		},
 		wantSteps: nil,
 	}, {
+		name: "Resource with TargetPath as output",
+		desc: "Resource with TargetPath defined only in output",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-only-output-step",
+				Namespace: "marshmallow",
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind: "PipelineRun",
+					Name: "pipelinerun",
+				}},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				Outputs: v1alpha1.TaskRunOutputs{
+					Resources: []v1alpha1.TaskResourceBinding{{
+						Name: "source-workspace",
+						ResourceRef: v1alpha1.PipelineResourceRef{
+							Name: "source-image",
+						},
+					}},
+				},
+			},
+		},
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{
+						Name:       "source-workspace",
+						Type:       "image",
+						TargetPath: "/workspace",
+					}},
+				},
+			},
+		},
+		wantSteps: nil,
+	}, {
 		desc: "image output resource with no steps",
 		taskRun: &v1alpha1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Use TargetPath in resource definition to point source path of output resource. 
#841 
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._


