### PR TITLE
Fix the last of the lint errors and add lint checking to presubmits.

### DIFF
--- a/.errcheck.txt
+++ b/.errcheck.txt
@@ -1,0 +1,8 @@
+(*github.com/tektoncd/pipeline/vendor/go.uber.org/zap.SugaredLogger).Sync
+flag.Set
+os.Setenv
+logger.Sync
+fmt.Fprintf
+fmt.Fprintln
+(io.Closer).Close
+updateConfigMap

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,9 @@
+run:
+  build-tags:
+  - e2e
+  skip-dirs:
+  - vendor
+  - pkg/client/clientset/versioned/fake
+linters-settings:
+  errcheck:
+    exclude: .errcheck.txt

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -53,7 +53,7 @@ func TestRecorderOptions(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	c, _ := test.SeedTestData(d)
+	c, _ := test.SeedTestData(t, d)
 
 	observer, _ := observer.New(zap.InfoLevel)
 

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -67,7 +67,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	c, _ := test.SeedTestData(d)
+	c, _ := test.SeedTestData(t, d)
 	observer, _ := observer.New(zap.InfoLevel)
 	th := NewTimeoutHandler(c.Kube, c.Pipeline, stopCh, zap.New(observer).Sugar())
 	gotCallback := sync.Map{}
@@ -169,7 +169,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			},
 		}},
 	}
-	c, _ := test.SeedTestData(d)
+	c, _ := test.SeedTestData(t, d)
 	stopCh := make(chan struct{})
 	observer, _ := observer.New(zap.InfoLevel)
 	th := NewTimeoutHandler(c.Kube, c.Pipeline, stopCh, zap.New(observer).Sugar())
@@ -245,7 +245,7 @@ func TestWithNoFunc(t *testing.T) {
 		}},
 	}
 	stopCh := make(chan struct{})
