### PR TITLE
Add ClusterTask to webhook (for validation)

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -94,6 +94,7 @@ func main() {
 			v1alpha1.SchemeGroupVersion.WithKind("Pipeline"):         &v1alpha1.Pipeline{},
 			v1alpha1.SchemeGroupVersion.WithKind("PipelineResource"): &v1alpha1.PipelineResource{},
 			v1alpha1.SchemeGroupVersion.WithKind("Task"):             &v1alpha1.Task{},
+			v1alpha1.SchemeGroupVersion.WithKind("ClusterTask"):      &v1alpha1.ClusterTask{},
 			v1alpha1.SchemeGroupVersion.WithKind("TaskRun"):          &v1alpha1.TaskRun{},
 			v1alpha1.SchemeGroupVersion.WithKind("PipelineRun"):      &v1alpha1.PipelineRun{},
 		},

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_defaults.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Tekton Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+)
+
+func (t *ClusterTask) SetDefaults(ctx context.Context) {
+	t.Spec.SetDefaults(ctx)
+}

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
@@ -17,27 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"context"
-
 	"github.com/knative/pkg/apis"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-func (t *ClusterTask) TaskSpec() TaskSpec {
-	return t.Spec
-}
-
-func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
-	return t.ObjectMeta
-}
-
-func (t *ClusterTask) Copy() TaskInterface {
-	return t.DeepCopy()
-}
-
-func (t *ClusterTask) SetDefaults(ctx context.Context) {
-	t.Spec.SetDefaults(ctx)
-}
 
 // Check that Task may be validated and defaulted.
 var _ apis.Validatable = (*ClusterTask)(nil)
@@ -69,4 +51,16 @@ type ClusterTaskList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ClusterTask `json:"items"`
+}
+
+func (t *ClusterTask) TaskSpec() TaskSpec {
+	return t.Spec
+}
+
+func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
+	return t.ObjectMeta
+}
+
+func (t *ClusterTask) Copy() TaskInterface {
+	return t.DeepCopy()
 }


### PR DESCRIPTION
# Changes

We are not validating **nor** mutating `ClusterTask` as we do for
other objects. This fixes that by adding it to what the webhook watches.

Will be cherry-picked in v0.5.2 :angel: 

/cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
Make sure ClusterTask are validated by the webhook (as are other resources)
```