### PR TITLE
skaffold: use a working revision instead of master

### DIFF
--- a/examples/pipelineruns/output-pipelinerun.yaml
+++ b/examples/pipelineruns/output-pipelinerun.yaml
@@ -6,7 +6,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: v0.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---

--- a/examples/pipelineruns/pipelinerun.yaml
+++ b/examples/pipelineruns/pipelinerun.yaml
@@ -44,7 +44,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: v0.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---

--- a/examples/taskruns/git-resource-spec-taskrun.yaml
+++ b/examples/taskruns/git-resource-spec-taskrun.yaml
@@ -22,6 +22,6 @@ spec:
         type: git
         params:
           - name: revision
-            value: master
+            value: v0.32.0
           - name: url
             value: https://github.com/GoogleContainerTools/skaffold

--- a/examples/taskruns/task-multiple-output-image.yaml
+++ b/examples/taskruns/task-multiple-output-image.yaml
@@ -42,7 +42,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: v0.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---

--- a/examples/taskruns/task-output-image.yaml
+++ b/examples/taskruns/task-output-image.yaml
@@ -32,7 +32,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: v0.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---

--- a/examples/taskruns/taskrun.yaml
+++ b/examples/taskruns/taskrun.yaml
@@ -32,7 +32,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: master
+    value: v0.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---


### PR DESCRIPTION
# Changes

Recent changes in `GoogleContaineTools/skaffold` broked the
examples (and thus the CI it seems). Let's use a revision we know
works instead of depending on random changes.

A better option would be to use `pipeline` itself in the example, but
that can be done later on.

This should fix the CI on pull requests.

/cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ :no_good_man: ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ :no_good_man: ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

