### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -159,7 +159,8 @@ kubectl create clusterrolebinding cluster-admin-binding \
    - modify the `subjects.namespace`
      [here](https://github.com/tektoncd/pipeline/blob/c1500fab83b09edadefb38bb8920a0c837d8f32b/config/201-clusterrolebinding.yaml#L21)
      value to the desired namespace
-   - look up all the lines with the namespace `namespace: tekton-pipelines`, and set the value to the desired namespace 
+   - look up all the lines with the namespace `namespace: tekton-pipelines`, and
+     set the value to the desired namespace
    - add `downwardapi` entry to webhook and controller `deployment` resources.
      E.g. add the environment variable section from the code snippet below to
      [controller](https://github.com/tektoncd/pipeline/blob/c1500fab83b09edadefb38bb8920a0c837d8f32b/config/controller.yaml#L29)

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -91,8 +91,8 @@ spec:
         image: gcr.io/kaniko-project/executor
         # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
         env:
-        - name: "DOCKER_CONFIG"
-          value: "/builder/home/.docker/"
+          - name: "DOCKER_CONFIG"
+            value: "/builder/home/.docker/"
         command:
           - /kaniko/executor
         args:
@@ -340,8 +340,8 @@ spec:
         image: gcr.io/kaniko-project/executor
         # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
         env:
-        - name: "DOCKER_CONFIG"
-          value: "/builder/home/.docker/"
+          - name: "DOCKER_CONFIG"
+            value: "/builder/home/.docker/"
         command:
           - /kaniko/executor
         args:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -184,8 +184,8 @@ spec:
       image: gcr.io/kaniko-project/executor
       # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
       env:
-      - name: "DOCKER_CONFIG"
-        value: "/builder/home/.docker/"
+        - name: "DOCKER_CONFIG"
+          value: "/builder/home/.docker/"
       command:
         - /kaniko/executor
       args:


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`