### PR TITLE
Actually call PipelineSpec.Validate().

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -33,7 +33,7 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(p.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
-	return nil
+	return p.Spec.Validate(ctx)
 }
 
 func validateDeclaredResources(ps *PipelineSpec) error {


### PR DESCRIPTION
# Changes

Call PipelineSpec.Validate() within Pipeline.Validate(), and add tests for Pipeline.Validate().

I was adding logic for array-specific template-string testing, and was confused why my validation wasn't working in my test cluster's pipelines. I eventually realized that PipelineSpec isn't actually being validated, despite all the existing code intended to do so :laughing: 

You can check this yourself by deploying a pipeline with duplicate tasks. There is code and tests specifically written to catch this immediately via the webhook, but it will deploy fine if you actually try it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
PipelineSpec verification fixed.
```