### PR TITLE
If no resources are linked, don't make a PVC 🗑️

### DIFF
--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -380,7 +380,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	rprts := pipelineState.GetNextTasks(candidateTasks)
 
 	var as artifacts.ArtifactStorageInterface
-	if as, err = artifacts.InitializeArtifactStorage(pr, c.KubeClientSet, c.Logger); err != nil {
+	if as, err = artifacts.InitializeArtifactStorage(pr, p.Spec.Tasks, c.KubeClientSet, c.Logger); err != nil {
 		c.Logger.Infof("PipelineRun failed to initialize artifact storage %s", pr.Name)
 		return err
 	}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -682,6 +682,56 @@ func TestReconcileWithTimeout(t *testing.T) {
 		t.Errorf("TaskRun timeout %s should be less than or equal to PipelineRun timeout %s", actual.Spec.Timeout.Duration.String(), prs[0].Spec.Timeout.Duration.String())
 	}
 }
+
+func TestReconcileWithoutPVC(t *testing.T) {
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hello-world"),
+		tb.PipelineTask("hello-world-2", "hello-world"),
+	))}
+
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run", "foo",
+		tb.PipelineRunSpec("test-pipeline")),
+	}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+	}
+
+	// create fake recorder for testing
+	fr := record.NewFakeRecorder(2)
+
+	testAssets := getPipelineRunController(t, d, fr)
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run")
+	if err != nil {
+		t.Errorf("Did not expect to see error when reconciling PipelineRun but saw %s", err)
+	}
+
+	// Check that the PipelineRun was reconciled correctly
+	reconciledRun, err := clients.Pipeline.Tekton().PipelineRuns("foo").Get("test-pipeline-run", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
+	}
+
+	// Check that the expected TaskRun was created
+	for _, a := range clients.Kube.Actions() {
+		if ca, ok := a.(ktesting.CreateAction); ok {
+			obj := ca.GetObject()
+			if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+				t.Errorf("Did not expect to see a PVC created when no resources are linked. %s was created", pvc)
+			}
+		}
+	}
+
+	if !reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
+		t.Errorf("Expected PipelineRun to be running, but condition status is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
+	}
+}
 func TestReconcileCancelledPipelineRun(t *testing.T) {
 	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world", tb.Retries(1)),
@@ -881,7 +931,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 			),
 			tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 			tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
-                        tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-0"),
+			tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-0"),
 		),
 		tb.TaskRun(taskRunNames[1], "foo",
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
@@ -894,7 +944,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 			),
 			tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 			tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
-                        tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-1"),
+			tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-1"),
 		),
 	}
 	for i := range ps[0].Spec.Tasks {


### PR DESCRIPTION
# Changes

When outputs of a Task are linked to the inputs of another we create a
PVC (or use a bucket) to share the data between executing Tasks. However
we were doing this even when no Resources were linked! Now we only do it
when we need to.

Co-authored-by: Christie Wilson <bobcatfish@gmail.com>
Fixes: #937 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

Fixed an issue that caused PVCs to be created in some PipelineRuns when they were not necessary.
