### PR TITLE
Add message and reason fields for each stage of a taskRun

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -1386,6 +1386,8 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 	if d := cmp.Diff(newTr.Status.GetCondition(apis.ConditionSucceeded), &apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionTrue,
+		Reason:  status.ReasonSucceeded,
+		Message: "All Steps have completed executing",
 	}, ignoreLastTransitionTime); d != "" {
 		t.Errorf("Taskrun Status diff -got, +want: %v", d)
 	}

--- a/pkg/status/taskrunpod.go
+++ b/pkg/status/taskrunpod.go
@@ -59,12 +59,15 @@ func updateCompletedTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 		taskRun.Status.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionFalse,
+			Reason:  ReasonFailed,
 			Message: msg,
 		})
 	} else {
 		taskRun.Status.SetCondition(&apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionTrue,
+			Reason:  ReasonSucceeded,
+			Message: "All Steps have completed executing",
 		})
 	}
 	// update tr completed time
@@ -78,6 +81,7 @@ func updateIncompleteTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
 			Reason: ReasonBuilding,
+			Message: "Not all Steps in the Task have finished executing",
 		})
 	case corev1.PodPending:
 		var reason, msg string

--- a/pkg/status/taskrunpod_test.go
+++ b/pkg/status/taskrunpod_test.go
@@ -30,11 +30,14 @@ func TestUpdateStatusFromPod(t *testing.T) {
 	conditionTrue := apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionTrue,
+		Reason:  ReasonSucceeded,
+		Message: "All Steps have completed executing",
 	}
 	conditionBuilding := apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown,
 		Reason: ReasonBuilding,
+		Message: "Not all Steps in the Task have finished executing",
 	}
 	for _, c := range []struct {
 		desc      string
@@ -177,6 +180,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
+					Reason:  ReasonFailed,
 					Message: `"step-failure" exited with code 123 (image: "image-id"); for logs run: kubectl -n foo logs pod -c step-failure`,
 				}},
 			},
@@ -201,6 +205,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
+					Reason:  ReasonFailed,
 					Message: "boom",
 				}},
 			},
@@ -216,6 +221,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
+					Reason:  ReasonFailed,
 					Message: "build failed for unspecified reasons.",
 				}},
 			},

--- a/pkg/status/taskrunreasons.go
+++ b/pkg/status/taskrunreasons.go
@@ -31,4 +31,11 @@ const (
 	// reasonExceededNodeResources indicates that the TaskRun's pod has failed to start due
 	// to resource constraints on the node
 	ReasonExceededNodeResources = "ExceededNodeResources"
+
+	// ReasonSucceeded indicates that the reason for the finished status is that all of the steps
+	// completed successfully
+	ReasonSucceeded = "Succeeded"
+
+	// ReasonFailed indicates that the reason for the failure status is unknown or that one of the steps failed
+	ReasonFailed = "Failed"
 )


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

https://github.com/tektoncd/pipeline/issues/981

Adds message and reason fields for taskRuns at different stages. Came across this in dashboard where we use the message to show information on the run. Also consistently populates the printer columns.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
-  n/a Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._