### PR TITLE
Propagate annotations from Pipeline/Task to PipelineRun/TaskRun

### DIFF
--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -270,6 +270,16 @@ func PipelineRunLabel(key, value string) PipelineRunOp {
 	}
 }
 
+// PipelineRunAnnotations adds a annotation to the PipelineRun.
+func PipelineRunAnnotation(key, value string) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		if pr.ObjectMeta.Annotations == nil {
+			pr.ObjectMeta.Annotations = map[string]string{}
+		}
+		pr.ObjectMeta.Annotations[key] = value
+	}
+}
+
 // PipelineRunResourceBinding adds bindings from actual instances to a Pipeline's declared resources.
 func PipelineRunResourceBinding(name string, ops ...PipelineResourceBindingOp) PipelineRunSpecOp {
 	return func(prs *v1alpha1.PipelineRunSpec) {

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -266,8 +266,9 @@ func ParamDefault(value string) TaskParamOp {
 func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
 	tr := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: map[string]string{},
 		},
 	}
 
@@ -392,6 +393,15 @@ func TaskRunLabel(key, value string) TaskRunOp {
 			tr.ObjectMeta.Labels = map[string]string{}
 		}
 		tr.ObjectMeta.Labels[key] = value
+	}
+}
+
+func TaskRunAnnotation(key, value string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		if tr.ObjectMeta.Annotations == nil {
+			tr.ObjectMeta.Annotations = map[string]string{}
+		}
+		tr.ObjectMeta.Annotations[key] = value
 	}
 }
 

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -117,7 +117,7 @@ func TestClusterTask(t *testing.T) {
 	}
 }
 
-func TestTaskRunWitTaskRef(t *testing.T) {
+func TestTaskRunWithTaskRef(t *testing.T) {
 	var trueB = true
 	taskRun := tb.TaskRun("test-taskrun", "foo",
 		tb.TaskRunOwnerReference("PipelineRun", "test",
@@ -164,7 +164,8 @@ func TestTaskRunWitTaskRef(t *testing.T) {
 				Controller:         &trueB,
 				BlockOwnerDeletion: &trueB,
 			}},
-			Labels: map[string]string{"label": "label-value"},
+			Labels:      map[string]string{"label": "label-value"},
+			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.TaskRunSpec{
 			Inputs: v1alpha1.TaskRunInputs{
@@ -223,6 +224,7 @@ func TestTaskRunWithTaskSpec(t *testing.T) {
 	expectedTaskRun := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-taskrun", Namespace: "foo",
+			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.TaskRunSpec{
 			TaskSpec: &v1alpha1.TaskSpec{


### PR DESCRIPTION
With this change, annotations are propagated from Pipeline and Task to
PipelineRun and TaskRun, respectively, giving us full annotation propagation
from Pipeline to PipelineRun to TaskRun to Pod and Task to TaskRun to
Pod.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

`s/label/annotation/g`: https://github.com/tektoncd/pipeline/commit/69ade033a723da3cae044862dddd7e844ce5f09d 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Annotations are now propagated from Pipeline/Task to PipelineRun/TaskRun identically to labels.
```
