### PR TITLE
Use tetkoncd build-base base image for the release

### DIFF
--- a/.ko.yaml.release
+++ b/.ko.yaml.release
@@ -1,7 +1,6 @@
 baseImageOverrides:
-  # TODO(christiewilson): Use our built base image
-  github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/knative-release/github.com/knative/build/build-base:latest
-  github.com/tektoncd/pipeline/cmd/git-init: gcr.io/knative-release/github.com/knative/build/build-base:latest
+  github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tektoncd-release/github.com/tektoncd/pipeline/build-base:latest
+  github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tektoncd-release/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/bash: busybox # image should have shell in $PATH
   github.com/tektoncd/pipeline/cmd/entrypoint: busybox # image should have shell in $PATH
   github.com/tektoncd/pipeline/cmd/gsutil: google/cloud-sdk:alpine # image should have gsutil in $PATH


### PR DESCRIPTION
# Changes

Those images are built and published during the release, so let's use
them. We'll do the same for `.ko.yaml` shortly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
creds-init and git-init images are now using tektoncd/pipeline/build-base image as base instead of knative/build/build-base
```
