### PR TITLE
Use moar builders in tests 👷‍♀️

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -23,7 +23,8 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
 func Test_Invalid_BuildGCSResource(t *testing.T) {
@@ -32,120 +33,50 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "no location params",
-		pipelineResource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "buildgcs-resource-with-no-location-param",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeStorage,
-				Params: []v1alpha1.Param{{
-					Name:  "NotLocation",
-					Value: "doesntmatter",
-				}, {
-					Name:  "type",
-					Value: "build-gcs",
-				}},
-			},
-		},
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-location-param", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeStorage,
+			tb.PipelineResourceSpecParam("NotLocation", "doesntmatter"),
+			tb.PipelineResourceSpecParam("type", "build-gcs"),
+		)),
 	}, {
 		name: "location param with empty value",
-		pipelineResource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gcs-resource-with-empty-location-param",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeStorage,
-				Params: []v1alpha1.Param{{
-					Name:  "Location",
-					Value: "",
-				}, {
-					Name:  "type",
-					Value: "build-gcs",
-				}},
-			},
-		},
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-location-param", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeStorage,
+			tb.PipelineResourceSpecParam("Location", ""),
+			tb.PipelineResourceSpecParam("type", "build-gcs"),
+		)),
 	}, {
 		name: "no artifactType params",
-		pipelineResource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "buildgcs-resource-with-no-artifactType-param",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeStorage,
-				Params: []v1alpha1.Param{{
-					Name:  "Location",
-					Value: "gs://test",
-				}, {
-					Name:  "type",
-					Value: "build-gcs",
-				}},
-			},
-		},
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-artifactType-param", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeStorage,
+			tb.PipelineResourceSpecParam("Location", "gs://test"),
+			tb.PipelineResourceSpecParam("type", "build-gcs"),
+		)),
 	}, {
 		name: "artifactType param with empty value",
-		pipelineResource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gcs-resource-with-empty-location-param",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeStorage,
-				Params: []v1alpha1.Param{{
-					Name:  "Location",
-					Value: "gs://test",
-				}, {
-					Name:  "type",
-					Value: "build-gcs",
-				}, {
-					Name:  "ArtifactType",
-					Value: "",
-				}},
-			},
-		},
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-artifactType-param", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeStorage,
+			tb.PipelineResourceSpecParam("Location", "gs://test"),
+			tb.PipelineResourceSpecParam("type", "build-gcs"),
+			tb.PipelineResourceSpecParam("ArtifactType", ""),
+		)),
 	}, {
 		name: "artifactType param with invalid value",
-		pipelineResource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gcs-resource-with-empty-location-param",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeStorage,
-				Params: []v1alpha1.Param{{
-					Name:  "Location",
-					Value: "gs://test",
-				}, {
-					Name:  "type",
-					Value: "build-gcs",
-				}, {
-					Name:  "ArtifactType",
-					Value: "invalid-type",
-				}},
-			},
-		},
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeStorage,
+			tb.PipelineResourceSpecParam("Location", "gs://test"),
+			tb.PipelineResourceSpecParam("type", "build-gcs"),
+			tb.PipelineResourceSpecParam("ArtifactType", "invalid-type"),
+		)),
 	}, {
 		name: "artifactType param with secrets value",
-		pipelineResource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gcs-resource-with-secrets",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeStorage,
-				Params: []v1alpha1.Param{{
-					Name:  "Location",
-					Value: "gs://test",
-				}, {
-					Name:  "type",
-					Value: "build-gcs",
-				}, {
-					Name:  "ArtifactType",
-					Value: "invalid-type",
-				}},
-				SecretParams: []v1alpha1.SecretParam{{
-					SecretKey:  "secretKey",
-					SecretName: "secretName",
-					FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
-				}},
-			},
-		},
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param-and-secrets", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeStorage,
+			tb.PipelineResourceSpecParam("Location", "gs://test"),
+			tb.PipelineResourceSpecParam("type", "build-gcs"),
+			tb.PipelineResourceSpecParam("ArtifactType", "invalid-type"),
+			tb.PipelineResourceSpecSecretParam("secretKey", "secretName", "GOOGLE_APPLICATION_CREDENTIALS"),
+		)),
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -158,24 +89,12 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 }
 
 func Test_Valid_NewBuildGCSResource(t *testing.T) {
-	pr := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "build-gcs-resource",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeStorage,
-			Params: []v1alpha1.Param{{
-				Name:  "Location",
-				Value: "gs://fake-bucket",
-			}, {
-				Name:  "type",
-				Value: "build-gcs",
-			}, {
-				Name:  "ArtifactType",
-				Value: "Manifest",
-			}},
-		},
-	}
+	pr := tb.PipelineResource("build-gcs-resource", "default", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeStorage,
+		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
+		tb.PipelineResourceSpecParam("type", "build-gcs"),
+		tb.PipelineResourceSpecParam("ArtifactType", "Manifest"),
+	))
 	expectedGCSResource := &v1alpha1.BuildGCSResource{
 		Name:         "build-gcs-resource",
 		Location:     "gs://fake-bucket",

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -20,7 +20,8 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
 func TestNewClusterResource(t *testing.T) {
@@ -30,29 +31,13 @@ func TestNewClusterResource(t *testing.T) {
 		want     *v1alpha1.ClusterResource
 	}{{
 		desc: "basic cluster resource",
-		resource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-clus ter-resource",
-				Namespace: "foo",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeCluster,
-				Params: []v1alpha1.Param{{
-					Name:  "name",
-					Value: "test_cluster_resource",
-				}, {
-					Name:  "url",
-					Value: "http://10.10.10.10",
-				}, {
-					Name:  "cadata",
-					Value: "bXktY2x1c3Rlci1jZXJ0Cg",
-				}, {
-					Name:  "token",
-					Value: "my-token",
-				},
-				},
-			},
-		},
+		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeCluster,
+			tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+			tb.PipelineResourceSpecParam("token", "my-token"),
+		)),
 		want: &v1alpha1.ClusterResource{
 			Name:   "test_cluster_resource",
 			Type:   v1alpha1.PipelineResourceTypeCluster,
@@ -62,32 +47,14 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "resource with password instead of token",
-		resource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cluster-resource",
-				Namespace: "foo",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeCluster,
-				Params: []v1alpha1.Param{{
-					Name:  "name",
-					Value: "test_cluster_resource",
-				}, {
-					Name:  "url",
-					Value: "http://10.10.10.10",
-				}, {
-					Name:  "cadata",
-					Value: "bXktY2x1c3Rlci1jZXJ0Cg",
-				}, {
-					Name:  "username",
-					Value: "user",
-				}, {
-					Name:  "password",
-					Value: "pass",
-				},
-				},
-			},
-		},
+		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeCluster,
+			tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+			tb.PipelineResourceSpecParam("username", "user"),
+			tb.PipelineResourceSpecParam("password", "pass"),
+		)),
 		want: &v1alpha1.ClusterResource{
 			Name:     "test_cluster_resource",
 			Type:     v1alpha1.PipelineResourceTypeCluster,
@@ -98,26 +65,12 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "set insecure flag to true when there is no cert",
-		resource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cluster-resource",
-				Namespace: "foo",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeCluster,
-				Params: []v1alpha1.Param{{
-					Name:  "Name",
-					Value: "test.cluster.resource",
-				}, {
-					Name:  "url",
-					Value: "http://10.10.10.10",
-				}, {
-					Name:  "token",
-					Value: "my-token",
-				},
-				},
-			},
-		},
+		resource: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeCluster,
+			tb.PipelineResourceSpecParam("name", "test.cluster.resource"),
+			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+			tb.PipelineResourceSpecParam("token", "my-token"),
+		)),
 		want: &v1alpha1.ClusterResource{
 			Name:     "test.cluster.resource",
 			Type:     v1alpha1.PipelineResourceTypeCluster,
@@ -127,31 +80,13 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "basic resource with secrets",
-		resource: &v1alpha1.PipelineResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cluster-resource",
-				Namespace: "foo",
-			},
-			Spec: v1alpha1.PipelineResourceSpec{
-				Type: v1alpha1.PipelineResourceTypeCluster,
-				Params: []v1alpha1.Param{{
-					Name:  "name",
-					Value: "test-cluster-resource",
-				}, {
-					Name:  "url",
-					Value: "http://10.10.10.10",
-				}},
-				SecretParams: []v1alpha1.SecretParam{{
-					FieldName:  "cadata",
-					SecretKey:  "cadatakey",
-					SecretName: "secret1",
-				}, {
-					FieldName:  "token",
-					SecretKey:  "tokenkey",
-					SecretName: "secret1",
-				}},
-			},
-		},
+		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeCluster,
+			tb.PipelineResourceSpecParam("name", "test-cluster-resource"),
+			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+			tb.PipelineResourceSpecSecretParam("cadata", "secret1", "cadatakey"),
+			tb.PipelineResourceSpecSecretParam("token", "secret1", "tokenkey"),
+		)),
 		want: &v1alpha1.ClusterResource{
 			Name: "test-cluster-resource",
 			Type: v1alpha1.PipelineResourceTypeCluster,

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -23,188 +23,91 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/knative/pkg/apis"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestResourceValidation_Invalid(t *testing.T) {
 	tests := []struct {
 		name string
-		res  v1alpha1.PipelineResource
+		res  *v1alpha1.PipelineResource
 		want *apis.FieldError
 	}{
 		{
 			name: "cluster with invalid url",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster-resource",
-					Namespace: "foo",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeCluster,
-					Params: []v1alpha1.Param{{
-						Name:  "name",
-						Value: "test-cluster-resource",
-					}, {
-						Name:  "url",
-						Value: "10.10.10",
-					}, {
-						Name:  "username",
-						Value: "admin",
-					}, {
-						Name:  "cadata",
-						Value: "bXktY2x1c3Rlci1jZXJ0Cg",
-					}, {
-						Name:  "token",
-						Value: "my-token",
-					},
-					},
-				},
-			},
+			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeCluster,
+				tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+				tb.PipelineResourceSpecParam("url", "10.10.10"),
+				tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+				tb.PipelineResourceSpecParam("username", "admin"),
+				tb.PipelineResourceSpecParam("token", "my-token"),
+			)),
 			want: apis.ErrInvalidValue("10.10.10", "URL"),
 		},
 		{
 			name: "cluster with missing username",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster-resource",
-					Namespace: "foo",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeCluster,
-					Params: []v1alpha1.Param{{
-						Name:  "name",
-						Value: "test-cluster-resource",
-					}, {
-						Name:  "url",
-						Value: "http://10.10.10.10",
-					}, {
-						Name:  "cadata",
-						Value: "bXktY2x1c3Rlci1jZXJ0Cg",
-					}, {
-						Name:  "token",
-						Value: "my-token",
-					},
-					},
-				},
-			},
+			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeCluster,
+				tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+				tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+				tb.PipelineResourceSpecParam("token", "my-token"),
+			)),
 			want: apis.ErrMissingField("username param"),
 		},
 		{
 			name: "cluster with missing name",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster-resource",
-					Namespace: "foo",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeCluster,
-					Params: []v1alpha1.Param{{
-						Name:  "url",
-						Value: "http://10.10.10.10",
-					}, {
-						Name:  "cadata",
-						Value: "bXktY2x1c3Rlci1jZXJ0Cg",
-					}, {
-						Name:  "token",
-						Value: "my-token",
-					},
-					},
-				},
-			},
+			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeCluster,
+				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+				tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+				tb.PipelineResourceSpecParam("token", "my-token"),
+			)),
 			want: apis.ErrMissingField("name param"),
 		},
 		{
 			name: "cluster with missing cadata",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster-resource",
-					Namespace: "foo",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeCluster,
-					Params: []v1alpha1.Param{{
-						Name:  "Name",
-						Value: "test-cluster-resource",
-					}, {
-						Name:  "url",
-						Value: "http://10.10.10.10",
-					}, {
-						Name:  "username",
-						Value: "admin",
-					}, {
-						Name:  "token",
-						Value: "my-token",
-					},
-					},
-				},
-			},
+			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeCluster,
+				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+				tb.PipelineResourceSpecParam("Name", "admin"),
+				tb.PipelineResourceSpecParam("token", "my-token"),
+				tb.PipelineResourceSpecParam("username", "admin"),
+			)),
 			want: apis.ErrMissingField("CAData param"),
 		}, {
 			name: "storage with no type",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-resource",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeStorage,
-					Params: []v1alpha1.Param{{
-						Name:  "no-type-param",
-						Value: "sometype",
-					}},
-				},
-			},
+			res: tb.PipelineResource("storage-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeStorage,
+				tb.PipelineResourceSpecParam("no-type-param", "something"),
+			)),
 			want: apis.ErrMissingField("spec.params.type"),
 		}, {
 			name: "storage with unimplemented type",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-resource",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeStorage,
-					Params: []v1alpha1.Param{{
-						Name:  "type",
-						Value: "not-implemented-yet",
-					}},
-				},
-			},
+			res: tb.PipelineResource("storage-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeStorage,
+				tb.PipelineResourceSpecParam("type", "not-implemented-yet"),
+			)),
 			want: apis.ErrInvalidValue("not-implemented-yet", "spec.params.type"),
 		}, {
 			name: "storage with gcs type with no location param",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-resource",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeStorage,
-					Params: []v1alpha1.Param{{
-						Name:  "type",
-						Value: "gcs",
-					}},
-				},
-			},
+			res: tb.PipelineResource("storage-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeStorage,
+				tb.PipelineResourceSpecParam("type", "gcs"),
+			)),
 			want: apis.ErrMissingField("spec.params.location"),
 		}, {
 			name: "storage with gcs type with empty location param",
-			res: v1alpha1.PipelineResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "storage-resource",
-				},
-				Spec: v1alpha1.PipelineResourceSpec{
-					Type: v1alpha1.PipelineResourceTypeStorage,
-					Params: []v1alpha1.Param{{
-						Name:  "type",
-						Value: "gcs",
-					}, {
-						Name:  "location",
-						Value: "",
-					}},
-				},
-			},
+			res: tb.PipelineResource("storage-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeStorage,
+				tb.PipelineResourceSpecParam("type", "gcs"),
+				tb.PipelineResourceSpecParam("location", ""),
+			)),
 			want: apis.ErrMissingField("spec.params.location"),
 		}, {
-			name: "invalid resoure type",
-			res: v1alpha1.PipelineResource{
+			name: "invalid resource type",
+			res: &v1alpha1.PipelineResource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "invalid-resource",
 				},
@@ -219,39 +122,21 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.res.Validate(context.Background())
 			if d := cmp.Diff(err.Error(), tt.want.Error()); d != "" {
-				t.Errorf("PipleineResource.Validate/%s (-want, +got) = %v", tt.name, d)
+				t.Errorf("PipelineResource.Validate/%s (-want, +got) = %v", tt.name, d)
 			}
 		})
 	}
 }
 
 func TestClusterResourceValidation_Valid(t *testing.T) {
-	res := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-cluster-resource",
-			Namespace: "foo",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeCluster,
-			Params: []v1alpha1.Param{{
-				Name:  "name",
-				Value: "test-cluster-resource",
-			}, {
-				Name:  "url",
-				Value: "http://10.10.10.10",
-			}, {
-				Name:  "username",
-				Value: "admin",
-			}, {
-				Name:  "cadata",
-				Value: "bXktY2x1c3Rlci1jZXJ0Cg",
-			}, {
-				Name:  "token",
-				Value: "my-token",
-			},
-			},
-		},
-	}
+	res := tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeCluster,
+		tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+		tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+		tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+		tb.PipelineResourceSpecParam("username", "admin"),
+		tb.PipelineResourceSpecParam("token", "my-token"),
+	))
 	if err := res.Validate(context.Background()); err != nil {
 		t.Errorf("Unexpected PipelineRun.Validate() error = %v", err)
 	}

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -23,31 +23,18 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
 func TestPullRequest_NewResource(t *testing.T) {
 	url := "https://github.com/tektoncd/pipeline/pulls/1"
-	pr := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypePullRequest,
-			Params: []v1alpha1.Param{{
-				Name:  "type",
-				Value: "github",
-			}, {
-				Name:  "url",
-				Value: url,
-			}},
-			SecretParams: []v1alpha1.SecretParam{{
-				FieldName:  "githubToken",
-				SecretKey:  "test-secret-key",
-				SecretName: "test-secret-name",
-			}},
-		},
-	}
+	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypePullRequest,
+		tb.PipelineResourceSpecParam("type", "github"),
+		tb.PipelineResourceSpecParam("url", url),
+		tb.PipelineResourceSpecSecretParam("githubToken", "test-secret-key", "test-secret-name"),
+	))
 	got, err := v1alpha1.NewPullRequestResource(pr)
 	if err != nil {
 		t.Fatalf("Error creating storage resource: %s", err.Error())
@@ -65,14 +52,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 }
 
 func TestPullRequest_NewResource_error(t *testing.T) {
-	pr := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeGit,
-		},
-	}
+	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
 	if _, err := v1alpha1.NewPullRequestResource(pr); err == nil {
 		t.Error("NewPullRequestResource() want error, got nil")
 	}

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -24,31 +24,24 @@ import (
 	"github.com/knative/pkg/apis"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
 func TestTaskRun_Invalidate(t *testing.T) {
 	tests := []struct {
 		name string
-		task v1alpha1.TaskRun
+		task *v1alpha1.TaskRun
 		want *apis.FieldError
 	}{
 		{
 			name: "invalid taskspec",
-			task: v1alpha1.TaskRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "taskmetaname",
-				},
-			},
+			task: tb.TaskRun("taskmetaname", "default"),
 			want: apis.ErrMissingField("spec"),
 		},
 		{
 			name: "invalid taskrun metadata",
-			task: v1alpha1.TaskRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "task.name",
-				},
-			},
+			task: tb.TaskRun("task.name", "default"),
 			want: &apis.FieldError{
 				Message: "Invalid resource name: special character . must not be present",
 				Paths:   []string{"metadata.name"},
@@ -67,16 +60,9 @@ func TestTaskRun_Invalidate(t *testing.T) {
 }
 
 func TestTaskRun_Validate(t *testing.T) {
-	tr := v1alpha1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "taskname",
-		},
-		Spec: v1alpha1.TaskRunSpec{
-			TaskRef: &v1alpha1.TaskRef{
-				Name: "taskrefname",
-			},
-		},
-	}
+	tr := tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+		tb.TaskRunTaskRef("taskrefname"),
+	))
 	if err := tr.Validate(context.Background()); err != nil {
 		t.Errorf("TaskRun.Validate() error = %v", err)
 	}

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -447,6 +447,14 @@ func TaskRunTaskRef(name string, ops ...TaskRefOp) TaskRunSpecOp {
 	}
 }
 
