### PR TITLE
Do not panic if Timeout is nil

### DIFF
--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -44,6 +44,15 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now()),
 	))
 
+	taskRunRunningNilTimeout := tb.TaskRun("test-taskrun-running-nil-timeout", testNs, tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
+		tb.TaskRunNilTimeout,
+	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+		Type:   apis.ConditionSucceeded,
+		Status: corev1.ConditionUnknown}),
+		tb.TaskRunStartTime(time.Now()),
+	))
+
 	taskRunDone := tb.TaskRun("test-taskrun-completed", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
@@ -62,7 +71,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	))
 
 	d := test.Data{
-		TaskRuns: []*v1alpha1.TaskRun{taskRunTimedout, taskRunRunning, taskRunDone, taskRunCancelled},
+		TaskRuns: []*v1alpha1.TaskRun{taskRunTimedout, taskRunRunning, taskRunDone, taskRunCancelled, taskRunRunningNilTimeout},
 		Tasks:    []*v1alpha1.Task{simpleTask},
 		Namespaces: []*corev1.Namespace{{
 			ObjectMeta: metav1.ObjectMeta{
@@ -97,6 +106,10 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	}, {
 		name:           "running",
 		taskRun:        taskRunRunning,
+		expectCallback: false,
+	}, {
+		name:           "running-with-nil-timeout",
+		taskRun:        taskRunRunningNilTimeout,
 		expectCallback: false,
 	}, {
 		name:           "completed",
@@ -152,6 +165,16 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			tb.PipelineRunStartTime(time.Now()),
 		),
 	)
+	prRunningNilTimeout := tb.PipelineRun("test-pipeline-running-nil-timeout", testNs,
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunNilTimeout,
+		),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown}),
+			tb.PipelineRunStartTime(time.Now()),
+		),
+	)
 	prDone := tb.PipelineRun("test-pipeline-done", testNs,
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
@@ -172,7 +195,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 		),
 	)
 	d := test.Data{
-		PipelineRuns: []*v1alpha1.PipelineRun{prTimeout, prRunning, prDone, prCancelled},
+		PipelineRuns: []*v1alpha1.PipelineRun{prTimeout, prRunning, prDone, prCancelled, prRunningNilTimeout},
 		Pipelines:    []*v1alpha1.Pipeline{simplePipeline},
 		Tasks:        []*v1alpha1.Task{ts},
 		Namespaces: []*corev1.Namespace{{
@@ -204,6 +227,10 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 	}{{
 		name:           "pr-running",
 		pr:             prRunning,
+		expectCallback: false,
+	}, {
+		name:           "pr-running-nil-timeout",
+		pr:             prRunningNilTimeout,
 		expectCallback: false,
 	}, {
 		name:           "pr-timedout",

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -1364,8 +1364,8 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error fetching taskrun: %v", err)
 	}
 	if d := cmp.Diff(newTr.Status.GetCondition(apis.ConditionSucceeded), &apis.Condition{
-		Type:   apis.ConditionSucceeded,
-		Status: corev1.ConditionTrue,
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionTrue,
 		Reason:  status.ReasonSucceeded,
 		Message: "All Steps have completed executing",
 	}, ignoreLastTransitionTime); d != "" {
@@ -1512,6 +1512,24 @@ func TestReconcileTimeouts(t *testing.T) {
 				Status:  corev1.ConditionFalse,
 				Reason:  "TaskRunTimeout",
 				Message: `TaskRun "test-taskrun-default-timeout-60-minutes" failed to finish within "1h0m0s"`,
+			},
+		},
+		{
+			taskRun: tb.TaskRun("test-taskrun-nil-timeout-default-60-minutes", "foo",
+				tb.TaskRunSpec(
+					tb.TaskRunTaskRef(simpleTask.Name),
+					tb.TaskRunNilTimeout,
+				),
+				tb.TaskRunStatus(tb.Condition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown}),
+					tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
+
+			expectedStatus: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  "TaskRunTimeout",
+				Message: `TaskRun "test-taskrun-nil-timeout-default-60-minutes" failed to finish within "1h0m0s"`,
 			},
 		},
 	}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -333,11 +333,16 @@ func PipelineRunParam(name, value string) PipelineRunSpecOp {
 	}
 }
 
-// PipelineRunTimeout sets the timeout to the PipelineSpec.
+// PipelineRunTimeout sets the timeout to the PipelineRunSpec.
 func PipelineRunTimeout(duration time.Duration) PipelineRunSpecOp {
 	return func(prs *v1alpha1.PipelineRunSpec) {
 		prs.Timeout = &metav1.Duration{Duration: duration}
 	}
+}
+
+// PipelineRunNilTimeout sets the timeout to nil on the PipelineRunSpec
+func PipelineRunNilTimeout(prs *v1alpha1.PipelineRunSpec) {
+	prs.Timeout = nil
 }
 
 // PipelineRunNodeSelector sets the Node selector to the PipelineSpec.

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -349,6 +349,11 @@ func TaskRunTimeout(d time.Duration) TaskRunSpecOp {
 	}
 }
 
+// TaskRunNilTimeout sets the timeout duration to nil on the TaskRunSpec.
+func TaskRunNilTimeout(spec *v1alpha1.TaskRunSpec) {
+	spec.Timeout = nil
+}
+
 // TaskRunNodeSelector sets the NodeSelector to the PipelineSpec.
 func TaskRunNodeSelector(values map[string]string) TaskRunSpecOp {
 	return func(spec *v1alpha1.TaskRunSpec) {


### PR DESCRIPTION
# Changes

`TaskRun` and `PipelineRun` should have a default Timeout set by the
webhook. That said, if the webhook didn't do its work, or the object
where created before those webhook defaults, it could be nil and makes
the controller panicking.

This is a simplest fix for #1075 than #1083 to make the simplest fix for the bug-fix release. Closes #1075.

/cc @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
Fix controller panicking on missing Timeout on TaskRun (existing or new)
```