### PR TITLE
tekton task to run linting

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -13,6 +13,23 @@ TODO(#538): In #538 or #537 we will update
 to invoke these `Pipelines` automatically, but for now we will have to invoke
 them manually.
 
+## Pull Request Pipeline
+
+The `Tasks` which are going to make up our Pull Request Pipeline are:
+
+- [`ci-unit-test.yaml`](ci-unit-test.yaml) — This `Task` uses `go
+  test` to run the Pipeline unit tests.
+- [`ci-lint.yaml`](ci-lint.yaml) — This `Task` uses
+  [`golangci-lint`](https://github.com/golangci/golangci-lint) to
+  validate the code based on common best practices.
+
+TODO(#922) & TODO(#860): Add the Pipeline and hook it up with Prow,
+for now all we have are `Tasks` which we can invoke individually by
+creating
+[`TaskRuns`](https://github.com/tektoncd/pipeline/blob/master/docs/taskruns.md)
+and
+[`PipelineResources`](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md).
+
 ## Release Pipeline
 
 The `Tasks` which make up our release `Pipeline` are:

--- a/tekton/ci-lint-run.yaml
+++ b/tekton/ci-lint-run.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: tekton-pipelines
+spec:
+  type: git
+  params:
+  - name: url
+    value: https://github.com/tektoncd/pipeline # REPLACE with your own fork
+  - name: revision
+    value: master # REPLACE with your own commit
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: golangci-lint-run
+spec:
+  taskRef:
+    name: golangci-lint
+  inputs:
+    resources:
+    - name: source
+      resourceRef:
+        name: tekton-pipelines
+

--- a/tekton/ci-lint.yaml
+++ b/tekton/ci-lint.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: golangci-lint
+spec:
+  inputs:
+    params:
+    - name: package
+      description: package (and its children) under test
+      default: github.com/tektoncd/pipeline
+    - name: flags
+      description: flags to use for the lint command
+      default: --verbose
+    - name: version
+      description: golangci-lint version to use
+      default: v1.16
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  steps:
+  - name: lint
+    image: golangci/golangci-lint:${inputs.params.version}
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - /bin/bash
+    args:
+    - -c
+    - "golangci-lint run ${inputs.params.flags}"
+    env:
+    - name: GOPATH
+      value: /workspace
+


### PR DESCRIPTION
# Changes

This adds a Task to run `golangci-lint` on the repository.
This is part of the dogfooding effort on tektoncd/pipeline.

- This will move to `tektoncd/catalog` later on as it's meant to be a reusable task :angel: 
- This will be hooked-up to the CI once we work on #922

Closes #558 

cc @bobcatfish 
cc @chmouel I know you'll like it :angel: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._