### PR TITLE
Graceful sidecar support

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -29,22 +29,26 @@ import (
 )
 
 var (
-	ep       = flag.String("entrypoint", "", "Original specified entrypoint to execute")
-	waitFile = flag.String("wait_file", "", "If specified, file to wait for")
-	postFile = flag.String("post_file", "", "If specified, file to write upon completion")
+	ep              = flag.String("entrypoint", "", "Original specified entrypoint to execute")
+	waitFile        = flag.String("wait_file", "", "If specified, file to wait for")
+	waitFileContent = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
+	postFile        = flag.String("post_file", "", "If specified, file to write upon completion")
+
+	waitPollingInterval = time.Second
 )
 
 func main() {
 	flag.Parse()
 
 	e := entrypoint.Entrypointer{
-		Entrypoint: *ep,
-		WaitFile:   *waitFile,
-		PostFile:   *postFile,
-		Args:       flag.Args(),
-		Waiter:     &RealWaiter{},
-		Runner:     &RealRunner{},
-		PostWriter: &RealPostWriter{},
+		Entrypoint:      *ep,
+		WaitFile:        *waitFile,
+		WaitFileContent: *waitFileContent,
+		PostFile:        *postFile,
+		Args:            flag.Args(),
+		Waiter:          &RealWaiter{},
+		Runner:          &RealRunner{},
+		PostWriter:      &RealPostWriter{},
 	}
 	if err := e.Go(); err != nil {
 		switch err.(type) {
@@ -75,18 +79,27 @@ type RealWaiter struct{}
 
 var _ entrypoint.Waiter = (*RealWaiter)(nil)
 
-func (*RealWaiter) Wait(file string) error {
+// Wait watches a file and returns when either a) the file exists and, if
+// the expectContent argument is true, the file has non-zero size or b) there
+// is an error polling the file.
+//
+// If the passed-in file is an empty string then this function returns
+// immediately.
+//
+// If a file of the same name with a ".err" extension exists then this Wait
+// will end with a skipError.
+func (*RealWaiter) Wait(file string, expectContent bool) error {
 	if file == "" {
 		return nil
 	}
-	for ; ; time.Sleep(time.Second) {
-		// Watch for the post file
-		if _, err := os.Stat(file); err == nil {
-			return nil
+	for ; ; time.Sleep(waitPollingInterval) {
+		if info, err := os.Stat(file); err == nil {
+			if !expectContent || info.Size() > 0 {
+				return nil
+			}
 		} else if !os.IsNotExist(err) {
 			return xerrors.Errorf("Waiting for %q: %w", file, err)
 		}
-		// Watch for the post error file
 		if _, err := os.Stat(file + ".err"); err == nil {
 			return skipError("error file present, bail and skip the step")
 		}

--- a/cmd/entrypoint/main_test.go
+++ b/cmd/entrypoint/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestRealWaiterWaitMissingFile(t *testing.T) {
+	// Create a temp file and then immediately delete it to get
+	// a legitimate tmp path and ensure the file doesnt exist
+	// prior to testing Wait().
+	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	os.Remove(tmp.Name())
+	rw := RealWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		err := rw.Wait(tmp.Name(), false)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		t.Errorf("did not expect Wait() to have detected a file at path %q", tmp.Name())
+	case <-time.After(2 * waitPollingInterval):
+		// Success
+	}
+}
+
+func TestRealWaiterWaitWithFile(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	rw := RealWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		err := rw.Wait(tmp.Name(), false)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		// Success
+	case <-time.After(2 * waitPollingInterval):
+		t.Errorf("expected Wait() to have detected the file's existence by now")
+	}
+}
+
+func TestRealWaiterWaitMissingContent(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	rw := RealWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		err := rw.Wait(tmp.Name(), true)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+		t.Errorf("no data was written to tmp file, did not expect Wait() to have detected a non-zero file size and returned")
+	case <-time.After(2 * waitPollingInterval):
+		// Success
+	}
+}
+
+func TestRealWaiterWaitWithContent(t *testing.T) {
+	tmp, err := ioutil.TempFile("", "real_waiter_test_file")
+	if err != nil {
+		t.Errorf("error creating temp file: %v", err)
+	}
+	defer os.Remove(tmp.Name())
+	rw := RealWaiter{}
+	doneCh := make(chan struct{})
+	go func() {
+		err := rw.Wait(tmp.Name(), true)
+		if err != nil {
+			t.Errorf("error waiting on tmp file %q", tmp.Name())
+		}
+		close(doneCh)
+	}()
+	if err := ioutil.WriteFile(tmp.Name(), []byte("😺"), 0700); err != nil {
+		t.Errorf("error writing content to temp file: %v", err)
+	}
+	select {
+	case <-doneCh:
+		// Success
+	case <-time.After(2 * waitPollingInterval):
+		t.Errorf("expected Wait() to have detected a non-zero file size by now")
+	}
+}

--- a/cmd/nop/main.go
+++ b/cmd/nop/main.go
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// The nop command is a no-op, it simply prints a message and exits. Nop
+// is used to stop sidecar containers in TaskRun Pods. When a Task's Steps
+// are complete any sidecars running alongside the Step containers need
+// to be terminated. Whatever image the sidecars are running is replaced
+// with nop and the sidecar quickly exits.
+
 package main
 
 import "fmt"

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -20,6 +20,7 @@ A `TaskRun` runs until all `steps` have completed or until a failure occurs.
 - [Steps](#steps)
 - [Cancelling a TaskRun](#cancelling-a-taskrun)
 - [Examples](#examples)
+- [Sidecars](#sidecars)
 - [Logs](logs.md)
 
 ---
@@ -543,6 +544,29 @@ of the `Task` resource object.
 
 For examples and more information about specifying service accounts, see the
 [`ServiceAccount`](./auth.md) reference topic.
+
+## Sidecars
+
+A well-established pattern in Kubernetes is that of the "sidecar" - a
+container which runs alongside your workloads to provide ancillary support.
+Typical examples of the sidecar pattern are logging daemons, services to
+update files on a shared volume, and network proxies.
+
+Tekton doesn't provide a mechanism to specify sidecars for Task steps
+but it's still possible for sidecars to be added to your Pods:
+[Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)
+provide cluster admins a mechanism to inject sidecar containers as Pods launch.
+As a concrete example this is one possible method [used by Istio](https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#automatic-sidecar-injection)
+to inject an envoy proxy in to pods so that they can be included as part of
+Istio's service mesh.
+
+Tekton will happily work with sidecars injected into a TaskRun's
+pods but the behaviour is a bit nuanced: When TaskRun's steps are complete
+any sidecar containers running inside the Pod will be terminated. In
+order to terminate the sidecars they will be restarted with a new
+"nop" image that quickly exits. The result will be that your TaskRun's
+Pod will include the sidecar container with a Retry Count of 1 and
+with a different container image than you might be expecting.
 
 ---
 

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -30,6 +30,9 @@ type Entrypointer struct {
 	// WaitFile is the file to wait for. If not specified, execution begins
 	// immediately.
 	WaitFile string
+	// WaitFileContent indicates the WaitFile should have non-zero size
+	// before continuing with execution.
+	WaitFileContent bool
 	// PostFile is the file to write when complete. If not specified, no
 	// file is written.
 	PostFile string
@@ -45,7 +48,7 @@ type Entrypointer struct {
 // Waiter encapsulates waiting for files to exist.
 type Waiter interface {
 	// Wait blocks until the specified file exists.
-	Wait(file string) error
+	Wait(file string, expectContent bool) error
 }
 
 // Runner encapsulates running commands.
@@ -63,7 +66,7 @@ type PostWriter interface {
 // post file.
 func (e Entrypointer) Go() error {
 	if e.WaitFile != "" {
-		if err := e.Waiter.Wait(e.WaitFile); err != nil {
+		if err := e.Waiter.Wait(e.WaitFile, e.WaitFileContent); err != nil {
 			// An error happened while waiting, so we bail
 			// *but* we write postfile to make next steps bail too
 			e.WritePostFile(e.PostFile, err)

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -175,7 +175,7 @@ func TestEntrypointer(t *testing.T) {
 
 type fakeWaiter struct{ waited *string }
 
-func (f *fakeWaiter) Wait(file string) error {
+func (f *fakeWaiter) Wait(file string, expectContent bool) error {
 	f.waited = &file
 	return nil
 }
@@ -193,7 +193,7 @@ func (f *fakePostWriter) Write(file string) { f.wrote = &file }
 
 type fakeErrorWaiter struct{ waited *string }
 
-func (f *fakeErrorWaiter) Wait(file string) error {
+func (f *fakeErrorWaiter) Wait(file string, expectContent bool) error {
 	f.waited = &file
 	return xerrors.New("waiter failed")
 }

--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint.go
@@ -37,17 +37,24 @@ import (
 const (
 	// MountName is the name of the pvc being mounted (which
 	// will contain the entrypoint binary and eventually the logs)
-	MountName         = "tools"
-	MountPoint        = "/builder/tools"
-	BinaryLocation    = MountPoint + "/entrypoint"
-	JSONConfigEnvVar  = "ENTRYPOINT_OPTIONS"
-	InitContainerName = "place-tools"
-	cacheSize         = 1024
+	MountName              = "tools"
+	MountPoint             = "/builder/tools"
+	DownwardMountName      = "downward"
+	DownwardMountPoint     = "/builder/downward"
+	DownwardMountReadyFile = "ready"
+	BinaryLocation         = MountPoint + "/entrypoint"
+	JSONConfigEnvVar       = "ENTRYPOINT_OPTIONS"
+	InitContainerName      = "place-tools"
+	cacheSize              = 1024
 )
 
 var toolsMount = corev1.VolumeMount{
 	Name:      MountName,
 	MountPath: MountPoint,
+}
+var downwardMount = corev1.VolumeMount{
+	Name:      DownwardMountName,
+	MountPath: DownwardMountPoint,
 }
 var (
 	entrypointImage = flag.String("entrypoint-image", "override-with-entrypoint:latest",
@@ -135,16 +142,19 @@ func RedirectStep(cache *Cache, stepNum int, step *corev1.Container, kubeclient 
 	step.Args = GetArgs(stepNum, step.Command, step.Args)
 	step.Command = []string{BinaryLocation}
 	step.VolumeMounts = append(step.VolumeMounts, toolsMount)
+	// The first step in a Task waits for the existence of a file projected into the Pod
+	// from the Downward API. That file will be populated only when all sidecars are ready,
+	// thereby ensuring that steps don't start executing while helper sidecars are still pending.
+	if stepNum == 0 {
+		step.VolumeMounts = append(step.VolumeMounts, downwardMount)
+	}
 	return nil
 }
 
 // GetArgs returns the arguments that should be specified for the step which has been wrapped
 // such that it will execute our custom entrypoint instead of the user provided Command and Args.
 func GetArgs(stepNum int, commands, args []string) []string {
-	waitFile := fmt.Sprintf("%s/%s", MountPoint, strconv.Itoa(stepNum-1))
-	if stepNum == 0 {
-		waitFile = ""
-	}
+	waitFile := getWaitFile(stepNum)
 	// The binary we want to run must be separated from its arguments by --
 	// so if commands has more than one value, we'll move the other values
 	// into the arg list so we can separate them
@@ -152,15 +162,26 @@ func GetArgs(stepNum int, commands, args []string) []string {
 		args = append(commands[1:], args...)
 		commands = commands[:1]
 	}
-	argsForEntrypoint := append([]string{
+	argsForEntrypoint := []string{
 		"-wait_file", waitFile,
-		"-post_file", fmt.Sprintf("%s/%s", MountPoint, strconv.Itoa(stepNum)),
-		"-entrypoint"},
-		commands...,
-	)
+		"-post_file", getWaitFile(stepNum + 1),
+	}
+	if stepNum == 0 {
+		argsForEntrypoint = append(argsForEntrypoint, "-wait_file_content")
+	}
+	argsForEntrypoint = append(argsForEntrypoint, "-entrypoint")
+	argsForEntrypoint = append(argsForEntrypoint, commands...)
 	// TODO: what if Command has multiple elements, do we need "--" between command and args?
 	argsForEntrypoint = append(argsForEntrypoint, "--")
 	return append(argsForEntrypoint, args...)
+}
+
+func getWaitFile(stepNum int) string {
+	if stepNum == 0 {
+		return fmt.Sprintf("%s/%s", DownwardMountPoint, DownwardMountReadyFile)
+	}
+
+	return fmt.Sprintf("%s/%s", MountPoint, strconv.Itoa(stepNum-1))
 }
 
 // GetRemoteEntrypoint accepts a cache of digest lookups, as well as the digest

--- a/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/entrypoint/entrypoint_test.go
@@ -93,8 +93,9 @@ func TestGetArgs(t *testing.T) {
 		commands: []string{"echo"},
 		args:     []string{"hello", "world"},
 		expectedArgs: []string{
-			"-wait_file", "",
+			"-wait_file", "/builder/downward/ready",
 			"-post_file", "/builder/tools/0",
+			"-wait_file_content",
 			"-entrypoint", "echo",
 			"--",
 			"hello", "world",

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -41,16 +41,6 @@ var (
 	resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0
 	})
-	nopContainer = corev1.Container{
-		Name:    "nop",
-		Image:   *nopImage,
-		Command: []string{"/builder/tools/entrypoint"},
-		Args:    []string{"-wait_file", "/builder/tools/0", "-post_file", "/builder/tools/1", "-entrypoint", "/ko-app/nop", "--"},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      entrypoint.MountName,
-			MountPath: entrypoint.MountPoint,
-		}},
-	}
 )
 
 func TestTryGetPod(t *testing.T) {
@@ -173,7 +163,6 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			},
-				nopContainer,
 			},
 			Volumes: implicitVolumes,
 		},
@@ -219,7 +208,6 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			},
-				nopContainer,
 			},
 			Volumes: implicitVolumesWithSecrets,
 		},
@@ -259,7 +247,6 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			},
-				nopContainer,
 			},
 			Volumes: implicitVolumes,
 		},
@@ -299,7 +286,6 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			},
-				nopContainer,
 			},
 			Volumes: implicitVolumes,
 		},
@@ -345,7 +331,6 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			},
-				nopContainer,
 			},
 			Volumes: implicitVolumes,
 		},
@@ -397,7 +382,7 @@ func TestMakePod(t *testing.T) {
 				t.Errorf("Diff spec:\n%s", d)
 			}
 
-			wantAnnotations := map[string]string{"sidecar.istio.io/inject": "false"}
+			wantAnnotations := map[string]string{ReadyAnnotation: ""}
 			if c.bAnnotations != nil {
 				for key, val := range c.bAnnotations {
 					wantAnnotations[key] = val
@@ -431,6 +416,96 @@ func TestMakeWorkingDirScript(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			if script := makeWorkingDirScript(c.workingDirs); script != c.want {
 				t.Errorf("Expected `%v`, got `%v`", c.want, script)
+			}
+		})
+	}
+}
+
+func TestAddReadyAnnotation(t *testing.T) {
+	type testcase struct {
+		desc       string
+		pod        *corev1.Pod
+		updateFunc UpdatePod
+	}
+	for _, c := range []testcase{{
+		desc:       "missing ready annotation is added to provided pod",
+		pod:        &corev1.Pod{},
+		updateFunc: func(p *corev1.Pod) (*corev1.Pod, error) { return p, nil },
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			err := AddReadyAnnotation(c.pod, c.updateFunc)
+			if err != nil {
+				t.Errorf("error received: %v", err)
+			}
+			if v := c.pod.ObjectMeta.Annotations[ReadyAnnotation]; v != readyAnnotationValue {
+				t.Errorf("Annotation %q=%q missing from Pod", ReadyAnnotation, readyAnnotationValue)
+			}
+		})
+	}
+}
+
+func TestAddReadyAnnotationUpdateError(t *testing.T) {
+	type testcase struct {
+		desc       string
+		pod        *corev1.Pod
+		updateFunc UpdatePod
+	}
+	testerror := xerrors.New("error updating pod")
+	for _, c := range []testcase{{
+		desc:       "errors experienced during update are returned",
+		pod:        &corev1.Pod{},
+		updateFunc: func(p *corev1.Pod) (*corev1.Pod, error) { return p, testerror },
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			err := AddReadyAnnotation(c.pod, c.updateFunc)
+			if err != testerror {
+				t.Errorf("expected %v received %v", testerror, err)
+			}
+		})
+	}
+}
+
+func TestMakeAnnotations(t *testing.T) {
+	type testcase struct {
+		desc                     string
+		taskRun                  *v1alpha1.TaskRun
+		expectedAnnotationSubset map[string]string
+	}
+	for _, c := range []testcase{
+		{
+			desc: "a taskruns annotations are copied to the pod",
+			taskRun: &v1alpha1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "a-taskrun",
+					Annotations: map[string]string{
+						"foo": "bar",
+						"baz": "quux",
+					},
+				},
+			},
+			expectedAnnotationSubset: map[string]string{
+				"foo": "bar",
+				"baz": "quux",
+			},
+		},
+		{
+			desc:    "initial pod annotations contain the ReadyAnnotation to pause steps until sidecars are ready",
+			taskRun: &v1alpha1.TaskRun{},
+			expectedAnnotationSubset: map[string]string{
+				ReadyAnnotation: "",
+			},
+		},
+	} {
+		t.Run(c.desc, func(t *testing.T) {
+			annos := makeAnnotations(c.taskRun)
+			for k, v := range c.expectedAnnotationSubset {
+				receivedValue, ok := annos[k]
+				if !ok {
+					t.Errorf("expected annotation %q was missing", k)
+				}
+				if receivedValue != v {
+					t.Errorf("expected annotation %q=%q, received %q=%q", k, v, k, receivedValue)
+				}
 			}
 		})
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/sidecars/stop.go
+++ b/pkg/reconciler/v1alpha1/taskrun/sidecars/stop.go
@@ -1,0 +1,46 @@
+package sidecars
+
+import (
+	"flag"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	nopImage = flag.String("nop-image", "override-with-nop:latest", "The container image used to kill sidecars")
+)
+
+type GetPod func(string, metav1.GetOptions) (*corev1.Pod, error)
+type UpdatePod func(*corev1.Pod) (*corev1.Pod, error)
+
+// Stop stops all sidecar containers inside a pod. A container is considered
+// to be a sidecar if it is currently running. This func is only expected to
+// be called after a TaskRun completes and all Step containers Step containers
+// have already stopped.
+//
+// A sidecar is killed by replacing its current container image with the nop
+// image, which in turn quickly exits. If the sidedcar defines a command then
+// it will exit with a non-zero status. When we check for TaskRun success we
+// have to check for the containers we care about - not the final Pod status.
+func Stop(pod *corev1.Pod, updatePod UpdatePod) error {
+	updated := false
+	if pod.Status.Phase == corev1.PodRunning {
+		for _, s := range pod.Status.ContainerStatuses {
+			if s.State.Running != nil {
+				for j, c := range pod.Spec.Containers {
+					if c.Name == s.Name && c.Image != *nopImage {
+						updated = true
+						pod.Spec.Containers[j].Image = *nopImage
+					}
+				}
+			}
+		}
+	}
+	if updated {
+		if _, err := updatePod(pod); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/v1alpha1/taskrun/sidecars/stop_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/sidecars/stop_test.go
@@ -1,0 +1,102 @@
+package sidecars
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestStop exercises the Stop() method of the sidecars package.
+// A sidecar is killed by having its container image changed to that of the nop image.
+// This test therefore runs through a series of pod and sidecar configurations,
+// checking whether the resulting image in the sidecar's container matches that expected.
+func TestStop(t *testing.T) {
+	testcases := []struct {
+		description      string
+		podPhase         corev1.PodPhase
+		sidecarContainer corev1.Container
+		sidecarState     corev1.ContainerState
+		expectedImage    string
+	}{{
+		description: "a running sidecar container should be stopped",
+		podPhase:    corev1.PodRunning,
+		sidecarContainer: corev1.Container{
+			Name:    "echo-hello",
+			Image:   "echo-hello:latest",
+			Command: []string{"echo"},
+			Args:    []string{"hello"},
+		},
+		sidecarState: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())},
+		},
+		expectedImage: *nopImage,
+	}, {
+		description: "a pending pod should not have its sidecars stopped",
+		podPhase:    corev1.PodPending,
+		sidecarContainer: corev1.Container{
+			Name:    "echo-hello",
+			Image:   "echo-hello:latest",
+			Command: []string{"echo"},
+			Args:    []string{"hello"},
+		},
+		sidecarState: corev1.ContainerState{
+			Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())},
+		},
+		expectedImage: "echo-hello:latest",
+	}, {
+		description: "a sidecar container that is not in a running state should not be stopped",
+		podPhase:    corev1.PodRunning,
+		sidecarContainer: corev1.Container{
+			Name:    "echo-hello",
+			Image:   "echo-hello:latest",
+			Command: []string{"echo"},
+			Args:    []string{"hello"},
+		},
+		sidecarState: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{},
+		},
+		expectedImage: "echo-hello:latest",
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test_pod",
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:  corev1.RestartPolicyNever,
+					InitContainers: nil,
+					Containers: []corev1.Container{
+						{
+							Name:    "test-task-step",
+							Image:   "test-task-step:latest",
+							Command: []string{"test"},
+						},
+						tc.sidecarContainer,
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: tc.podPhase,
+					ContainerStatuses: []corev1.ContainerStatus{
+						corev1.ContainerStatus{},
+						corev1.ContainerStatus{
+							Name:  tc.sidecarContainer.Name,
+							State: tc.sidecarState,
+						},
+					},
+				},
+			}
+			updatePod := func(p *corev1.Pod) (*corev1.Pod, error) { return nil, nil }
+			if err := Stop(pod, updatePod); err != nil {
+				t.Errorf("error stopping sidecar: %v", err)
+			}
+			sidecarIdx := len(pod.Spec.Containers) - 1
+			if pod.Spec.Containers[sidecarIdx].Image != tc.expectedImage {
+				t.Errorf("expected sidecar image %q, actual: %q", tc.expectedImage, pod.Spec.Containers[sidecarIdx].Image)
+			}
+		})
+	}
+}

