### PR TITLE
Revert "If no resources are linked, don't make a PVC 🗑️"

### DIFF
--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -33,41 +33,21 @@ import (
 )
 
 var (
-	quantityComparer = cmp.Comparer(func(x, y resource.Quantity) bool {
-		return x.Cmp(y) == 0
-	})
-	tasksWithFrom = []v1alpha1.PipelineTask{
-		{
-			Name: "task1",
-			TaskRef: v1alpha1.TaskRef{
-				Name: "task",
-			},
-			Resources: &v1alpha1.PipelineTaskResources{
-				Outputs: []v1alpha1.PipelineTaskOutputResource{{
-					Name:     "output",
-					Resource: "resource",
-				}},
-			},
-		},
-		{
-			Name: "task2",
-			TaskRef: v1alpha1.TaskRef{
-				Name: "task",
-			},
-			Resources: &v1alpha1.PipelineTaskResources{
-				Inputs: []v1alpha1.PipelineTaskInputResource{{
-					Name:     "input1",
-					Resource: "resource",
-					From:     []string{"task1"},
-				}},
-			},
+	pipelinerun = &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "pipelineruntest",
 		},
 	}
+	persistentVolumeClaim = GetPersistentVolumeClaim(DefaultPvcSize)
+	quantityComparer      = cmp.Comparer(func(x, y resource.Quantity) bool {
+		return x.Cmp(y) == 0
+	})
 )
 
-func GetPersistentVolumeClaim(pipelinerun *v1alpha1.PipelineRun, size string) *corev1.PersistentVolumeClaim {
+func GetPersistentVolumeClaim(size string) *corev1.PersistentVolumeClaim {
 	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: pipelinerun.Namespace, OwnerReferences: pipelinerun.GetOwnerReference()},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: "foo", OwnerReferences: pipelinerun.GetOwnerReference()},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources:   corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)}},
@@ -76,7 +56,7 @@ func GetPersistentVolumeClaim(pipelinerun *v1alpha1.PipelineRun, size string) *c
 	return pvc
 }
 
-func TestConfigMapNeedsPVC(t *testing.T) {
+func TestNeedsPVC(t *testing.T) {
 	logger := logtesting.TestLogger(t)
 	for _, c := range []struct {
 		desc      string
@@ -146,12 +126,12 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 		pvcNeeded: false,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			needed, err := ConfigMapNeedsPVC(c.configMap, nil, logger)
+			needed, err := NeedsPVC(c.configMap, nil, logger)
 			if err != nil {
 				t.Fatalf("Somehow had error checking if PVC was needed run: %s", err)
 			}
 			if needed != c.pvcNeeded {
-				t.Fatalf("Expected that ConfigMapNeedsPVC would be %t, but was %t", c.pvcNeeded, needed)
+				t.Fatalf("Expected that NeedsPVC would be %t, but was %t", c.pvcNeeded, needed)
 			}
 		})
 	}
@@ -159,20 +139,11 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 }
 
 func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
-	pipelinerun := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pipelineruntest",
-		},
-		Spec: v1alpha1.PipelineRunSpec{
-			PipelineRef: v1alpha1.PipelineRef{
-				Name: "pipelineWithFrom",
-			},
-		},
-	}
 	logger := logtesting.TestLogger(t)
 	for _, c := range []struct {
 		desc                    string
 		configMap               *corev1.ConfigMap
+		pipelinerun             *v1alpha1.PipelineRun
 		expectedArtifactStorage ArtifactStorageInterface
 		storagetype             string
 	}{{
@@ -186,9 +157,10 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				PvcSizeKey: "10Gi",
 			},
 		},
+		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
 			Name:                  "pipelineruntest",
-			PersistentVolumeClaim: GetPersistentVolumeClaim(pipelinerun, "10Gi"),
+			PersistentVolumeClaim: GetPersistentVolumeClaim("10Gi"),
 		},
 		storagetype: "pvc",
 	}, {
@@ -204,6 +176,7 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
+		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
 			Location: "gs://fake-bucket",
 			Secrets: []v1alpha1.SecretParam{{
@@ -226,9 +199,10 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
+		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
 			Name:                  "pipelineruntest",
-			PersistentVolumeClaim: GetPersistentVolumeClaim(pipelinerun, DefaultPvcSize),
+			PersistentVolumeClaim: persistentVolumeClaim,
 		},
 		storagetype: "pvc",
 	}, {
@@ -243,9 +217,10 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
+		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
 			Name:                  "pipelineruntest",
-			PersistentVolumeClaim: GetPersistentVolumeClaim(pipelinerun, DefaultPvcSize),
+			PersistentVolumeClaim: persistentVolumeClaim,
 		},
 		storagetype: "pvc",
 	}, {
@@ -256,9 +231,10 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				Name:      v1alpha1.BucketConfigName,
 			},
 		},
