### PR TITLE
Implement 0 as no timeout for TaskRun and PipelineRun

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -35,5 +35,5 @@ data:
     # to actually change the configuration.
 
     # default-timeout-minutes contains the default number of
-    # minutes to use for TaskRun, if none is specified.
+    # minutes to use for TaskRun and PipelineRun, if none is specified.
     default-timeout-minutes: "60"  # 60 minutes

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -41,7 +41,11 @@ following fields:
     information.
   - [`serviceAccounts`](#service-accounts) - Specifies a list of `ServiceAccount` 
     and `PipelineTask` pairs that enable you to overwrite `ServiceAccount` for concrete `PipelineTask`.
-  - `timeout` - Specifies timeout after which the `PipelineRun` will fail.
+  - [`timeout`] - Specifies timeout after which the `PipelineRun` will fail. If the value of
+    `timeout` is empty, the default timeout will be applied. If the value is set to 0,
+    there is no timeout. `PipelineRun` shares the same default timeout as `TaskRun`. You can
+    follow the instruction [here](taskruns.md#Configuring-default-timeout) to configure the
+    default timeout, the same way as `TaskRun`.
   - [`nodeSelector`] - A selector which must be true for the pod to fit on a
     node. The selector which must match a node's labels for the pod to be
     scheduled on that node. More info:

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -49,8 +49,10 @@ following fields:
   - [`inputs`] - Specifies [input parameters](#input-parameters) and
     [input resources](#providing-resources)
   - [`outputs`] - Specifies [output resources](#providing-resources)
-  - `timeout` - Specifies timeout after which the `TaskRun` will fail. Defaults
-    to 60 minutes.
+  - [`timeout`] - Specifies timeout after which the `TaskRun` will fail. If the value of
+    `timeout` is empty, the default timeout will be applied. If the value is set to 0,
+    there is no timeout. You can also follow the instruction [here](#Configuring-default-timeout)
+    to configure the default timeout.
   - [`nodeSelector`] - a selector which must be true for the pod to fit on a
     node. The selector which must match a node's labels for the pod to be
     scheduled on that node. More info:
@@ -145,6 +147,13 @@ spec:
             - name: url
               value: https://github.com/pivotal-nader-ziada/gohelloworld
 ```
+
+### Configuring Default Timeout
+
+You can configure the default timeout by changing the value of `default-timeout-minutes`
+in [`config/config-defaults.yaml`](./../config/config-defaults.yaml). The default timeout
+is 60 minutes, if `default-timeout-minutes` is not available. There is no timeout by
+default, if `default-timeout-minutes` is set to 0.
 
 ### Service Account
 

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -27,6 +28,7 @@ const (
 	// ConfigName is the name of the configmap
 	DefaultsConfigName       = "config-defaults"
 	DefaultTimeoutMinutes    = 60
+	NoTimeoutDuration        = 0 * time.Minute
 	defaultTimeoutMinutesKey = "default-timeout-minutes"
 )
 

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
@@ -51,8 +51,8 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	if ps.Timeout != nil {
 		// timeout should be a valid duration of at least 0.
-		if ps.Timeout.Duration <= 0 {
-			return apis.ErrInvalidValue(fmt.Sprintf("%s should be > 0", ps.Timeout.Duration.String()), "spec.timeout")
+		if ps.Timeout.Duration < 0 {
+			return apis.ErrInvalidValue(fmt.Sprintf("%s should be >= 0", ps.Timeout.Duration.String()), "spec.timeout")
 		}
 	}
 

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -66,6 +66,13 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
+	if ts.Timeout != nil {
+		// timeout should be a valid duration of at least 0.
+		if ts.Timeout.Duration < 0 {
+			return apis.ErrInvalidValue(fmt.Sprintf("%s should be >= 0", ts.Timeout.Duration.String()), "spec.timeout")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/reconciler/v1alpha1/taskrun/timeout_check.go
+++ b/pkg/reconciler/v1alpha1/taskrun/timeout_check.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"time"
+
+	apisconfig "github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+func CheckTimeout(tr *v1alpha1.TaskRun) bool {
+	// If tr has not started, startTime should be zero.
+	if tr.Status.StartTime.IsZero() {
+		return false
+	}
+
+	timeout := tr.Spec.Timeout.Duration
+	// If timeout is set to 0 or defaulted to 0, there is no timeout.
+	if timeout == apisconfig.NoTimeoutDuration {
+		return false
+	}
+	runtime := time.Since(tr.Status.StartTime.Time)
+	if runtime > timeout {
+		return true
+	} else {
+		return false
+	}
+}

--- a/pkg/reconciler/v1alpha1/taskrun/timeout_check_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/timeout_check_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrun
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+)
+
+func TestCheckTimeout(t *testing.T) {
+	// IsZero reports whether t represents the zero time instant, January 1, year 1, 00:00:00 UTC
+	zeroTime := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+	testCases := []struct {
+		name           string
+		taskRun        *v1alpha1.TaskRun
+		expectedStatus bool
+	}{{
+		name: "TaskRun not started",
+		taskRun: tb.TaskRun("test-taskrun-not-started", "foo", tb.TaskRunSpec(
+			tb.TaskRunTaskRef(simpleTask.Name),
+		), tb.TaskRunStatus(tb.Condition(apis.Condition{
+		}), tb.TaskRunStartTime(zeroTime))),
+		expectedStatus: false,
+	}, {
+		name: "TaskRun no timeout",
+		taskRun: tb.TaskRun("test-taskrun-no-timeout", "foo", tb.TaskRunSpec(
+			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(0),
+		), tb.TaskRunStatus(tb.Condition(apis.Condition{
+		}), tb.TaskRunStartTime(time.Now().Add(-15 * time.Hour)))),
+		expectedStatus: false,
+	}, {
+		name: "TaskRun timed out",
+		taskRun: tb.TaskRun("test-taskrun-timeout", "foo", tb.TaskRunSpec(
+			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(10 * time.Second),
+		), tb.TaskRunStatus(tb.Condition(apis.Condition{
+		}), tb.TaskRunStartTime(time.Now().Add(-15 * time.Second)))),
+		expectedStatus: true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CheckTimeout(tc.taskRun)
+			if d := cmp.Diff(result, tc.expectedStatus); d != "" {
+				t.Fatalf("-want, +got: %v", d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

* If the timeout is set to 0, there is no timeout for the TaskRun or PipelineRun.
* If the timeout is empty, the default timeout 60 mins will be applied.
* If the timeout is set to -1, the taskrun is created in pipelinerun after it timed out.

Closes: #978

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

<!--
Does your PR contain User facing changes?

If so, briefly describe them here so we can include this description in the
release notes for the next release!
-->

```
The default timeout of TaskRun and PipelineRun is configurable by editing the value of
`default-timeout-minutes` in config/config-defaults.yaml. The default timeout
is 60 minutes, if it is unset. If it is set to 0, there is no timeout for TaskRun or PipelineRun
by default.

If the `timeout` is unset for the TaskRun or PipelineRun, the default timeout will be picked.
If the `timeout` is set to 0, there is no timeout for the TaskRun or PipelineRun.
```