--- a/pkg/status/taskrunpod.go
+++ b/pkg/status/taskrunpod.go
@@ -1,0 +1,192 @@
+package status
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/v1alpha1/taskrun/resources"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// UpdateStatusFromPod modifies the task run status based on the pod and then returns true if the pod is running and
+// all sidecars are ready
+func UpdateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod, resourceLister listers.PipelineResourceLister, kubeclient kubernetes.Interface, logger *zap.SugaredLogger) bool {
+	if taskRun.Status.GetCondition(apis.ConditionSucceeded) == nil || taskRun.Status.GetCondition(apis.ConditionSucceeded).Status == corev1.ConditionUnknown {
+		// If the taskRunStatus doesn't exist yet, it's because we just started running
+		taskRun.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  ReasonRunning,
+			Message: ReasonRunning,
+		})
+	}
+
+	taskRun.Status.PodName = pod.Name
+
+	taskRun.Status.Steps = []v1alpha1.StepState{}
+	for _, s := range pod.Status.ContainerStatuses {
+		if resources.IsContainerStep(s.Name) {
+			taskRun.Status.Steps = append(taskRun.Status.Steps, v1alpha1.StepState{
+				ContainerState: *s.State.DeepCopy(),
+				Name:           resources.TrimContainerNamePrefix(s.Name),
+			})
+		}
+	}
+
+	// Complete if we did not find a step that is not complete, or the pod is in a definitely complete phase
+	complete := areStepsComplete(pod) || pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+
+	if complete {
+		updateCompletedTaskRun(taskRun, pod)
+	} else {
+		updateIncompleteTaskRun(taskRun, pod)
+	}
+
+	sidecarsCount, readySidecarsCount := countSidecars(pod)
+	return pod.Status.Phase == corev1.PodRunning && readySidecarsCount == sidecarsCount
+}
+
+func updateCompletedTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
+	if didTaskRunFail(pod) {
+		msg := getFailureMessage(pod)
+		taskRun.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Message: msg,
+		})
+	} else {
+		taskRun.Status.SetCondition(&apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		})
+	}
+	// update tr completed time
+	taskRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+}
+
+func updateIncompleteTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
+	switch pod.Status.Phase {
+	case corev1.PodRunning:
+		taskRun.Status.SetCondition(&apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
+			Reason: ReasonBuilding,
+		})
+	case corev1.PodPending:
+		var reason, msg string
+		if IsPodExceedingNodeResources(pod) {
+			reason = ReasonExceededNodeResources
+			msg = GetExceededResourcesMessage(taskRun)
+		} else {
+			reason = "Pending"
+			msg = GetWaitingMessage(pod)
+		}
+		taskRun.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  reason,
+			Message: msg,
+		})
+	}
+}
+
+func didTaskRunFail(pod *corev1.Pod) bool {
+	f := pod.Status.Phase == corev1.PodFailed
+	for _, s := range pod.Status.ContainerStatuses {
+		if resources.IsContainerStep(s.Name) {
+			if s.State.Terminated != nil {
+				f = f || s.State.Terminated.ExitCode != 0
+			}
+		}
+	}
+	return f
+}
+
+func areStepsComplete(pod *corev1.Pod) bool {
+	stepsComplete := len(pod.Status.ContainerStatuses) > 0 && pod.Status.Phase == corev1.PodRunning
+	for _, s := range pod.Status.ContainerStatuses {
+		if resources.IsContainerStep(s.Name) {
+			if s.State.Terminated == nil {
+				stepsComplete = false
+			}
+		}
+	}
+	return stepsComplete
+}
+
+func countSidecars(pod *corev1.Pod) (total int, ready int) {
+	for _, s := range pod.Status.ContainerStatuses {
+		if !resources.IsContainerStep(s.Name) {
+			if s.State.Running != nil && s.Ready {
+				ready++
+			}
+			total++
+		}
+	}
+	return total, ready
+}
+
+func getFailureMessage(pod *corev1.Pod) string {
+	// First, try to surface an error about the actual build step that failed.
+	for _, status := range pod.Status.ContainerStatuses {
+		term := status.State.Terminated
+		if term != nil && term.ExitCode != 0 {
+			return fmt.Sprintf("%q exited with code %d (image: %q); for logs run: kubectl -n %s logs %s -c %s",
+				status.Name, term.ExitCode, status.ImageID,
+				pod.Namespace, pod.Name, status.Name)
+		}
+	}
+	// Next, return the Pod's status message if it has one.
+	if pod.Status.Message != "" {
+		return pod.Status.Message
+	}
+	// Lastly fall back on a generic error message.
+	return "build failed for unspecified reasons."
+}
+
+func IsPodExceedingNodeResources(pod *corev1.Pod) bool {
+	for _, podStatus := range pod.Status.Conditions {
+		if podStatus.Reason == corev1.PodReasonUnschedulable && strings.Contains(podStatus.Message, "Insufficient") {
+			return true
+		}
+	}
+	return false
+}
+
+func GetExceededResourcesMessage(tr *v1alpha1.TaskRun) string {
+	return fmt.Sprintf("TaskRun pod %q exceeded available resources", tr.Name)
+}
+
+func GetWaitingMessage(pod *corev1.Pod) string {
+	// First, try to surface reason for pending/unknown about the actual build step.
+	for _, status := range pod.Status.ContainerStatuses {
+		wait := status.State.Waiting
+		if wait != nil && wait.Message != "" {
+			return fmt.Sprintf("build step %q is pending with reason %q",
+				status.Name, wait.Message)
+		}
+	}
+	// Try to surface underlying reason by inspecting pod's recent status if condition is not true
+	for i, podStatus := range pod.Status.Conditions {
+		if podStatus.Status != corev1.ConditionTrue {
+			return fmt.Sprintf("pod status %q:%q; message: %q",
+				pod.Status.Conditions[i].Type,
+				pod.Status.Conditions[i].Status,
+				pod.Status.Conditions[i].Message)
+		}
+	}
+	// Next, return the Pod's status message if it has one.
+	if pod.Status.Message != "" {
+		return pod.Status.Message
+	}
+
+	// Lastly fall back on a generic pending message.
+	return "Pending"
+}

