### PR TITLE
Add pod output to build logs

### DIFF
--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -174,15 +174,6 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	// Verify status of PipelineRun (wait for it)
 	if err := WaitForPipelineRunState(c, bucketTestPipelineRunName, timeout, PipelineRunSucceed(bucketTestPipelineRunName), "PipelineRunCompleted"); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", bucketTestPipelineRunName, err)
-		taskruns, err := c.TaskRunClient.List(metav1.ListOptions{})
-		if err != nil {
-			t.Errorf("Error getting TaskRun list for PipelineRun %s %s", bucketTestPipelineRunName, err)
-		}
-		for _, tr := range taskruns.Items {
-			if tr.Status.PodName != "" {
-				CollectPodLogs(c, tr.Status.PodName, namespace, t.Logf)
-			}
-		}
 		t.Fatalf("PipelineRun execution failed")
 	}
 }

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -180,7 +180,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 		}
 		for _, tr := range taskruns.Items {
 			if tr.Status.PodName != "" {
-				CollectBuildLogs(c, tr.Status.PodName, namespace, t.Logf)
+				CollectPodLogs(c, tr.Status.PodName, namespace, t.Logf)
 			}
 		}
 		t.Fatalf("PipelineRun execution failed")

--- a/test/build_logs.go
+++ b/test/build_logs.go
@@ -31,7 +31,7 @@ import (
 func CollectPodLogs(c *clients, podName, namespace string, logf logging.FormatLogger) {
 	logs, err := getContainerLogsFromPod(c.KubeClient.Kube, podName, namespace)
 	if err != nil {
-		logf("Expected there to be logs for pod %s: %s", podName, err)
+		logf("Could not get logs for pod %s: %s", podName, err)
 	}
 	logf("build logs %s", logs)
 }

--- a/test/build_logs.go
+++ b/test/build_logs.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -26,24 +27,25 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// CollectBuildLogs will get the build logs for a task run
-func CollectBuildLogs(c *clients, podName, namespace string, logf logging.FormatLogger) {
-	logs, err := getInitContainerLogsFromPod(c.KubeClient.Kube, podName, namespace)
+// CollectPodLogs will get the logs for all containers in a Pod
+func CollectPodLogs(c *clients, podName, namespace string, logf logging.FormatLogger) {
+	logs, err := getContainerLogsFromPod(c.KubeClient.Kube, podName, namespace)
 	if err != nil {
-		logf("Expected there to be logs from build helm-deploy-pipeline-run-helm-deploy %s", err)
+		logf("Expected there to be logs for pod %s: %s", podName, err)
 	}
 	logf("build logs %s", logs)
 }
 
-func getInitContainerLogsFromPod(c kubernetes.Interface, pod, namespace string) (string, error) {
+func getContainerLogsFromPod(c kubernetes.Interface, pod, namespace string) (string, error) {
 	p, err := c.CoreV1().Pods(namespace).Get(pod, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
 
 	sb := strings.Builder{}
-	for _, initContainer := range p.Spec.InitContainers {
-		req := c.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{Follow: true, Container: initContainer.Name})
+	for _, container := range p.Spec.Containers {
+		sb.WriteString(fmt.Sprintf("\n>>> Container %s:\n", container.Name))
+		req := c.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{Follow: true, Container: container.Name})
 		rc, err := req.Stream()
 		if err != nil {
 			return "", err

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -98,7 +98,7 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 		}
 		for _, tr := range taskruns.Items {
 			if tr.Status.PodName != "" {
-				CollectBuildLogs(c, tr.Status.PodName, namespace, t.Logf)
+				CollectPodLogs(c, tr.Status.PodName, namespace, t.Logf)
 			}
 		}
 		t.Fatalf("PipelineRun execution failed; helm may or may not have been installed :(")

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -92,15 +92,6 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	// Verify status of PipelineRun (wait for it)
 	if err := WaitForPipelineRunState(c, helmDeployPipelineRunName, timeout, PipelineRunSucceed(helmDeployPipelineRunName), "PipelineRunCompleted"); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", helmDeployPipelineRunName, err)
-		taskruns, err := c.TaskRunClient.List(metav1.ListOptions{})
-		if err != nil {
-			t.Errorf("Error getting TaskRun list for PipelineRun %s %s", helmDeployPipelineRunName, err)
-		}
-		for _, tr := range taskruns.Items {
-			if tr.Status.PodName != "" {
-				CollectPodLogs(c, tr.Status.PodName, namespace, t.Logf)
-			}
-		}
 		t.Fatalf("PipelineRun execution failed; helm may or may not have been installed :(")
 	}
 

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -77,6 +77,16 @@ func tearDown(t *testing.T, cs *clients, namespace string) {
 		} else {
 			t.Log(string(bs))
 		}
+		header(t.Logf, fmt.Sprintf("Dumping logs from Pods in the %s", namespace))
+		taskruns, err := cs.TaskRunClient.List(metav1.ListOptions{})
+		if err != nil {
+			t.Errorf("Error getting TaskRun list %s", err)
+		}
+		for _, tr := range taskruns.Items {
+			if tr.Status.PodName != "" {
+				CollectPodLogs(cs, tr.Status.PodName, namespace, t.Logf)
+			}
+		}
 	}
 
 	t.Logf("Deleting namespace %s", namespace)


### PR DESCRIPTION
Fixes #944

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add the output of pods attached to taskruns used by failed E2E
tests. We do this today for YAML tests but not for other E2E tests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
