### PR TITLE
Move TaskResource to task_types.go

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -82,22 +82,6 @@ type PipelineResourceStatus struct {
 var _ apis.Validatable = (*PipelineResource)(nil)
 var _ apis.Defaultable = (*PipelineResource)(nil)
 
-// TaskResource defines an input or output Resource declared as a requirement
-// by a Task. The Name field will be used to refer to these Resources within
-// the Task definition, and when provided as an Input, the Name will be the
-// path to the volume mounted containing this Resource as an input (e.g.
-// an input Resource named `workspace` will be mounted at `/workspace`).
-type TaskResource struct {
-	Name string               `json:"name"`
-	Type PipelineResourceType `json:"type"`
-	// +optional
-	// TargetPath is the path in workspace directory where the task resource will be copied.
-	TargetPath string `json:"targetPath"`
-	// +optional
-	// Path to the index.json file for output container images
-	OutputImageDir string `json:"outputImageDir"`
-}
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -87,6 +87,22 @@ type Inputs struct {
 	Params []TaskParam `json:"params,omitempty"`
 }
 
+// TaskResource defines an input or output Resource declared as a requirement
+// by a Task. The Name field will be used to refer to these Resources within
+// the Task definition, and when provided as an Input, the Name will be the
+// path to the volume mounted containing this Resource as an input (e.g.
+// an input Resource named `workspace` will be mounted at `/workspace`).
+type TaskResource struct {
+	Name string               `json:"name"`
+	Type PipelineResourceType `json:"type"`
+	// +optional
+	// TargetPath is the path in workspace directory where the task resource will be copied.
+	TargetPath string `json:"targetPath"`
+	// +optional
+	// Path to the index.json file for output container images
+	OutputImageDir string `json:"outputImageDir"`
+}
+
 // TaskParam defines arbitrary parameters needed by a task beyond typed inputs
 // such as resources.
 type TaskParam struct {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR moves the definition of `TaskResource` to the task_types.go file. Overall the resource_types.go file has a few different things:

- The `PipelineResource` API resource and supporting types
- `PipelineResourceBinding` type used in `PipelineRuns`
- `TaskRunBinding` type used in `TaskRun`
- `TaskResource` type used in `Task`

I would expect everything but the first item in the list to be defined in the types file that references it, and made an initial move in this PR to test how people felt.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
