### PR TITLE
Cleanup of initializing working dirs

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -83,7 +83,7 @@ func (b *ArtifactBucket) GetCopyFromStorageToContainerSpec(name, sourcePath, des
 
 	return []corev1.Container{{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-dest-mkdir-%s", name)),
-		Image:   *bashNoopImage,
+		Image:   *BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " "),

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
@@ -27,7 +27,7 @@ import (
 
 var (
 	pvcDir        = "/pvc"
-	bashNoopImage = flag.String("bash-noop-image", "override-with-bash-noop:latest", "The container image containing bash shell")
+	BashNoopImage = flag.String("bash-noop-image", "override-with-bash-noop:latest", "The container image containing bash shell")
 )
 
 // ArtifactPVC represents the pvc created by the pipelinerun
@@ -50,7 +50,7 @@ func (p *ArtifactPVC) StorageBasePath(pr *PipelineRun) string {
 func (p *ArtifactPVC) GetCopyFromStorageToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	return []corev1.Container{{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
-		Image:   *bashNoopImage,
+		Image:   *BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args:    []string{"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " ")},
 	}}
@@ -60,7 +60,7 @@ func (p *ArtifactPVC) GetCopyFromStorageToContainerSpec(name, sourcePath, destin
 func (p *ArtifactPVC) GetCopyToStorageFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
 	return []corev1.Container{{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-mkdir-%s", name)),
-		Image:   *bashNoopImage,
+		Image:   *BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args: []string{
 
@@ -69,7 +69,7 @@ func (p *ArtifactPVC) GetCopyToStorageFromContainerSpec(name, sourcePath, destin
 		VolumeMounts: []corev1.VolumeMount{getPvcMount(p.Name)},
 	}, {
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
-		Image:   *bashNoopImage,
+		Image:   *BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " "),
@@ -89,7 +89,7 @@ func getPvcMount(name string) corev1.VolumeMount {
 func CreateDirContainer(name, destinationPath string) corev1.Container {
 	return corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("create-dir-%s", name)),
-		Image:   *bashNoopImage,
+		Image:   *BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args:    []string{"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " ")},
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -99,9 +99,6 @@ const (
 )
 
 var (
-	// The container used to initialize working directories before the build runs.
-	bashWorkingDirImage = flag.String("bash-noop-image", "override-with-bash-noop:latest",
-		"The container image for preparing our Build's working directories.")
 	// The container used to initialize credentials before the build runs.
 	credsImage = flag.String("creds-image", "override-with-creds:latest",
 		"The container image for preparing our Build's credentials.")
@@ -202,7 +199,7 @@ func makeWorkingDirInitializer(steps []corev1.Container) *corev1.Container {
 	if script := makeWorkingDirScript(workingDirs); script != "" {
 		return &corev1.Container{
 			Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(containerPrefix + workingDirInit),
-			Image:        *bashWorkingDirImage,
+			Image:        *v1alpha1.BashNoopImage,
 			Command:      []string{"/ko-app/bash"},
 			Args:         []string{"-args", script},
 			VolumeMounts: implicitVolumeMounts,

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -100,7 +100,7 @@ const (
 
 var (
 	// The container used to initialize working directories before the build runs.
-	bashWorkingDirImage = flag.String("bash-working-dir-image", "override-with-bash-noop:latest",
+	bashWorkingDirImage = flag.String("bash-noop-image", "override-with-bash-noop:latest",
 		"The container image for preparing our Build's working directories.")
 	// The container used to initialize credentials before the build runs.
 	credsImage = flag.String("creds-image", "override-with-creds:latest",

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"go.uber.org/zap"
@@ -169,15 +170,22 @@ func makeCredentialInitializer(serviceAccountName, namespace string, kubeclient 
 
 func makeWorkingDirScript(workingDirs map[string]bool) string {
 	script := ""
+	var orderedDirs []string
+
 	for wd := range workingDirs {
 		if wd != "" {
-			p := filepath.Clean(wd)
-			if rel, err := filepath.Rel(workspaceDir, p); err == nil && !strings.HasPrefix(rel, ".") {
-				if script == "" {
-					script = fmt.Sprintf("mkdir -p %s", p)
-				} else {
-					script = fmt.Sprintf("%s %s", script, p)
-				}
+			orderedDirs = append(orderedDirs, wd)
+		}
+	}
+	sort.Strings(orderedDirs)
+
+	for _, wd := range orderedDirs {
+		p := filepath.Clean(wd)
+		if rel, err := filepath.Rel(workspaceDir, p); err == nil && !strings.HasPrefix(rel, ".") {
+			if script == "" {
+				script = fmt.Sprintf("mkdir -p %s", p)
+			} else {
+				script = fmt.Sprintf("%s %s", script, p)
 			}
 		}
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -434,7 +434,7 @@ func TestMakeWorkingDirScript(t *testing.T) {
 	}, {
 		desc:        "simple",
 		workingDirs: map[string]bool{"/workspace/foo": true, "/workspace/bar": true, "/baz": true},
-		want:        "mkdir -p /workspace/foo /workspace/bar",
+		want:        "mkdir -p /workspace/bar /workspace/foo",
 	}, {
 		desc:        "empty",
 		workingDirs: map[string]bool{"/workspace": true, "": true, "/baz": true, "/workspacedir": true},

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -336,7 +336,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 			}, {
 				Name:         containerPrefix + workingDirInit + "-mz4c7",
-				Image:        *bashWorkingDirImage,
+				Image:        *v1alpha1.BashNoopImage,
 				Command:      []string{"/ko-app/bash"},
 				Args:         []string{"-args", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
 				Env:          implicitEnvVars,

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -48,7 +48,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 		t.Skip("GCP_SERVICE_ACCOUNT_KEY_PATH variable is not set.")
 	}
 	c, namespace := setup(t)
-	t.Parallel()
+	// Bucket tests can't run in parallel without causing issues with other tests.
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)


### PR DESCRIPTION
# Changes

Subsumes #726, to fix #725, with a unit test fix and a tweak to make sure that
artifact_bucket_test doesn't try to run in parallel, since that messes
up various PipelineRun tests.

Note that I can't reproduce the e2e test failure seen in #726 locally, at least. We'll see if it pops up here.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

n/a