### PR TITLE
Remove unused Params field from TaskRunOutputs.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -102,8 +102,6 @@ type TaskResourceBinding struct {
 type TaskRunOutputs struct {
 	// +optional
 	Resources []TaskResourceBinding `json:"resources,omitempty"`
-	// +optional
-	Params []Param `json:"params,omitempty"`
 }
 
 var taskRunCondSet = apis.NewBatchConditionSet()

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1346,11 +1346,6 @@ func (in *TaskRunOutputs) DeepCopyInto(out *TaskRunOutputs) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.Params != nil {
-		in, out := &in.Params, &out.Params
-		*out = make([]Param, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I was reading through code trying to implement #207 and noticed that TaskRunOutputs has a param field that appears unused.

To my knowledge, taskruns can output resources, but not parameters, so I decided to remove that field and include it in a separate PR.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) **(no functionality changed or added)**
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) **(I believe no docs previously mentioned taskrun output parameters)**
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

N/A
