### PR TITLE
Remove the GetParams method from the PipelineResource interface.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
@@ -107,9 +107,6 @@ func (s BuildGCSResource) GetType() PipelineResourceType {
 	return PipelineResourceTypeStorage
 }
 
-// GetParams get params
-func (s *BuildGCSResource) GetParams() []Param { return []Param{} }
-
 // GetSecretParams returns the resource secret params
 func (s *BuildGCSResource) GetSecretParams() []SecretParam { return nil }
 

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -118,9 +118,6 @@ func (s *ClusterResource) GetURL() string {
 	return s.URL
 }
 
-// GetParams returns the resource params
-func (s ClusterResource) GetParams() []Param { return []Param{} }
-
 // Replacements is used for template replacement on a ClusterResource inside of a Taskrun.
 func (s *ClusterResource) Replacements() map[string]string {
 	return map[string]string{

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -86,9 +86,6 @@ func (s GCSResource) GetType() PipelineResourceType {
 	return PipelineResourceTypeStorage
 }
 
-// GetParams get params
-func (s *GCSResource) GetParams() []Param { return []Param{} }
-
 // GetSecretParams returns the resource secret params
 func (s *GCSResource) GetSecretParams() []SecretParam { return s.Secrets }
 

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -86,9 +86,6 @@ func (s *GitResource) GetURL() string {
 	return s.URL
 }
 
-// GetParams returns the resource params
-func (s GitResource) GetParams() []Param { return []Param{} }
-
 // Replacements is used for template replacement on a GitResource inside of a Taskrun.
 func (s *GitResource) Replacements() map[string]string {
 	return map[string]string{

--- a/pkg/apis/pipeline/v1alpha1/image_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource.go
@@ -65,9 +65,6 @@ func (s ImageResource) GetType() PipelineResourceType {
 	return PipelineResourceTypeImage
 }
 
-// GetParams returns the resource params
-func (s ImageResource) GetParams() []Param { return []Param{} }
-
 // Replacements is used for template replacement on an ImageResource inside of a Taskrun.
 func (s *ImageResource) Replacements() map[string]string {
 	return map[string]string{

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -85,9 +85,6 @@ func (s *PullRequestResource) GetURL() string {
 	return s.URL
 }
 
-// GetParams returns the resource params
-func (s PullRequestResource) GetParams() []Param { return []Param{} }
-
 // Replacements is used for template replacement on a PullRequestResource inside of a Taskrun.
 func (s *PullRequestResource) Replacements() map[string]string {
 	return map[string]string{

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -52,7 +52,6 @@ var AllResourceTypes = []PipelineResourceType{PipelineResourceTypeGit, PipelineR
 type PipelineResourceInterface interface {
 	GetName() string
 	GetType() PipelineResourceType
-	GetParams() []Param
 	Replacements() map[string]string
 	GetDownloadContainerSpec() ([]corev1.Container, error)
 	GetUploadContainerSpec() ([]corev1.Container, error)


### PR DESCRIPTION
# Changes

I didn't spend the time to track down why this was added, but it's not
used anywhere meaningfully.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)