### PR TITLE
Initial Implementation of conditionals 

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1,0 +1,50 @@
+# Conditions
+
+This document defines `Conditions` and their capabilities.
+
+*NOTE*: This feature is currently a WIP being tracked in [#1137](https://github.com/tektoncd/pipeline/issues/1137)
+
+---
+
+- [Syntax](#syntax)
+  - [Check](#check)
+- [Examples](#examples)
+
+## Syntax
+
+To define a configuration file for a `Condition` resource, you can specify the
+following fields:
+
+- Required:
+  - [`apiVersion`][kubernetes-overview] - Specifies the API version, for example
+    `tekton.dev/v1alpha1`.
+  - [`kind`][kubernetes-overview] - Specify the `Condition` resource object.
+  - [`metadata`][kubernetes-overview] - Specifies data to uniquely identify the
+    `Condition` resource object, for example a `name`.
+  - [`spec`][kubernetes-overview] - Specifies the configuration information for
+    your `Condition` resource object. In order for a `Condition` to do anything,
+    the spec must include:
+    - [`check`](#check) - Specifies a container that you want to run for evaluating the condition 
+
+[kubernetes-overview]:
+  https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
+
+### Check
+
+The `check` field is required. You define a single check to define the body of a `Condition`. The 
+check must specify a container image that adheres to the [container contract](./container-contract.md). The container image 
+runs till completion. The container must exit successfully i.e. with an exit code 0 for the 
+condition evaluation to be successful. All other exit codes are considered to be a condition check
+failure.
+
+## Examples
+
+For complete examples, see
+[the examples folder](https://github.com/tektoncd/pipeline/tree/master/examples).
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -45,6 +45,8 @@ following fields:
       - [`retries`](#retries) - Used when the task is wanted to be executed if
         it fails. Could a network error or a missing dependency. It does not
         apply to cancellations.
+      - [`conditions`](#conditions) - Used when a task is to be executed only if the specified
+        conditons are evaluated to be true.
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -284,6 +286,28 @@ tasks:
 In this example, the task "build-the-image" will be executed and if the first
 run fails a second one would triggered. But, if that fails no more would
 triggered: a max of two executions.
+
+
+#### conditions
+
+Sometimes you will need to run tasks only when some conditions are true. The `conditions` field 
+allows you to list a series of references to [`Conditions`](./conditions.md) that are run before the task
+is run. If all of the conditions evaluate to true, the task is run. If any of the conditions are false,
+the Task is not run. Its status.ConditionSucceeded is set to False with the reason set to  `ConditionCheckFailed`.
+However, unlike regular task failures, condition failures do not automatically fail the entire pipeline 
+run -- other tasks that are not dependent on the task (via `from` or `runAfter`) are still run.
+
+```yaml
+tasks:
+  - name: conditional-task
+    taskRef:
+      name: build-push
+    conditions:
+      - conditionRef: my-condition
+```
+
+In this example, `my-condition` refers to a [Condition](#conditions) custom resource. The `build-push` 
+task will only be executed if the condition evaluates to true. 
 
 ## Ordering
 

--- a/examples/pipelineruns/conditional-pipelinerun.yaml
+++ b/examples/pipelineruns/conditional-pipelinerun.yaml
@@ -1,0 +1,68 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: always-true
+spec:
+ check:
+    image: alpine
+    command: ["/bin/sh"]
+    args: ['-c', 'exit 0']
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: pipeline-git
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/tektoncd/pipeline
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: list-files
+spec:
+  inputs:
+    resources:
+      - name: workspace
+        type: git
+  steps:
+    - name: run-ls
+      image: ubuntu
+      command: ["/bin/bash"]
+      args: ['-c', 'ls -al ${inputs.resources.workspace.path}']
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: list-files-pipeline
+spec:
+  resources:
+    - name: source-repo
+      type: git
+  tasks:
+    - name: list-files-1
+      taskRef:
+        name: list-files
+      conditions:
+        - conditionRef: "always-true"
+      resources:
+        inputs:
+          - name: workspace
+            resource: source-repo
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-condtional-pr
+spec:
+  pipelineRef:
+    name: list-files-pipeline
+  serviceAccount: 'default'
+  resources:
+    - name: source-repo
+      resourceRef:
+        name: pipeline-git

--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -18,10 +18,11 @@ package pipeline
 
 // GroupName is the Kubernetes resource group name for Pipeline types.
 const (
-	GroupName            = "tekton.dev"
-	TaskLabelKey         = "/task"
-	TaskRunLabelKey      = "/taskRun"
-	PipelineLabelKey     = "/pipeline"
-	PipelineRunLabelKey  = "/pipelineRun"
-	PipelineTaskLabelKey = "/pipelineTask"
+	GroupName                    = "tekton.dev"
+	TaskLabelKey                 = "/task"
+	TaskRunLabelKey              = "/taskRun"
+	PipelineLabelKey             = "/pipeline"
+	PipelineRunLabelKey          = "/pipelineRun"
+	PipelineTaskLabelKey         = "/pipelineTask"
+	PipelineRunConditionCheckKey = "/pipelineConditionCheck"
 )

--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -16,13 +16,25 @@ limitations under the License.
 
 package pipeline
 
-// GroupName is the Kubernetes resource group name for Pipeline types.
 const (
-	GroupName                    = "tekton.dev"
-	TaskLabelKey                 = "/task"
-	TaskRunLabelKey              = "/taskRun"
-	PipelineLabelKey             = "/pipeline"
-	PipelineRunLabelKey          = "/pipelineRun"
-	PipelineTaskLabelKey         = "/pipelineTask"
-	PipelineRunConditionCheckKey = "/pipelineConditionCheck"
+	// GroupName is the Kubernetes resource group name for Pipeline types.
+	GroupName = "tekton.dev"
+
+	// TaskLabelKey is used as the label identifier for a task
+	TaskLabelKey = "/task"
+
+	// TaskRunLabelKey is used as the label identifier for a TaskRun
+	TaskRunLabelKey = "/taskRun"
+
+	// PipelineLabelKey is used as the label identifier for a Pipeline
+	PipelineLabelKey = "/pipeline"
+
+	// PipelineRunLabelKey is used as the label identifier for a PipelineRun
+	PipelineRunLabelKey = "/pipelineRun"
+
+	// PipelineRunLabelKey is used as the label identifier for a PipelineTask
+	PipelineTaskLabelKey = "/pipelineTask"
+
+	// ConditionCheck is used as the label identifier for a ConditionCheck
+	ConditionCheckKey = "/conditionCheck"
 )

--- a/pkg/apis/pipeline/v1alpha1/condition_types.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types.go
@@ -98,3 +98,13 @@ func NewConditionCheck(tr *TaskRun) *ConditionCheck {
 	cc := ConditionCheck(*tr)
 	return &cc
 }
+
+// IsDone returns true if the ConditionCheck's status indicates that it is done.
+func (cc *ConditionCheck) IsDone() bool {
+	return !cc.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()
+}
+
+// IsSuccessful returns true if the ConditionCheck's status indicates that it is done.
+func (cc *ConditionCheck) IsSuccessful() bool {
+	return cc.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+}

--- a/pkg/apis/pipeline/v1alpha1/condition_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types_test.go
@@ -49,7 +49,7 @@ func TestConditionCheck_IsSuccessful(t *testing.T) {
 	)))
 
 	cc := v1alpha1.ConditionCheck(*tr)
-	if !cc.IsDone() {
+	if !cc.IsSuccessful() {
 		t.Fatal("Expected conditionCheck status to be done")
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/condition_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types_test.go
@@ -1,0 +1,55 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+)
+
+func TestConditionCheck_IsDone(t *testing.T) {
+	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+		apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		},
+	)))
+
+	cc := v1alpha1.ConditionCheck(*tr)
+	if !cc.IsDone() {
+		t.Fatal("Expected conditionCheck status to be done")
+	}
+}
+
+func TestConditionCheck_IsSuccessful(t *testing.T) {
+	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+		apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		},
+	)))
+
+	cc := v1alpha1.ConditionCheck(*tr)
+	if !cc.IsDone() {
+		t.Fatal("Expected conditionCheck status to be done")
+	}
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/controller.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/controller.go
@@ -22,6 +22,7 @@ import (
 
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	clustertaskinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/clustertask"
+	conditioninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/condition"
 	pipelineinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/pipeline"
 	resourceinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/pipelineresource"
 	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/pipelinerun"
@@ -54,6 +55,7 @@ func NewController(
 	pipelineRunInformer := pipelineruninformer.Get(ctx)
 	pipelineInformer := pipelineinformer.Get(ctx)
 	resourceInformer := resourceinformer.Get(ctx)
+	conditionInformer := conditioninformer.Get(ctx)
 	timeoutHandler := reconciler.NewTimeoutHandler(ctx.Done(), logger)
 
 	opt := reconciler.Options{
@@ -72,6 +74,7 @@ func NewController(
 		clusterTaskLister: clusterTaskInformer.Lister(),
 		taskRunLister:     taskRunInformer.Lister(),
 		resourceLister:    resourceInformer.Lister(),
+		conditionLister:   conditionInformer.Lister(),
 		timeoutHandler:    timeoutHandler,
 	}
 	impl := controller.NewImpl(c, c.Logger, pipelineRunControllerName)

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -620,7 +620,7 @@ func (c *Reconciler) updateLabelsAndAnnotations(pr *v1alpha1.PipelineRun) (*v1al
 
 func (c *Reconciler) makeConditionCheckContainer(rprt *resources.ResolvedPipelineRunTask, rcc *resources.ResolvedConditionCheck, pr *v1alpha1.PipelineRun) (*v1alpha1.ConditionCheck, error) {
 	labels := getTaskrunLabels(pr, rprt.PipelineTask.Name)
-	labels[pipeline.GroupName+pipeline.PipelineRunConditionCheckKey] = rcc.ConditionCheckName
+	labels[pipeline.GroupName+pipeline.ConditionCheckKey] = rcc.ConditionCheckName
 
 	tr := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -1362,7 +1362,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
-			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunConditionCheckKey, conditionCheckName),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.ConditionCheckKey, conditionCheckName),
 			tb.TaskRunSpec(tb.TaskRunTaskSpec()),
 			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 				Type:   apis.ConditionSucceeded,
@@ -1429,7 +1429,7 @@ func makeExpectedTr(condName, ccName string) *v1alpha1.TaskRun {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run"),
-		tb.TaskRunLabel("tekton.dev/pipelineConditionCheck", ccName),
+		tb.TaskRunLabel("tekton.dev/conditionCheck", ccName),
 		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskSpec(tb.Step("condition-check-"+condName, "foo", tb.Args("bar"))),

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -39,6 +39,10 @@ import (
 	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
+var (
+	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
+)
+
 func getRunName(pr *v1alpha1.PipelineRun) string {
 	return strings.Join([]string{pr.Namespace, pr.Name}, "/")
 }
@@ -57,6 +61,12 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.TestAssets, func(
 		),
 		Clients: c,
 	}, cancel
+}
+
+// conditionCheckFromTaskRun converts takes a pointer to a TaskRun and wraps it into a ConditionCheck
+func conditionCheckFromTaskRun(tr *v1alpha1.TaskRun) *v1alpha1.ConditionCheck {
+	cc := v1alpha1.ConditionCheck(*tr)
+	return &cc
 }
 
 func TestReconcile(t *testing.T) {
@@ -264,6 +274,7 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 		tb.Pipeline("a-pipeline-with-array-params", "foo", tb.PipelineSpec(
 			tb.PipelineParamSpec("some-param", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("some-task", "a-task-that-needs-array-params"))),
+		tb.Pipeline("a-pipeline-with-missing-conditions", "foo", tb.PipelineSpec(tb.PipelineTask("some-task", "a-task-that-exists", tb.PipelineTaskCondition("condition-does-not-exist")))),
 	}
 	prs := []*v1alpha1.PipelineRun{
 		tb.PipelineRun("invalid-pipeline", "foo", tb.PipelineRunSpec("pipeline-not-exist")),
@@ -274,6 +285,7 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			tb.PipelineRunResourceBinding("a-resource", tb.PipelineResourceBindingRef("missing-resource")))),
 		tb.PipelineRun("pipeline-resources-not-declared", "foo", tb.PipelineRunSpec("a-pipeline-that-should-be-caught-by-admission-control")),
 		tb.PipelineRun("pipeline-mismatching-param-type", "foo", tb.PipelineRunSpec("a-pipeline-with-array-params", tb.PipelineRunParam("some-param", "stringval"))),
+		tb.PipelineRun("pipeline-conditions-missing", "foo", tb.PipelineRunSpec("a-pipeline-with-missing-conditions")),
 	}
 	d := test.Data{
 		Tasks:        ts,
@@ -313,6 +325,10 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			name:        "invalid-pipeline-mismatching-parameter-types",
 			pipelineRun: prs[6],
 			reason:      ReasonParameterTypeMismatch,
+		}, {
+			name:        "invalid-pipeline-missing-conditions-shd-stop-reconciling",
+			pipelineRun: prs[7],
+			reason:      ReasonCouldntGetCondition,
 		},
 	}
 
@@ -429,13 +445,294 @@ func TestUpdateTaskRunsState(t *testing.T) {
 
 }
 
-func TestReconcileOnCompletedPipelineRun(t *testing.T) {
-	prtrs := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
-	taskRunName := "test-pipeline-run-completed-hello-world"
-	prtrs[taskRunName] = &v1alpha1.PipelineRunTaskRunStatus{
-		PipelineTaskName: "hello-world-1",
-		Status:           &v1alpha1.TaskRunStatus{},
+func TestUpdateTaskRunState_WithPassingConditionChecks(t *testing.T) {
+	pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+
+	cond := v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "always-true",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{},
+		},
 	}
+
+	taskCondition := v1alpha1.PipelineTaskCondition{
+		ConditionRef: "always-true",
+	}
+
+	pipelineTask := v1alpha1.PipelineTask{
+		Name:       "unit-test-1",
+		TaskRef:    v1alpha1.TaskRef{Name: "unit-test-task"},
+		Conditions: []v1alpha1.PipelineTaskCondition{taskCondition},
+	}
+
+	conditioncheck := conditionCheckFromTaskRun(tb.TaskRun("test-pipeline-run-success-unit-test-1-always-true", "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskSpec(tb.TaskContainerTemplate()),
+	), tb.TaskRunStatus(
+		tb.StatusCondition(apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}),
+		tb.StepState(tb.StateTerminated(0)),
+	)))
+
+	expectedConditionCheckStatus := make(map[string]*v1alpha1.PipelineRunConditionCheckStatus)
+	expectedConditionCheckStatus[conditioncheck.Name] = &v1alpha1.PipelineRunConditionCheckStatus{
+		ConditionName: cond.Name,
+		Status: &v1alpha1.ConditionCheckStatus{
+			Check: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+			},
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue}},
+			},
+		},
+	}
+	expectedTaskRunsStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	expectedTaskRunsStatus["test-pipeline-run-success-unit-test-1"] = &v1alpha1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "unit-test-1",
+		ConditionChecks:  expectedConditionCheckStatus,
+	}
+	expectedPipelineRunStatus := v1alpha1.PipelineRunStatus{
+		TaskRuns: expectedTaskRunsStatus,
+	}
+
+	state := []*resources.ResolvedPipelineRunTask{{
+		PipelineTask: &pipelineTask,
+		TaskRunName:  "test-pipeline-run-success-unit-test-1",
+		TaskRun:      nil,
+		ResolvedTaskResources: &taskrunresources.ResolvedTaskResources{
+			TaskSpec: &v1alpha1.TaskSpec{},
+		},
+		ResolvedConditionChecks: resources.TaskConditionCheckState{{
+			ConditionCheckName: "test-pipeline-run-success-unit-test-1-always-true",
+			Condition:          &cond,
+			ConditionCheck:     conditioncheck,
+		}},
+	}}
+	pr.Status.InitializeConditions()
+	updateTaskRunsStatus(pr, state)
+	if d := cmp.Diff(pr.Status.TaskRuns, expectedPipelineRunStatus.TaskRuns); d != "" {
+		t.Fatalf("Expected PipelineRun status to match ConditionCheck(s) status, but got a mismatch: %s", d)
+	}
+}
+
+func TestUpdateTaskRunState_WithFailingConditionChecks(t *testing.T) {
+	pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+
+	cond := v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "always-true",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{},
+		},
+	}
+
+	taskCondition := v1alpha1.PipelineTaskCondition{
+		ConditionRef: "always-true",
+	}
+
+	pipelineTask := v1alpha1.PipelineTask{
+		Name:       "unit-test-1",
+		TaskRef:    v1alpha1.TaskRef{Name: "unit-test-task"},
+		Conditions: []v1alpha1.PipelineTaskCondition{taskCondition},
+	}
+
+	taskrunName := "test-pipeline-run-success-unit-test-1"
+	conditioncheck := conditionCheckFromTaskRun(tb.TaskRun("test-pipeline-run-success-unit-test-1-always-true", "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskSpec(tb.TaskContainerTemplate()),
+	), tb.TaskRunStatus(
+		tb.StatusCondition(apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}),
+		tb.StepState(tb.StateTerminated(127)),
+	)))
+
+	expectedConditionCheckStatus := make(map[string]*v1alpha1.PipelineRunConditionCheckStatus)
+	expectedConditionCheckStatus[conditioncheck.Name] = &v1alpha1.PipelineRunConditionCheckStatus{
+		ConditionName: cond.Name,
+		Status: &v1alpha1.ConditionCheckStatus{
+			Check: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 127},
+			},
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}},
+			},
+		},
+	}
+
+	expectedTaskRunsStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+	expectedTaskRunsStatus["test-pipeline-run-success-unit-test-1"] = &v1alpha1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "unit-test-1",
+		ConditionChecks:  expectedConditionCheckStatus,
+		Status: &v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Reason:  resources.ReasonConditionCheckFailed,
+					Message: fmt.Sprintf("ConditionChecks failed for Task %s in PipelineRun %s", taskrunName, pr.Name),
+				}},
+			},
+		},
+	}
+	expectedPipelineRunStatus := v1alpha1.PipelineRunStatus{
+		TaskRuns: expectedTaskRunsStatus,
+	}
+
+	state := makePRState(taskrunName, pipelineTask, resources.TaskConditionCheckState{{
+		ConditionCheckName: "test-pipeline-run-success-unit-test-1-always-true",
+		Condition:          &cond,
+		ConditionCheck:     conditioncheck,
+	}})
+	pr.Status.InitializeConditions()
+	updateTaskRunsStatus(pr, state)
+	ignoreLastTransitionTime := cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
+	if d := cmp.Diff(pr.Status.TaskRuns, expectedPipelineRunStatus.TaskRuns, ignoreLastTransitionTime); d != "" {
+		t.Fatalf("Expected PipelineRun status to match ConditionCheck(s) status, but got a mismatch: %s", d)
+	}
+}
+
+func makePRState(trName string, pt v1alpha1.PipelineTask, tccs resources.TaskConditionCheckState) resources.PipelineRunState {
+	pipelineTask := v1alpha1.PipelineTask{
+		Name:    "unit-test-1",
+		TaskRef: v1alpha1.TaskRef{Name: "unit-test-task"},
+	}
+	var ptc []v1alpha1.PipelineTaskCondition
+	for _, rcc := range tccs {
+		ptc = append(ptc, v1alpha1.PipelineTaskCondition{
+			ConditionRef: rcc.Condition.Name,
+		})
+	}
+	pipelineTask.Conditions = ptc
+	state := []*resources.ResolvedPipelineRunTask{{
+		PipelineTask:            &pt,
+		TaskRunName:             trName,
+		ResolvedConditionChecks: tccs,
+	}}
+	return state
+}
+
+func TestUpdateTaskRunState_MultipleConditionChecks(t *testing.T) {
+	taskrunName := "test-pipeline-run-success-unit-test-1"
+	successConditionCheckName := "test-pipeline-run-success-unit-test-1-cond-1"
+	failingConditionCheckName := "test-pipeline-run-success-unit-test-1-cond-2"
+
+	successCondition := v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cond-1",
+		},
+	}
+	failingCondition := v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cond-2",
+		},
+	}
+
+	pipelineTask := v1alpha1.PipelineTask{
+		Name:    "unit-test-1",
+		TaskRef: v1alpha1.TaskRef{Name: "unit-test-task"},
+		Conditions: []v1alpha1.PipelineTaskCondition{{
+			ConditionRef: successCondition.Name,
+		}, {
+			ConditionRef: failingCondition.Name,
+		}},
+	}
+
+	successConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(successConditionCheckName, "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskSpec(tb.TaskContainerTemplate()),
+	), tb.TaskRunStatus(
+		tb.StatusCondition(apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		}),
+		tb.StepState(tb.StateTerminated(0)),
+	)))
+	failingConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(failingConditionCheckName, "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskSpec(tb.TaskContainerTemplate()),
+	), tb.TaskRunStatus(
+		tb.StatusCondition(apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		}),
+		tb.StepState(tb.StateTerminated(127)),
+	)))
+
+	successConditionCheckStatus := &v1alpha1.PipelineRunConditionCheckStatus{
+		ConditionName: successCondition.Name,
+		Status: &v1alpha1.ConditionCheckStatus{
+			Check: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+			},
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue}},
+			},
+		},
+	}
+	failingConditionCheckStatus := &v1alpha1.PipelineRunConditionCheckStatus{
+		ConditionName: failingCondition.Name,
+		Status: &v1alpha1.ConditionCheckStatus{
+			Check: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 127},
+			},
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}},
+			},
+		},
+	}
+
+	successrcc := resources.ResolvedConditionCheck{
+		ConditionCheckName: successConditionCheckName,
+		Condition:          &successCondition,
+		ConditionCheck:     successConditionCheck,
+	}
+	failingrcc := resources.ResolvedConditionCheck{
+		ConditionCheckName: failingConditionCheckName,
+		Condition:          &failingCondition,
+		ConditionCheck:     failingConditionCheck,
+	}
+
+	expectedConditionCheckStatus := make(map[string]*v1alpha1.PipelineRunConditionCheckStatus)
+	expectedConditionCheckStatus[successConditionCheckName] = successConditionCheckStatus
+	expectedConditionCheckStatus[failingConditionCheckName] = failingConditionCheckStatus
+
+	expectedTaskRunsStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+
+	//sucessfulTaskRunStatus := v1alpha1.TaskRunStatus{}
+	failedTaskRunStatus := v1alpha1.TaskRunStatus{
+		Status: duckv1beta1.Status{
+			Conditions: []apis.Condition{{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  resources.ReasonConditionCheckFailed,
+				Message: fmt.Sprintf("ConditionChecks failed for Task %s in PipelineRun %s", taskrunName, "test-pipeline-run"),
+			}},
+		},
+	}
+
+	expectedTaskRunsStatus[taskrunName] = &v1alpha1.PipelineRunTaskRunStatus{
+		PipelineTaskName: "unit-test-1",
+		ConditionChecks:  expectedConditionCheckStatus,
+		Status:           &failedTaskRunStatus,
+	}
+	expectedPipelineRunStatus := v1alpha1.PipelineRunStatus{
+		TaskRuns: expectedTaskRunsStatus,
+	}
+
+	pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+	state := makePRState(taskrunName, pipelineTask, resources.TaskConditionCheckState{&successrcc, &failingrcc})
+	pr.Status.InitializeConditions()
+	updateTaskRunsStatus(pr, state)
+	if d := cmp.Diff(pr.Status.TaskRuns, expectedPipelineRunStatus.TaskRuns, ignoreLastTransitionTime); d != "" {
+		t.Fatalf("Expected PipelineRun status to match ConditionCheck(s) status, but got a mismatch: %s", d)
+	}
+}
+
+func TestReconcileOnCompletedPipelineRun(t *testing.T) {
+	taskRunName := "test-pipeline-run-completed-hello-world"
 	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", "foo",
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccount("test-sa")),
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
@@ -444,7 +741,10 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 			Reason:  resources.ReasonSucceeded,
 			Message: "All Tasks have completed executing",
 		}),