+		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
 			Name:                  "pipelineruntest",
-			PersistentVolumeClaim: GetPersistentVolumeClaim(pipelinerun, DefaultPvcSize),
+			PersistentVolumeClaim: persistentVolumeClaim,
 		},
 		storagetype: "pvc",
 	}, {
@@ -272,6 +248,7 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				v1alpha1.BucketLocationKey: "gs://fake-bucket",
 			},
 		},
+		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
 			Location: "gs://fake-bucket",
 		},
@@ -279,157 +256,38 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			fakekubeclient := fakek8s.NewSimpleClientset(c.configMap)
-			artifactStorage, err := InitializeArtifactStorage(pipelinerun, tasksWithFrom, fakekubeclient, logger)
+			artifactStorage, err := InitializeArtifactStorage(c.pipelinerun, fakekubeclient, logger)
 			if err != nil {
 				t.Fatalf("Somehow had error initializing artifact storage run out of fake client: %s", err)
 			}
-			if artifactStorage == nil {
-				t.Fatal("artifactStorage was nil, expected an actual value")
-			}
 			// If the expected storage type is PVC, make sure we're actually creating that PVC.
 			if c.storagetype == "pvc" {
-				_, err := fakekubeclient.CoreV1().PersistentVolumeClaims(pipelinerun.Namespace).Get(GetPVCName(pipelinerun), metav1.GetOptions{})
+				_, err := fakekubeclient.CoreV1().PersistentVolumeClaims(c.pipelinerun.Namespace).Get(GetPVCName(c.pipelinerun), metav1.GetOptions{})
 				if err != nil {
-					t.Fatalf("Error getting expected PVC %s for PipelineRun %s: %s", GetPVCName(pipelinerun), pipelinerun.Name, err)
+					t.Fatalf("Error getting expected PVC %s for PipelineRun %s: %s", GetPVCName(c.pipelinerun), c.pipelinerun.Name, err)
 				}
 			}
 			// Make sure we don't get any errors running CleanupArtifactStorage against the resulting storage, whether it's
 			// a bucket or a PVC.
