### PR TITLE
Enforce Default TaskRun Timeout

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -49,7 +49,8 @@ following fields:
   - [`inputs`] - Specifies [input parameters](#input-parameters) and
     [input resources](#providing-resources)
   - [`outputs`] - Specifies [output resources](#providing-resources)
-  - `timeout` - Specifies timeout after which the `TaskRun` will fail.
+  - `timeout` - Specifies timeout after which the `TaskRun` will fail. Defaults
+    to ten minutes.
   - [`nodeSelector`] - a selector which must be true for the pod to fit on a
     node. The selector which must match a node's labels for the pod to be
     scheduled on that node. More info:

--- a/pkg/reconciler/timeout_handler.go
+++ b/pkg/reconciler/timeout_handler.go
@@ -90,7 +90,10 @@ func (t *TimeoutSet) getOrCreateFinishedChan(runObj StatusKey) chan bool {
 	return finished
 }
 
-func getTimeout(d *metav1.Duration) time.Duration {
+// GetTimeout takes a kubernetes Duration representing the timeout period for a
+// resource and returns it as a time.Duration. If the provided duration is nil
+// then fallback behaviour is to return a default timeout period.
+func GetTimeout(d *metav1.Duration) time.Duration {
 	timeout := defaultTimeout
 	if d != nil {
 		timeout = d.Duration
@@ -154,14 +157,14 @@ func (t *TimeoutSet) checkTaskRunTimeouts(namespace string) {
 // 1. Stop signal, 2. TaskRun to complete or 3. Taskrun to time out, which is
 // determined by checking if the tr's timeout has occurred since the startTime
 func (t *TimeoutSet) WaitTaskRun(tr *v1alpha1.TaskRun, startTime *metav1.Time) {
-	t.waitRun(tr, getTimeout(tr.Spec.Timeout), startTime, t.taskRunCallbackFunc)
+	t.waitRun(tr, GetTimeout(tr.Spec.Timeout), startTime, t.taskRunCallbackFunc)
 }
 
 // WaitPipelineRun function creates a blocking function for pipelinerun to wait for
 // 1. Stop signal, 2. pipelinerun to complete or 3. pipelinerun to time out which is
 // determined by checking if the tr's timeout has occurred since the startTime
 func (t *TimeoutSet) WaitPipelineRun(pr *v1alpha1.PipelineRun, startTime *metav1.Time) {
-	t.waitRun(pr, getTimeout(pr.Spec.Timeout), startTime, t.pipelineRunCallbackFunc)
+	t.waitRun(pr, GetTimeout(pr.Spec.Timeout), startTime, t.pipelineRunCallbackFunc)
 }
 
 func (t *TimeoutSet) waitRun(runObj StatusKey, timeout time.Duration, startTime *metav1.Time, callback func(interface{})) {


### PR DESCRIPTION
# Changes

The [TaskRun spec](https://github.com/tektoncd/pipeline/blob/81f178ed51a35bfe40df1f0b558926341c7bf06e/pkg/apis/pipeline/v1alpha1/taskrun_types.go#L51) describes a default timeout of ten minutes but this isn't documented anywhere else or enforced by the TaskRun reconciler.

This commit:
- updates the docs for TaskRuns to make the default timeout clear for users
- changes the taskrun reconciler to use the default timeout if one isn't specified in the TaskRun yaml

Before, TaskRuns don't timeout after ten minutes:

![2019-05-16_11-16-21](https://user-images.githubusercontent.com/34253460/57873588-a833fa80-77dc-11e9-85cc-ce49c1a59930.png)

After, TaskRuns timeout after ten minutes by default:

![2019-05-16_12-45-15](https://user-images.githubusercontent.com/34253460/57873599-b08c3580-77dc-11e9-83d4-004a52103255.png)


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
TaskRuns will now time out by default after ten minutes. This behaviour was previously documented as part of the TaskRun spec but not enforced; now it will also be enforced.
```