--- a/pkg/status/taskrunpod_test.go
+++ b/pkg/status/taskrunpod_test.go
@@ -1,0 +1,422 @@
+package status
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
+	duckv1beta1 "github.com/knative/pkg/apis/duck/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	fakeclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
+	informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+var ignoreVolatileTime = cmp.Comparer(func(_, _ apis.VolatileTime) bool { return true })
+
+func TestUpdateStatusFromPod(t *testing.T) {
+	conditionRunning := apis.Condition{
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionUnknown,
+		Reason:  ReasonRunning,
+		Message: ReasonRunning,
+	}
+	conditionTrue := apis.Condition{
+		Type:   apis.ConditionSucceeded,
+		Status: corev1.ConditionTrue,
+	}
+	conditionBuilding := apis.Condition{
+		Type:   apis.ConditionSucceeded,
+		Status: corev1.ConditionUnknown,
+		Reason: ReasonBuilding,
+	}
+	for _, c := range []struct {
+		desc      string
+		podStatus corev1.PodStatus
+		want      v1alpha1.TaskRunStatus
+	}{{
+		desc:      "empty",
+		podStatus: corev1.PodStatus{},
+
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{conditionRunning},
+			},
+			Steps: []v1alpha1.StepState{},
+		},
+	}, {
+		desc: "ignore-creds-init",
+		podStatus: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				// creds-init; ignored
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-state-name",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 123,
+					},
+				},
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{conditionRunning},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 123,
+					}},
+				Name: "state-name",
+			}},
+		},
+	}, {
+		desc: "ignore-init-containers",
+		podStatus: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				// creds-init; ignored.
+			}, {
+				// git-init; ignored.
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-state-name",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 123,
+					},
+				},
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{conditionRunning},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 123,
+					}},
+				Name: "state-name",
+			}},
+		},
+	}, {
+		desc: "success",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-step-push",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+					},
+				},
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{conditionTrue},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+					}},
+				Name: "step-push",
+			}},
+			// We don't actually care about the time, just that it's not nil
+			CompletionTime: &metav1.Time{Time: time.Now()},
+		},
+	}, {
+		desc: "running",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-running-step",
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{conditionBuilding},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+				Name: "running-step",
+			}},
+		},
+	}, {
+		desc: "failure-terminated",
+		podStatus: corev1.PodStatus{
+			Phase:                 corev1.PodFailed,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				// creds-init status; ignored
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "step-failure",
+				ImageID: "image-id",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 123,
+					},
+				},
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Message: `"step-failure" exited with code 123 (image: "image-id"); for logs run: kubectl -n foo logs pod -c step-failure`,
+				}},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 123,
+					}},
+				Name: "failure",
+			}},
+			// We don't actually care about the time, just that it's not nil
+			CompletionTime: &metav1.Time{Time: time.Now()},
+		},
+	}, {
+		desc: "failure-message",
+		podStatus: corev1.PodStatus{
+			Phase:   corev1.PodFailed,
+			Message: "boom",
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Message: "boom",
+				}},
+			},
+			Steps: []v1alpha1.StepState{},
+			// We don't actually care about the time, just that it's not nil
+			CompletionTime: &metav1.Time{Time: time.Now()},
+		},
+	}, {
+		desc:      "failure-unspecified",
+		podStatus: corev1.PodStatus{Phase: corev1.PodFailed},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Message: "build failed for unspecified reasons.",
+				}},
+			},
+			Steps: []v1alpha1.StepState{},
+			// We don't actually care about the time, just that it's not nil
+			CompletionTime: &metav1.Time{Time: time.Now()},
+		},
+	}, {
+		desc: "pending-waiting-message",
+		podStatus: corev1.PodStatus{
+			Phase:                 corev1.PodPending,
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				// creds-init status; ignored
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "step-status-name",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Message: "i'm pending",
+					},
+				},
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Reason:  "Pending",
+					Message: `build step "step-status-name" is pending with reason "i'm pending"`,
+				}},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Message: "i'm pending",
+					},
+				},
+				Name: "status-name",
+			}},
+		},
+	}, {
+		desc: "pending-pod-condition",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Status:  corev1.ConditionUnknown,
+				Type:    "the type",
+				Message: "the message",
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Reason:  "Pending",
+					Message: `pod status "the type":"Unknown"; message: "the message"`,
+				}},
+			},
+			Steps: []v1alpha1.StepState{},
+		},
+	}, {
+		desc: "pending-message",
+		podStatus: corev1.PodStatus{
+			Phase:   corev1.PodPending,
+			Message: "pod status message",
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Reason:  "Pending",
+					Message: "pod status message",
+				}},
+			},
+			Steps: []v1alpha1.StepState{},
+		},
+	}, {
+		desc:      "pending-no-message",
+		podStatus: corev1.PodStatus{Phase: corev1.PodPending},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Reason:  "Pending",
+					Message: "Pending",
+				}},
+			},
+			Steps: []v1alpha1.StepState{},
+		},
+	}, {
+		desc: "pending-not-enough-node-resources",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			Conditions: []corev1.PodCondition{{
+				Reason:  corev1.PodReasonUnschedulable,
+				Message: "0/1 nodes are available: 1 Insufficient cpu.",
+			}},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionUnknown,
+					Reason:  ReasonExceededNodeResources,
+					Message: `TaskRun pod "taskRun" exceeded available resources`,
+				}},
+			},
+			Steps: []v1alpha1.StepState{},
+		},
+	}, {
+		desc: "with-running-sidecar",
+		podStatus: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "step-running-step",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+				{
+					Name: "running-sidecar",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+					Ready: true,
+				},
+			},
+		},
+		want: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{conditionBuilding},
+			},
+			Steps: []v1alpha1.StepState{{
+				ContainerState: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{},
+				},
+				Name: "running-step",
+			}},
+		},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			observer, _ := observer.New(zap.InfoLevel)
+			logger := zap.New(observer).Sugar()
+			fakeClient := fakeclientset.NewSimpleClientset()
+			sharedInfomer := informers.NewSharedInformerFactory(fakeClient, 0)
+			pipelineResourceInformer := sharedInfomer.Tekton().V1alpha1().PipelineResources()
+			resourceLister := pipelineResourceInformer.Lister()
+			fakekubeclient := fakekubeclientset.NewSimpleClientset()
+
+			rs := []*v1alpha1.PipelineResource{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "source-image",
+					Namespace: "marshmallow",
+				},
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: "image",
+				},
+			}}
+
+			for _, r := range rs {
+				err := pipelineResourceInformer.Informer().GetIndexer().Add(r)
+				if err != nil {
+					t.Errorf("pipelineResourceInformer.Informer().GetIndexer().Add(r) failed with err: %s", err)
+				}
+			}
+
+			now := metav1.Now()
+			p := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "pod",
+					Namespace:         "foo",
+					CreationTimestamp: now,
+				},
+				Status: c.podStatus,
+			}
+			startTime := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+			tr := tb.TaskRun("taskRun", "foo", tb.TaskRunStatus(tb.TaskRunStartTime(startTime)))
+			UpdateStatusFromPod(tr, p, resourceLister, fakekubeclient, logger)
+
+			// Common traits, set for test case brevity.
+			c.want.PodName = "pod"
+			c.want.StartTime = &metav1.Time{Time: startTime}
+
+			ensureTimeNotNil := cmp.Comparer(func(x, y *metav1.Time) bool {
+				if x == nil {
+					return y == nil
+				}
+				return y != nil
+			})
+			if d := cmp.Diff(c.want, tr.Status, ignoreVolatileTime, ensureTimeNotNil); d != "" {
+				t.Errorf("Wanted:%s %v", c.desc, c.want.Conditions[0])
+				t.Errorf("Diff:\n%s", d)
+			}
+			if tr.Status.StartTime.Time != c.want.StartTime.Time {
+				t.Errorf("Expected TaskRun startTime to be unchanged but was %s", tr.Status.StartTime)
+			}
+		})
+	}
+}

