### PR TITLE
Initialize PipelineResources in declared order 📝

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -36,9 +36,10 @@ The current process would look something like:
 
 TODO(bobcatfish): This policy really _should_ include the entire API.
 
-_This policy does not yet cover other functionality which could be considered
-part of the API, but isn’t part of the CRD definition (e.g. a contract re. files
-expected to be written in certain locations by a resulting pod)._
+The API is considered to consist of:
+
+- The spec if the CRDs
+- The order that `PipelineResources` declared within a `Task` are applied in
 
 ## `Build` and `BuildTemplate`
 

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resource_test.go
@@ -299,7 +299,7 @@ func TestAddResourceToTask(t *testing.T) {
 			}},
 		},
 	}, {
-		desc: "same git input resource for task with diff resource name",
+		desc: "reuse git input resource and verify order",
 		task: taskWithMultipleGitSources,
 		taskRun: &v1alpha1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
@@ -329,16 +329,16 @@ func TestAddResourceToTask(t *testing.T) {
 		want: &v1alpha1.TaskSpec{
 			Inputs: multipleGitInputs,
 			Steps: []corev1.Container{{
-				Name:       "git-source-the-git-with-branch-mz4c7",
-				Image:      "override-with-git:latest",
-				Command:    []string{"/ko-app/git-init"},
-				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/git-duplicate-space"},
-				WorkingDir: "/workspace",
-			}, {
 				Name:       "git-source-the-git-with-branch-9l9zj",
 				Image:      "override-with-git:latest",
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
+				WorkingDir: "/workspace",
+			}, {
+				Name:       "git-source-the-git-with-branch-mz4c7",
+				Image:      "override-with-git:latest",
+				Command:    []string{"/ko-app/git-init"},
+				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/git-duplicate-space"},
 				WorkingDir: "/workspace",
 			}},
 		},

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -71,6 +71,8 @@ func AddInputResource(
 		return nil, err
 	}
 
+	allResourceContainers := []corev1.Container{}
+
 	for _, input := range taskSpec.Inputs.Resources {
 		boundResource, err := getBoundResource(input.Name, taskRun.Spec.Inputs.Resources)
 		if err != nil {
@@ -132,10 +134,11 @@ func AddInputResource(
 				}
 			}
 
-			taskSpec.Steps = append(resourceContainers, taskSpec.Steps...)
+			allResourceContainers = append(allResourceContainers, resourceContainers...)
 			taskSpec.Volumes = append(taskSpec.Volumes, resourceVolumes...)
 		}
 	}
+	taskSpec.Steps = append(allResourceContainers, taskSpec.Steps...)
 
 	if mountPVC {
 		taskSpec.Volumes = append(taskSpec.Volumes, GetPVCVolume(pvcName))


### PR DESCRIPTION
# Changes

@pwittrock was trying to use PipelineResources such that the contents of
a GCS bucket could be copied over a previously checked out dir in a
github repo. Unfortunately, PipelineResources were being applied in the
opposite order that they were declared in!

This change makes it so that the PipelineResources will be applied in
the declared order, which means that the order these PipelineResources
are applied in is now part of our API.

Fixes #775

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
PipelineResources will now be applied in the order they are declared in a Task.
```