-			tb.PipelineRunTaskRunsStatus(prtrs),
+			tb.PipelineRunTaskRunsStatus(taskRunName, &v1alpha1.PipelineRunTaskRunStatus{
+				PipelineTaskName: "hello-world-1",
+				Status:           &v1alpha1.TaskRunStatus{},
+			}),
 		),
 	)}
 	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
@@ -510,7 +810,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 
 	expectedTaskRunsStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
 	expectedTaskRunsStatus[taskRunName] = &v1alpha1.PipelineRunTaskRunStatus{
-		PipelineTaskName: prtrs[taskRunName].PipelineTaskName,
+		PipelineTaskName: "hello-world-1",
 		Status: &v1alpha1.TaskRunStatus{
 			Status: duckv1beta1.Status{
 				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
@@ -1061,4 +1361,225 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReconcileWithConditionChecks(t *testing.T) {
+	names.TestingSeed()
+	prName := "test-pipeline-run"
+	conditions := []*v1alpha1.Condition{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cond-1",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{
+				Image: "foo",
+				Args:  []string{"bar"},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cond-2",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{
+				Image: "foo",
+				Args:  []string{"bar"},
+			},
+		},
+	}}
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hello-world",
+			tb.PipelineTaskCondition("cond-1"),
+			tb.PipelineTaskCondition("cond-2")),
+	))}
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(prName, "foo",
+		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccount("test-sa"),
+		),
+	)}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		Conditions:   conditions,
+	}
+
+	testAssets, cancel := getPipelineRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	err := c.Reconciler.Reconcile(context.Background(), "foo/"+prName)
+	if err != nil {
+		t.Errorf("Did not expect to see error when reconciling completed PipelineRun but saw %s", err)
+	}
+
+	// Check that the PipelineRun was reconciled correctly
+	_, err = clients.Pipeline.Tekton().PipelineRuns("foo").Get(prName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
+	}
+	ccNameBase := prName + "-hello-world-1-9l9zj"
+	expectedConditionChecks := []*v1alpha1.TaskRun{
+		makeExpectedTr("cond-1", ccNameBase+"-cond-1-mz4c7"),
+		makeExpectedTr("cond-2", ccNameBase+"-cond-2-mssqb"),
+	}
+
+	// Check that the expected TaskRun was created
+	condCheck0 := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject().(*v1alpha1.TaskRun)
+	condCheck1 := clients.Pipeline.Actions()[1].(ktesting.CreateAction).GetObject().(*v1alpha1.TaskRun)
+	if condCheck0 == nil || condCheck1 == nil {
+		t.Errorf("Expected two ConditionCheck TaskRuns to be created, but it wasn't.")
+	}
+
+	actual := []*v1alpha1.TaskRun{condCheck0, condCheck1}
+	if d := cmp.Diff(actual, expectedConditionChecks); d != "" {
+		t.Errorf("expected to see 2 ConditionCheck TaskRuns created. Diff %s", d)
+	}
+}
+
+func TestReconcileWithFailingConditionChecks(t *testing.T) {
+	names.TestingSeed()
+	conditions := []*v1alpha1.Condition{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "always-false",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{
+				Image: "foo",
+				Args:  []string{"bar"},
+			},
+		},
+	}}
+	pipelineRunName := "test-pipeline-run-with-conditions"
+	prccs := make(map[string]*v1alpha1.PipelineRunConditionCheckStatus)
+
+	conditionCheckName := pipelineRunName + "task-2-always-false-xxxyyy"
+	prccs[conditionCheckName] = &v1alpha1.PipelineRunConditionCheckStatus{
+		ConditionName: "always-false",
+		Status:        &v1alpha1.ConditionCheckStatus{},
+	}
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+		tb.PipelineTask("task-1", "hello-world"),
+		tb.PipelineTask("task-2", "hello-world", tb.PipelineTaskCondition("always-false")),
+		tb.PipelineTask("task-3", "hello-world", tb.RunAfter("task-1")),
+	))}
+
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-conditions", "foo",
+		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccount("test-sa"),
+		),
+		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  resources.ReasonRunning,
+			Message: "Not all Tasks in the Pipeline have finished executing",
+		}), tb.PipelineRunTaskRunsStatus(pipelineRunName+"task-1", &v1alpha1.PipelineRunTaskRunStatus{
+			PipelineTaskName: "task-1",
+			Status:           &v1alpha1.TaskRunStatus{},
+		}), tb.PipelineRunTaskRunsStatus(pipelineRunName+"task-2", &v1alpha1.PipelineRunTaskRunStatus{
+			PipelineTaskName: "task-2",
+			Status:           &v1alpha1.TaskRunStatus{},
+			ConditionChecks:  prccs,
+		})),
+	)}
+
+	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	trs := []*v1alpha1.TaskRun{
+		tb.TaskRun(pipelineRunName+"task-1", "foo",
+			tb.TaskRunOwnerReference("kind", "name"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("hello-world")),
+			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+			}),
+			),
+		),
+		tb.TaskRun(conditionCheckName, "foo",
+			tb.TaskRunOwnerReference("kind", "name"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunConditionCheckKey, conditionCheckName),
+			tb.TaskRunSpec(tb.TaskRunTaskSpec()),
+			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+			}),
+			),
+		),
+	}
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		Conditions:   conditions,
+		TaskRuns:     trs,
+	}
+
+	testAssets, cancel := getPipelineRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	err := c.Reconciler.Reconcile(context.Background(), "foo/test-pipeline-run-with-conditions")
+	if err != nil {
+		t.Errorf("Did not expect to see error when reconciling completed PipelineRun but saw %s", err)
+	}
+
+	// Check that the PipelineRun was reconciled correctly
+	_, err = clients.Pipeline.Tekton().PipelineRuns("foo").Get("test-pipeline-run-with-conditions", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
+	}
+
+	// Check that the expected TaskRun was created
+	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject().(*v1alpha1.TaskRun)
+	if actual == nil {
+		t.Errorf("Expected a ConditionCheck TaskRun to be created, but it wasn't.")
+	}
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-conditions-task-3-9l9zj", "foo",
+		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-conditions",
+			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
+			tb.Controller, tb.BlockOwnerDeletion,
+		),
+		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "task-3"),
+		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-with-conditions"),
+		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
+		tb.TaskRunSpec(
+			tb.TaskRunTaskRef("hello-world"),
+			tb.TaskRunServiceAccount("test-sa"),
+		),
+	)
+
+	if d := cmp.Diff(actual, expectedTaskRun); d != "" {
+		t.Errorf("expected to see ConditionCheck TaskRun %v created. Diff %s", expectedTaskRun, d)
+	}
+}
+
+func makeExpectedTr(condName, ccName string) *v1alpha1.TaskRun {
+	return tb.TaskRun(ccName, "foo",
+		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run",
+			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
+			tb.Controller, tb.BlockOwnerDeletion,
+		),
+		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
+		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run"),
+		tb.TaskRunLabel("tekton.dev/pipelineConditionCheck", ccName),
+		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
+		tb.TaskRunSpec(
+			tb.TaskRunTaskSpec(tb.Step("condition-check-"+condName, "foo", tb.Args("bar"))),
+			tb.TaskRunServiceAccount("test-sa"),
+		),
+	)
 }

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution.go
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	// unnamedCheckNamePrefix is the prefix added to the name of a condition's
+	// spec.Check.Image if the name is missing
 	unnamedCheckNamePrefix = "condition-check-"
 )
 

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution.go
@@ -99,7 +99,7 @@ func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() *v1alpha1.TaskSpec {
 }
 
 // NewConditionCheck status creates a ConditionCheckStatus from a ConditionCheck
