### PR TITLE
Format markdown

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -3,8 +3,9 @@
 This directory contains several scripts useful in the development process of
 Tekton Pipelines.
 
-- [`update-codegen.sh`](./update-codegen.sh): Updates auto-generated client libraries.
+- [`update-codegen.sh`](./update-codegen.sh): Updates auto-generated client
+  libraries.
 - [`update-deps.sh`](./update-deps.sh): Updates Go dependencies.
-- [`verify-codegen.sh`](./verify-codegen.sh): Verifies that auto-generated client libraries are
-  up-to-date.
+- [`verify-codegen.sh`](./verify-codegen.sh): Verifies that auto-generated
+  client libraries are up-to-date.
 - Release docs have been moved to [the top-level `tekton` dir](../tekton)

--- a/test/README.md
+++ b/test/README.md
@@ -181,9 +181,8 @@ against, i.e. override
 go test -v -tags=e2e -count=1 ./test --kubeconfig ~/special/kubeconfig --cluster myspecialcluster
 ```
 
-Tests importing
-[`github.com/tektoncd/pipeline/test`](#adding-integration-tests) recognize
-the
+Tests importing [`github.com/tektoncd/pipeline/test`](#adding-integration-tests)
+recognize the
 [flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags).
 
 ### One test case


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`