### PR TITLE
Fix Pipeline error with ClusterTasks

### DIFF
--- a/examples/pipelineruns/clustertask-pipelinerun.yaml
+++ b/examples/pipelineruns/clustertask-pipelinerun.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1alpha1
+kind: ClusterTask
+metadata:
+  name: cluster-task-pipeline-4
+spec:
+  steps:
+  - name: task-two-step-one
+    image: ubuntu
+    command: ["/bin/bash"]
+    args: ['-c', 'echo success']
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: sample-pipeline-cluster-task-4
+spec:
+  tasks:
+  - name: cluster-task-pipeline-4
+    taskRef:
+      name: cluster-task-pipeline-4
+      kind: ClusterTask
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline-run-4
+spec:
+  pipelineRef:
+    name: sample-pipeline-cluster-task-4
+  trigger:
+    type: manual
+  serviceAccount: 'default'

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -504,6 +504,7 @@ func (c *Reconciler) createTaskRun(logger *zap.SugaredLogger, rprt *resources.Re
 		Spec: v1alpha1.TaskRunSpec{
 			TaskRef: &v1alpha1.TaskRef{
 				Name: rprt.ResolvedTaskResources.TaskName,
+				Kind: rprt.ResolvedTaskResources.Kind,
 			},
 			Inputs: v1alpha1.TaskRunInputs{
 				Params: rprt.PipelineTask.Params,
@@ -513,7 +514,8 @@ func (c *Reconciler) createTaskRun(logger *zap.SugaredLogger, rprt *resources.Re
 			NodeSelector:   pr.Spec.NodeSelector,
 			Tolerations:    pr.Spec.Tolerations,
 			Affinity:       pr.Spec.Affinity,
-		}}
+		},
+	}
 
 	resources.WrapSteps(&tr.Spec, rprt.PipelineTask, rprt.ResolvedTaskResources.Inputs, rprt.ResolvedTaskResources.Outputs, storageBasePath)
 

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution.go
@@ -246,7 +246,7 @@ func ResolvePipelineRun(
 		}
 
 		spec := t.TaskSpec()
-		rtr, err := resources.ResolveTaskResources(&spec, t.TaskMetadata().Name, inputs, outputs, getResource)
+		rtr, err := resources.ResolveTaskResources(&spec, t.TaskMetadata().Name, pt.TaskRef.Kind, inputs, outputs, getResource)
 		if err != nil {
 			return nil, &ResourceNotFoundError{Msg: err.Error()}
 		}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution.go
