### PR TITLE
Add docs on how to access Run logs 🗎

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -14,7 +14,7 @@
 1. [Set up a docker repository you can push to](https://github.com/knative/serving/blob/master/docs/setting-up-a-docker-registry.md)
 
 Then you can [iterate](#iterating) (including
-[runing the controllers with `ko`](#install-pipeline)).
+[running the controllers with `ko`](#install-pipeline)).
 
 ### Ramp up
 
@@ -270,6 +270,9 @@ To look at the webhook logs, run:
 ```shell
 kubectl -n tekton-pipelines logs $(kubectl -n tekton-pipelines get pods -l app=tekton-pipelines-webhook -o name)
 ```
+
+To look at the logs for individual `TaskRuns` or `PipelineRuns`, see
+[docs on accessing logs](docs/logs.md).
 
 ## Adding new types
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ High level details of this design:
 - [How do I control auth?](auth.md)
 - [How do I run a Pipeline?](pipelineruns.md)
 - [How do I run a Task on its own?](taskruns.md)
+- [How do I get logs?](logs.md)
 
 ## Learn more
 
@@ -49,6 +50,7 @@ components:
 Additional reference topics not related to a specific component:
 
 - [Labels](labels.md)
+- [Logs](logs.md)
 
 ## Try it out
 

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,0 +1,32 @@
+# Logs
+
+Logs for [`PipelineRuns`](pipelineruns.md) and [`TaskRuns`](taskruns.md) are
+associated with the underlying pod.
+
+_In [#107](https://github.com/tektoncd/pipeline/issues/107)
+we will add a solution to persist logs outside of your kubernetes cluster._
+
+To access these logs currently you have a few options:
+
+* [You can get the logs from the pod](https://kubernetes.io/docs/reference/kubectl/cheatsheet/#interacting-with-running-pods)
+  e.g. using `kubectl`:
+
+  ```bash
+  # Get the name of the pod from the instance of the TaskRun
+  kubectl get taskruns -o yaml | grep podName
+
+  # Or get the pod name from the PipelineRun
+  kubectl get pipelineruns -o yaml | grep podName
+
+  # Use kubectl to access the logs for all containers in the pod
+  kubectl logs $POD_NAME --all-containers
+
+  # Or get the logs from a specific container in the pod
+  kubectl logs $POD_NAME -c $CONTAINER_NAME
+  kubectl logs $POD_NAME -c step-run-kubectl
+  ```
+
+* You can use [the `tkn` cli tool](https://github.com/tektoncd/cli) to access logs
+* You can use [the dashboard web interface](https://github.com/tektoncd/dashboard) to access logs
+* You can setup an external service to consume and display logs, for example
+  [Elasticsearch, Beats and Kibana](https://github.com/mgreau/tekton-pipelines-elastic-tutorials)

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -16,6 +16,7 @@ Creation of a `PipelineRun` will trigger the creation of
   - [Service account](#service-account)
 - [Cancelling a PipelineRun](#cancelling-a-pipelinerun)
 - [Examples](#examples)
+- [Logs](logs.md)
 
 ## Syntax
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -19,6 +19,7 @@ A `TaskRun` runs until all `steps` have completed or until a failure occurs.
   - [Service Account](#service-account)
 - [Cancelling a TaskRun](#cancelling-a-taskrun)
 - [Examples](#examples)
+- [Logs](logs.md)
 
 ---
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -583,6 +583,7 @@ Tekton Pipelines is known to work with:
 
 - Logs can remain in-memory only as opposed to sent to a service such as
   [Stackdriver](https://cloud.google.com/logging/).
+- See [docs on getting logs from Runs](logs.md)
 
 Elasticsearch, Beats and Kibana can be deployed locally as a means to view logs:
 an example is provided at


### PR DESCRIPTION
# Changes

As @cmoulliard pointed out, it's not obvious how to get to the logs for
a PipelineRun or a TaskRun. If you know how the underlying kubernetes
resources work you can figure it out but it can be hard to know where to
start. Plus, folks may not realize that we are working on better ways of
accessing logs.

And once we work on #107 we can build up these docs with more detail
about how to upload logs too.

Fixes #898
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