-	c, _ := test.SeedTestData(d)
+	c, _ := test.SeedTestData(t, d)
 	observer, _ := observer.New(zap.InfoLevel)
 	testHandler := NewTimeoutHandler(c.Kube, c.Pipeline, stopCh, zap.New(observer).Sugar())
 	defer func() {

--- a/pkg/reconciler/v1alpha1/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/cancel_test.go
@@ -72,7 +72,7 @@ func TestCancelPipelineRun(t *testing.T) {
 				PipelineRuns: []*v1alpha1.PipelineRun{tc.pipelineRun},
 				TaskRuns:     tc.taskRuns,
 			}
-			c, _ := test.SeedTestData(d)
+			c, _ := test.SeedTestData(t, d)
 			err := cancelPipelineRun(tc.pipelineRun, tc.pipelineState, c.Pipeline)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -49,8 +49,8 @@ func getRunName(pr *v1alpha1.PipelineRun) string {
 // getPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 // recorder can be a fake recorder that is used for testing
-func getPipelineRunController(d test.Data, recorder record.EventRecorder) test.TestAssets {
-	c, i := test.SeedTestData(d)
+func getPipelineRunController(t *testing.T, d test.Data, recorder record.EventRecorder) test.TestAssets {
+	c, i := test.SeedTestData(t, d)
 	observer, logs := observer.New(zap.InfoLevel)
 	stopCh := make(chan struct{})
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.GetNamespace())
@@ -183,7 +183,7 @@ func TestReconcile(t *testing.T) {
 	// create fake recorder for testing
 	fr := record.NewFakeRecorder(1)
 
-	testAssets := getPipelineRunController(d, fr)
+	testAssets := getPipelineRunController(t, d, fr)
 	c := testAssets.Controller
 	clients := testAssets.Clients
 
@@ -333,7 +333,7 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			testAssets := getPipelineRunController(d, fr)
+			testAssets := getPipelineRunController(t, d, fr)
 			c := testAssets.Controller
 
 			if err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.pipelineRun)); err != nil {
@@ -387,7 +387,7 @@ func TestReconcile_InvalidPipelineRunNames(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			testAssets := getPipelineRunController(test.Data{}, fr)
+			testAssets := getPipelineRunController(t, test.Data{}, fr)
 			c := testAssets.Controller
 			logs := testAssets.Logs
 
@@ -500,7 +500,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 	// create fake recorder for testing
 	fr := record.NewFakeRecorder(1)
 
-	testAssets := getPipelineRunController(d, fr)
+	testAssets := getPipelineRunController(t, d, fr)
 	c := testAssets.Controller
 	clients := testAssets.Clients
 
@@ -598,7 +598,7 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 	// create fake recorder for testing
 	fr := record.NewFakeRecorder(1)
 
-	testAssets := getPipelineRunController(d, fr)
+	testAssets := getPipelineRunController(t, d, fr)
 	c := testAssets.Controller
 	clients := testAssets.Clients
 
@@ -646,7 +646,7 @@ func TestReconcileWithTimeout(t *testing.T) {
 	// create fake recorder for testing
 	fr := record.NewFakeRecorder(2)
 
-	testAssets := getPipelineRunController(d, fr)
+	testAssets := getPipelineRunController(t, d, fr)
 	c := testAssets.Controller
 	clients := testAssets.Clients
 
@@ -701,7 +701,7 @@ func TestReconcileCancelledPipelineRun(t *testing.T) {
 	// create fake recorder for testing
 	fr := record.NewFakeRecorder(2)
 
-	testAssets := getPipelineRunController(d, fr)
+	testAssets := getPipelineRunController(t, d, fr)
 	c := testAssets.Controller
 	clients := testAssets.Clients
 
@@ -755,7 +755,7 @@ func TestReconcilePropagateLabels(t *testing.T) {
 	// create fake recorder for testing
 	fr := record.NewFakeRecorder(2)
 
-	testAssets := getPipelineRunController(d, fr)
+	testAssets := getPipelineRunController(t, d, fr)
 	c := testAssets.Controller
 	clients := testAssets.Clients
 
@@ -866,7 +866,7 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 
 			fr := record.NewFakeRecorder(2)
 
-			testAssets := getPipelineRunController(d, fr)
+			testAssets := getPipelineRunController(t, d, fr)
 			c := testAssets.Controller
 			clients := testAssets.Clients
 

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
@@ -801,7 +801,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			c := GetPipelineConditionStatus("somepipelinerun", tc.state, zap.NewNop().Sugar(), &metav1.Time{time.Now()},
+			c := GetPipelineConditionStatus("somepipelinerun", tc.state, zap.NewNop().Sugar(), &metav1.Time{Time: time.Now()},
 				nil)
 			if c.Status != tc.expectedStatus {
 				t.Fatalf("Expected to get status %s but got %s for state %v", tc.expectedStatus, c.Status, tc.state)

--- a/pkg/reconciler/v1alpha1/taskrun/cancel_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/cancel_test.go
@@ -82,7 +82,7 @@ func TestCancelTaskRun(t *testing.T) {
 			}
 
 			observer, _ := observer.New(zap.InfoLevel)
-			c, _ := test.SeedTestData(d)
+			c, _ := test.SeedTestData(t, d)
 			err := cancelTaskRun(tc.taskRun, c.Kube, zap.New(observer).Sugar())
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
@@ -215,12 +215,16 @@ func TestGetRemoteEntrypoint(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
-			w.Write(mustRawConfigFile(t, img))
+			if _, err := w.Write(mustRawConfigFile(t, img)); err != nil {
+				t.Fatal(err)
+			}
 		case manifestPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
-			w.Write(mustRawManifest(t, img))
+			if _, err := w.Write(mustRawManifest(t, img)); err != nil {
+				t.Fatal(err)
+			}
 		default:
 			t.Fatalf("Unexpected path: %v", r.URL.Path)
 		}
@@ -284,12 +288,16 @@ func TestGetRemoteEntrypointWithNonDefaultSA(t *testing.T) {
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
-			w.Write(mustRawConfigFile(t, img))
+			if _, err := w.Write(mustRawConfigFile(t, img)); err != nil {
+				t.Fatal(err)
+			}
 		case manifestPath:
 			if r.Method != http.MethodGet {
 				t.Errorf("Method; got %v, want %v", r.Method, http.MethodGet)
 			}
-			w.Write(mustRawManifest(t, img))
+			if _, err := w.Write(mustRawManifest(t, img)); err != nil {
+				t.Fatal(err)
+			}
 		default:
 			t.Fatalf("Unexpected path: %v", r.URL.Path)
 		}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -278,10 +278,9 @@ func TestVolumeReplacement(t *testing.T) {
 				Name: "${name}",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
-						corev1.LocalObjectReference{"${configmapname}"},
-						nil,
-						nil,
-						nil,
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "${configmapname}",
+						},
 					},
 				}},
 			},
@@ -295,10 +294,9 @@ func TestVolumeReplacement(t *testing.T) {
 				Name: "myname",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
-						corev1.LocalObjectReference{"cfgmapname"},
-						nil,
-						nil,
-						nil,
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "cfgmapname",
+						},
 					},
 				}},
 			},
@@ -310,10 +308,7 @@ func TestVolumeReplacement(t *testing.T) {
 				Name: "${name}",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						"${secretname}",
-						nil,
-						nil,
-						nil,
+						SecretName: "${secretname}",
 					},
 				}},
 			},
