### PR TITLE
Rename package name in test files under v1alpha1

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
@@ -18,10 +18,10 @@ package v1alpha1_test
 
 import (
 	"fmt"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 )

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"fmt"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -32,9 +33,9 @@ const (
 var (
 	expectedVolumeName = fmt.Sprintf("volume-bucket-%s", secretName)
 
-	bucket = ArtifactBucket{
+	bucket = v1alpha1.ArtifactBucket{
 		Location: "gs://fake-bucket",
-		Secrets: []SecretParam{{
+		Secrets: []v1alpha1.SecretParam{{
 			FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			SecretName: secretName,
 			SecretKey:  "serviceaccount",

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,7 +29,7 @@ import (
 func TestPVCGetCopyFromContainerSpec(t *testing.T) {
 	names.TestingSeed()
 
-	pvc := ArtifactPVC{
+	pvc := v1alpha1.ArtifactPVC{
 		Name: "pipelinerun-pvc",
 	}
 	want := []corev1.Container{{
@@ -47,7 +48,7 @@ func TestPVCGetCopyFromContainerSpec(t *testing.T) {
 func TestPVCGetCopyToContainerSpec(t *testing.T) {
 	names.TestingSeed()
 
-	pvc := ArtifactPVC{
+	pvc := v1alpha1.ArtifactPVC{
 		Name: "pipelinerun-pvc",
 	}
 	want := []corev1.Container{{
@@ -79,7 +80,7 @@ func TestPVCGetPvcMount(t *testing.T) {
 		Name:      name,
 		MountPath: pvcDir,
 	}
-	got := GetPvcMount(name)
+	got := v1alpha1.GetPvcMount(name)
 	if d := cmp.Diff(got, want); d != "" {
 		t.Errorf("Diff:\n%s", d)
 	}
@@ -94,17 +95,17 @@ func TestPVCGetMakeDirContainerSpec(t *testing.T) {
 		Command: []string{"/ko-app/bash"},
 		Args:    []string{"-args", "mkdir -p /workspace/destination"},
 	}
-	got := CreateDirContainer("workspace", "/workspace/destination")
+	got := v1alpha1.CreateDirContainer("workspace", "/workspace/destination")
 	if d := cmp.Diff(got, want); d != "" {
 		t.Errorf("Diff:\n%s", d)
 	}
 }
 
 func TestStorageBasePath(t *testing.T) {
-	pvc := ArtifactPVC{
+	pvc := v1alpha1.ArtifactPVC{
 		Name: "pipelinerun-pvc",
 	}
-	pipelinerun := &PipelineRun{
+	pipelinerun := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "pipelineruntest",

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,16 +29,16 @@ import (
 func Test_Invalid_BuildGCSResource(t *testing.T) {
 	testcases := []struct {
 		name             string
-		pipelineResource *PipelineResource
+		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "no location params",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "buildgcs-resource-with-no-location-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "NotLocation",
 					Value: "doesntmatter",
 				}, {
@@ -48,13 +49,13 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 		},
 	}, {
 		name: "location param with empty value",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource-with-empty-location-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "",
 				}, {
@@ -65,13 +66,13 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 		},
 	}, {
 		name: "no artifactType params",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "buildgcs-resource-with-no-artifactType-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "gs://test",
 				}, {
@@ -82,13 +83,13 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 		},
 	}, {
 		name: "artifactType param with empty value",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource-with-empty-location-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "gs://test",
 				}, {
@@ -102,13 +103,13 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 		},
 	}, {
 		name: "artifactType param with invalid value",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource-with-empty-location-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "gs://test",
 				}, {
@@ -122,13 +123,13 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 		},
 	}, {
 		name: "artifactType param with secrets value",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource-with-secrets",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "gs://test",
 				}, {
@@ -138,7 +139,7 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 					Name:  "ArtifactType",
 					Value: "invalid-type",
 				}},
-				SecretParams: []SecretParam{{
+				SecretParams: []v1alpha1.SecretParam{{
 					SecretKey:  "secretKey",
 					SecretName: "secretName",
 					FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
@@ -148,7 +149,7 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewStorageResource(tc.pipelineResource)
+			_, err := v1alpha1.NewStorageResource(tc.pipelineResource)
 			if err == nil {
 				t.Error("Expected error creating BuildGCS resource")
 			}
@@ -157,13 +158,13 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 }
 
 func Test_Valid_NewBuildGCSResource(t *testing.T) {
-	pr := &PipelineResource{
+	pr := &v1alpha1.PipelineResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "build-gcs-resource",
 		},
-		Spec: PipelineResourceSpec{
-			Type: PipelineResourceTypeStorage,
-			Params: []Param{{
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeStorage,
+			Params: []v1alpha1.Param{{
 				Name:  "Location",
 				Value: "gs://fake-bucket",
 			}, {
@@ -175,14 +176,14 @@ func Test_Valid_NewBuildGCSResource(t *testing.T) {
 			}},
 		},
 	}
-	expectedGCSResource := &BuildGCSResource{
+	expectedGCSResource := &v1alpha1.BuildGCSResource{
 		Name:         "build-gcs-resource",
 		Location:     "gs://fake-bucket",
-		Type:         PipelineResourceTypeStorage,
+		Type:         v1alpha1.PipelineResourceTypeStorage,
 		ArtifactType: "Manifest",
 	}
 
-	r, err := NewBuildGCSResource(pr)
+	r, err := v1alpha1.NewBuildGCSResource(pr)
 	if err != nil {
 		t.Fatalf("Unexpected error creating BuildGCS resource: %s", err)
 	}
@@ -192,10 +193,10 @@ func Test_Valid_NewBuildGCSResource(t *testing.T) {
 }
 
 func Test_BuildGCSGetReplacements(t *testing.T) {
-	r := &BuildGCSResource{
+	r := &v1alpha1.BuildGCSResource{
 		Name:     "gcs-resource",
 		Location: "gs://fake-bucket",
-		Type:     PipelineResourceTypeBuildGCS,
+		Type:     v1alpha1.PipelineResourceTypeBuildGCS,
 	}
 	expectedReplacementMap := map[string]string{
 		"name":     "gcs-resource",
@@ -211,12 +212,12 @@ func Test_BuildGCSGetReplacements(t *testing.T) {
 func Test_BuildGCSGetDownloadContainerSpec(t *testing.T) {
 	testcases := []struct {
 		name           string
-		resource       *BuildGCSResource
+		resource       *v1alpha1.BuildGCSResource
 		wantContainers []corev1.Container
 		wantErr        bool
 	}{{
 		name: "valid download protected buckets",
-		resource: &BuildGCSResource{
+		resource: &v1alpha1.BuildGCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket",
 			DestinationDir: "/workspace",
@@ -235,7 +236,7 @@ func Test_BuildGCSGetDownloadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "invalid no destination directory set",
-		resource: &BuildGCSResource{
+		resource: &v1alpha1.BuildGCSResource{
 			Name:         "gcs-invalid",
 			Location:     "gs://some-bucket",
 			ArtifactType: "Archive",
@@ -259,12 +260,12 @@ func Test_BuildGCSGetDownloadContainerSpec(t *testing.T) {
 func Test_BuildGCSGetUploadContainerSpec(t *testing.T) {
 	testcases := []struct {
 		name           string
-		resource       *BuildGCSResource
+		resource       *v1alpha1.BuildGCSResource
 		wantContainers []corev1.Container
 		wantErr        bool
 	}{{
 		name: "valid upload to protected buckets with directory paths",
-		resource: &BuildGCSResource{
+		resource: &v1alpha1.BuildGCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket/manifest.json",
 			DestinationDir: "/workspace",
@@ -277,7 +278,7 @@ func Test_BuildGCSGetUploadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "invalid upload to protected buckets with single file",
-		resource: &BuildGCSResource{
+		resource: &v1alpha1.BuildGCSResource{
 			Name:           "gcs-valid",
 			ArtifactType:   "Archive",
 			Location:       "gs://some-bucket",
@@ -286,7 +287,7 @@ func Test_BuildGCSGetUploadContainerSpec(t *testing.T) {
 		wantErr: true,
 	}, {
 		name: "invalid upload with no source directory path",
-		resource: &BuildGCSResource{
+		resource: &v1alpha1.BuildGCSResource{
 			Name:     "gcs-invalid",
 			Location: "gs://some-bucket/manifest.json",
 		},

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -14,10 +14,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -11,9 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -25,18 +26,18 @@ import (
 func TestNewClusterResource(t *testing.T) {
 	for _, c := range []struct {
 		desc     string
-		resource *PipelineResource
-		want     *ClusterResource
+		resource *v1alpha1.PipelineResource
+		want     *v1alpha1.ClusterResource
 	}{{
 		desc: "basic cluster resource",
-		resource: &PipelineResource{
+		resource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cluster-resource",
+				Name:      "test-clus ter-resource",
 				Namespace: "foo",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeCluster,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeCluster,
+				Params: []v1alpha1.Param{{
 					Name:  "name",
 					Value: "test_cluster_resource",
 				}, {
@@ -52,23 +53,23 @@ func TestNewClusterResource(t *testing.T) {
 				},
 			},
 		},
-		want: &ClusterResource{
+		want: &v1alpha1.ClusterResource{
 			Name:   "test_cluster_resource",
-			Type:   PipelineResourceTypeCluster,
+			Type:   v1alpha1.PipelineResourceTypeCluster,
 			URL:    "http://10.10.10.10",
 			CAData: []byte("my-cluster-cert"),
 			Token:  "my-token",
 		},
 	}, {
 		desc: "resource with password instead of token",
-		resource: &PipelineResource{
+		resource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster-resource",
 				Namespace: "foo",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeCluster,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeCluster,
+				Params: []v1alpha1.Param{{
 					Name:  "name",
 					Value: "test_cluster_resource",
 				}, {
@@ -87,9 +88,9 @@ func TestNewClusterResource(t *testing.T) {
 				},
 			},
 		},
-		want: &ClusterResource{
+		want: &v1alpha1.ClusterResource{
 			Name:     "test_cluster_resource",
-			Type:     PipelineResourceTypeCluster,
+			Type:     v1alpha1.PipelineResourceTypeCluster,
 			URL:      "http://10.10.10.10",
 			CAData:   []byte("my-cluster-cert"),
 			Username: "user",
@@ -97,14 +98,14 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "set insecure flag to true when there is no cert",
-		resource: &PipelineResource{
+		resource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster-resource",
 				Namespace: "foo",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeCluster,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeCluster,
+				Params: []v1alpha1.Param{{
 					Name:  "Name",
 					Value: "test.cluster.resource",
 				}, {
@@ -117,30 +118,30 @@ func TestNewClusterResource(t *testing.T) {
 				},
 			},
 		},
-		want: &ClusterResource{
+		want: &v1alpha1.ClusterResource{
 			Name:     "test.cluster.resource",
-			Type:     PipelineResourceTypeCluster,
+			Type:     v1alpha1.PipelineResourceTypeCluster,
 			URL:      "http://10.10.10.10",
 			Token:    "my-token",
 			Insecure: true,
 		},
 	}, {
 		desc: "basic resource with secrets",
-		resource: &PipelineResource{
+		resource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cluster-resource",
 				Namespace: "foo",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeCluster,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeCluster,
+				Params: []v1alpha1.Param{{
 					Name:  "name",
 					Value: "test-cluster-resource",
 				}, {
 					Name:  "url",
 					Value: "http://10.10.10.10",
 				}},
-				SecretParams: []SecretParam{{
+				SecretParams: []v1alpha1.SecretParam{{
 					FieldName:  "cadata",
 					SecretKey:  "cadatakey",
 					SecretName: "secret1",
@@ -151,11 +152,11 @@ func TestNewClusterResource(t *testing.T) {
 				}},
 			},
 		},
-		want: &ClusterResource{
+		want: &v1alpha1.ClusterResource{
 			Name: "test-cluster-resource",
-			Type: PipelineResourceTypeCluster,
+			Type: v1alpha1.PipelineResourceTypeCluster,
 			URL:  "http://10.10.10.10",
-			Secrets: []SecretParam{{
+			Secrets: []v1alpha1.SecretParam{{
 				FieldName:  "cadata",
 				SecretKey:  "cadatakey",
 				SecretName: "secret1",
@@ -167,7 +168,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			got, err := NewClusterResource(c.resource)
+			got, err := v1alpha1.NewClusterResource(c.resource)
 			if err != nil {
 				t.Errorf("Test: %q; TestNewClusterResource() error = %v", c.desc, err)
 			}
@@ -182,16 +183,16 @@ func Test_ClusterResource_GetDownloadContainerSpec(t *testing.T) {
 	names.TestingSeed()
 	testcases := []struct {
 		name            string
-		clusterResource *ClusterResource
+		clusterResource *v1alpha1.ClusterResource
 		wantContainers  []corev1.Container
 		wantErr         bool
 	}{{
 		name: "valid cluster resource config",
-		clusterResource: &ClusterResource{
+		clusterResource: &v1alpha1.ClusterResource{
 			Name: "test-cluster-resource",
-			Type: PipelineResourceTypeCluster,
+			Type: v1alpha1.PipelineResourceTypeCluster,
 			URL:  "http://10.10.10.10",
-			Secrets: []SecretParam{{
+			Secrets: []v1alpha1.SecretParam{{
 				FieldName:  "cadata",
 				SecretKey:  "cadatakey",
 				SecretName: "secret1",

--- a/pkg/apis/pipeline/v1alpha1/dag_test.go
+++ b/pkg/apis/pipeline/v1alpha1/dag_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/list"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,26 +29,26 @@ import (
 func Test_Invalid_NewStorageResource(t *testing.T) {
 	testcases := []struct {
 		name             string
-		pipelineResource *PipelineResource
+		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "wrong-resource-type",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeGit,
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeGit,
 			},
 		},
 	}, {
 		name: "unimplemented type",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "gs://fake-bucket",
 				}, {
@@ -58,13 +59,13 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 		},
 	}, {
 		name: "no type",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "gs://fake-bucket",
 				}},
@@ -72,13 +73,13 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 		},
 	}, {
 		name: "no location params",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource-with-no-location-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "NotLocation",
 					Value: "doesntmatter",
 				}, {
@@ -89,13 +90,13 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 		},
 	}, {
 		name: "location param with empty value",
-		pipelineResource: &PipelineResource{
+		pipelineResource: &v1alpha1.PipelineResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gcs-resource-with-empty-location-param",
 			},
-			Spec: PipelineResourceSpec{
-				Type: PipelineResourceTypeStorage,
-				Params: []Param{{
+			Spec: v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeStorage,
+				Params: []v1alpha1.Param{{
 					Name:  "Location",
 					Value: "",
 				}, {
@@ -107,7 +108,7 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := NewStorageResource(tc.pipelineResource)
+			_, err := v1alpha1.NewStorageResource(tc.pipelineResource)
 			if err == nil {
 				t.Error("Expected error creating GCS resource")
 			}
@@ -116,13 +117,13 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 }
 
 func Test_Valid_NewGCSResource(t *testing.T) {
-	pr := &PipelineResource{
+	pr := &v1alpha1.PipelineResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "gcs-resource",
 		},
-		Spec: PipelineResourceSpec{
-			Type: PipelineResourceTypeStorage,
-			Params: []Param{{
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeStorage,
+			Params: []v1alpha1.Param{{
 				Name:  "Location",
 				Value: "gs://fake-bucket",
 			}, {
@@ -132,26 +133,26 @@ func Test_Valid_NewGCSResource(t *testing.T) {
 				Name:  "dir",
 				Value: "anything",
 			}},
-			SecretParams: []SecretParam{{
+			SecretParams: []v1alpha1.SecretParam{{
 				SecretKey:  "secretKey",
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
 		},
 	}
-	expectedGCSResource := &GCSResource{
+	expectedGCSResource := &v1alpha1.GCSResource{
 		Name:     "gcs-resource",
 		Location: "gs://fake-bucket",
-		Type:     PipelineResourceTypeStorage,
+		Type:     v1alpha1.PipelineResourceTypeStorage,
 		TypeDir:  true,
-		Secrets: []SecretParam{{
+		Secrets: []v1alpha1.SecretParam{{
 			SecretName: "secretName",
 			SecretKey:  "secretKey",
 			FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 		}},
 	}
 
-	gcsRes, err := NewGCSResource(pr)
+	gcsRes, err := v1alpha1.NewGCSResource(pr)
 	if err != nil {
 		t.Fatalf("Unexpected error creating GCS resource: %s", err)
 	}
@@ -161,10 +162,10 @@ func Test_Valid_NewGCSResource(t *testing.T) {
 }
 
 func Test_GCSGetReplacements(t *testing.T) {
-	gcsResource := &GCSResource{
+	gcsResource := &v1alpha1.GCSResource{
 		Name:     "gcs-resource",
 		Location: "gs://fake-bucket",
-		Type:     PipelineResourceTypeGCS,
+		Type:     v1alpha1.PipelineResourceTypeGCS,
 	}
 	expectedReplacementMap := map[string]string{
 		"name":     "gcs-resource",
@@ -178,28 +179,28 @@ func Test_GCSGetReplacements(t *testing.T) {
 }
 
 func Test_GetParams(t *testing.T) {
-	pr := &PipelineResource{
-		Spec: PipelineResourceSpec{
-			Type: PipelineResourceTypeStorage,
-			Params: []Param{{
+	pr := &v1alpha1.PipelineResource{
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeStorage,
+			Params: []v1alpha1.Param{{
 				Name:  "type",
 				Value: "gcs",
 			}, {
 				Name:  "location",
 				Value: "gs://some-bucket.zip",
 			}},
-			SecretParams: []SecretParam{{
+			SecretParams: []v1alpha1.SecretParam{{
 				SecretKey:  "test-secret-key",
 				SecretName: "test-secret-name",
 				FieldName:  "test-field-name",
 			}},
 		},
 	}
-	gcsResource, err := NewStorageResource(pr)
+	gcsResource, err := v1alpha1.NewStorageResource(pr)
 	if err != nil {
 		t.Fatalf("Error creating storage resource: %s", err.Error())
 	}
-	expectedSp := []SecretParam{{
+	expectedSp := []v1alpha1.SecretParam{{
 		SecretKey:  "test-secret-key",
 		SecretName: "test-secret-name",
 		FieldName:  "test-field-name",
@@ -214,17 +215,17 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 
 	testcases := []struct {
 		name           string
-		gcsResource    *GCSResource
+		gcsResource    *v1alpha1.GCSResource
 		wantContainers []corev1.Container
 		wantErr        bool
 	}{{
 		name: "valid download protected buckets",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket",
 			DestinationDir: "/workspace",
 			TypeDir:        true,
-			Secrets: []SecretParam{{
+			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
@@ -251,11 +252,11 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "duplicate secret mount paths",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket",
 			DestinationDir: "/workspace",
-			Secrets: []SecretParam{{
+			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "fieldName",
 				SecretKey:  "key.json",
@@ -286,7 +287,7 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "invalid no destination directory set",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:     "gcs-invalid",
 			Location: "gs://some-bucket",
 		},
@@ -310,17 +311,17 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 
 	testcases := []struct {
 		name           string
-		gcsResource    *GCSResource
+		gcsResource    *v1alpha1.GCSResource
 		wantContainers []corev1.Container
 		wantErr        bool
 	}{{
 		name: "valid upload to protected buckets with directory paths",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket",
 			DestinationDir: "/workspace/",
 			TypeDir:        true,
-			Secrets: []SecretParam{{
+			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
@@ -339,11 +340,11 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "duplicate secret mount paths",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket",
 			DestinationDir: "/workspace",
-			Secrets: []SecretParam{{
+			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
@@ -368,7 +369,7 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "valid upload to protected buckets with single file",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:           "gcs-valid",
 			Location:       "gs://some-bucket",
 			DestinationDir: "/workspace/",
@@ -382,7 +383,7 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 		}},
 	}, {
 		name: "invalid upload with no source directory path",
-		gcsResource: &GCSResource{
+		gcsResource: &v1alpha1.GCSResource{
 			Name:     "gcs-invalid",
 			Location: "gs://some-bucket",
 		},

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const workspaceDir = "/workspace"
+const WorkspaceDir = "/workspace"
 
 var (
 	gitSource = "git-source"
@@ -109,7 +109,7 @@ func (s *GitResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 		Image:      *gitImage,
 		Command:    []string{"/ko-app/git-init"},
 		Args:       args,
-		WorkingDir: workspaceDir,
+		WorkingDir: WorkspaceDir,
 	}}, nil
 }
 

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -78,7 +78,7 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		for _, param := range rs.Params {
 			switch {
 			case strings.EqualFold(param.Name, "type"):
-				if !allowedStorageType(param.Value) {
+				if !AllowedStorageType(param.Value) {
 					return apis.ErrInvalidValue(param.Value, "spec.params.type")
 				}
 				foundTypeParam = true
@@ -104,7 +104,7 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	return apis.ErrInvalidValue("spec.type", string(rs.Type))
 }
 
-func allowedStorageType(gotType string) bool {
+func AllowedStorageType(gotType string) bool {
 	switch gotType {
 	case string(PipelineResourceTypeGCS):
 		return true

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,19 +29,19 @@ import (
 func TestResourceValidation_Invalid(t *testing.T) {
 	tests := []struct {
 		name string
-		res  PipelineResource
+		res  v1alpha1.PipelineResource
 		want *apis.FieldError
 	}{
 		{
 			name: "cluster with invalid url",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster-resource",
 					Namespace: "foo",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeCluster,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeCluster,
+					Params: []v1alpha1.Param{{
 						Name:  "name",
 						Value: "test-cluster-resource",
 					}, {
@@ -63,14 +64,14 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		},
 		{
 			name: "cluster with missing username",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster-resource",
 					Namespace: "foo",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeCluster,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeCluster,
+					Params: []v1alpha1.Param{{
 						Name:  "name",
 						Value: "test-cluster-resource",
 					}, {
@@ -90,14 +91,14 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		},
 		{
 			name: "cluster with missing name",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster-resource",
 					Namespace: "foo",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeCluster,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeCluster,
+					Params: []v1alpha1.Param{{
 						Name:  "url",
 						Value: "http://10.10.10.10",
 					}, {
@@ -114,14 +115,14 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		},
 		{
 			name: "cluster with missing cadata",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster-resource",
 					Namespace: "foo",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeCluster,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeCluster,
+					Params: []v1alpha1.Param{{
 						Name:  "Name",
 						Value: "test-cluster-resource",
 					}, {
@@ -140,13 +141,13 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrMissingField("CAData param"),
 		}, {
 			name: "storage with no type",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "storage-resource",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeStorage,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeStorage,
+					Params: []v1alpha1.Param{{
 						Name:  "no-type-param",
 						Value: "sometype",
 					}},
@@ -155,13 +156,13 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrMissingField("spec.params.type"),
 		}, {
 			name: "storage with unimplemented type",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "storage-resource",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeStorage,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeStorage,
+					Params: []v1alpha1.Param{{
 						Name:  "type",
 						Value: "not-implemented-yet",
 					}},
@@ -170,13 +171,13 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrInvalidValue("not-implemented-yet", "spec.params.type"),
 		}, {
 			name: "storage with gcs type with no location param",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "storage-resource",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeStorage,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeStorage,
+					Params: []v1alpha1.Param{{
 						Name:  "type",
 						Value: "gcs",
 					}},
@@ -185,13 +186,13 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrMissingField("spec.params.location"),
 		}, {
 			name: "storage with gcs type with empty location param",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "storage-resource",
 				},
-				Spec: PipelineResourceSpec{
-					Type: PipelineResourceTypeStorage,
-					Params: []Param{{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypeStorage,
+					Params: []v1alpha1.Param{{
 						Name:  "type",
 						Value: "gcs",
 					}, {
@@ -203,11 +204,11 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrMissingField("spec.params.location"),
 		}, {
 			name: "invalid resoure type",
-			res: PipelineResource{
+			res: v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "invalid-resource",
 				},
-				Spec: PipelineResourceSpec{
+				Spec: v1alpha1.PipelineResourceSpec{
 					Type: "not-supported",
 				},
 			},
@@ -225,14 +226,14 @@ func TestResourceValidation_Invalid(t *testing.T) {
 }
 
 func TestClusterResourceValidation_Valid(t *testing.T) {
-	res := &PipelineResource{
+	res := &v1alpha1.PipelineResource{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-cluster-resource",
 			Namespace: "foo",
 		},
-		Spec: PipelineResourceSpec{
-			Type: PipelineResourceTypeCluster,
-			Params: []Param{{
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeCluster,
+			Params: []v1alpha1.Param{{
 				Name:  "name",
 				Value: "test-cluster-resource",
 			}, {
@@ -281,7 +282,7 @@ func TestAllowedGCSStorageType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if allowedStorageType(tt.storageType) != tt.want {
+			if v1alpha1.AllowedStorageType(tt.storageType) != tt.want {
 				t.Errorf("PipleineResource.allowedStorageType should return %t, got %t for %s", tt.want, !tt.want, tt.storageType)
 			}
 		})

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -18,11 +18,11 @@ package v1alpha1_test
 
 import (
 	"context"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -1,6 +1,23 @@
-package v1alpha1
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 	"time"
 
@@ -11,7 +28,7 @@ import (
 )
 
 func TestPipelineRunStatusConditions(t *testing.T) {
-	p := &PipelineRun{}
+	p := &v1alpha1.PipelineRun{}
 	foo := &apis.Condition{
 		Type:   "Foo",
 		Status: "True",
@@ -44,7 +61,7 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 }
 
 func TestPipelineRun_TaskRunref(t *testing.T) {
-	p := &PipelineRun{
+	p := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-ns",
@@ -64,7 +81,7 @@ func TestPipelineRun_TaskRunref(t *testing.T) {
 }
 
 func TestInitializeConditions(t *testing.T) {
-	p := &PipelineRun{
+	p := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-name",
 			Namespace: "test-ns",
@@ -80,7 +97,7 @@ func TestInitializeConditions(t *testing.T) {
 		t.Fatalf("PipelineRun StartTime not initialized correctly")
 	}
 
-	p.Status.TaskRuns["fooTask"] = &PipelineRunTaskRunStatus{}
+	p.Status.TaskRuns["fooTask"] = &v1alpha1.PipelineRunTaskRunStatus{}
 
 	p.Status.InitializeConditions()
 	if len(p.Status.TaskRuns) != 1 {
@@ -89,7 +106,7 @@ func TestInitializeConditions(t *testing.T) {
 }
 
 func TestPipelineRunIsDone(t *testing.T) {
-	pr := &PipelineRun{}
+	pr := &v1alpha1.PipelineRun{}
 	foo := &apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionFalse,
@@ -101,9 +118,9 @@ func TestPipelineRunIsDone(t *testing.T) {
 }
 
 func TestPipelineRunIsCancelled(t *testing.T) {
-	pr := &PipelineRun{
-		Spec: PipelineRunSpec{
-			Status: PipelineRunSpecStatusCancelled,
+	pr := &v1alpha1.PipelineRun{
+		Spec: v1alpha1.PipelineRunSpec{
+			Status: v1alpha1.PipelineRunSpecStatusCancelled,
 		},
 	}
 	if !pr.IsCancelled() {
@@ -112,7 +129,7 @@ func TestPipelineRunIsCancelled(t *testing.T) {
 }
 
 func TestPipelineRunKey(t *testing.T) {
-	pr := &PipelineRun{
+	pr := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "prunname",
 			Namespace: "testns",
@@ -127,28 +144,28 @@ func TestPipelineRunKey(t *testing.T) {
 func TestPipelineRunHasStarted(t *testing.T) {
 	params := []struct {
 		name          string
-		prStatus      PipelineRunStatus
+		prStatus      v1alpha1.PipelineRunStatus
 		expectedValue bool
 	}{{
 		name:          "prWithNoStartTime",
-		prStatus:      PipelineRunStatus{},
+		prStatus:      v1alpha1.PipelineRunStatus{},
 		expectedValue: false,
 	}, {
 		name: "prWithStartTime",
-		prStatus: PipelineRunStatus{
+		prStatus: v1alpha1.PipelineRunStatus{
 			StartTime: &metav1.Time{Time: time.Now()},
 		},
 		expectedValue: true,
 	}, {
 		name: "prWithZeroStartTime",
-		prStatus: PipelineRunStatus{
+		prStatus: v1alpha1.PipelineRunStatus{
 			StartTime: &metav1.Time{},
 		},
 		expectedValue: false,
 	}}
 	for _, tc := range params {
 		t.Run(tc.name, func(t *testing.T) {
-			pr := &PipelineRun{
+			pr := &v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prunname",
 					Namespace: "testns",

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
@@ -13,10 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package v1alpha1
+
+package v1alpha1_test
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 	"time"
 
@@ -28,12 +30,12 @@ import (
 func TestPipelineRun_Invalidate(t *testing.T) {
 	tests := []struct {
 		name string
-		pr   PipelineRun
+		pr   v1alpha1.PipelineRun
 		want *apis.FieldError
 	}{
 		{
 			name: "invalid pipelinerun",
-			pr: PipelineRun{
+			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "prmetaname",
 				},
@@ -42,7 +44,7 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 		},
 		{
 			name: "invalid pipelinerun metadata",
-			pr: PipelineRun{
+			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pipelinerun.name",
 				},
@@ -53,23 +55,23 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 			},
 		}, {
 			name: "no pipeline reference",
-			pr: PipelineRun{
+			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pipelinelineName",
 				},
-				Spec: PipelineRunSpec{
+				Spec: v1alpha1.PipelineRunSpec{
 					ServiceAccount: "foo",
 				},
 			},
 			want: apis.ErrMissingField("pipelinerun.spec.Pipelineref.Name"),
 		}, {
 			name: "negative pipeline timeout",
-			pr: PipelineRun{
+			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pipelinelineName",
 				},
-				Spec: PipelineRunSpec{
-					PipelineRef: PipelineRef{
+				Spec: v1alpha1.PipelineRunSpec{
+					PipelineRef: v1alpha1.PipelineRef{
 						Name: "prname",
 					},
 					Timeout: &metav1.Duration{Duration: -48 * time.Hour},
@@ -90,15 +92,15 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 }
 
 func TestPipelineRun_Validate(t *testing.T) {
-	tr := PipelineRun{
+	tr := v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pipelinelineName",
 		},
-		Spec: PipelineRunSpec{
-			PipelineRef: PipelineRef{
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
 				Name: "prname",
 			},
-			Results: &Results{
+			Results: &v1alpha1.Results{
 				URL:  "http://www.google.com",
 				Type: "gcs",
 			},

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
@@ -18,12 +18,12 @@ package v1alpha1_test
 
 import (
 	"context"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -129,7 +129,7 @@ func (s *PullRequestResource) getContainerSpec(mode string) ([]corev1.Container,
 		Image:      *prImage,
 		Command:    []string{"/ko-app/pullrequest-init"},
 		Args:       args,
-		WorkingDir: workspaceDir,
+		WorkingDir: WorkspaceDir,
 		Env:        evs,
 	}}, nil
 }

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/pipeline/v1alpha1/result_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/result_types_test.go
@@ -18,11 +18,11 @@ package v1alpha1_test
 
 import (
 	"context"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
 func TestValidate(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/result_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/result_types_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -25,7 +26,7 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-	results := Results{
+	results := v1alpha1.Results{
 		URL:  "http://google.com",
 		Type: "gcs",
 	}
@@ -38,12 +39,12 @@ func TestValidate(t *testing.T) {
 func TestValidate_Invalid(t *testing.T) {
 	tests := []struct {
 		name    string
-		results *Results
+		results *v1alpha1.Results
 		want    *apis.FieldError
 	}{
 		{
 			name: "invalid task type result",
-			results: &Results{
+			results: &v1alpha1.Results{
 				URL:  "http://www.google.com",
 				Type: "wrongtype",
 			},
@@ -51,23 +52,23 @@ func TestValidate_Invalid(t *testing.T) {
 		},
 		{
 			name: "invalid task type results missing url",
-			results: &Results{
-				Type: ResultTargetTypeGCS,
+			results: &v1alpha1.Results{
+				Type: v1alpha1.ResultTargetTypeGCS,
 				URL:  "",
 			},
 			want: apis.ErrMissingField("spec.results.URL"),
 		},
 		{
 			name: "invalid task type results bad url",
-			results: &Results{
-				Type: ResultTargetTypeGCS,
+			results: &v1alpha1.Results{
+				Type: v1alpha1.ResultTargetTypeGCS,
 				URL:  "badurl",
 			},
 			want: apis.ErrInvalidValue("badurl", "spec.results.URL"),
 		},
 		{
 			name: "invalid task type results type",
-			results: &Results{
+			results: &v1alpha1.Results{
 				Type: "badtype",
 				URL:  "http://www.google.com",
 			},

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -18,12 +18,12 @@ package v1alpha1_test
 
 import (
 	"context"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,12 +27,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var validResource = TaskResource{
+var validResource = v1alpha1.TaskResource{
 	Name: "source",
 	Type: "git",
 }
 
-var validImageResource = TaskResource{
+var validImageResource = v1alpha1.TaskResource{
 	Name: "source",
 	Type: "image",
 }
@@ -48,8 +49,8 @@ var invalidBuildSteps = []corev1.Container{{
 
 func TestTaskSpecValidate(t *testing.T) {
 	type fields struct {
-		Inputs            *Inputs
-		Outputs           *Outputs
+		Inputs            *v1alpha1.Inputs
+		Outputs           *v1alpha1.Outputs
 		BuildSteps        []corev1.Container
 		StepTemplate      *corev1.Container
 		ContainerTemplate *corev1.Container
@@ -60,9 +61,9 @@ func TestTaskSpecValidate(t *testing.T) {
 	}{{
 		name: "valid inputs",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{validResource},
-				Params: []ParamSpec{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{validResource},
+				Params: []v1alpha1.ParamSpec{
 					{
 						Name:        "task",
 						Description: "param",
@@ -75,49 +76,49 @@ func TestTaskSpecValidate(t *testing.T) {
 	}, {
 		name: "valid outputs",
 		fields: fields{
-			Outputs: &Outputs{
-				Resources: []TaskResource{validResource},
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
 			BuildSteps: validBuildSteps,
 		},
 	}, {
 		name: "both valid",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{validResource},
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{validResource},
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
 			BuildSteps: validBuildSteps,
 		},
 	}, {
 		name: "output image resoure",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{validImageResource},
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{validImageResource},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{validImageResource},
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{validImageResource},
 			},
 			BuildSteps: validBuildSteps,
 		},
 	}, {
 		name: "valid template variable",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{{
 					Name: "foo",
-					Type: PipelineResourceTypeImage,
+					Type: v1alpha1.PipelineResourceTypeImage,
 				}},
-				Params: []ParamSpec{{
+				Params: []v1alpha1.ParamSpec{{
 					Name: "baz",
 				}, {
 					Name: "foo-is-baz",
 				}},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{validResource},
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
 			BuildSteps: []corev1.Container{{
 				Name:       "mystep",
@@ -171,7 +172,7 @@ func TestTaskSpecValidate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := &TaskSpec{
+			ts := &v1alpha1.TaskSpec{
 				Inputs:            tt.fields.Inputs,
 				Outputs:           tt.fields.Outputs,
 				Steps:             tt.fields.BuildSteps,
@@ -189,8 +190,8 @@ func TestTaskSpecValidate(t *testing.T) {
 
 func TestTaskSpecValidateError(t *testing.T) {
 	type fields struct {
-		Inputs     *Inputs
-		Outputs    *Outputs
+		Inputs     *v1alpha1.Inputs
+		Outputs    *v1alpha1.Outputs
 		BuildSteps []corev1.Container
 	}
 	tests := []struct {
@@ -206,8 +207,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "no build",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{validResource},
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
 		},
 		expectedError: apis.FieldError{
@@ -217,8 +218,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "one invalid input",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{
 					{
 						Name: "source",
 						Type: "what",
@@ -226,8 +227,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 					validResource,
 				},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{
 					validResource,
 				},
 			},
@@ -240,13 +241,13 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "one invalid output",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{
 					validResource,
 				},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{
 					{
 						Name: "who",
 						Type: "what",
@@ -263,14 +264,14 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "duplicated inputs",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{
 					validResource,
 					validResource,
 				},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{
 					validResource,
 				},
 			},
@@ -283,13 +284,13 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "duplicated outputs",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{
 					validResource,
 				},
 			},
-			Outputs: &Outputs{
-				Resources: []TaskResource{
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{
 					validResource,
 					validResource,
 				},
@@ -303,8 +304,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "invalid build",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{validResource},
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
 			BuildSteps: []corev1.Container{},
 		},
@@ -315,8 +316,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "invalid build step name",
 		fields: fields{
-			Inputs: &Inputs{
-				Resources: []TaskResource{validResource},
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{validResource},
 			},
 			BuildSteps: invalidBuildSteps,
 		},
@@ -366,8 +367,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}, {
 		name: "Inexistent param variable with existing",
 		fields: fields{
-			Inputs: &Inputs{
-				Params: []ParamSpec{
+			Inputs: &v1alpha1.Inputs{
+				Params: []v1alpha1.ParamSpec{
 					{
 						Name:        "foo",
 						Description: "param",
@@ -388,7 +389,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ts := &TaskSpec{
+			ts := &v1alpha1.TaskSpec{
 				Inputs:  tt.fields.Inputs,
 				Outputs: tt.fields.Outputs,
 				Steps:   tt.fields.BuildSteps,

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ import (
 )
 
 func TestTaskRun_GetBuildPodRef(t *testing.T) {
-	tr := TaskRun{
+	tr := v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "taskrunname",
 			Namespace: "testns",
@@ -46,11 +47,11 @@ func TestTaskRun_GetBuildPodRef(t *testing.T) {
 func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 	tests := []struct {
 		name            string
-		tr              *TaskRun
+		tr              *v1alpha1.TaskRun
 		expectedPVCName string
 	}{{
 		name: "invalid owner reference",
-		tr: &TaskRun{
+		tr: &v1alpha1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "taskrunname",
 				Namespace: "testns",
@@ -63,7 +64,7 @@ func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 		expectedPVCName: "",
 	}, {
 		name: "valid pipelinerun owner",
-		tr: &TaskRun{
+		tr: &v1alpha1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "taskrunname",
 				Namespace: "testns",
@@ -90,11 +91,11 @@ func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 func TestTaskRun_HasPipelineRun(t *testing.T) {
 	tests := []struct {
 		name string
-		tr   *TaskRun
+		tr   *v1alpha1.TaskRun
 		want bool
 	}{{
 		name: "invalid owner reference",
-		tr: &TaskRun{
+		tr: &v1alpha1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "taskrunname",
 				Namespace: "testns",
@@ -107,7 +108,7 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 		want: false,
 	}, {
 		name: "valid pipelinerun owner",
-		tr: &TaskRun{
+		tr: &v1alpha1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "taskrunname",
 				Namespace: "testns",
@@ -129,7 +130,7 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 }
 
 func TestTaskRunIsDone(t *testing.T) {
-	tr := &TaskRun{}
+	tr := &v1alpha1.TaskRun{}
 	foo := &apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionFalse,
@@ -141,9 +142,9 @@ func TestTaskRunIsDone(t *testing.T) {
 }
 
 func TestTaskRunIsCancelled(t *testing.T) {
-	tr := &TaskRun{
-		Spec: TaskRunSpec{
-			Status: TaskRunSpecStatusCancelled,
+	tr := &v1alpha1.TaskRun{
+		Spec: v1alpha1.TaskRunSpec{
+			Status: v1alpha1.TaskRunSpecStatusCancelled,
 		},
 	}
 
@@ -153,7 +154,7 @@ func TestTaskRunIsCancelled(t *testing.T) {
 }
 
 func TestTaskRunKey(t *testing.T) {
-	tr := &TaskRun{
+	tr := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "taskrunname",
 			Namespace: "testns",
@@ -168,28 +169,28 @@ func TestTaskRunKey(t *testing.T) {
 func TestTaskRunHasStarted(t *testing.T) {
 	params := []struct {
 		name          string
-		trStatus      TaskRunStatus
+		trStatus      v1alpha1.TaskRunStatus
 		expectedValue bool
 	}{{
 		name:          "trWithNoStartTime",
-		trStatus:      TaskRunStatus{},
+		trStatus:      v1alpha1.TaskRunStatus{},
 		expectedValue: false,
 	}, {
 		name: "trWithStartTime",
-		trStatus: TaskRunStatus{
+		trStatus: v1alpha1.TaskRunStatus{
 			StartTime: &metav1.Time{Time: time.Now()},
 		},
 		expectedValue: true,
 	}, {
 		name: "trWithZeroStartTime",
-		trStatus: TaskRunStatus{
+		trStatus: v1alpha1.TaskRunStatus{
 			StartTime: &metav1.Time{},
 		},
 		expectedValue: false,
 	}}
 	for _, tc := range params {
 		t.Run(tc.name, func(t *testing.T) {
-			tr := &TaskRun{
+			tr := &v1alpha1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "prunname",
 					Namespace: "testns",

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -18,11 +18,11 @@ package v1alpha1_test
 
 import (
 	"context"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -13,10 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package v1alpha1
+
+package v1alpha1_test
 
 import (
 	"context"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -28,12 +30,12 @@ import (
 func TestTaskRun_Invalidate(t *testing.T) {
 	tests := []struct {
 		name string
-		task TaskRun
+		task v1alpha1.TaskRun
 		want *apis.FieldError
 	}{
 		{
 			name: "invalid taskspec",
-			task: TaskRun{
+			task: v1alpha1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "taskmetaname",
 				},
@@ -42,7 +44,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 		},
 		{
 			name: "invalid taskrun metadata",
-			task: TaskRun{
+			task: v1alpha1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "task.name",
 				},
@@ -65,12 +67,12 @@ func TestTaskRun_Invalidate(t *testing.T) {
 }
 
 func TestTaskRun_Validate(t *testing.T) {
-	tr := TaskRun{
+	tr := v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "taskname",
 		},
-		Spec: TaskRunSpec{
-			TaskRef: &TaskRef{
+		Spec: v1alpha1.TaskRunSpec{
+			TaskRef: &v1alpha1.TaskRef{
 				Name: "taskrefname",
 			},
 		},
@@ -83,28 +85,28 @@ func TestTaskRun_Validate(t *testing.T) {
 func TestTaskRunSpec_Invalidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		spec    TaskRunSpec
+		spec    v1alpha1.TaskRunSpec
 		wantErr *apis.FieldError
 	}{
 		{
 			name:    "invalid taskspec",
-			spec:    TaskRunSpec{},
+			spec:    v1alpha1.TaskRunSpec{},
 			wantErr: apis.ErrMissingField("spec"),
 		},
 		{
 			name: "invalid taskref name",
-			spec: TaskRunSpec{
-				TaskRef: &TaskRef{},
+			spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{},
 			},
 			wantErr: apis.ErrMissingField("spec.taskref.name, spec.taskspec"),
 		},
 		{
 			name: "invalid taskref and taskspec together",
-			spec: TaskRunSpec{
-				TaskRef: &TaskRef{
+			spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{
 					Name: "taskrefname",
 				},
-				TaskSpec: &TaskSpec{
+				TaskSpec: &v1alpha1.TaskSpec{
 					Steps: []corev1.Container{{
 						Name:  "mystep",
 						Image: "myimage",
@@ -128,12 +130,12 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 func TestTaskRunSpec_Validate(t *testing.T) {
 	tests := []struct {
 		name string
-		spec TaskRunSpec
+		spec v1alpha1.TaskRunSpec
 	}{
 		{
 			name: "taskspec without a taskRef",
-			spec: TaskRunSpec{
-				TaskSpec: &TaskSpec{
+			spec: v1alpha1.TaskRunSpec{
+				TaskSpec: &v1alpha1.TaskSpec{
 					Steps: []corev1.Container{{
 						Name:  "mystep",
 						Image: "myimage",
@@ -153,13 +155,13 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 }
 
 func TestInput_Validate(t *testing.T) {
-	i := TaskRunInputs{
-		Params: []Param{{
+	i := v1alpha1.TaskRunInputs{
+		Params: []v1alpha1.Param{{
 			Name:  "name",
 			Value: "value",
 		}},
-		Resources: []TaskResourceBinding{{
-			ResourceRef: PipelineResourceRef{
+		Resources: []v1alpha1.TaskResourceBinding{{
+			ResourceRef: v1alpha1.PipelineResourceRef{
 				Name: "testresource",
 			},
 			Name: "workspace",
@@ -173,19 +175,19 @@ func TestInput_Validate(t *testing.T) {
 func TestInput_Invalidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		inputs  TaskRunInputs
+		inputs  v1alpha1.TaskRunInputs
 		wantErr *apis.FieldError
 	}{
 		{
 			name: "duplicate task inputs",
-			inputs: TaskRunInputs{
-				Resources: []TaskResourceBinding{{
-					ResourceRef: PipelineResourceRef{
+			inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					ResourceRef: v1alpha1.PipelineResourceRef{
 						Name: "testresource1",
 					},
 					Name: "workspace",
 				}, {
-					ResourceRef: PipelineResourceRef{
+					ResourceRef: v1alpha1.PipelineResourceRef{
 						Name: "testresource2",
 					},
 					Name: "workspace",
@@ -195,14 +197,14 @@ func TestInput_Invalidate(t *testing.T) {
 		},
 		{
 			name: "invalid task input params",
-			inputs: TaskRunInputs{
-				Resources: []TaskResourceBinding{{
-					ResourceRef: PipelineResourceRef{
+			inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					ResourceRef: v1alpha1.PipelineResourceRef{
 						Name: "testresource",
 					},
 					Name: "resource",
 				}},
-				Params: []Param{{
+				Params: []v1alpha1.Param{{
 					Name:  "name",
 					Value: "value",
 				}, {
@@ -213,13 +215,13 @@ func TestInput_Invalidate(t *testing.T) {
 			wantErr: apis.ErrMultipleOneOf("spec.inputs.params"),
 		}, {
 			name: "duplicate resource ref and resource spec",
-			inputs: TaskRunInputs{
-				Resources: []TaskResourceBinding{{
-					ResourceRef: PipelineResourceRef{
+			inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					ResourceRef: v1alpha1.PipelineResourceRef{
 						Name: "testresource",
 					},
-					ResourceSpec: &PipelineResourceSpec{
-						Type: PipelineResourceTypeGit,
+					ResourceSpec: &v1alpha1.PipelineResourceSpec{
+						Type: v1alpha1.PipelineResourceTypeGit,
 					},
 					Name: "resource-dup",
 				}},
@@ -227,9 +229,9 @@ func TestInput_Invalidate(t *testing.T) {
 			wantErr: apis.ErrDisallowedFields("spec.Inputs.Resources.Name.ResourceRef", "spec.Inputs.Resources.Name.ResourceSpec"),
 		}, {
 			name: "invalid resource spec",
-			inputs: TaskRunInputs{
-				Resources: []TaskResourceBinding{{
-					ResourceSpec: &PipelineResourceSpec{
+			inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					ResourceSpec: &v1alpha1.PipelineResourceSpec{
 						Type: "non-existent",
 					},
 					Name: "resource-inv",
@@ -238,8 +240,8 @@ func TestInput_Invalidate(t *testing.T) {
 			wantErr: apis.ErrInvalidValue("spec.type", "non-existent"),
 		}, {
 			name: "no resource ref and resource spec",
-			inputs: TaskRunInputs{
-				Resources: []TaskResourceBinding{{
+			inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
 					Name: "resource",
 				}},
 			},
@@ -257,9 +259,9 @@ func TestInput_Invalidate(t *testing.T) {
 }
 
 func TestOutput_Validate(t *testing.T) {
-	i := TaskRunOutputs{
-		Resources: []TaskResourceBinding{{
-			ResourceRef: PipelineResourceRef{
+	i := v1alpha1.TaskRunOutputs{
+		Resources: []v1alpha1.TaskResourceBinding{{
+			ResourceRef: v1alpha1.PipelineResourceRef{
 				Name: "testresource",
 			},
 			Name: "someimage",
@@ -272,19 +274,19 @@ func TestOutput_Validate(t *testing.T) {
 func TestOutput_Invalidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		outputs TaskRunOutputs
+		outputs v1alpha1.TaskRunOutputs
 		wantErr *apis.FieldError
 	}{
 		{
 			name: "duplicated task outputs",
-			outputs: TaskRunOutputs{
-				Resources: []TaskResourceBinding{{
-					ResourceRef: PipelineResourceRef{
+			outputs: v1alpha1.TaskRunOutputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					ResourceRef: v1alpha1.PipelineResourceRef{
 						Name: "testresource1",
 					},
 					Name: "workspace",
 				}, {
-					ResourceRef: PipelineResourceRef{
+					ResourceRef: v1alpha1.PipelineResourceRef{
 						Name: "testresource2",
 					},
 					Name: "workspace",
@@ -293,8 +295,8 @@ func TestOutput_Invalidate(t *testing.T) {
 			wantErr: apis.ErrMultipleOneOf("spec.Outputs.Resources.Name"),
 		}, {
 			name: "no output resource with resource spec nor resource ref",
-			outputs: TaskRunOutputs{
-				Resources: []TaskResourceBinding{{
+			outputs: v1alpha1.TaskRunOutputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
 					Name: "workspace",
 				}},
 			},

--- a/pkg/apis/pipeline/v1alpha1/types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/types_test.go
@@ -1,6 +1,23 @@
-package v1alpha1
+/*
+Copyright 2019 The Tekton Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/knative/pkg/webhook"
@@ -8,9 +25,9 @@ import (
 
 func TestTypes(t *testing.T) {
 	// Assert that types satisfy webhook interface.
-	var _ webhook.GenericCRD = (*ClusterTask)(nil)
-	var _ webhook.GenericCRD = (*TaskRun)(nil)
-	var _ webhook.GenericCRD = (*PipelineResource)(nil)
-	var _ webhook.GenericCRD = (*Task)(nil)
-	var _ webhook.GenericCRD = (*TaskRun)(nil)
+	var _ webhook.GenericCRD = (*v1alpha1.ClusterTask)(nil)
+	var _ webhook.GenericCRD = (*v1alpha1.TaskRun)(nil)
+	var _ webhook.GenericCRD = (*v1alpha1.PipelineResource)(nil)
+	var _ webhook.GenericCRD = (*v1alpha1.Task)(nil)
+	var _ webhook.GenericCRD = (*v1alpha1.TaskRun)(nil)
 }

--- a/pkg/apis/pipeline/v1alpha1/types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/types_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1alpha1_test
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"testing"
 
 	"github.com/knative/pkg/webhook"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
 func TestTypes(t *testing.T) {


### PR DESCRIPTION
# Changes

_Taken directly from commit message:_

For test files directly under `pkg/apis/pipeline/v1alpha1`, rename the
package to `v1alpha1_test` to avoid circular dependencies in the future.

I was trying to reuse some of the building logic under `test/builder` for
a test in `pipeline/v1alpha`. However, it wasn't possible due to circular
dependencies. I noticed that there were some tests that already had the
package renamed to "v1alpha1_test", so I followed that convention for
the other tests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) **(no functionality changed)**
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) **(no user facing changes)**
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

N/A
