### PR TITLE
Bump tektoncd/plumbing to fix ./hack/ scripts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -544,11 +544,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:85d26e62f0132efc647fd3412450d2c2e2feb4af9c237149f4c576e018c975f0"
+  digest = "1:5558ceef0c045f9c8a0c08c6e0de89bb0895b1aad69d9722b3748f003564b8cb"
   name = "github.com/tektoncd/plumbing"
   packages = ["scripts"]
   pruneopts = "UT"
-  revision = "36c78101beb7981e90cd736053e01cf914ac245e"
+  revision = "373083123d6a795a29afd25b4b8f3efc4b7d14bc"
 
 [[projects]]
   digest = "1:e65b395598ef96d96c1df34e3fd3ec4dabe629edb1511de33a59efd9931df0e8"

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -349,7 +349,7 @@ function update_licenses() {
   cd ${REPO_ROOT_DIR} || return 1
   local dst=$1
   shift
-  run_go_tool ./vendor/github.com/tektoncd/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
+  run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector $@ > ./${dst}
 }
 
 # Run dep-collector to check for forbidden liceses.


### PR DESCRIPTION
# Changes

This repo exists in knative/test-infra. This repo does not exist in
tekton. We missed one in the previous fix.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Related to https://github.com/tektoncd/plumbing/pull/33
cc @wlynch 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details.