### PR TITLE
Annotate controller jobs to prevent node eviction

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -20,6 +20,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: tekton-pipelines-controller
     spec:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -21,6 +21,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: tekton-pipelines-webhook
     spec:


### PR DESCRIPTION
# Changes

This change annotates pods running controller components (controller and webhook) to prevent the node they're on from being evicted when autoscaling scales nodes down.

Without this change, when nodes are autoscaled up and then back down, the node that gets selected to kill might be the one that runs Tekton components, causing a brief outage until the pod can be scheduled on another node (which _itself_ might be able to be scaled down! :cold_sweat: )


See also https://github.com/knative/serving/pull/4329

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ nope ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ nope ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ yep ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
release-note
```
