### PR TITLE
Fix flaky TestGetStatuses by sorting slices before comparing them

### DIFF
--- a/cmd/pullrequest-init/github_test.go
+++ b/cmd/pullrequest-init/github_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -597,7 +598,7 @@ func TestGetStatuses(t *testing.T) {
 			if err != nil {
 				t.Fatalf("getStatuses: %v", err)
 			}
-			if diff := cmp.Diff(tc.want, s); diff != "" {
+			if diff := cmp.Diff(tc.want, s, cmpopts.SortSlices(func(x, y *Status) bool { return x.ID < y.ID })); diff != "" {
 				t.Errorf("-want +got: %s", diff)
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix flaky TestGetStatuses by sorting slices before comparing them.

This should also help fix some of the flakiness with the integration tests because one of the YAML tasks clones and runs unit tests for the pipeline repo in a taskrun e.g. https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/1071/pull-tekton-pipeline-integration-tests/1149698811799539712/

Fixes #1049 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
