### PR TITLE
github enterprise support for pullrequest pipeline resource

### DIFF
--- a/cmd/pullrequest-init/github.go
+++ b/cmd/pullrequest-init/github.go
@@ -40,13 +40,22 @@ func NewGitHubHandler(ctx context.Context, logger *zap.SugaredLogger, rawURL str
 		hc = oauth2.NewClient(ctx, ts)
 	}
 
-	owner, repo, prNumber, err := parseGitHubURL(rawURL)
+	owner, repo, host, prNumber, err := parseGitHubURL(rawURL)
 	if err != nil {
 		return nil, err
 	}
-
+	var client *github.Client
+	if !strings.Contains(host, "github.com") {
+		u := fmt.Sprintf("%s/api/v3/", host)
+		client, err = github.NewEnterpriseClient(u, u, hc)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		client = github.NewClient(hc)
+	}
 	return &GitHubHandler{
-		Client: github.NewClient(hc),
+		Client: client,
 		Logger: logger,
 		owner:  owner,
 		repo:   repo,
@@ -55,24 +64,24 @@ func NewGitHubHandler(ctx context.Context, logger *zap.SugaredLogger, rawURL str
 }
 
 // parseURL takes in a raw GitHub URL
-// (e.g. https://github.com/owner/repo/pull/1) and extracts the owner, repo,
+// (e.g. https://github.com/owner/repo/pull/1) and extracts the owner, repo, host,
 // and pull request number.
-func parseGitHubURL(raw string) (string, string, int, error) {
+func parseGitHubURL(raw string) (string, string, string, int, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
-		return "", "", 0, err
+		return "", "", "", 0, err
 	}
 	split := strings.Split(u.Path, "/")
 	if len(split) < 5 {
-		return "", "", 0, fmt.Errorf("could not determine PR from URL: %v", raw)
+		return "", "", "", 0, fmt.Errorf("could not determine PR from URL: %v", raw)
 	}
 	owner, repo, pr := split[1], split[2], split[4]
 	prNumber, err := strconv.Atoi(pr)
 	if err != nil {
-		return "", "", 0, fmt.Errorf("error parsing PR number: %s", pr)
+		return "", "", "", 0, fmt.Errorf("error parsing PR number: %s", pr)
 	}
 
-	return owner, repo, prNumber, nil
+	return owner, repo, u.Scheme + "://" + u.Host, prNumber, nil
 }
 
 // writeJSON writes an arbitrary interface to the given path.


### PR DESCRIPTION
The pull request resource supports only public github.  This PR adds the support for the enterprise github.  When the url in the pull request resource has the base url other than "github.com", it sets the url as the base url for the pull request.

Test for the NewGitHubHandler is added in cmd/pullrequest-init/github_test.go 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

When the url in the pull request resource has the base url other than "github.com", it sets the url as the base url for the pull request.

Code changes are in NewGitHubHandler in cmd/pullrequest-init/github.go
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
github enterprise support
```
