### PR TITLE
Disallow unknown fields from resources struct

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -97,8 +97,8 @@ func main() {
 			v1alpha1.SchemeGroupVersion.WithKind("TaskRun"):          &v1alpha1.TaskRun{},
 			v1alpha1.SchemeGroupVersion.WithKind("PipelineRun"):      &v1alpha1.PipelineRun{},
 		},
-		Logger: logger,
-
+		Logger:                logger,
+		DisallowUnknownFields: true,
 		// Decorate contexts with the current state of the config.
 		WithContext: func(ctx context.Context) context.Context {
 			return v1alpha1.WithDefaultConfigurationName(store.ToContext(ctx))

--- a/examples/pipelineruns/clustertask-pipelinerun.yaml
+++ b/examples/pipelineruns/clustertask-pipelinerun.yaml
@@ -27,6 +27,4 @@ metadata:
 spec:
   pipelineRef:
     name: sample-pipeline-cluster-task-4
-  trigger:
-    type: manual
   serviceAccount: 'default'

--- a/examples/pipelineruns/pipelinerun.yaml
+++ b/examples/pipelineruns/pipelinerun.yaml
@@ -123,9 +123,9 @@ spec:
       description: Okay this is a hack, but I didn't feel right hard-codeing `-d1` down below
     - name: yamlPathToImage
       description: The path to the image to replace in the yaml manifest (arg to yq)
-    clusters:
-    - name: targetCluster
-      description: Not yet used, kubectl command below should use this cluster
+    #clusters:
+    #- name: targetCluster
+    #  description: Not yet used, kubectl command below should use this cluster
   steps:
   - name: replace-image
     image: mikefarah/yq

--- a/examples/taskruns/gcs-resource-spec-taskrun.yaml
+++ b/examples/taskruns/gcs-resource-spec-taskrun.yaml
@@ -4,10 +4,10 @@ metadata:
   name: list-file
 spec:
   taskSpec:
-   inputs:
-    resources:
-    - name: workspace
-      type: storage
+    inputs:
+      resources:
+      - name: rules
+        type: storage
     steps:
     - name: list
       image: ubuntu
@@ -15,7 +15,7 @@ spec:
       args: ['-c', 'ls -al /workspace/rules/rules_docker-master'] # tests build-gcs resource
   inputs:
     resources:
-    - name: workspace
+    - name: rules
       resourceSpec:
         type: storage
         params:

--- a/examples/taskruns/git-resource-spec-taskrun.yaml
+++ b/examples/taskruns/git-resource-spec-taskrun.yaml
@@ -5,11 +5,11 @@ metadata:
   name: read-file
 spec:
   taskSpec:
-   inputs:
-    resources:
-    - name: workspace
-      type: git
-      targetPath: skaffold
+    inputs:
+      resources:
+      - name: workspace
+        type: git
+        targetPath: skaffold
     steps:
     - name: read
       image: ubuntu

--- a/examples/taskruns/task-multiple-output-image.yaml
+++ b/examples/taskruns/task-multiple-output-image.yaml
@@ -113,8 +113,6 @@ metadata:
 spec:
   taskRef:
     name: multiple-build-push-kaniko
-  trigger:
-    type: manual
   inputs:
     resources:
     - name: sourcerepo


### PR DESCRIPTION
# Changes

Before this change, it is possible to passe any additionnal field (in
the yaml/json form) with Tekton resources. This is now disallowed.

Closes #297

cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
Unknown fields in resource YAML/JSON will now be rejected when running "kubectl apply"
```