### PR TITLE
Add validation of embedded TaskSpec in a TaskRun

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -94,7 +94,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	// Validate task step names
 	for _, step := range ts.Steps {
-		if errs := validation.IsDNS1123Label(step.Name); len(errs) > 0 {
+		if errs := validation.IsDNS1123Label(step.Name); step.Name != "" && len(errs) > 0 {
 			return &apis.FieldError{
 				Message: fmt.Sprintf("invalid value %q", step.Name),
 				Paths:   []string{"taskspec.steps.name"},

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -59,6 +59,15 @@ func TestTaskSpecValidate(t *testing.T) {
 		name   string
 		fields fields
 	}{{
+		name: "unnamed steps",
+		fields: fields{
+			BuildSteps: []corev1.Container{{
+				Image: "myimage",
+			}, {
+				Image: "myotherimage",
+			}},
+		},
+	}, {
 		name: "valid inputs",
 		fields: fields{
 			Inputs: &v1alpha1.Inputs{

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -49,6 +49,13 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField("spec.taskref.name", "spec.taskspec")
 	}
 
+	// Validate TaskSpec if it's present
+	if ts.TaskSpec != nil {
+		if err := ts.TaskSpec.Validate(ctx); err != nil {
+			return err
+		}
+	}
+
 	// check for input resources
 	if err := ts.Inputs.Validate(ctx, "spec.Inputs"); err != nil {
 		return err

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -113,6 +113,22 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			},
 			wantErr: apis.ErrInvalidValue("-48h0m0s should be >= 0", "spec.timeout"),
 		},
+		{
+			name: "invalid taskspec",
+			spec: v1alpha1.TaskRunSpec{
+				TaskSpec: &v1alpha1.TaskSpec{
+					Steps: []corev1.Container{{
+						Name:  "invalid-name-with-$weird-char*/%",
+						Image: "myimage",
+					}},
+				},
+			},
+			wantErr: &apis.FieldError{
+				Message: `invalid value "invalid-name-with-$weird-char*/%"`,
+				Paths:   []string{"taskspec.steps.name"},
+				Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+			},
+		},
 	}
 
 	for _, ts := range tests {


### PR DESCRIPTION
# Changes

If a `TaskRun` embeddeds a Task spec (using `taskSpec` instead of
`taskRef`) we should validate the `TaskSpec` too.

/cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
Validates the embedded TaskSpec of a TaskRun
```