### PR TITLE
tekton task to run unit tests

### DIFF
--- a/tekton/ci-unit-test-run.yaml
+++ b/tekton/ci-unit-test-run.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: tekton-pipelines
+spec:
+  type: git
+  params:
+  - name: url
+    value: https://github.com/tektoncd/pipeline # REPLACE with your own fork
+  - name: revision
+    value: master # REPLACE with your own commit
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: unit-tests-run
+spec:
+  taskRef:
+    name: unit-tests
+  inputs:
+    resources:
+    - name: source
+      resourceRef:
+        name: tekton-pipelines
+

--- a/tekton/ci-unit-test-run.yaml
+++ b/tekton/ci-unit-test-run.yaml
@@ -18,6 +18,9 @@ spec:
   taskRef:
     name: unit-tests
   inputs:
+    params:
+    - name: flags
+      value: -race -cover -v
     resources:
     - name: source
       resourceRef:

--- a/tekton/ci-unit-test.yaml
+++ b/tekton/ci-unit-test.yaml
@@ -8,18 +8,22 @@ spec:
     - name: package
       description: package (and its children) under test
       default: github.com/tektoncd/pipeline
+    - name: flags
+      description: flags to use for the test command
+      default: -race -cover
     resources:
     - name: source
       type: git
       targetPath: src/${inputs.params.package}
-  #outputs: # coverage file
   steps:
   - name: unit-test
     image: golang:1.12
     workingdir: /workspace/src/${inputs.params.package}
     command:
-    - go 
-    args: ["test", "-v", "-cover", "./..."]
+    - /bin/bash
+    args:
+    - -c
+    - "go test ${inputs.params.flags} ./..."
     env:
     - name: GOPATH
       value: /workspace

--- a/tekton/ci-unit-test.yaml
+++ b/tekton/ci-unit-test.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: unit-tests
+spec:
+  inputs:
+    params:
+    - name: package
+      description: package (and its children) under test
+      default: github.com/tektoncd/pipeline
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  #outputs: # coverage file
+  steps:
+  - name: unit-test
+    image: golang:1.12
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - go 
+    args: ["test", "-v", "-cover", "./..."]
+    env:
+    - name: GOPATH
+      value: /workspace
+


### PR DESCRIPTION
# Changes

This adds a Task to run pipeline's unit tests

- This will move to `tektoncd/catalog` later on as it's meant to be a reusable task :angel: 
- This will be hooked-up to the CI once we work on #922

Improvements possible:

- [ ] Save the cover file somewhere (in a resource or *as a resource* :smiling_imp:)
- [x] More parameters (to be able to filter tests, or add build tags)

Closes #532 

cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
