### PR TITLE
Skip TestStorageTaskRun if GCP_SERVICE_ACCOUNT_KEY_PAT is not defined

### DIFF
--- a/test/gcs_taskrun_test.go
+++ b/test/gcs_taskrun_test.go
@@ -30,6 +30,10 @@ import (
 // - places files in expected place
 
 func TestStorageTaskRun(t *testing.T) {
+	configFilePath := os.Getenv("GCP_SERVICE_ACCOUNT_KEY_PATH")
+	if configFilePath == "" {
+		t.Skip("GCP_SERVICE_ACCOUNT_KEY_PATH variable is not set.")
+	}
 	t.Parallel()
 
 	c, namespace := setup(t)
@@ -43,8 +47,7 @@ func TestStorageTaskRun(t *testing.T) {
 	}
 
 	resName := "gcs-resource"
-	configFile := os.Getenv("GCP_SERVICE_ACCOUNT_KEY_PATH")
-	if _, err := c.PipelineResourceClient.Create(getResources(namespace, resName, secretName, configFile)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getResources(namespace, resName, secretName, configFilePath)); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", resName, err)
 	}
 


### PR DESCRIPTION
# Changes

This fails locally or under system that do not use/connect to GCP. We
are already doing this check on another test 👼

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [.] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
