### PR TITLE
Replace hard coded loggingConfig location with a flag

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -54,11 +54,12 @@ var (
 	masterURL  string
 	kubeconfig string
 	namespace  string
+	loggingConfig string
 )
 
 func main() {
 	flag.Parse()
-	loggingConfigMap, err := configmap.Load("/etc/config-logging")
+	loggingConfigMap, err := configmap.Load(loggingConfig)
 	if err != nil {
 		log.Fatalf("Error loading logging configuration: %v", err)
 	}
@@ -188,4 +189,5 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&namespace, "namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
+	flag.StringVar(&loggingConfig, "loggingconfig", "/etc/config-logging", "Path to config logging file. Optional. Defaults to /etc/config-logging")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Using a flag here is more consistent since all other config values for
the controller also come via flags. Also, this makes it easier to run
the controller locally outside a cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
