### PR TITLE
Add subfolder to the target path when input source has more than one from condition

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -40,6 +40,8 @@ Input resources, like source code (git) or artifacts, are dumped at path
 target directory. If `targetPath` is mentioned in task input then the
 controllers are responsible for adding container definitions to create
 directories and also to fetch the versioned artifacts into that directory.
+If an input resource includes more than one `from` condition then the a sub directory named of previous_task will be addend to the original directory, like this:
+/workspace/task_resource_name/previous_task or /targetPath/previous_task
 
 ## How are outputs handled
 

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -90,14 +91,19 @@ func AddInputResource(
 		// if taskrun is fetching resource from previous task then execute copy step instead of fetching new copy
 		// to the desired destination directory, as long as the resource exports output to be copied
 		if allowedOutputResources[resource.Spec.Type] && taskRun.HasPipelineRunOwnerReference() {
+			needSubFolder := len(boundResource.Paths) > 1
 			for _, path := range boundResource.Paths {
-				cpContainers := as.GetCopyFromStorageToContainerSpec(boundResource.Name, path, dPath)
+				dPathSub := dPath
+				if needSubFolder {
+					dPathSub = addSubFolder(path, dPath)
+				}
+				cpContainers := as.GetCopyFromStorageToContainerSpec(boundResource.Name, path, dPathSub)
 				if as.GetType() == v1alpha1.ArtifactStoragePVCType {
 
 					mountPVC = true
 					for _, ct := range cpContainers {
 						ct.VolumeMounts = []corev1.VolumeMount{getPvcMount(pvcName)}
-						createAndCopyContainers := []corev1.Container{v1alpha1.CreateDirContainer(boundResource.Name, dPath), ct}
+						createAndCopyContainers := []corev1.Container{v1alpha1.CreateDirContainer(boundResource.Name, dPathSub), ct}
 						copyStepsFromPrevTasks = append(copyStepsFromPrevTasks, createAndCopyContainers...)
 					}
 				} else {
@@ -206,4 +212,9 @@ func destinationPath(name, path string) string {
 		return filepath.Join(workspaceDir, name)
 	}
 	return filepath.Join(workspaceDir, path)
+}
+
+//Assume the source path from PV is /pvc/previous_task/resource_name
+func addSubFolder(path, dpath string) string {
+	return strings.Join([]string{dpath, "/", strings.Split(path, "/")[2]}, "")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Change the target path for input resource to 
`/workspace/task_resource_name/previous_task` (or `/TargetPath/previous_task`)
when input resource has more than one `from` condition.
#851 
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
