### PR TITLE
Add GitHub status updates to Pull Request CRD.

### DIFF
--- a/cmd/pullrequest-init/README.md
+++ b/cmd/pullrequest-init/README.md
@@ -44,7 +44,16 @@ like:
             "Text": "my-label"
         }
     ],
-    "Raw": "/tmp/prtest/github/pr.json"
+    "Statuses": [
+        {
+            "Code": "success",
+            "Description": "Job succeeded.",
+            "ID": "pull-tekton-pipeline-go-coverage",
+            "URL": "https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/895/pull-tekton-pipeline-go-coverage/1141483806818045953/"
+        },
+    ],
+    "Raw": "/tmp/prtest/github/pr.json",
+    "RawStatus": "/tmp/pr/github/status.json"
 }
 ```
 
@@ -54,6 +63,9 @@ GitHub pull requests will output these additional files:
 
 *   `$PATH/github/pr.json`: The raw GitHub payload as specified by
     https://developer.github.com/v3/pulls/#get-a-single-pull-request
+*   `$PATH/github/status.json`: The raw GitHub combined status payload as
+    specified by
+    https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
 *   `$PATH/github/comments/#.json`: Comments associated to the PR as specified
     by https://developer.github.com/v3/issues/comments/#get-a-single-comment
 
@@ -62,3 +74,18 @@ For now, these files are *read-only*.
 The binary will look for GitHub credentials in the `${GITHUBTOKEN}` environment
 variable. This should generally be specified as a secret with the field name
 `githubToken` in the `PullRequestResource` definition.
+
+### Status code conversion
+
+Tekton Status Code | GitHub Status State
+------------------ | -------------------
+success            | success
+neutral            | success
+queued             | pending
+in_progress        | pending
+failure            | failure
+unknown            | error
+error              | error
+timeout            | error
+canceled           | error
+action_required    | error

--- a/cmd/pullrequest-init/types.go
+++ b/cmd/pullrequest-init/types.go
@@ -3,16 +3,37 @@ package main
 // These are the generic resource types used for interacting with Pull Requests
 // and related resources. They should not be tied to any particular SCM system.
 
+type StatusCode string
+
+// TODO: Figure out how to do case insensitive statuses.
+const (
+	Unknown        StatusCode = "unknown"
+	Success        StatusCode = "success"
+	Failure        StatusCode = "failure"
+	Error          StatusCode = "error"
+	Neutral        StatusCode = "neutral"
+	Queued         StatusCode = "queued"
+	InProgress     StatusCode = "in_progress"
+	Timeout        StatusCode = "timeout"
+	Canceled       StatusCode = "canceled"
+	ActionRequired StatusCode = "action_required"
+)
+
+// TODO: Add getters to make types nil-safe.
+
 // PullRequest represents a generic pull request resource.
 type PullRequest struct {
 	Type       string
 	ID         int64
 	Head, Base *GitReference
+	Statuses   []*Status
 	Comments   []*Comment
 	Labels     []*Label
 
 	// Path to raw pull request payload.
 	Raw string
+	// Path to raw status payload.
+	RawStatus string
 }
 
 // GitReference represents a git ref object. See
@@ -21,6 +42,17 @@ type GitReference struct {
 	Repo   string
 	Branch string
 	SHA    string
+}
+
+type Status struct {
+	// ID uniquely distinguish this status from other status types.
+	ID string
+	// Code defines the status of the status.
+	Code StatusCode
+	// Short summary of the status.
+	Description string
+	// Where the status should link to.
+	URL string
 }
 
 // Comment represents a pull request comment.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -191,6 +191,15 @@ Example payload:
   ],
   "Raw": "/tmp/pr/github/pr.json",
   "Type": "github"
+  "Statuses": [
+        {
+            "Code": "success",
+            "Description": "Job succeeded.",
+            "ID": "pull-tekton-pipeline-go-coverage",
+            "URL": "https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/895/pull-tekton-pipeline-go-coverage/1141483806818045953/"
+        },
+  ],
+  "RawStatus": "/tmp/pr/github/status.json"
 }
 ```
 
@@ -218,6 +227,29 @@ spec:
 Params that can be added are the following:
 
 1.  `url`: represents the location of the pull request to fetch.
+
+#### Statuses
+
+The following status codes are available to use for the Pull Request resource:
+
+Status          |
+--------------- |
+success         |
+neutral         |
+queued          |
+in_progress     |
+failure         |
+unknown         |
+error           |
+timeout         |
+canceled        |
+action_required |
+
+Note: Status codes are currently **case sensitive**.
+
+For more information on how Tekton Pull Request status codes convert to SCM
+provider statuses, see
+[pullrequest-init/README.md](/cmd/pullrequest-init/README.md).
 
 #### GitHub
 


### PR DESCRIPTION
This adds support for the GitHub Status API
(https://developer.github.com/v3/repos/statuses/).

This accompanies #778 and #895 to complete initial Pull Request support
support for GitHub OAuth.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds GitHub status fetching and updates to Pull Request CRD.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
Adds GitHub status fetching and updates to Pull Request CRD.
```