--- a/pkg/status/taskrunreasons.go
+++ b/pkg/status/taskrunreasons.go
@@ -1,0 +1,34 @@
+package status
+
+const (
+	// reasonCouldntGetTask indicates that the reason for the failure status is that the
+	// Task couldn't be found
+	ReasonCouldntGetTask = "CouldntGetTask"
+
+	// reasonFailedResolution indicated that the reason for failure status is
+	// that references within the TaskRun could not be resolved
+	ReasonFailedResolution = "TaskRunResolutionFailed"
+
+	// reasonFailedValidation indicated that the reason for failure status is
+	// that taskrun failed runtime validation
+	ReasonFailedValidation = "TaskRunValidationFailed"
+
+	// reasonRunning indicates that the reason for the inprogress status is that the TaskRun
+	// is just starting to be reconciled
+	ReasonRunning = "Running"
+
+	// reasonBuilding indicates that the reason for the in-progress status is that the TaskRun
+	// is just being built
+	ReasonBuilding = "Building"
+
+	// reasonTimedOut indicates that the TaskRun has taken longer than its configured timeout
+	ReasonTimedOut = "TaskRunTimeout"
+
+	// reasonExceededResourceQuota indicates that the TaskRun failed to create a pod due to
+	// a ResourceQuota in the namespace
+	ReasonExceededResourceQuota = "ExceededResourceQuota"
+
+	// reasonExceededNodeResources indicates that the TaskRun's pod has failed to start due
+	// to resource constraints on the node
+	ReasonExceededNodeResources = "ExceededNodeResources"
+)

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -41,7 +41,6 @@ const (
 	kanikoTaskName     = "kanikotask"
 	kanikoTaskRunName  = "kanikotask-run"
 	kanikoResourceName = "go-example-git"
-	kanikoBuildOutput  = "Task completed successfully"
 )
 
 func getGitResource(namespace string) *v1alpha1.PipelineResource {
@@ -133,10 +132,6 @@ func TestKanikoTaskRun(t *testing.T) {
 	logs, err := getAllLogsFromPod(c.KubeClient.Kube, podName, namespace)
 	if err != nil {
 		t.Fatalf("Expected to get logs from pod %s: %v", podName, err)
-	}
-	// check the logs contain our success criteria
-	if !strings.Contains(logs, kanikoBuildOutput) {
-		t.Fatalf("Expected output %s from pod %s but got %s", kanikoBuildOutput, podName, logs)
 	}
 	// make sure the pushed digest matches the one we pushed
 	re := regexp.MustCompile(`digest: (sha256:\w+)`)

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -95,14 +95,6 @@ func TestTaskRunFailure(t *testing.T) {
 			},
 		},
 		Name: "world",
-	}, {
-		ContainerState: corev1.ContainerState{
-			Terminated: &corev1.ContainerStateTerminated{
-				ExitCode: 0,
-				Reason:   "Completed",
-			},
-		},
-		Name: "nop",
 	}}
 	ignoreFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreFields); d != "" {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

TL;DR Tekton Pipelines now gracefully start and stop with injected sidecars running alongside TaskRun pods.

Long Version :-

TaskRun pods can have sidecars injected by Admission Controllers. This is common practice with Istio where a proxy sidecar is injected into pods so that they can be included as part of a service mesh. Unfortunately there is no built-in Kubernetes mechanism to set the lifetime of a sidecar container to match that of the pod's "primary" container. In practice this means that pods injected with sidecars will not stop until both the primary and all sidecar containers are stopped.

Prior to this commit any non-istio injected sidecars would cause a TaskRun pod to run forever, even when all Step containers of a Task had completed.  Istio injection was also disabled completely on TR pods. This commit introduces mechanisms to start and stop sidecars gracefully meaning that a) Step containers wait until all sidecars are in a ready state before starting and b) Sidecar containers are stopped when a TaskRun's Step containers are done.  Additionally, the annotation that prevented Istio sidecar injection has been removed.  Istio now adds sidecars to TaskRun pods as expected.

No end-to-end tests have been added as part of this PR because doing so would require Istio to be enabled on the CI cluster (or a dummy Admission Controller / Mutating Webhook thing to be written just for injecting containers into test Pods). The Istio requirement would put an undue burden on those users running tests in non-GKE environments. It's currently planned for a follow-up PR to introduce a) user-defined sidecars and b) a Tekton-injected sidecar that performs logging. Once that work is complete it will be much simpler to e2e test this sidecar code.

For reference, see the POC PR that was originally created here: https://github.com/tektoncd/pipeline/pull/728

For the design proposal and associated discussion around the original POC please see https://github.com/tektoncd/pipeline/issues/727

For the remaining work, test coverage, code organization, etc, see https://github.com/tektoncd/pipeline/issues/926

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Sidecar containers injected by, for example, Istio, will now gracefully start up and shutdown in tandem with a Task Steps' containers.
```
