### PR TITLE
 Update auth documentation to document kubernetes.io/* secrets

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -248,6 +248,62 @@ generated containing the credentials configured in the `Secret`, and these
 credentials are then used to authenticate when retrieving any
 `PipelineResources`.
 
+## Kubernetes's Docker registry's secret
+
+Kubernetes defines two types of secrets for Docker registries : 
+the old format `kubernetes.io/dockercfg` and the new
+`kubernetes.io/dockerconfigjson`. Tekton supports those secrets in
+addition to the one described above.
+
+1. Define a `Secret` from a Docker client configuration file, as documented in
+   [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+
+   ```bash
+   kubectl create secret generic regcred \
+    --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
+    --type=kubernetes.io/dockerconfigjson
+   ```
+
+1. Instruct a `ServiceAccount` to use this `Secret`:
+
+   ```yaml
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     name: build-bot
+   secrets:
+     - name: regcred
+   ```
+
+1. Use that `ServiceAccount` in your `TaskRun`:
+
+   ```yaml
+   apiVersion: tetkon.dev/v1alpha1
+   kind: TaskRun
+   metadata:
+     name: build-with-basic-auth
+   spec:
+     serviceAccount: build-bot
+     steps:
+     ...
+   ```
+
+1. Execute the build:
+
+   ```shell
+   kubectl apply --filename secret.yaml --filename serviceaccount.yaml --filename taskrun.yaml
+   ```
+
+When this TaskRun executes, before the steps are getting executed, a
+`~/.docker/config.json` will be generated containing the credentials
+configured in the `Secret`, and these credentials are then used to
+authenticate with the Docker registry.
+
+If both `kubernetes.io/*` and tekton flavored basic authentication secret are
+provided, tekton will merge the credentials from those two ; tekton flavored
+credentials taking precedence over `kubernetes.io/dockerconfigjson` (or
+`kubernetes.io/dockercfg`) ones.
+
 ## Guiding credential selection
 
 A `Run` might require many different types of authentication. For instance, a


### PR DESCRIPTION
# Changes

Since few release, tektoncd/pipeline supports additional secrets for
docker registries : `kubernetes.io/dockerconfigjson` and
`kubernetes/dockercfg`. This was not documented here.

/cc @bobcatfish @abayer 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._
