### PR TITLE
Fix typo and change import order

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -17,12 +17,11 @@ limitations under the License.
 package resources
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/templating"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // ApplyParameters applies the params from a TaskRun.Input.Parameters to a TaskSpec

--- a/pkg/reconciler/v1alpha1/taskrun/sidecars/stop.go
+++ b/pkg/reconciler/v1alpha1/taskrun/sidecars/stop.go
@@ -20,7 +20,7 @@ type UpdatePod func(*corev1.Pod) (*corev1.Pod, error)
 // have already stopped.
 //
 // A sidecar is killed by replacing its current container image with the nop
-// image, which in turn quickly exits. If the sidedcar defines a command then
+// image, which in turn quickly exits. If the sidecar defines a command then
 // it will exit with a non-zero status. When we check for TaskRun success we
 // have to check for the containers we care about - not the final Pod status.
 func Stop(pod *corev1.Pod, updatePod UpdatePod) error {


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

In my last PR, @vdemeester commented that I should move the corev1 import to the bottom of the import list to match the current convention. The PR was merged before I could make that change, though. This addresses that, and also corrects a minor typo I thought I would include. Thanks!

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->
