### PR TITLE
Format markdown

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,8 +20,8 @@ High level details of this design:
   triggered by events or by manually creating [PipelineRuns](pipelineruns.md)
 - [Tasks](tasks.md) can exist and be invoked completely independently of
   [Pipelines](pipelines.md); they are highly cohesive and loosely coupled
-- [Tasks](tasks.md) can depend on artifacts and parameters created by
-  other tasks.
+- [Tasks](tasks.md) can depend on artifacts and parameters created by other
+  tasks.
 - [Tasks](tasks.md) can be invoked via [TaskRuns](taskruns.md)
 - [PipelineResources](resources.md) are the artifacts used as inputs and outputs
   of Tasks.

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -93,8 +93,8 @@ expected in directory path `/workspace/output/resource_name`.
 
   - If resource is declared both in input and output for task without custom
     target directory then copy step includes resource being copied to PVC to
-    path `/pvc/task_name/resource_name` from `/workspace/resource_name/` like the
-    following example.
+    path `/pvc/task_name/resource_name` from `/workspace/resource_name/` like
+    the following example.
 
   ```yaml
   kind: Task


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`