### PR TITLE
Replace install_pipeline_crd for setup_tekton

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -118,7 +118,7 @@ function run_yaml_tests() {
   return 1
 }
 
-function install_pipeline_crd() {
+function setup_tekton() {
   echo ">> Deploying Tekton Pipelines"
   ko apply -f config/ || fail_test "Build pipeline installation failed"
 

--- a/test/e2e-tests-yaml.sh
+++ b/test/e2e-tests-yaml.sh
@@ -29,8 +29,6 @@ header "Setting up environment"
 set +o errexit
 set +o pipefail
 
-install_pipeline_crd
-
 # Run the tests
 failed=0
 for test in taskrun pipelinerun; do


### PR DESCRIPTION
The E2E test scripts invokes install_pipeline_crd which is defined
by the E2E common script. However the E2E script in the plumbing
repo already invokes a setup_tekton function (if defined) as part
of the initialization process.

Rename install_pipeline_crd to setup_tekton and delete the invocation
in the E2E script.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image