-			if err := CleanupArtifactStorage(pipelinerun, fakekubeclient, logger); err != nil {
+			if err := CleanupArtifactStorage(c.pipelinerun, fakekubeclient, logger); err != nil {
 				t.Fatalf("Error cleaning up artifact storage: %s", err)
 			}
 			if diff := cmp.Diff(artifactStorage.GetType(), c.storagetype); diff != "" {
-				t.Fatalf(diff)
+				t.Fatalf("want %v, but got %v", c.storagetype, artifactStorage.GetType())
 			}
 			if diff := cmp.Diff(artifactStorage, c.expectedArtifactStorage, quantityComparer); diff != "" {
-				t.Fatalf(diff)
-			}
-		})
-	}
-}
-
-func TestInitializeArtifactStorageNoStorageNeeded(t *testing.T) {
-	logger := logtesting.TestLogger(t)
-	// This Pipeline has Tasks that use both inputs and outputs, but there is
-	// no link between the inputs and outputs, so no storage is needed
-	pipeline := &v1alpha1.Pipeline{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-			Name:      "pipelineruntest",
-		},
-		Spec: v1alpha1.PipelineSpec{
-			Tasks: []v1alpha1.PipelineTask{
-				{
-					Name: "task1",
-					TaskRef: v1alpha1.TaskRef{
-						Name: "task",
-					},
-					Resources: &v1alpha1.PipelineTaskResources{
-						Inputs: []v1alpha1.PipelineTaskInputResource{{
-							Name:     "input1",
-							Resource: "resource",
-						}},
-						Outputs: []v1alpha1.PipelineTaskOutputResource{{
-							Name:     "output",
-							Resource: "resource",
-						}},
-					},
-				},
-				{
-					Name: "task2",
-					TaskRef: v1alpha1.TaskRef{
-						Name: "task",
-					},
-					Resources: &v1alpha1.PipelineTaskResources{
-						Inputs: []v1alpha1.PipelineTaskInputResource{{
-							Name:     "input1",
-							Resource: "resource",
-						}},
-						Outputs: []v1alpha1.PipelineTaskOutputResource{{
-							Name:     "output",
-							Resource: "resource",
-						}},
-					},
-				},
-			},
-		},
-	}
-	pipelinerun := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pipelinerun",
-			Namespace: "namespace",
-		},
-		Spec: v1alpha1.PipelineRunSpec{
-			PipelineRef: v1alpha1.PipelineRef{
-				Name: "pipeline",
-			},
-		},
-	}
-	for _, c := range []struct {
-		desc      string
-		configMap *corev1.ConfigMap
-	}{{
-		desc: "has pvc configured",
-		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.GetNamespace(),
-				Name:      PvcConfigName,
-			},
-			Data: map[string]string{
-				PvcSizeKey: "10Gi",
-			},
-		},
-	}, {
-		desc: "has bucket configured",
-		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
-			},
-			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "gs://fake-bucket",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
-			},
-		},
-	}, {
-		desc: "no configmap",
-		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
-			},
-			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
-			},
-		},
-	}} {
-		t.Run(c.desc, func(t *testing.T) {
-			fakekubeclient := fakek8s.NewSimpleClientset(c.configMap)
-			artifactStorage, err := InitializeArtifactStorage(pipelinerun, pipeline.Spec.Tasks, fakekubeclient, logger)
-			if err != nil {
-				t.Fatalf("Somehow had error initializing artifact storage run out of fake client: %s", err)
-			}
-			if artifactStorage.GetType() != "none" {
-				t.Errorf("Expected NoneArtifactStorage when none is needed but got %s", artifactStorage.GetType())
+				t.Fatalf("want %v, but got %v", c.expectedArtifactStorage, artifactStorage)
 			}
 		})
 	}
 }
 
 func TestCleanupArtifactStorage(t *testing.T) {
-	pipelinerun := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-			Name:      "pipelineruntest",
-		},
-	}
 	logger := logtesting.TestLogger(t)
 	for _, c := range []struct {
-		desc      string
-		configMap *corev1.ConfigMap
+		desc        string
+		configMap   *corev1.ConfigMap
+		pipelinerun *v1alpha1.PipelineRun
 	}{{
 		desc: "location empty",
 		configMap: &corev1.ConfigMap{
@@ -441,6 +299,12 @@ func TestCleanupArtifactStorage(t *testing.T) {
 				v1alpha1.BucketLocationKey:              "",
 				v1alpha1.BucketServiceAccountSecretName: "secret1",
 				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+			},
+		},
+		pipelinerun: &v1alpha1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "pipelineruntest",
 			},
 		},
 	}, {
@@ -455,6 +319,12 @@ func TestCleanupArtifactStorage(t *testing.T) {
 				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
+		pipelinerun: &v1alpha1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "pipelineruntest",
+			},
+		},
 	}, {
 		desc: "no config map data",
 		configMap: &corev1.ConfigMap{
@@ -463,57 +333,52 @@ func TestCleanupArtifactStorage(t *testing.T) {
 				Name:      v1alpha1.BucketConfigName,
 			},
 		},
+		pipelinerun: &v1alpha1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "pipelineruntest",
+			},
+		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			fakekubeclient := fakek8s.NewSimpleClientset(c.configMap, GetPVCSpec(pipelinerun, GetPersistentVolumeClaim(pipelinerun, DefaultPvcSize).Spec.Resources.Requests["storage"]))
-			_, err := fakekubeclient.CoreV1().PersistentVolumeClaims(pipelinerun.Namespace).Get(GetPVCName(pipelinerun), metav1.GetOptions{})
+			fakekubeclient := fakek8s.NewSimpleClientset(c.configMap, GetPVCSpec(c.pipelinerun, persistentVolumeClaim.Spec.Resources.Requests["storage"]))
+			_, err := fakekubeclient.CoreV1().PersistentVolumeClaims(c.pipelinerun.Namespace).Get(GetPVCName(c.pipelinerun), metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Error getting expected PVC %s for PipelineRun %s: %s", GetPVCName(pipelinerun), pipelinerun.Name, err)
+				t.Fatalf("Error getting expected PVC %s for PipelineRun %s: %s", GetPVCName(c.pipelinerun), c.pipelinerun.Name, err)
 			}
