### PR TITLE
Remove dead code: sync.Map in TimeoutSet struct

### DIFF
--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -33,7 +33,6 @@ type TimeoutSet struct {
 	taskRunCallbackFunc     func(interface{})
 	pipelineRunCallbackFunc func(interface{})
 	stopCh                  <-chan struct{}
-	statusMap               *sync.Map
 	done                    map[string]chan bool
 	doneMut                 sync.Mutex
 }
@@ -49,7 +48,6 @@ func NewTimeoutHandler(
 		kubeclientset:     kubeclientset,
 		pipelineclientset: pipelineclientset,
 		stopCh:            stopCh,
-		statusMap:         &sync.Map{},
 		done:              make(map[string]chan bool),
 		doneMut:           sync.Mutex{},
 		logger:            logger,
@@ -70,7 +68,6 @@ func (t *TimeoutSet) SetPipelineRunCallbackFunc(f func(interface{})) {
 func (t *TimeoutSet) Release(runObj StatusKey) {
 	key := runObj.GetRunKey()
 	t.doneMut.Lock()
-	defer t.statusMap.Delete(key)
 	defer t.doneMut.Unlock()
 
 	if finished, ok := t.done[key]; ok {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Since the `StatusLock` and `StatusUnlock` functions were removed from
`TimeoutSet`, it seems the `statusMap sync.Map` is no longer used. I can't find any
references to it elsewhere in the codebase and tests continue to pass
without its presence.

StatusLock and StatusUnlock were removed during the fix of a
pernicious timing bug that affected integration tests. The commit that
removed them is fab388a

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

I'm assuming this won't be required but happy to add if needed.