### PR TITLE
pullrequest-init: Add getters to make PullRequest nil-safe.

### DIFF
--- a/cmd/pullrequest-init/fake_github_test.go
+++ b/cmd/pullrequest-init/fake_github_test.go
@@ -41,7 +41,10 @@ func TestFakeGitHubComments(t *testing.T) {
 		t.Fatalf("List Issues: wanted [], got %+v, %+v, %v", got, resp, err)
 	}
 
-	if _, _, err := client.Issues.CreateComment(ctx, owner, repo, prNum, comment); err != nil {
+	comment, _, err := client.Issues.CreateComment(ctx, owner, repo, prNum, &github.IssueComment{
+		Body: github.String("tacocat"),
+	})
+	if err != nil {
 		t.Fatalf("CreateComment: %v", err)
 	}
 

--- a/cmd/pullrequest-init/types.go
+++ b/cmd/pullrequest-init/types.go
@@ -15,12 +15,92 @@ type PullRequest struct {
 	Raw string
 }
 
+// GetType returns the Type field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetType() string {
+	if pr == nil {
+		return ""
+	}
+	return pr.Type
+}
+
+// GetID returns the ID field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetID() int64 {
+	if pr == nil {
+		return 0
+	}
+	return pr.ID
+}
+
+// GetHead returns the Head field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetHead() *GitReference {
+	if pr == nil {
+		return nil
+	}
+	return pr.Head
+}
+
+// GetBase returns the Base field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetBase() *GitReference {
+	if pr == nil {
+		return nil
+	}
+	return pr.Base
+}
+
+// GetComments returns the Comments field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetComments() []*Comment {
+	if pr == nil {
+		return nil
+	}
+	return pr.Comments
+}
+
+// GetLabels returns the Labels field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetLabels() []*Label {
+	if pr == nil {
+		return nil
+	}
+	return pr.Labels
+}
+
+// GetRaw returns the Raw field, or zero value if PullRequest is nil.
+func (pr *PullRequest) GetRaw() string {
+	if pr == nil {
+		return ""
+	}
+	return pr.Raw
+}
+
 // GitReference represents a git ref object. See
 // https://git-scm.com/book/en/v2/Git-Internals-Git-References for more details.
 type GitReference struct {
 	Repo   string
 	Branch string
 	SHA    string
+}
+
+// GetRepo returns the Repo field, or zero value if GitReference is nil.
+func (r *GitReference) GetRepo() string {
+	if r == nil {
+		return ""
+	}
+	return r.Repo
+}
+
+// GetBranch returns the Branch field, or zero value if GitReference is nil.
+func (r *GitReference) GetBranch() string {
+	if r == nil {
+		return ""
+	}
+	return r.Branch
+}
+
+// GetSHA returns the SHA field, or zero value if GitReference is nil.
+func (r *GitReference) GetSHA() string {
+	if r == nil {
+		return ""
+	}
+	return r.SHA
 }
 
 // Comment represents a pull request comment.
@@ -31,7 +111,46 @@ type Comment struct {
 	Raw    string
 }
 
+func (c *Comment) GetText() string {
+	if c == nil {
+		return ""
+	}
+	return c.Text
+}
+
+// GetAuthor returns the Author field, or zero value if Comment is nil.
+func (c *Comment) GetAuthor() string {
+	if c == nil {
+		return ""
+	}
+	return c.Author
+}
+
+// GetID returns the ID field, or zero value if Comment is nil.
+func (c *Comment) GetID() int64 {
+	if c == nil {
+		return 0
+	}
+	return c.ID
+}
+
+// GetRaw returns the Raw field, or zero value if Comment is nil.
+func (c *Comment) GetRaw() string {
+	if c == nil {
+		return ""
+	}
+	return c.Raw
+}
+
 // Label represents a Pull Request Label
 type Label struct {
 	Text string
+}
+
+// GetText returns the Text field, or zero value if Label is nil.
+func (l *Label) GetText() string {
+	if l == nil {
+		return ""
+	}
+	return l.Text
 }


### PR DESCRIPTION
# Changes

Adds getters to all funcs so that libraries can safely handle the struct
without needing to worry about doing nil checks to avoid panics. This is
heavily influenced by the behavior of Go protobufs and other libraries
like https://github.com/google/go-github.

Also adds test coverage for uploadComments and uploadLabels for nil
lists.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

None.