-			if err := CleanupArtifactStorage(pipelinerun, fakekubeclient, logger); err != nil {
+			if err := CleanupArtifactStorage(c.pipelinerun, fakekubeclient, logger); err != nil {
 				t.Fatalf("Error cleaning up artifact storage: %s", err)
 			}
-			_, err = fakekubeclient.CoreV1().PersistentVolumeClaims(pipelinerun.Namespace).Get(GetPVCName(pipelinerun), metav1.GetOptions{})
+			_, err = fakekubeclient.CoreV1().PersistentVolumeClaims(c.pipelinerun.Namespace).Get(GetPVCName(c.pipelinerun), metav1.GetOptions{})
 			if err == nil {
-				t.Fatalf("Found PVC %s for PipelineRun %s after it should have been cleaned up", GetPVCName(pipelinerun), pipelinerun.Name)
+				t.Fatalf("Found PVC %s for PipelineRun %s after it should have been cleaned up", GetPVCName(c.pipelinerun), c.pipelinerun.Name)
 			} else if !errors.IsNotFound(err) {
-				t.Fatalf("Error checking if PVC %s for PipelineRun %s has been cleaned up: %s", GetPVCName(pipelinerun), pipelinerun.Name, err)
+				t.Fatalf("Error checking if PVC %s for PipelineRun %s has been cleaned up: %s", GetPVCName(c.pipelinerun), c.pipelinerun.Name, err)
 			}
 		})
 	}
 }
 
 func TestInitializeArtifactStorageWithoutConfigMap(t *testing.T) {
-	pipelinerun := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "pipelineruntest",
-		},
-	}
 	logger := logtesting.TestLogger(t)
 	fakekubeclient := fakek8s.NewSimpleClientset()
 
-	pvc, err := InitializeArtifactStorage(pipelinerun, tasksWithFrom, fakekubeclient, logger)
+	pvc, err := InitializeArtifactStorage(pipelinerun, fakekubeclient, logger)
 	if err != nil {
 		t.Fatalf("Somehow had error initializing artifact storage run out of fake client: %s", err)
 	}
 
 	expectedArtifactPVC := &v1alpha1.ArtifactPVC{
 		Name:                  "pipelineruntest",
-		PersistentVolumeClaim: GetPersistentVolumeClaim(pipelinerun, DefaultPvcSize),
+		PersistentVolumeClaim: persistentVolumeClaim,
 	}
 
 	if diff := cmp.Diff(pvc, expectedArtifactPVC, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-		t.Fatal(diff)
+		t.Fatalf("want %v, but got %v", expectedArtifactPVC, pvc)
 	}
 }
 
 func TestGetArtifactStorageWithConfigMap(t *testing.T) {
-	pipelinerun := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-			Name:      "pipelineruntest",
-		},
-	}
 	logger := logtesting.TestLogger(t)
 	for _, c := range []struct {
 		desc                    string

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -53,55 +53,11 @@ type ArtifactStorageInterface interface {
 	StorageBasePath(pr *v1alpha1.PipelineRun) string
 }
 
-// ArtifactStorageNone is used when no storage is needed.
-type ArtifactStorageNone struct{}
-
-// GetCopyToStorageFromContainerSpec returns no containers because none are needed.
-func (a *ArtifactStorageNone) GetCopyToStorageFromContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
-	return nil
-}
-
-// GetCopyFromStorageToContainerSpec returns no containers because none are needed.
-func (a *ArtifactStorageNone) GetCopyFromStorageToContainerSpec(name, sourcePath, destinationPath string) []corev1.Container {
-	return nil
-}
-
-// GetSecretsVolumes returns no volumes because none are needed.
-func (a *ArtifactStorageNone) GetSecretsVolumes() []corev1.Volume {
-	return nil
-}
-
-// GetType returns the string "none" to indicate this is the None storage type.
-func (a *ArtifactStorageNone) GetType() string {
-	return "none"
-}
-
-// StorageBasePath returns an empty string because no storage is being used and so
-// there is no path that resources should be copied from / to.
-func (a *ArtifactStorageNone) StorageBasePath(pr *v1alpha1.PipelineRun) string {
-	return ""
-}
-
 // InitializeArtifactStorage will check if there is there is a
