### PR TITLE
Implement templating within stepTemplate.

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply.go
@@ -65,8 +65,14 @@ func ApplyReplacements(spec *v1alpha1.TaskSpec, replacements map[string]string) 
 	}
 
 	// Apply variable expansion to containerTemplate fields.
+	// Should eventually be removed; ContainerTemplate is the deprecated previous name of the StepTemplate field (#977).
 	if spec.ContainerTemplate != nil {
 		applyContainerReplacements(spec.ContainerTemplate, replacements)
+	}
+
+	// Apply variable expansion to stepTemplate fields.
+	if spec.StepTemplate != nil {
+		applyContainerReplacements(spec.StepTemplate, replacements)
 	}
 
 	// Apply variable expansion to the build's volumes


### PR DESCRIPTION
# Changes

Utilize the applyContanierReplacements() logic for the stepTemplate field. This was done for containerTemplate (now deprecated), but not stepTemplate — which was pointed out by @bobcatfish [here](https://github.com/tektoncd/pipeline/pull/1006#discussion_r301808463).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) **-  no necessary doc changes**
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md)
for more details._

# Release Notes

Technically this is a new feature, but I think everyone expected this behavior already (following containerTemplate's behavior). I personally don't think this warrants a release note but here it is just in case:

```
`stepTemplate` now supports variable interpolation
```