### PR TITLE
golang format tools

### DIFF
--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package artifacts
 
 import (
-	"k8s.io/apimachinery/pkg/api/errors"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/google/go-cmp/cmp"
 	logtesting "github.com/knative/pkg/logging/testing"

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -21,11 +21,12 @@ package test
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/tektoncd/pipeline/pkg/artifacts"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/tektoncd/pipeline/pkg/artifacts"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/knative/pkg/apis"
 	knativetest "github.com/knative/pkg/test"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
