### PR TITLE
Add support for secret and configMap valueFrom and envFrom fields in …

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -401,7 +401,9 @@ Use these code snippets to help you understand how to define your `Tasks`.
 
 - [Example of image building and pushing](#example-task)
 - [Mounting extra volumes](#using-an-extra-volume)
-- [Mounting configMap as volume source](#using-kubernetes-configmap-as-volume-source)
+- [Mounting configMap as volume
+  source](#using-kubernetes-configmap-as-volume-source)
+- [Using secret as environment source](#using-secret-as-environment-source)
 
 _Tip: See the collection of simple
 [examples](https://github.com/tektoncd/pipeline/tree/master/examples) for
@@ -514,6 +516,43 @@ spec:
     - name: "${inputs.params.volumeName}"
       configMap:
         name: "${inputs.params.CFGNAME}"
+```
+
+#### Using secret as environment source
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: goreleaser
+spec:
+  inputs:
+    params:
+    - name: package
+      description: base package to build in
+    - name: github-token-secret
+      description: name of the secret holding the github-token
+      default: github-token
+    resources:
+    - name: source
+      type: git
+      targetPath: src/${inputs.params.package}
+  steps:
+  - name: release
+    image: goreleaser/goreleaser
+    workingdir: /workspace/src/${inputs.params.package}
+    command:
+    - goreleaser
+    args:
+    - release
+    env:
+    - name: GOPATH
+      value: /workspace
+    - name: GITHUB_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: ${inputs.params.github-token-secret}
+          key: bot-token
 ```
 
 Except as otherwise noted, the content of this page is licensed under the

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -67,6 +67,25 @@ func ApplyReplacements(spec *v1alpha1.TaskSpec, replacements map[string]string) 
 		}
 		for ie, e := range steps[i].Env {
 			steps[i].Env[ie].Value = templating.ApplyReplacements(e.Value, replacements)
+			if steps[i].Env[ie].ValueFrom != nil {
+				if e.ValueFrom.SecretKeyRef != nil {
+					steps[i].Env[ie].ValueFrom.SecretKeyRef.LocalObjectReference.Name = templating.ApplyReplacements(e.ValueFrom.SecretKeyRef.LocalObjectReference.Name, replacements)
+					steps[i].Env[ie].ValueFrom.SecretKeyRef.Key = templating.ApplyReplacements(e.ValueFrom.SecretKeyRef.Key, replacements)
+				}
+				if e.ValueFrom.ConfigMapKeyRef != nil {
+					steps[i].Env[ie].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name = templating.ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name, replacements)
+					steps[i].Env[ie].ValueFrom.ConfigMapKeyRef.Key = templating.ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.Key, replacements)
+				}
+			}
+		}
+		for ie, e := range steps[i].EnvFrom {
+			steps[i].EnvFrom[ie].Prefix = templating.ApplyReplacements(e.Prefix, replacements)
+			if e.ConfigMapRef != nil {
+				steps[i].EnvFrom[ie].ConfigMapRef.LocalObjectReference.Name = templating.ApplyReplacements(e.ConfigMapRef.LocalObjectReference.Name, replacements)
+			}
+			if e.SecretRef != nil {
+				steps[i].EnvFrom[ie].SecretRef.LocalObjectReference.Name = templating.ApplyReplacements(e.SecretRef.LocalObjectReference.Name, replacements)
+			}
 		}
 		steps[i].WorkingDir = templating.ApplyReplacements(steps[i].WorkingDir, replacements)
 		for ic, c := range steps[i].Command {


### PR DESCRIPTION
# Changes

…templating

Currently, we support template on the environment variables key, *but*
not if the environment variable comes from a `ConfigMap` or a
`Secret`.

The following won't work.

```
    env:
    - name: GOPATH
      value: /workspace
    - name: GITHUB_TOKEN
      valueFrom:
        secretKeyRef:
          name: ${inputs.params.github-token-secret}
          key: bot-token
```

This fixes that and add support for using variable interpolation on
`valueFrom.secretKeyRef` and `valueFrom.configMapKeyRef`.

This also adds variable interpolation on `envFrom`.

This would fix [this](https://github.com/tektoncd/cli/pull/78/files#diff-4f89a80414974a200c54702b4f886884R38) :angel: 

/cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
`env.$var.valueFrom` and `envFrom` now supports variable interpolation
```
