### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,7 +104,8 @@ To setup a cluster with GKE:
    (You may find it useful to save the ID of the project in an environment
    variable (e.g. `PROJECT_ID`).
 
-1. Create a GKE cluster (with `--cluster-version=latest` but you can use any version 1.11 or later):
+1. Create a GKE cluster (with `--cluster-version=latest` but you can use any
+   version 1.11 or later):
 
    ```bash
    export PROJECT_ID=my-gcp-project
@@ -127,8 +128,8 @@ To setup a cluster with GKE:
 
    Note that
    [the `--scopes` argument to `gcloud container cluster create`](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--scopes)
-   controls what GCP resources the cluster's default service account has access to;
-   for example to give the default service account full access to your GCR
+   controls what GCP resources the cluster's default service account has access
+   to; for example to give the default service account full access to your GCR
    registry, you can add `storage-full` to your `--scopes` arg.
 
 1. Grant cluster-admin permissions to the current user:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -212,7 +212,7 @@ Input resources, like source code (git) or artifacts, are dumped at path
 [volume](https://kubernetes.io/docs/concepts/storage/volumes/) and is available
 to all [`steps`](#steps) of your `Task`. The path that the resources are mounted
 at can be overridden with the `targetPath` value. Steps can use the `path`
- [template](#Templating) key to refer to the local path to the mounted resource.
+[template](#Templating) key to refer to the local path to the mounted resource.
 
 ### Outputs
 


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`