@@ -327,10 +322,7 @@ func TestVolumeReplacement(t *testing.T) {
 				Name: "mysecret",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						"totallysecure",
-						nil,
-						nil,
-						nil,
+						SecretName: "totallysecure",
 					},
 				}},
 			},

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -63,7 +63,7 @@ var (
 	}
 )
 
-func setUp() {
+func setUp(t *testing.T) {
 	logger, _ = logging.NewLogger("", "")
 	fakeClient := fakeclientset.NewSimpleClientset()
 	sharedInfomer := informers.NewSharedInformerFactory(fakeClient, 0)
@@ -195,7 +195,9 @@ func setUp() {
 		},
 	}}
 	for _, r := range rs {
-		pipelineResourceInformer.Informer().GetIndexer().Add(r)
+		if err := pipelineResourceInformer.Informer().GetIndexer().Add(r); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
@@ -694,7 +696,7 @@ func TestAddResourceToTask(t *testing.T) {
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			setUp()
+			setUp(t)
 			names.TestingSeed()
 			fakekubeclient := fakek8s.NewSimpleClientset()
 			got, err := AddInputResource(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, pipelineResourceLister, logger)
@@ -901,7 +903,7 @@ func TestStorageInputResource(t *testing.T) {
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
-			setUp()
+			setUp(t)
 			fakekubeclient := fakek8s.NewSimpleClientset()
 			got, err := AddInputResource(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, pipelineResourceLister, logger)
 			if (err != nil) != c.wantErr {
@@ -1017,7 +1019,7 @@ func TestAddStepsToTaskWithBucketFromConfigMap(t *testing.T) {
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			setUp()
+			setUp(t)
 			fakekubeclient := fakek8s.NewSimpleClientset(
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -35,7 +35,7 @@ var (
 	outputpipelineResourceLister listers.PipelineResourceLister
 )
 
-func outputResourceSetup() {
+func outputResourceSetup(t *testing.T) {
 	logger, _ = logging.NewLogger("", "")
 	fakeClient := fakeclientset.NewSimpleClientset()
 	sharedInfomer := informers.NewSharedInformerFactory(fakeClient, 0)
@@ -99,7 +99,9 @@ func outputResourceSetup() {
 	}}
 
 	for _, r := range rs {
-		pipelineResourceInformer.Informer().GetIndexer().Add(r)
+		if err := pipelineResourceInformer.Informer().GetIndexer().Add(r); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 func TestValidOutputResources(t *testing.T) {
@@ -680,7 +682,7 @@ func TestValidOutputResources(t *testing.T) {
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			names.TestingSeed()
-			outputResourceSetup()
+			outputResourceSetup(t)
 			fakekubeclient := fakek8s.NewSimpleClientset()
 			err := AddOutputResources(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, outputpipelineResourceLister, logger)
 			if err != nil {
@@ -855,7 +857,7 @@ func TestValidOutputResourcesWithBucketStorage(t *testing.T) {
 		},
 	}} {
 		t.Run(c.name, func(t *testing.T) {
-			outputResourceSetup()
+			outputResourceSetup(t)
 			names.TestingSeed()
 			fakekubeclient := fakek8s.NewSimpleClientset(
 				&corev1.ConfigMap{
@@ -1108,7 +1110,7 @@ func TestInValidOutputResources(t *testing.T) {
 		wantErr: true,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			outputResourceSetup()
+			outputResourceSetup(t)
 			fakekubeclient := fakek8s.NewSimpleClientset()
 			err := AddOutputResources(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, outputpipelineResourceLister, logger)
 			if (err != nil) != c.wantErr {

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -108,8 +108,10 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 		v1alpha1.BucketServiceAccountSecretName: bucketSecretName,
 		v1alpha1.BucketServiceAccountSecretKey:  bucketSecretKey,
 	}
-	updateConfigMap(c.KubeClient, systemNamespace, v1alpha1.BucketConfigName, configMapData)
-	defer resetConfigMap(c, systemNamespace, v1alpha1.BucketConfigName, originalConfigMapData)
+	if err := updateConfigMap(c.KubeClient, systemNamespace, v1alpha1.BucketConfigName, configMapData); err != nil {
+		t.Fatal(err)
+	}
+	defer resetConfigMap(t, c, systemNamespace, v1alpha1.BucketConfigName, originalConfigMapData)
 
 	t.Logf("Creating Git PipelineResource %s", helloworldResourceName)
 	helloworldResource := tb.PipelineResource(helloworldResourceName, namespace, tb.PipelineResourceSpec(
@@ -228,8 +230,10 @@ func deleteBucketSecret(c *clients, t *testing.T, namespace string) {
 	}
 }
 
-func resetConfigMap(c *clients, namespace, configName string, values map[string]string) error {
-	return updateConfigMap(c.KubeClient, namespace, configName, values)
+func resetConfigMap(t *testing.T, c *clients, namespace, configName string, values map[string]string) {
+	if err := updateConfigMap(c.KubeClient, namespace, configName, values); err != nil {
+		t.Log(err)
+	}
 }
 
 func runTaskToDeleteBucket(c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {

--- a/test/controller.go
+++ b/test/controller.go
@@ -14,6 +14,8 @@ limitations under the License.
 package test
 
 import (
+	"testing"
+
 	"github.com/knative/pkg/controller"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
@@ -76,7 +78,7 @@ type TestAssets struct {
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-func SeedTestData(d Data) (Clients, Informers) {
+func SeedTestData(t *testing.T, d Data) (Clients, Informers) {
 	objs := []runtime.Object{}
 	for _, r := range d.PipelineResources {
 		objs = append(objs, r)
@@ -122,25 +124,39 @@ func SeedTestData(d Data) (Clients, Informers) {
 	}
 
 	for _, pr := range d.PipelineRuns {
-		i.PipelineRun.Informer().GetIndexer().Add(pr)
+		if err := i.PipelineRun.Informer().GetIndexer().Add(pr); err != nil {
+			t.Fatal(err)
+		}
 	}
 	for _, p := range d.Pipelines {
-		i.Pipeline.Informer().GetIndexer().Add(p)
+		if err := i.Pipeline.Informer().GetIndexer().Add(p); err != nil {
+			t.Fatal(err)
+		}
 	}
 	for _, tr := range d.TaskRuns {
-		i.TaskRun.Informer().GetIndexer().Add(tr)
+		if err := i.TaskRun.Informer().GetIndexer().Add(tr); err != nil {
+			t.Fatal(err)
+		}
 	}
-	for _, t := range d.Tasks {
-		i.Task.Informer().GetIndexer().Add(t)
+	for _, ta := range d.Tasks {
+		if err := i.Task.Informer().GetIndexer().Add(ta); err != nil {
+			t.Fatal(err)
+		}
 	}
 	for _, ct := range d.ClusterTasks {
-		i.ClusterTask.Informer().GetIndexer().Add(ct)
+		if err := i.ClusterTask.Informer().GetIndexer().Add(ct); err != nil {
+			t.Fatal(err)
+		}
 	}
 	for _, r := range d.PipelineResources {
-		i.PipelineResource.Informer().GetIndexer().Add(r)
+		if err := i.PipelineResource.Informer().GetIndexer().Add(r); err != nil {
+			t.Fatal(err)
+		}
 	}
 	for _, p := range d.Pods {
-		i.Pod.Informer().GetIndexer().Add(p)
+		if err := i.Pod.Informer().GetIndexer().Add(p); err != nil {
+			t.Fatal(err)
+		}
 	}
 	return c, i
 }

--- a/test/gcs_taskrun_test.go
+++ b/test/gcs_taskrun_test.go
@@ -98,10 +98,3 @@ func getResources(namespace, name, secretName, configFile string) *v1alpha1.Pipe
 	}
 	return res
 }
-
-type GCPProject struct {
-	GCPconfig `json:"core"`
-}
-type GCPconfig struct {
-	Name string `json:"project"`
-}

--- a/test/gohelloworld/main.go
+++ b/test/gohelloworld/main.go
@@ -15,5 +15,7 @@ func main() {
 	log.Print("Hello world sample started.")
 
 	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		panic(err)
+	}
 }

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -138,7 +138,7 @@ func TestKanikoTaskRun(t *testing.T) {
 		t.Fatalf("Expected output %s from pod %s but got %s", kanikoBuildOutput, podName, logs)
 	}
 	// make sure the pushed digest matches the one we pushed
-	re := regexp.MustCompile("digest: (sha256:\\w+)")
+	re := regexp.MustCompile(`digest: (sha256:\w+)`)
 	match := re.FindStringSubmatch(logs)
 	// make sure we found a match and it has the capture group
 	if len(match) != 2 {

--- a/test/logs/pod/watcher.go
+++ b/test/logs/pod/watcher.go
@@ -54,11 +54,8 @@ func (w *Watcher) Start(ctx context.Context) error {
 			case <-ctx.Done():
 				watcher.Stop()
 				return
-			case evt, ok := <-watcher.ResultChan():
-				if !ok {
-					// TODO: reconnect watch
-				}
-
+			case evt := <-watcher.ResultChan():
+				// TODO: reconnect watch
 				w.versions <- evt.Object.(*v1.Pod)
 			}
 		}

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -27,6 +27,10 @@ export DISABLE_MD_LINTING=1
 
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
 
+function post_build_tests() {
+    golangci-lint run
+}
+
 # We use the default build, unit and integration test runners.
 
 main $@

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -43,7 +43,7 @@ func TestWaitForTaskRunStateSucceed(t *testing.T) {
 			)),
 		},
 	}
-	c := fakeClients(d)
+	c := fakeClients(t, d)
 	err := WaitForTaskRunState(c, "foo", TaskRunSucceed("foo"), "TestTaskRunSucceed")
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +57,7 @@ func TestWaitForTaskRunStateFailed(t *testing.T) {
 			)),
 		},
 	}
-	c := fakeClients(d)
+	c := fakeClients(t, d)
 	err := WaitForTaskRunState(c, "foo", TaskRunFailed("foo"), "TestTaskRunFailed")
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +72,7 @@ func TestWaitForPipelineRunStateSucceed(t *testing.T) {
 			)),
 		},
 	}
-	c := fakeClients(d)
+	c := fakeClients(t, d)
 	err := WaitForPipelineRunState(c, "bar", 2*time.Second, PipelineRunSucceed("bar"), "TestWaitForPipelineRunSucceed")
 	if err != nil {
 		t.Fatal(err)
@@ -87,15 +87,15 @@ func TestWaitForPipelineRunStateFailed(t *testing.T) {
 			)),
 		},
 	}
-	c := fakeClients(d)
+	c := fakeClients(t, d)
 	err := WaitForPipelineRunState(c, "bar", 2*time.Second, PipelineRunFailed("bar"), "TestWaitForPipelineRunFailed")
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
-func fakeClients(d Data) *clients {
-	fakeClients, _ := SeedTestData(d)
+func fakeClients(t *testing.T, d Data) *clients {
+	fakeClients, _ := SeedTestData(t, d)
 	// 	c.KubeClient = fakeClients.Kube
 	return &clients{
 		PipelineClient:         fakeClients.Pipeline.TektonV1alpha1().Pipelines(waitNamespace),


### PR DESCRIPTION
# Changes

This commit adds the golangci-lint and errcheck.txt exclude files, and
runs golangci-lint during presubmits. It also fixes the last of the lint
errors!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._