### PR TITLE
Add variable substitution for resource paths

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -211,7 +211,8 @@ Input resources, like source code (git) or artifacts, are dumped at path
 `/workspace/task_resource_name` within a mounted
 [volume](https://kubernetes.io/docs/concepts/storage/volumes/) and is available
 to all [`steps`](#steps) of your `Task`. The path that the resources are mounted
-at can be overridden with the `targetPath` value.
+at can be overridden with the `targetPath` value. Steps can use the `path`
+ [template](#Templating) key to refer to the local path to the mounted resource.
 
 ### Outputs
 
@@ -370,6 +371,13 @@ Or for an output resource:
 
 ```shell
 ${outputs.resources.<name>.<key>}
+```
+
+The local path to a resource on the mounted volume can be accessed using the
+`path` key:
+
+```shell
+${inputs.resouces.<name>.path}
 ```
 
 To access an input parameter, replace `resources` with `params`.

--- a/examples/taskruns/task-output-image.yaml
+++ b/examples/taskruns/task-output-image.yaml
@@ -60,7 +60,7 @@ spec:
     - -ce
     - |
       set -e
-      cat <<EOF > /workspace/sourcerepo/index.json
+      cat <<EOF > ${inputs.resources.sourcerepo.path}/index.json
       {
         "schemaVersion": 2,
         "manifests": [
@@ -80,7 +80,7 @@ spec:
     - -ce
     - |
       set -e
-      cat /workspace/sourcerepo/index.json
+      cat ${inputs.resources.sourcerepo.path}/index.json
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun

--- a/examples/taskruns/taskrun-git-source.yaml
+++ b/examples/taskruns/taskrun-git-source.yaml
@@ -48,7 +48,7 @@ spec:
   - name: dump-workspace
     image: ubuntu
     command: ["cat"]
-    args: ["/workspace/gitspace/WORKSPACE"]
+    args: ["${inputs.resources.gitspace.path}/WORKSPACE"]
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun

--- a/examples/taskruns/taskrun-targetpath-gotest.yaml
+++ b/examples/taskruns/taskrun-targetpath-gotest.yaml
@@ -35,7 +35,7 @@ spec:
       - '-v'
       - '-count=1'
       - './...'
-      workingDir: "/workspace/go/src/github.com/tektoncd/pipeline"
+      workingDir: "${inputs.resources.gitspace.path}"
       env:
       - name: GOPATH
         value: /workspace/go

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
@@ -119,6 +119,7 @@ func (s *BuildGCSResource) Replacements() map[string]string {
 		"name":     s.Name,
 		"type":     string(s.Type),
 		"location": s.Location,
+		"path":     s.DestinationDir,
 	}
 }
 

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -201,6 +201,7 @@ func Test_BuildGCSGetReplacements(t *testing.T) {
 		"name":     "gcs-resource",
 		"type":     "build-gcs",
 		"location": "gs://fake-bucket",
+		"path": "",
 	}
 	if d := cmp.Diff(r.Replacements(), expectedReplacementMap); d != "" {
 		t.Errorf("BuildGCS Replacement map mismatch: %s", d)

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -201,7 +201,7 @@ func Test_BuildGCSGetReplacements(t *testing.T) {
 		"name":     "gcs-resource",
 		"type":     "build-gcs",
 		"location": "gs://fake-bucket",
-		"path": "",
+		"path":     "",
 	}
 	if d := cmp.Diff(r.Replacements(), expectedReplacementMap); d != "" {
 		t.Errorf("BuildGCS Replacement map mismatch: %s", d)

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -97,6 +97,7 @@ func (s *GCSResource) Replacements() map[string]string {
 		"name":     s.Name,
 		"type":     string(s.Type),
 		"location": s.Location,
+		"path":     s.DestinationDir,
 	}
 }
 

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -170,7 +170,7 @@ func Test_GCSGetReplacements(t *testing.T) {
 		"name":     "gcs-resource",
 		"type":     "gcs",
 		"location": "gs://fake-bucket",
-		"path": "",
+		"path":     "",
 	}
 	if d := cmp.Diff(gcsResource.Replacements(), expectedReplacementMap); d != "" {
 		t.Errorf("GCS Replacement map mismatch: %s", d)

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -170,6 +170,7 @@ func Test_GCSGetReplacements(t *testing.T) {
 		"name":     "gcs-resource",
 		"type":     "gcs",
 		"location": "gs://fake-bucket",
+		"path": "",
 	}
 	if d := cmp.Diff(gcsResource.Replacements(), expectedReplacementMap); d != "" {
 		t.Errorf("GCS Replacement map mismatch: %s", d)

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -91,11 +91,13 @@ func (s GitResource) GetParams() []Param { return []Param{} }
 
 // Replacements is used for template replacement on a GitResource inside of a Taskrun.
 func (s *GitResource) Replacements() map[string]string {
+
 	return map[string]string{
 		"name":     s.Name,
 		"type":     string(s.Type),
 		"url":      s.URL,
 		"revision": s.Revision,
+		"path":     s.TargetPath,
 	}
 }
 
@@ -103,14 +105,8 @@ func (s *GitResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 	args := []string{"-url", s.URL,
 		"-revision", s.Revision,
 	}
-	var dPath string
-	if s.TargetPath != "" {
-		dPath = s.TargetPath
-	} else {
-		dPath = s.Name
-	}
 
-	args = append(args, []string{"-path", dPath}...)
+	args = append(args, []string{"-path", s.TargetPath}...)
 
 	return []corev1.Container{{
 		Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(gitSource + "-" + s.Name),

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -91,7 +91,6 @@ func (s GitResource) GetParams() []Param { return []Param{} }
 
 // Replacements is used for template replacement on a GitResource inside of a Taskrun.
 func (s *GitResource) Replacements() map[string]string {
-
 	return map[string]string{
 		"name":     s.Name,
 		"type":     string(s.Type),

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -42,7 +42,7 @@ func ApplyParameters(spec *v1alpha1.TaskSpec, tr *v1alpha1.TaskRun, defaults ...
 }
 
 // ApplyResources applies the templating from values in resources which are referenced in spec as subitems
-// of the replacementStr. It retrieves the referenced resources via the getter.
+// of the replacementStr.
 func ApplyResources(spec *v1alpha1.TaskSpec, resolvedResources map[string]v1alpha1.PipelineResourceInterface, replacementStr string) *v1alpha1.TaskSpec {
 	replacements := map[string]string{}
 	for name, r := range resolvedResources {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -43,24 +43,14 @@ func ApplyParameters(spec *v1alpha1.TaskSpec, tr *v1alpha1.TaskRun, defaults ...
 
 // ApplyResources applies the templating from values in resources which are referenced in spec as subitems
 // of the replacementStr. It retrieves the referenced resources via the getter.
-func ApplyResources(spec *v1alpha1.TaskSpec, resources []v1alpha1.TaskResourceBinding, getter GetResource, replacementStr string) (*v1alpha1.TaskSpec, error) {
+func ApplyResources(spec *v1alpha1.TaskSpec, resolvedResources map[string]v1alpha1.PipelineResourceInterface, replacementStr string) *v1alpha1.TaskSpec {
 	replacements := map[string]string{}
-
-	for _, r := range resources {
-		pr, err := getResource(&r, getter)
-		if err != nil {
-			return nil, err
-		}
-
-		resource, err := v1alpha1.ResourceFromType(pr)
-		if err != nil {
-			return nil, err
-		}
-		for k, v := range resource.Replacements() {
-			replacements[fmt.Sprintf("%s.resources.%s.%s", replacementStr, r.Name, k)] = v
+	for name, r := range resolvedResources {
+		for k, v := range r.Replacements() {
+			replacements[fmt.Sprintf("%s.resources.%s.%s", replacementStr, name, k)] = v
 		}
 	}
-	return ApplyReplacements(spec, replacements), nil
+	return ApplyReplacements(spec, replacements)
 }
 
 // ApplyReplacements replaces placeholders for declared parameters with the specified replacements.

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -32,6 +32,7 @@ var simpleTaskSpec = &v1alpha1.TaskSpec{
 	}, {
 		Name:  "baz",
 		Image: "bat",
+		WorkingDir: "${inputs.resources.workspace.path}",
 		Args:  []string{"${inputs.resources.workspace.url}"},
 	}, {
 		Name:  "qux",
@@ -107,6 +108,10 @@ func applyMutation(ts *v1alpha1.TaskSpec, f func(*v1alpha1.TaskSpec)) *v1alpha1.
 	ts = ts.DeepCopy()
 	f(ts)
 	return ts
+}
+
+func setup() {
+	inputs["workspace"].SetDestinationDirectory("/workspace/workspace")
 }
 
 func TestApplyParameters(t *testing.T) {
@@ -203,6 +208,7 @@ func TestApplyResources(t *testing.T) {
 			rStr:   "inputs",
 		},
 		want: applyMutation(simpleTaskSpec, func(spec *v1alpha1.TaskSpec) {
+			spec.Steps[1].WorkingDir = "/workspace/workspace"
 			spec.Steps[1].Args = []string{"https://git-repo"}
 		}),
 	}, {
@@ -218,6 +224,7 @@ func TestApplyResources(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			setup()
 			got := ApplyResources(tt.args.ts, tt.args.r, tt.args.rStr)
 			if d := cmp.Diff(got, tt.want); d != "" {
 				t.Errorf("ApplyResources() diff %s", d)

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -30,10 +30,10 @@ var simpleTaskSpec = &v1alpha1.TaskSpec{
 		Name:  "foo",
 		Image: "${inputs.params.myimage}",
 	}, {
-		Name:  "baz",
-		Image: "bat",
+		Name:       "baz",
+		Image:      "bat",
 		WorkingDir: "${inputs.resources.workspace.path}",
-		Args:  []string{"${inputs.resources.workspace.url}"},
+		Args:       []string{"${inputs.resources.workspace.url}"},
 	}, {
 		Name:  "qux",
 		Image: "quux",
@@ -180,31 +180,30 @@ func TestApplyParameters(t *testing.T) {
 	}
 }
 
-
 func TestApplyResources(t *testing.T) {
 	type args struct {
-		ts     *v1alpha1.TaskSpec
-		r map[string]v1alpha1.PipelineResourceInterface
-		rStr   string
+		ts   *v1alpha1.TaskSpec
+		r    map[string]v1alpha1.PipelineResourceInterface
+		rStr string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    *v1alpha1.TaskSpec
+		name string
+		args args
+		want *v1alpha1.TaskSpec
 	}{{
 		name: "no replacements specified",
 		args: args{
-			ts:     simpleTaskSpec,
-			r:     	make(map[string]v1alpha1.PipelineResourceInterface),
-			rStr:   "inputs",
+			ts:   simpleTaskSpec,
+			r:    make(map[string]v1alpha1.PipelineResourceInterface),
+			rStr: "inputs",
 		},
 		want: simpleTaskSpec,
 	}, {
 		name: "input resource specified",
 		args: args{
-			ts:     simpleTaskSpec,
-			r:      inputs,
-			rStr:   "inputs",
+			ts:   simpleTaskSpec,
+			r:    inputs,
+			rStr: "inputs",
 		},
 		want: applyMutation(simpleTaskSpec, func(spec *v1alpha1.TaskSpec) {
 			spec.Steps[1].WorkingDir = "/workspace/workspace"
@@ -213,9 +212,9 @@ func TestApplyResources(t *testing.T) {
 	}, {
 		name: "output resource specified",
 		args: args{
-			ts:     simpleTaskSpec,
-			r:      outputs,
-			rStr:   "outputs",
+			ts:   simpleTaskSpec,
+			r:    outputs,
+			rStr: "outputs",
 		},
 		want: applyMutation(simpleTaskSpec, func(spec *v1alpha1.TaskSpec) {
 			spec.Steps[2].Args = []string{"gcr.io/hans/sandwiches"}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -191,7 +191,6 @@ func TestApplyResources(t *testing.T) {
 		name    string
 		args    args
 		want    *v1alpha1.TaskSpec
-		wantErr bool
 	}{{
 		name: "no replacements specified",
 		args: args{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -1008,7 +1008,7 @@ func mockResolveTaskResources(taskRun *v1alpha1.TaskRun) map[string]v1alpha1.Pip
 	for _, r := range taskRun.Spec.Inputs.Resources {
 		var i v1alpha1.PipelineResourceInterface
 		if name := r.ResourceRef.Name; name != "" {
-			i,_ = inputResourceInterfaces[name]
+			i = inputResourceInterfaces[name]
 			resolved[r.Name] = i
 		} else if r.ResourceSpec != nil {
 			i, _ =v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
-	logger                 *zap.SugaredLogger
+	logger                  *zap.SugaredLogger
 
 	gitInputs = &v1alpha1.Inputs{
 		Resources: []v1alpha1.TaskResource{{
@@ -189,7 +189,7 @@ func setUp(t *testing.T) {
 	}}
 	inputResourceInterfaces = make(map[string]v1alpha1.PipelineResourceInterface)
 	for _, r := range rs {
-		ri,_ := v1alpha1.ResourceFromType(r)
+		ri, _ := v1alpha1.ResourceFromType(r)
 		inputResourceInterfaces[r.Name] = ri
 	}
 }
@@ -1011,7 +1011,7 @@ func mockResolveTaskResources(taskRun *v1alpha1.TaskRun) map[string]v1alpha1.Pip
 			i = inputResourceInterfaces[name]
 			resolved[r.Name] = i
 		} else if r.ResourceSpec != nil {
-			i, _ =v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
+			i, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: r.Name,
 				},

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -142,7 +142,7 @@ func AddInputResource(
 	return taskSpec, nil
 }
 
-func addStorageFetchStep(taskSpec *v1alpha1.TaskSpec, storageResource v1alpha1.PipelineStorageResourceInterface,) ([]corev1.Container, []corev1.Volume, error) {
+func addStorageFetchStep(taskSpec *v1alpha1.TaskSpec, storageResource v1alpha1.PipelineStorageResourceInterface) ([]corev1.Container, []corev1.Volume, error) {
 	gcsContainers, err := storageResource.GetDownloadContainerSpec()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -115,7 +115,7 @@ func AddInputResource(
 				{
 					storageResource, ok := resource.(v1alpha1.PipelineStorageResourceInterface)
 					if !ok {
-						return nil, fmt.Errorf("task %q invalid gcs Pipeline Resource: %q: %s", taskName, boundResource.ResourceRef.Name, err.Error())
+						return nil, fmt.Errorf("task %q invalid gcs Pipeline Resource: %q", taskName, boundResource.ResourceRef.Name)
 					}
 					resourceContainers, resourceVolumes, err = addStorageFetchStep(taskSpec, storageResource)
 					if err != nil {

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -21,8 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	artifacts "github.com/tektoncd/pipeline/pkg/artifacts"
-	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/artifacts"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -56,18 +55,20 @@ func AddOutputResources(
 	taskName string,
 	taskSpec *v1alpha1.TaskSpec,
 	taskRun *v1alpha1.TaskRun,
-	pipelineResourceLister listers.PipelineResourceLister,
+	outputResources map[string]v1alpha1.PipelineResourceInterface,
 	logger *zap.SugaredLogger,
-) error {
+) (*v1alpha1.TaskSpec, error) {
 
 	if taskSpec == nil || taskSpec.Outputs == nil {
-		return nil
+		return taskSpec, nil
 	}
+
+	taskSpec = taskSpec.DeepCopy()
 
 	pvcName := taskRun.GetPipelineRunPVCName()
 	as, err := artifacts.GetArtifactStorage(pvcName, kubeclient, logger)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// track resources that are present in input of task cuz these resources will be copied onto PVC
@@ -82,12 +83,12 @@ func AddOutputResources(
 	for _, output := range taskSpec.Outputs.Resources {
 		boundResource, err := getBoundResource(output.Name, taskRun.Spec.Outputs.Resources)
 		if err != nil {
-			return fmt.Errorf("Failed to get bound resource: %s", err)
+			return nil, fmt.Errorf("failed to get bound resource: %s", err)
 		}
 
-		resource, err := getResource(boundResource, pipelineResourceLister.PipelineResources(taskRun.Namespace).Get)
-		if err != nil {
-			return fmt.Errorf("Failed to get output pipeline Resource for task %q resource %v; error: %s", taskName, boundResource, err.Error())
+		resource, ok := outputResources[boundResource.Name]
+		if !ok || resource == nil {
+			return nil, fmt.Errorf("failed to get output pipeline Resource for task %q resource %v", taskName, boundResource)
 		}
 		var (
 			resourceContainers []corev1.Container
@@ -103,37 +104,33 @@ func AddOutputResources(
 				sourcePath = output.TargetPath
 			}
 		}
-
-		switch resource.Spec.Type {
+		resource.SetDestinationDirectory(sourcePath)
+		switch resource.GetType() {
 		case v1alpha1.PipelineResourceTypeStorage:
 			{
-				storageResource, err := v1alpha1.NewStorageResource(resource)
-				if err != nil {
-					return fmt.Errorf("task %q invalid storage Pipeline Resource: %q",
+				storageResource, ok := resource.(v1alpha1.PipelineStorageResourceInterface)
+				if !ok {
+					return nil, fmt.Errorf("task %q invalid storage Pipeline Resource: %q",
 						taskName,
 						boundResource.ResourceRef.Name,
 					)
 				}
-				resourceContainers, resourceVolumes, err = addStoreUploadStep(taskSpec, storageResource, sourcePath)
+				resourceContainers, resourceVolumes, err = addStoreUploadStep(taskSpec, storageResource)
 				if err != nil {
-					return fmt.Errorf("task %q invalid Pipeline Resource: %q; invalid upload steps err: %v",
+					return nil, fmt.Errorf("task %q invalid Pipeline Resource: %q; invalid upload steps err: %v",
 						taskName, boundResource.ResourceRef.Name, err)
 				}
 			}
 		default:
 			{
-				resSpec, err := v1alpha1.ResourceFromType(resource)
+				resourceContainers, err = resource.GetUploadContainerSpec()
 				if err != nil {
-					return err
-				}
-				resourceContainers, err = resSpec.GetUploadContainerSpec()
-				if err != nil {
-					return fmt.Errorf("task %q invalid download spec: %q; error %s", taskName, boundResource.ResourceRef.Name, err.Error())
+					return nil, fmt.Errorf("task %q invalid download spec: %q; error %s", taskName, boundResource.ResourceRef.Name, err.Error())
 				}
 			}
 		}
 
-		if allowedOutputResources[resource.Spec.Type] && taskRun.HasPipelineRunOwnerReference() {
+		if allowedOutputResources[resource.GetType()] && taskRun.HasPipelineRunOwnerReference() {
 			var newSteps []corev1.Container
 			for _, dPath := range boundResource.Paths {
 				containers := as.GetCopyToStorageFromContainerSpec(resource.GetName(), sourcePath, dPath)
@@ -148,27 +145,25 @@ func AddOutputResources(
 
 		if as.GetType() == v1alpha1.ArtifactStoragePVCType {
 			if pvcName == "" {
-				return nil
+				return taskSpec, nil
 			}
 
 			// attach pvc volume only if it is not already attached
 			for _, buildVol := range taskSpec.Volumes {
 				if buildVol.Name == pvcName {
-					return nil
+					return taskSpec, nil
 				}
 			}
 			taskSpec.Volumes = append(taskSpec.Volumes, GetPVCVolume(pvcName))
 		}
 	}
-	return nil
+	return taskSpec, nil
 }
 
 func addStoreUploadStep(spec *v1alpha1.TaskSpec,
 	storageResource v1alpha1.PipelineStorageResourceInterface,
-	sourcePath string,
 ) ([]corev1.Container, []corev1.Volume, error) {
 
-	storageResource.SetDestinationDirectory(sourcePath)
 	gcsContainers, err := storageResource.GetUploadContainerSpec()
 	if err != nil {
 		return nil, nil, err

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -1019,7 +1019,7 @@ func resolveOutputResources(taskRun *v1alpha1.TaskRun) map[string]v1alpha1.Pipel
 	for _, r := range taskRun.Spec.Outputs.Resources {
 		var i v1alpha1.PipelineResourceInterface
 		if name := r.ResourceRef.Name; name != "" {
-			i,_ = outputResources[name]
+			i = outputResources[name]
 			resolved[r.Name] = i
 		} else if r.ResourceSpec != nil {
 			i, _ =v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource_test.go
@@ -93,7 +93,7 @@ func outputResourceSetup(t *testing.T) {
 
 	outputResources = make(map[string]v1alpha1.PipelineResourceInterface)
 	for _, r := range rs {
-		ri,_ := v1alpha1.ResourceFromType(r)
+		ri, _ := v1alpha1.ResourceFromType(r)
 		outputResources[r.Name] = ri
 	}
 }
@@ -1022,7 +1022,7 @@ func resolveOutputResources(taskRun *v1alpha1.TaskRun) map[string]v1alpha1.Pipel
 			i = outputResources[name]
 			resolved[r.Name] = i
 		} else if r.ResourceSpec != nil {
-			i, _ =v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
+			i, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: r.Name,
 				},

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -640,6 +640,7 @@ func isExceededResourceQuotaError(err error) bool {
 func getExceededResourcesMessage(tr *v1alpha1.TaskRun) string {
 	return fmt.Sprintf("TaskRun pod %q exceeded available resources", tr.Name)
 }
+
 // resourceImplBinding maps pipeline resource names to the actual resource type implementations
 func resourceImplBinding(resources map[string]*v1alpha1.PipelineResource) (map[string]v1alpha1.PipelineResourceInterface, error) {
 	p := make(map[string]v1alpha1.PipelineResourceInterface)

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun.go
@@ -303,7 +303,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 	}
 	if pod == nil {
 		// Pod is not present, create pod.
-		pod, err = c.createPod(tr, rtr.TaskSpec, rtr.TaskName)
+		pod, err = c.createPod(tr, rtr)
 		if err != nil {
 			// This Run has failed, so we need to mark it as failed and stop reconciling it
 			var reason, msg string
@@ -503,24 +503,37 @@ func (c *Reconciler) updateLabels(tr *v1alpha1.TaskRun) (*v1alpha1.TaskRun, erro
 	return newTr, nil
 }
 
-// createPod creates a Pod based on the Task's configuration, with pvcName as a
-// volumeMount
-func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, ts *v1alpha1.TaskSpec, taskName string) (*corev1.Pod, error) {
-	ts = ts.DeepCopy()
 
-	err := resources.AddOutputImageDigestExporter(tr, ts, c.resourceLister.PipelineResources(tr.Namespace).Get)
+// createPod creates a Pod based on the Task's configuration, with pvcName as a volumeMount
+// TODO(dibyom): Refactor resource setup/templating logic to its own function in the resources package
+func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTaskResources) (*corev1.Pod, error) {
+	ts := rtr.TaskSpec.DeepCopy()
+	inputResources, err := resourceImplBinding(rtr.Inputs)
+	if err != nil {
+		c.Logger.Errorf("Failed to initialize input resources: %v", err)
+		return nil, err
+	}
+	outputResources, err := resourceImplBinding(rtr.Outputs)
+	if err != nil {
+		c.Logger.Errorf("Failed to initialize output resources: %v", err)
+		return nil, err
+	}
+
+	// Get actual resource
+
+	err = resources.AddOutputImageDigestExporter(tr, ts, c.resourceLister.PipelineResources(tr.Namespace).Get)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a build for taskrun: %s due to output image resource error %v", tr.Name, err)
 		return nil, err
 	}
 
-	ts, err = resources.AddInputResource(c.KubeClientSet, taskName, ts, tr, c.resourceLister, c.Logger)
+	ts, err = resources.AddInputResource(c.KubeClientSet, rtr.TaskName, ts, tr, inputResources, c.Logger)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a build for taskrun: %s due to input resource error %v", tr.Name, err)
 		return nil, err
 	}
 
-	err = resources.AddOutputResources(c.KubeClientSet, taskName, ts, tr, c.resourceLister, c.Logger)
+	ts, err = resources.AddOutputResources(c.KubeClientSet, rtr.TaskName, ts, tr, outputResources, c.Logger)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a build for taskrun: %s due to output resource error %v", tr.Name, err)
 		return nil, err
@@ -539,14 +552,8 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, ts *v1alpha1.TaskSpec, task
 	ts = resources.ApplyParameters(ts, tr, defaults...)
 
 	// Apply bound resource templating from the taskrun.
-	ts, err = resources.ApplyResources(ts, tr.Spec.Inputs.Resources, c.resourceLister.PipelineResources(tr.Namespace).Get, "inputs")
-	if err != nil {
-		return nil, fmt.Errorf("couldnt apply input resource templating: %s", err)
-	}
-	ts, err = resources.ApplyResources(ts, tr.Spec.Outputs.Resources, c.resourceLister.PipelineResources(tr.Namespace).Get, "outputs")
-	if err != nil {
-		return nil, fmt.Errorf("couldnt apply output resource templating: %s", err)
-	}
+	ts = resources.ApplyResources(ts, inputResources, "inputs")
+	ts = resources.ApplyResources(ts, outputResources, "outputs")
 
 	pod, err := resources.MakePod(tr, *ts, c.KubeClientSet, c.cache, c.Logger)
 	if err != nil {
@@ -632,4 +639,16 @@ func isExceededResourceQuotaError(err error) bool {
 
 func getExceededResourcesMessage(tr *v1alpha1.TaskRun) string {
 	return fmt.Sprintf("TaskRun pod %q exceeded available resources", tr.Name)
+}
+// resourceImplBinding maps pipeline resource names to the actual resource type implementations
+func resourceImplBinding(resources map[string]*v1alpha1.PipelineResource) (map[string]v1alpha1.PipelineResourceInterface, error) {
+	p := make(map[string]v1alpha1.PipelineResourceInterface)
+	for rName, r := range resources {
+		i, err := v1alpha1.ResourceFromType(r)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create resource %s : %v with error: %v", rName, r, err)
+		}
+		p[rName] = i
+	}
+	return p, nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds the ability to substitute resource paths on disk using template variables e.g. `${inputs/outputs.resources.myresource.path}`. Prior to this, users would have to hardcode the paths
(e.g. /workspace/myresource).

In order to add this feature, we had to do some refactoring in order to reuse `PipelineResourceInterface` s when creating pods. Each resource processing step (e.g. adding input/output resources,
applying templating) would create its own `PipelineResourceInterface`. This is a problem since the interface uses a setter(`SetDestinationDirectory`) that would not always be called. The destination directory is required to be set in order to facilitate variable substitution for resource paths.

The first commit refactors the resource initialization process by creating a binding between the named resource and the interface implementation and passing it around instead of creating new `PipelineResourceInterface`each time.

Marking this as a WIP until I:
- [x] Add tests for output resources
- [x] Update the docs and examples

This PR is part of  #626 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Task authors can use template variables to refer to using `path`:

${inputs.resources.someresource.path} 
${outputs.resources.someresource.path}
```