-func (rcc *ResolvedConditionCheck) NewConditionCheckStatus() v1alpha1.ConditionCheckStatus {
+func (rcc *ResolvedConditionCheck) NewConditionCheckStatus() *v1alpha1.ConditionCheckStatus {
 	var checkStep corev1.ContainerState
 	trs := rcc.ConditionCheck.Status
 	for _, s := range trs.Steps {
@@ -109,7 +109,7 @@ func (rcc *ResolvedConditionCheck) NewConditionCheckStatus() v1alpha1.ConditionC
 		}
 	}
 
-	return v1alpha1.ConditionCheckStatus{
+	return &v1alpha1.ConditionCheckStatus{
 		Status:         trs.Status,
 		PodName:        trs.PodName,
 		StartTime:      trs.StartTime,

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution.go
@@ -1,0 +1,119 @@
+/*
+ *
+ * Copyright 2019 The Tekton Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+const (
+	unnamedCheckNamePrefix = "condition-check-"
+)
+
+// GetCondition is a function used to retrieve PipelineConditions.
+type GetCondition func(string) (*v1alpha1.Condition, error)
+
+// ResolvedConditionCheck contains a Condition and its associated ConditionCheck, if it
+// exists. ConditionCheck can be nil to represent there being no ConditionCheck (i.e the condition
+// has not been evaluated).
+type ResolvedConditionCheck struct {
+	ConditionCheckName string
+	Condition          *v1alpha1.Condition
+	ConditionCheck     *v1alpha1.ConditionCheck
+}
+
+// TaskConditionCheckState is a slice of ResolvedConditionCheck the represents the current execution
+// state of Conditions for a Task in a pipeline run.
+type TaskConditionCheckState []*ResolvedConditionCheck
+
+// HasStarted returns true if the conditionChecks for a given object have been created
+func (state TaskConditionCheckState) HasStarted() bool {
+	hasStarted := true
+	for _, j := range state {
+		if j.ConditionCheck == nil {
+			hasStarted = false
+		}
+	}
+	return hasStarted
+}
+
+// IsComplete returns true if the status for all conditionChecks for a task indicate that they are done
+func (state TaskConditionCheckState) IsDone() bool {
+	if !state.HasStarted() {
+		return false
+	}
+	isDone := true
+	for _, rcc := range state {
+		isDone = isDone && rcc.ConditionCheck.IsDone()
+	}
+	return isDone
+}
+
+// IsComplete returns true if the status for all conditionChecks for a task indicate they have
+// completed successfully
+func (state TaskConditionCheckState) IsSuccess() bool {
+	if !state.IsDone() {
+		return false
+	}
+	isSuccess := true
+	for _, rcc := range state {
+		isSuccess = isSuccess && rcc.ConditionCheck.IsSuccessful()
+	}
+	return isSuccess
+}
+
+// ConditionToTaskSpec creates a TaskSpec from a given Condition
+func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() *v1alpha1.TaskSpec {
+	if rcc.Condition.Spec.Check.Name == "" {
+		rcc.Condition.Spec.Check.Name = unnamedCheckNamePrefix + rcc.Condition.Name
+	}
+
+	t := &v1alpha1.TaskSpec{
+		Steps: []corev1.Container{rcc.Condition.Spec.Check},
+	}
+
+	if len(rcc.Condition.Spec.Params) > 0 {
+		t.Inputs = &v1alpha1.Inputs{
+			Params: rcc.Condition.Spec.Params,
+		}
+	}
+
+	return t
+}
+
+// NewConditionCheck status creates a ConditionCheckStatus from a ConditionCheck
+func (rcc *ResolvedConditionCheck) NewConditionCheckStatus() v1alpha1.ConditionCheckStatus {
+	var checkStep corev1.ContainerState
+	trs := rcc.ConditionCheck.Status
+	for _, s := range trs.Steps {
+		if s.Name == rcc.Condition.Spec.Check.Name {
+			checkStep = s.ContainerState
+			break
+		}
+	}
+
+	return v1alpha1.ConditionCheckStatus{
+		Status:         trs.Status,
+		PodName:        trs.PodName,
+		StartTime:      trs.StartTime,
+		CompletionTime: trs.CompletionTime,
+		Check:          checkStep,
+	}
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution_test.go
@@ -117,7 +117,7 @@ func TestTaskConditionCheckState_HasStarted(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.state.HasStarted()
-			if got != tc.want{
+			if got != tc.want {
 				t.Errorf("Expected HasStarted to be %v but got %v for %s", tc.want, got, tc.name)
 			}
 		})

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/conditionresolution_test.go
@@ -1,0 +1,269 @@
+/*
+ *
+ * Copyright 2019 The Tekton Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resources
+
+import (
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
+	"testing"
+)
+
+var c = &v1alpha1.Condition{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "conditionname",
+	},
+	Spec: v1alpha1.ConditionSpec{
+		Check: corev1.Container{},
+	},
+}
+
+var notStartedState = TaskConditionCheckState{{
+	ConditionCheckName: "foo",
+	Condition:          c,
+}}
+
+var runningState = TaskConditionCheckState{{
+	ConditionCheckName: "foo",
+	Condition:          c,
+	ConditionCheck: &v1alpha1.ConditionCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "running-condition-check",
+		},
+	},
+}}
+
+var successState = TaskConditionCheckState{{
+	ConditionCheckName: "foo",
+	Condition:          c,
+	ConditionCheck: &v1alpha1.ConditionCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "successful-condition-check",
+		},
+		Spec: v1alpha1.TaskRunSpec{},
+		Status: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		},
+	},
+}}
+
+var failedState = TaskConditionCheckState{{
+	ConditionCheckName: "foo",
+	Condition:          c,
+	ConditionCheck: &v1alpha1.ConditionCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "failed-condition-check",
+		},
+		Spec: v1alpha1.TaskRunSpec{},
+		Status: v1alpha1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
+				}},
+			},
+		},
+	},
+}}
+
+func TestTaskConditionCheckState_HasStarted(t *testing.T) {
+	tcs := []struct {
+		name  string
+		state TaskConditionCheckState
+		want  bool
+	}{{
+		name:  "no-condition-checks",
+		state: notStartedState,
+		want:  false,
+	}, {
+		name:  "running-condition-check",
+		state: runningState,
+		want:  true,
+	}, {
+		name:  "successful-condition-check",
+		state: successState,
+		want:  true,
+	}, {
+		name:  "failed-condition-check",
+		state: failedState,
+		want:  true,
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.state.HasStarted()
+			if got != tc.want{
+				t.Errorf("Expected HasStarted to be %v but got %v for %s", tc.want, got, tc.name)
+			}
+		})
+	}
+}
+
+func TestTaskConditionCheckState_IsComplete(t *testing.T) {
+	tcs := []struct {
+		name  string
+		state TaskConditionCheckState
+		want  bool
+	}{{
+		name:  "no-condition-checks",
+		state: notStartedState,
+		want:  false,
+	}, {
+		name:  "running-condition-check",
+		state: runningState,
+		want:  false,
+	}, {
+		name:  "successful-condition-check",
+		state: successState,
+		want:  true,
+	}, {
+		name:  "failed-condition-check",
+		state: failedState,
+		want:  true,
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.state.IsDone()
+			if got != tc.want {
+				t.Errorf("Expected IsComplete to be %v but got %v for %s", tc.want, got, tc.name)
+			}
+		})
+	}
+}
+
+func TestTaskConditionCheckState_IsSuccess(t *testing.T) {
+	tcs := []struct {
+		name  string
+		state TaskConditionCheckState
+		want  bool
+	}{{
+		name:  "no-condition-checks",
+		state: notStartedState,
+		want:  false,
+	}, {
+		name:  "running-condition-check",
+		state: runningState,
+		want:  false,
+	}, {
+		name:  "successful-condition-check",
+		state: successState,
+		want:  true,
+	}, {
+		name:  "failed-condition-check",
+		state: failedState,
+		want:  false,
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.state.IsSuccess()
+			if got != tc.want {
+				t.Errorf("Expected IsSuccess to be %v but got %v for %s", tc.want, got, tc.name)
+			}
+		})
+	}
+}
+
+func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
+	tcs := []struct {
+		name string
+		cond v1alpha1.Condition
+		want v1alpha1.TaskSpec
+	}{{
+		name: "user-provided-container-name",
+		cond: v1alpha1.Condition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "name",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Check: corev1.Container{
+					Name:  "foo",
+					Image: "ubuntu",
+				},
+			},
+		},
+		want: v1alpha1.TaskSpec{
+			Steps: []corev1.Container{{
+				Name:  "foo",
+				Image: "ubuntu",
+			}},
+		},
+	}, {
+		name: "default-container-name",
+		cond: v1alpha1.Condition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Check: corev1.Container{
+					Image: "ubuntu",
+				},
+			},
+		},
+		want: v1alpha1.TaskSpec{
+			Steps: []corev1.Container{{
+				Name:  "condition-check-bar",
+				Image: "ubuntu",
+			}},
+		},
+	}, {
+		name: "with-input-params",
+		cond: v1alpha1.Condition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bar",
+			},
+			Spec: v1alpha1.ConditionSpec{
+				Params: []v1alpha1.ParamSpec{{Name: "abc"}},
+				Check: corev1.Container{
+					Image: "ubuntu",
+				},
+			},
+		},
+		want: v1alpha1.TaskSpec{
+			Inputs: &v1alpha1.Inputs{
+				Params: []v1alpha1.ParamSpec{{
+					Name: "abc",
+				}},
+			},
+			Steps: []corev1.Container{{
+				Name:  "condition-check-bar",
+				Image: "ubuntu",
+			}},
+		},
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			rcc := &ResolvedConditionCheck{Condition: &tc.cond}
+			if d := cmp.Diff(tc.want, *rcc.ConditionToTaskSpec()); d != "" {
+				t.Errorf("TaskSpec generated from Condition is unexpected -want, +got: %v", d)
+			}
+		})
+	}
+}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -211,6 +211,17 @@ func PipelineTaskOutputResource(name, resource string) PipelineTaskOp {
 	}
 }
 
+// PipelineTaskCondition adds a condition to the PipelineTask with the
+// specified conditionRef
+func PipelineTaskCondition(conditionRef string) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		c := v1alpha1.PipelineTaskCondition{
+			ConditionRef: conditionRef,
+		}
+		pt.Conditions = append(pt.Conditions, c)
+	}
+}
+
 // PipelineRun creates a PipelineRun with default values.
 // Any number of PipelineRun modifier can be passed to transform it.
 func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
@@ -384,10 +395,13 @@ func PipelineRunCompletionTime(t time.Time) PipelineRunStatusOp {
 	}
 }
 
-// PipelineRunTaskRunsStatus sets the TaskRuns of the PipelineRunStatus.
-func PipelineRunTaskRunsStatus(taskRuns map[string]*v1alpha1.PipelineRunTaskRunStatus) PipelineRunStatusOp {
+// PipelineRunTaskRunsStatus sets the status of TaskRun to the PipelineRunStatus.
+func PipelineRunTaskRunsStatus(taskRunName string, status *v1alpha1.PipelineRunTaskRunStatus) PipelineRunStatusOp {
 	return func(s *v1alpha1.PipelineRunStatus) {
-		s.TaskRuns = taskRuns
+		if s.TaskRuns == nil {
+			s.TaskRuns = make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+		}
+		s.TaskRuns[taskRunName] = status
 	}
 }
 

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -35,6 +35,7 @@ func TestPipeline(t *testing.T) {
 		tb.PipelineTask("foo", "banana",
 			tb.PipelineTaskParam("stringparam", "value"),
 			tb.PipelineTaskParam("arrayparam", "array", "value"),
+			tb.PipelineTaskCondition("some-condition-ref"),
 		),
 		tb.PipelineTask("bar", "chocolate",
 			tb.PipelineTaskRefKind(v1alpha1.ClusterTaskKind),
@@ -76,6 +77,7 @@ func TestPipeline(t *testing.T) {
 					Name:  "arrayparam",
 					Value: *tb.ArrayOrString("array", "value"),
 				}},
+				Conditions: []v1alpha1.PipelineTaskCondition{{ConditionRef: "some-condition-ref"}},
 			}, {
 				Name:    "bar",
 				TaskRef: v1alpha1.TaskRef{Name: "chocolate", Kind: v1alpha1.ClusterTaskKind},

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -119,6 +119,9 @@ func TestPipelineRun(t *testing.T) {
 		apis.Condition{Type: apis.ConditionSucceeded}),
 		tb.PipelineRunStartTime(startTime),
 		tb.PipelineRunCompletionTime(completedTime),
+		tb.PipelineRunTaskRunsStatus("trname", &v1alpha1.PipelineRunTaskRunStatus{
+			PipelineTaskName: "task-1",
+		}),
 	), tb.PipelineRunLabel("label-key", "label-value"))
 	expectedPipelineRun := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -153,6 +156,9 @@ func TestPipelineRun(t *testing.T) {
 			},
 			StartTime:      &metav1.Time{Time: startTime},
 			CompletionTime: &metav1.Time{Time: completedTime},
+			TaskRuns: map[string]*v1alpha1.PipelineRunTaskRunStatus{
+				"trname": {PipelineTaskName: "task-1"},
+			},
 		},
 	}
 	if d := cmp.Diff(expectedPipelineRun, pipelineRun); d != "" {

--- a/test/clients.go
+++ b/test/clients.go
@@ -52,6 +52,7 @@ type clients struct {
 	TaskRunClient          v1alpha1.TaskRunInterface
 	PipelineRunClient      v1alpha1.PipelineRunInterface
 	PipelineResourceClient v1alpha1.PipelineResourceInterface
+	ConditionClient        v1alpha1.ConditionInterface
 }
 
 // newClients instantiates and returns several clientsets required for making requests to the
@@ -81,5 +82,6 @@ func newClients(t *testing.T, configPath, clusterName, namespace string) *client
 	c.TaskRunClient = cs.TektonV1alpha1().TaskRuns(namespace)
 	c.PipelineRunClient = cs.TektonV1alpha1().PipelineRuns(namespace)
 	c.PipelineResourceClient = cs.TektonV1alpha1().PipelineResources(namespace)
+	c.ConditionClient = cs.TektonV1alpha1().Conditions(namespace)
 	return c
 }

--- a/test/controller.go
+++ b/test/controller.go
@@ -20,6 +20,7 @@ import (
 	// Link in the fakes so they get injected into injection.Fake
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	fakeclustertaskinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/clustertask/fake"
+	fakeconditioninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/condition/fake"
 	fakepipelineinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/pipeline/fake"
 	fakeresourceinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/pipelineresource/fake"
 	fakepipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/pipelinerun/fake"
@@ -56,6 +57,7 @@ type Data struct {
 	Tasks             []*v1alpha1.Task
 	ClusterTasks      []*v1alpha1.ClusterTask
 	PipelineResources []*v1alpha1.PipelineResource
+	Conditions        []*v1alpha1.Condition
 	Pods              []*corev1.Pod
 	Namespaces        []*corev1.Namespace
 }
@@ -74,6 +76,7 @@ type Informers struct {
 	Task             informersv1alpha1.TaskInformer
 	ClusterTask      informersv1alpha1.ClusterTaskInformer
 	PipelineResource informersv1alpha1.PipelineResourceInformer
+	Condition        informersv1alpha1.ConditionInformer
 	Pod              coreinformers.PodInformer
 }
 
@@ -99,6 +102,7 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 		Task:             faketaskinformer.Get(ctx),
 		ClusterTask:      fakeclustertaskinformer.Get(ctx),
 		PipelineResource: fakeresourceinformer.Get(ctx),
+		Condition:        fakeconditioninformer.Get(ctx),
 		Pod:              fakepodinformer.Get(ctx),
 	}
 
@@ -147,6 +151,14 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 			t.Fatal(err)
 		}
 		if _, err := c.Pipeline.TektonV1alpha1().PipelineResources(r.Namespace).Create(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, cond := range d.Conditions {
+		if err := i.Condition.Informer().GetIndexer().Add(cond); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := c.Pipeline.TektonV1alpha1().Conditions(cond.Namespace).Create(cond); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -123,7 +123,7 @@ function install_pipeline_crd() {
   ko apply -f config/ || fail_test "Build pipeline installation failed"
 
   # Make sure thateveything is cleaned up in the current namespace.
-  for res in pipelineresources tasks pipelines taskruns pipelineruns; do
+  for res in conditions pipelineresources tasks pipelines taskruns pipelineruns; do
     kubectl delete --ignore-not-found=true ${res}.tekton.dev --all
   done
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds an initial implementation for conditionals and depends on #1031.

 
In this implementation, condition evaluations aka ConditionChecks are
backed by TaskRuns. All conditionChecks associated with a `PipelineTask`
have to succeed before the task is executed. If a ConditionCheck fails,
the PipelineTask's associated TaskRun is marked failed i.e. its
`Status.ConditionSucceeded` is False. However, the PipelineRun itself
is not marked as failed.

Future PRs will add full support for passing in parameters, resource contents, and ability to read pipelinerun status from within the conditional container.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

Adds a `Condition` type that can be used to conditionally execute tasks in a pipeline. Docs are  in `./docs/condtions.md` and `./docs/pipelines.md`