+// TaskRunSpecStatus sets the Status in the Spec, used for operations
+// such as cancelling executing TaskRuns.
+func TaskRunSpecStatus(status v1alpha1.TaskRunSpecStatus) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.Status = status
+	}
+}
+
 // TaskRefKind set the specified kind to the TaskRef.
 func TaskRefKind(kind v1alpha1.TaskKind) TaskRefOp {
 	return func(ref *v1alpha1.TaskRef) {

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -231,6 +231,7 @@ func TestTaskRunWithTaskSpec(t *testing.T) {
 		),
 		tb.TaskRunServiceAccount("sa"),
 		tb.TaskRunTimeout(2*time.Minute),
+		tb.TaskRunSpecStatus(v1alpha1.TaskRunSpecStatusCancelled),
 	))
 	expectedTaskRun := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -246,6 +247,7 @@ func TestTaskRunWithTaskSpec(t *testing.T) {
 				}},
 			},
 			ServiceAccount: "sa",
+			Status:         v1alpha1.TaskRunSpecStatusCancelled,
 			Timeout:        &metav1.Duration{Duration: 2 * time.Minute},
 		},
 	}


### PR DESCRIPTION
# Changes

In #1043 @EliZucker updated the package names of the v1alpha1 tests to
be `v1alpha1_test`. He did this b/c he wanted to use a function he was
adding to the builder test package for the work he is doing in #207, but
this has the nice side effect of making it so that we can use more
builders in these tests! (We couldn't before b/c the builders themselves
have to import and use `v1alpha1`). This commit updates many of these
tests to use builders.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

```
n/a
```
