### PR TITLE
Format markdown

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -17,15 +17,14 @@ them manually.
 
 The `Tasks` which are going to make up our Pull Request Pipeline are:
 
-- [`ci-unit-test.yaml`](ci-unit-test.yaml) — This `Task` uses `go
-  test` to run the Pipeline unit tests.
+- [`ci-unit-test.yaml`](ci-unit-test.yaml) — This `Task` uses `go test` to run
+  the Pipeline unit tests.
 - [`ci-lint.yaml`](ci-lint.yaml) — This `Task` uses
-  [`golangci-lint`](https://github.com/golangci/golangci-lint) to
-  validate the code based on common best practices.
+  [`golangci-lint`](https://github.com/golangci/golangci-lint) to validate the
+  code based on common best practices.
 
-TODO(#922) & TODO(#860): Add the Pipeline and hook it up with Prow,
-for now all we have are `Tasks` which we can invoke individually by
-creating
+TODO(#922) & TODO(#860): Add the Pipeline and hook it up with Prow, for now all
+we have are `Tasks` which we can invoke individually by creating
 [`TaskRuns`](https://github.com/tektoncd/pipeline/blob/master/docs/taskruns.md)
 and
 [`PipelineResources`](https://github.com/tektoncd/pipeline/blob/master/docs/resources.md).


### PR DESCRIPTION
Produced via: `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`