@@ -25,6 +25,7 @@ import (
 // the TaskRun: the TaskRun, it's Task and the PipelineResources it needs.
 type ResolvedTaskResources struct {
 	TaskName string
+	Kind     v1alpha1.TaskKind
 	TaskSpec *v1alpha1.TaskSpec
 	// Inputs is a map from the name of the input required by the Task
 	// to the actual Resource to use for it
@@ -40,10 +41,11 @@ type GetResource func(string) (*v1alpha1.PipelineResource, error)
 // ResolveTaskResources looks up PipelineResources referenced by inputs and outputs and returns
 // a structure that unites the resolved references and the Task Spec. If referenced PipelineResources
 // can't be found, an error is returned.
-func ResolveTaskResources(ts *v1alpha1.TaskSpec, taskName string, inputs []v1alpha1.TaskResourceBinding, outputs []v1alpha1.TaskResourceBinding, gr GetResource) (*ResolvedTaskResources, error) {
+func ResolveTaskResources(ts *v1alpha1.TaskSpec, taskName string, kind v1alpha1.TaskKind, inputs []v1alpha1.TaskResourceBinding, outputs []v1alpha1.TaskResourceBinding, gr GetResource) (*ResolvedTaskResources, error) {
 	rtr := ResolvedTaskResources{
 		TaskName: taskName,
 		TaskSpec: ts,
+		Kind:     kind,
 		Inputs:   map[string]*v1alpha1.PipelineResource{},
 		Outputs:  map[string]*v1alpha1.PipelineResource{},
 	}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/taskresourceresolution_test.go
@@ -61,6 +61,7 @@ func TestResolveTaskRun(t *testing.T) {
 	}}
 
 	taskName := "orchestrate"
+	kind := v1alpha1.NamespacedTaskKind
 	taskSpec := v1alpha1.TaskSpec{
 		Steps: []corev1.Container{{
 			Name: "step1",
@@ -90,7 +91,7 @@ func TestResolveTaskRun(t *testing.T) {
 		return r, nil
 	}
 
-	rtr, err := ResolveTaskResources(&taskSpec, taskName, inputs, outputs, gr)
+	rtr, err := ResolveTaskResources(&taskSpec, taskName, kind, inputs, outputs, gr)
 	if err != nil {
 		t.Fatalf("Did not expect error trying to resolve TaskRun: %s", err)
 	}
@@ -170,7 +171,7 @@ func TestResolveTaskRun_missingOutput(t *testing.T) {
 		}}}
 
 	gr := func(n string) (*v1alpha1.PipelineResource, error) { return nil, xerrors.New("nope") }
-	_, err := ResolveTaskResources(&v1alpha1.TaskSpec{}, "orchestrate", []v1alpha1.TaskResourceBinding{}, outputs, gr)
+	_, err := ResolveTaskResources(&v1alpha1.TaskSpec{}, "orchestrate", v1alpha1.NamespacedTaskKind, []v1alpha1.TaskResourceBinding{}, outputs, gr)
 	if err == nil {
 		t.Fatalf("Expected to get error because output resource couldn't be resolved")
 	}
@@ -184,7 +185,7 @@ func TestResolveTaskRun_missingInput(t *testing.T) {
 		}}}
 	gr := func(n string) (*v1alpha1.PipelineResource, error) { return nil, xerrors.New("nope") }
 
-	_, err := ResolveTaskResources(&v1alpha1.TaskSpec{}, "orchestrate", inputs, []v1alpha1.TaskResourceBinding{}, gr)
+	_, err := ResolveTaskResources(&v1alpha1.TaskSpec{}, "orchestrate", v1alpha1.NamespacedTaskKind, inputs, []v1alpha1.TaskResourceBinding{}, gr)
 	if err == nil {
 		t.Fatalf("Expected to get error because output resource couldn't be resolved")
 	}
@@ -198,7 +199,7 @@ func TestResolveTaskRun_noResources(t *testing.T) {
 
 	gr := func(n string) (*v1alpha1.PipelineResource, error) { return &v1alpha1.PipelineResource{}, nil }
 
-	rtr, err := ResolveTaskResources(&taskSpec, "orchestrate", []v1alpha1.TaskResourceBinding{}, []v1alpha1.TaskResourceBinding{}, gr)
+	rtr, err := ResolveTaskResources(&taskSpec, "orchestrate", v1alpha1.NamespacedTaskKind, []v1alpha1.TaskResourceBinding{}, []v1alpha1.TaskResourceBinding{}, gr)
 	if err != nil {
 		t.Fatalf("Did not expect error trying to resolve TaskRun: %s", err)
 	}


### PR DESCRIPTION
# Changes

It is possible to use `ClusterTask` in a Pipeline, for that you
specify that the `Task` you want to use is of type
`ClusterTask` (default being `Task`). But, before this change, the
`PipelineRun` using this `Pipeline` would fail as the `Kind`
information is not passed from the `PipelineTask.TaskRef` to the
actual `TaskRun`.

This fixes that by passing the `Kind` of a `TaskRef` when resolving
the `Task`/`TaskRun` in the `PipelineRun` reconcilier.

A yaml test is added as a regression test.

Fixes #1001 — thanks for the report @steveodonovan 

/cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
Fix ClusterTask usage in a PipelineRun, would previously fail.
```
