### PR TITLE
Adds PipelineTask.name metadata label in TaskRun

### DIFF
--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -23,4 +23,5 @@ const (
 	TaskRunLabelKey     = "/taskRun"
 	PipelineLabelKey    = "/pipeline"
 	PipelineRunLabelKey = "/pipelineRun"
+	PipelineTaskLabelKey = "/pipelineTask"
 )

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -463,6 +463,9 @@ func (c *Reconciler) createTaskRun(logger *zap.SugaredLogger, rprt *resources.Re
 		labels[key] = val
 	}
 	labels[pipeline.GroupName+pipeline.PipelineRunLabelKey] = pr.Name
+	if rprt.PipelineTask.Name != "" {
+		labels[pipeline.GroupName+pipeline.PipelineTaskLabelKey] = rprt.PipelineTask.Name
+	}
 
 	// Propagate annotations from PipelineRun to TaskRun.
 	annotations := make(map[string]string, len(pr.ObjectMeta.Annotations)+1)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Changes
If clients want to show the logs for particular TaskRun of a Pipeline,
it's not easy to relate which Task it belongs to in a Pipeline.
TaskRun should have some reference to PipelineTask.Name

In order to fix this issue, this patch adds a metadata.lable
in TaskRun while executing a Pipeline's Task.

Fixes #965

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Every `TaskRun` created by a `PipelineRun` would have a label `tekton.dev/pipelineTask`
which holds actual Task name give in Pipeline definition. 
```