-// bucket configured, create a PVC or return nil if no storage is required.
-func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, ts []v1alpha1.PipelineTask, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
-	// Artifact storage is only required if a pipeline has tasks that take inputs from previous tasks.
-	needStorage := false
-	for _, t := range ts {
-		if t.Resources != nil {
-			for _, i := range t.Resources.Inputs {
-				if len(i.From) != 0 {
-					needStorage = true
-				}
-			}
-		}
-	}
-	if !needStorage {
-		return &ArtifactStorageNone{}, nil
-	}
-
+// bucket configured or create a PVC
+func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
-	shouldCreatePVC, err := ConfigMapNeedsPVC(configMap, err, logger)
+	shouldCreatePVC, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +76,7 @@ func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, ts []v1alpha1.PipelineT
 // an output workspace or artifacts from one Task to another Task. No other PVCs will be impacted by this cleanup.
 func CleanupArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) error {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
-	shouldCreatePVC, err := ConfigMapNeedsPVC(configMap, err, logger)
+	shouldCreatePVC, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
 		return err
 	}
@@ -133,9 +89,9 @@ func CleanupArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, lo
 	return nil
 }
 
-// ConfigMapNeedsPVC checks if the possibly-nil config map passed to it is configured to use a bucket for artifact storage,
+// NeedsPVC checks if the possibly-nil config map passed to it is configured to use a bucket for artifact storage,
 // returning true if instead a PVC is needed.
-func ConfigMapNeedsPVC(configMap *corev1.ConfigMap, err error, logger *zap.SugaredLogger) (bool, error) {
+func NeedsPVC(configMap *corev1.ConfigMap, err error, logger *zap.SugaredLogger) (bool, error) {
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return true, nil
@@ -164,7 +120,7 @@ func ConfigMapNeedsPVC(configMap *corev1.ConfigMap, err error, logger *zap.Sugar
 // consumer code to get a container step for copy to/from storage
 func GetArtifactStorage(prName string, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
-	pvc, err := ConfigMapNeedsPVC(configMap, err, logger)
+	pvc, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't determine if PVC was needed from config map: %w", err)
 	}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -335,7 +335,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	rprts := pipelineState.GetNextTasks(candidateTasks)
 
 	var as artifacts.ArtifactStorageInterface
-	if as, err = artifacts.InitializeArtifactStorage(pr, p.Spec.Tasks, c.KubeClientSet, c.Logger); err != nil {
+	if as, err = artifacts.InitializeArtifactStorage(pr, c.KubeClientSet, c.Logger); err != nil {
 		c.Logger.Infof("PipelineRun failed to initialize artifact storage %s", pr.Name)
 		return err
 	}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -624,54 +624,6 @@ func TestReconcileWithTimeout(t *testing.T) {
 	}
 }
 
-func TestReconcileWithoutPVC(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
-		tb.PipelineTask("hello-world-1", "hello-world"),
-		tb.PipelineTask("hello-world-2", "hello-world"),
-	))}
-
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run", "foo",
-		tb.PipelineRunSpec("test-pipeline")),
-	}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
-
-	d := test.Data{
-		PipelineRuns: prs,
-		Pipelines:    ps,
-		Tasks:        ts,
-	}
-
-	testAssets, cancel := getPipelineRunController(t, d)
-	defer cancel()
-	c := testAssets.Controller
-	clients := testAssets.Clients
-
-	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run")
-	if err != nil {
-		t.Errorf("Did not expect to see error when reconciling PipelineRun but saw %s", err)
-	}
-
-	// Check that the PipelineRun was reconciled correctly
-	reconciledRun, err := clients.Pipeline.Tekton().PipelineRuns("foo").Get("test-pipeline-run", metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
-	}
-
-	// Check that the expected TaskRun was created
-	for _, a := range clients.Kube.Actions() {
-		if ca, ok := a.(ktesting.CreateAction); ok {
-			obj := ca.GetObject()
-			if pvc, ok := obj.(*corev1.PersistentVolumeClaim); ok {
-				t.Errorf("Did not expect to see a PVC created when no resources are linked. %s was created", pvc)
-			}
-		}
-	}
-
-	if !reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsUnknown() {
-		t.Errorf("Expected PipelineRun to be running, but condition status is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
-	}
-}
-
 func TestReconcileCancelledPipelineRun(t *testing.T) {
 	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world", tb.Retries(1)),


### PR DESCRIPTION
# Changes

This reverts commit 1d99c320f9a3a4b177fbd3a07bfee5de4744a7f9.

This fixes https://github.com/tektoncd/pipeline/issues/1068, but reopens https://github.com/tektoncd/pipeline/issues/937

We'll try again with a correct-fix for #937 after fixing the 0.5 release.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
Reverts attempt to "fix" extra PVC creation when no resources are linked - this fix will re-introduce #937 and an unneeded PVC will be created. This fixes #1068  such that unlinked TaskRuns with outputs will not hang.
```