### PR TITLE
Fix stale link in release docs + remove `hack` dir OWNERS 🗎

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,9 +1,0 @@
-# The OWNERS file is used by prow to automatically merge approved PRs.
-
-approvers:
-- adrcunha
-- dushyanthsc
-- ericKlawitter
-- jessiezcc
-- srinivashegde86
-- steuhs

--- a/hack/README.md
+++ b/hack/README.md
@@ -3,8 +3,8 @@
 This directory contains several scripts useful in the development process of
 Tekton Pipelines.
 
-- `release.sh` Creates a new [release](release.md) of Knative Build Pipeline.
-- `update-codegen.sh` Updates auto-generated client libraries.
-- `update-deps.sh` Updates Go dependencies.
-- `verify-codegen.sh` Verifies that auto-generated client libraries are
+- [`update-codegen.sh`](./update-codegen.sh): Updates auto-generated client libraries.
+- [`update-deps.sh`](./update-deps.sh): Updates Go dependencies.
+- [`verify-codegen.sh`](./verify-codegen.sh): Verifies that auto-generated client libraries are
   up-to-date.
+- Release docs have been moved to [the top-level `tekton` dir](../tekton)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

1. Update docs to indicate release script has moved 🗎: The release script has been replaced with Tekton Tasks in the tekton dir.
2. Remove OWNERS file from `hack` dir:  In #257 we made the knative productivity working group owners of the hack dir in order to make it easier for them to propagate changes across all the knative repos that they worked on. Since then the project has moved out of the `knative` org and also the scope of this dir has decreased (for example release scripts no longer live here, we now have Tekton tasks for these).

Fixes #826 FINALLY :sweat_smile: 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._