### PR TITLE
Format markdown

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -108,10 +108,9 @@ The PVC option can be configured using a ConfigMap with the name
 `config-artifact-pvc` and the following attributes:
 
 - size: the size of the volume (5Gi by default)
- 
-The GCS storage bucket can be configured
-using a ConfigMap with the name `config-artifact-bucket` with
-the following attributes:
+
+The GCS storage bucket can be configured using a ConfigMap with the name
+`config-artifact-bucket` with the following attributes:
 
 - location: the address of the bucket (for example gs://mybucket)
 - bucket.service.account.secret.name: the name of the secret that will contain

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -114,10 +114,9 @@ In more common scenarios, a Task needs multiple steps with input and output
 resources to process. For example a Task could fetch source code from a GitHub
 repository and build a Docker image from it.
 
-[`PipelineResources`](resources.md) are used to define the artifacts that can
-be passed in and out of a task. There are a few system defined resource types
-ready to use, and the following are two examples of the resources commonly
-needed.
+[`PipelineResources`](resources.md) are used to define the artifacts that can be
+passed in and out of a task. There are a few system defined resource types ready
+to use, and the following are two examples of the resources commonly needed.
 
 The [`git` resource](resources.md#git-resource) represents a git repository with
 a specific revision:


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`