### PR TITLE
minor consistency fixes

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -64,53 +64,50 @@ type testcase struct {
 }
 
 func containerTestCases(mode string) []testcase {
-	return []testcase{
-		{
-			in: &v1alpha1.PullRequestResource{
-				Name:           "nocreds",
-				DestinationDir: "/workspace",
-				URL:            "https://example.com",
-			},
-			out: []corev1.Container{{
-				Name:       "pr-source-nocreds-9l9zj",
-				Image:      "override-with-pr:latest",
-				WorkingDir: v1alpha1.WorkspaceDir,
-				Command:    []string{"/ko-app/pullrequest-init"},
-				Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode},
-				Env:        []corev1.EnvVar{},
+	return []testcase{{
+		in: &v1alpha1.PullRequestResource{
+			Name:           "nocreds",
+			DestinationDir: "/workspace",
+			URL:            "https://example.com",
+		},
+		out: []corev1.Container{{
+			Name:       "pr-source-nocreds-9l9zj",
+			Image:      "override-with-pr:latest",
+			WorkingDir: v1alpha1.WorkspaceDir,
+			Command:    []string{"/ko-app/pullrequest-init"},
+			Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode},
+			Env:        []corev1.EnvVar{},
+		}},
+	}, {
+		in: &v1alpha1.PullRequestResource{
+			Name:           "creds",
+			DestinationDir: "/workspace",
+			URL:            "https://example.com",
+			Secrets: []v1alpha1.SecretParam{{
+				FieldName:  "githubToken",
+				SecretName: "github-creds",
+				SecretKey:  "token",
 			}},
 		},
-		{
-			in: &v1alpha1.PullRequestResource{
-				Name:           "creds",
-				DestinationDir: "/workspace",
-				URL:            "https://example.com",
-				Secrets: []v1alpha1.SecretParam{{
-					FieldName:  "githubToken",
-					SecretName: "github-creds",
-					SecretKey:  "token",
-				}},
-			},
-			out: []corev1.Container{{
-				Name:       "pr-source-creds-mz4c7",
-				Image:      "override-with-pr:latest",
-				WorkingDir: v1alpha1.WorkspaceDir,
-				Command:    []string{"/ko-app/pullrequest-init"},
-				Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode},
-				Env: []corev1.EnvVar{{
-					Name: "GITHUBTOKEN",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "github-creds",
-							},
-							Key: "token",
+		out: []corev1.Container{{
+			Name:       "pr-source-creds-mz4c7",
+			Image:      "override-with-pr:latest",
+			WorkingDir: v1alpha1.WorkspaceDir,
+			Command:    []string{"/ko-app/pullrequest-init"},
+			Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode},
+			Env: []corev1.EnvVar{{
+				Name: "GITHUBTOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "github-creds",
 						},
+						Key: "token",
 					},
-				}},
+				},
 			}},
-		},
-	}
+		}},
+	}}
 }
 
 func TestPullRequest_GetDownloadContainerSpec(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/result_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/result_types_test.go
@@ -41,40 +41,35 @@ func TestValidate_Invalid(t *testing.T) {
 		name    string
 		results *v1alpha1.Results
 		want    *apis.FieldError
-	}{
-		{
-			name: "invalid task type result",
-			results: &v1alpha1.Results{
-				URL:  "http://www.google.com",
-				Type: "wrongtype",
-			},
-			want: apis.ErrInvalidValue("wrongtype", "spec.results.Type"),
+	}{{
+		name: "invalid task type result",
+		results: &v1alpha1.Results{
+			URL:  "http://www.google.com",
+			Type: "wrongtype",
 		},
-		{
-			name: "invalid task type results missing url",
-			results: &v1alpha1.Results{
-				Type: v1alpha1.ResultTargetTypeGCS,
-				URL:  "",
-			},
-			want: apis.ErrMissingField("spec.results.URL"),
+		want: apis.ErrInvalidValue("wrongtype", "spec.results.Type"),
+	}, {
+		name: "invalid task type results missing url",
+		results: &v1alpha1.Results{
+			Type: v1alpha1.ResultTargetTypeGCS,
+			URL:  "",
 		},
-		{
-			name: "invalid task type results bad url",
-			results: &v1alpha1.Results{
-				Type: v1alpha1.ResultTargetTypeGCS,
-				URL:  "badurl",
-			},
-			want: apis.ErrInvalidValue("badurl", "spec.results.URL"),
+		want: apis.ErrMissingField("spec.results.URL"),
+	}, {
+		name: "invalid task type results bad url",
+		results: &v1alpha1.Results{
+			Type: v1alpha1.ResultTargetTypeGCS,
+			URL:  "badurl",
 		},
-		{
-			name: "invalid task type results type",
-			results: &v1alpha1.Results{
-				Type: "badtype",
-				URL:  "http://www.google.com",
-			},
-			want: apis.ErrInvalidValue("badtype", "spec.results.Type"),
+		want: apis.ErrInvalidValue("badurl", "spec.results.URL"),
+	}, {
+		name: "invalid task type results type",
+		results: &v1alpha1.Results{
+			Type: "badtype",
+			URL:  "http://www.google.com",
 		},
-	}
+		want: apis.ErrInvalidValue("badtype", "spec.results.Type"),
+	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			path := "spec.results"

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -497,8 +497,7 @@ func TestGetArtifactStorageWithPvcConfigMap(t *testing.T) {
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
 			Name: "pipelineruntest",
 		},
-	},
-	} {
+	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			fakekubeclient := fakek8s.NewSimpleClientset(c.configMap)
 

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -15,62 +15,56 @@ func Test_EmitEvent(t *testing.T) {
 		before      *apis.Condition
 		after       *apis.Condition
 		expectEvent bool
-	}{
-		{
-			name: "unknown to true",
-			before: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionUnknown,
-			},
-			after: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			},
-			expectEvent: true,
+	}{{
+		name: "unknown to true",
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionUnknown,
 		},
-		{
-			name: "true to true",
-			before: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			},
-			after: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			},
-			expectEvent: false,
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
 		},
-		{
-			name: "false to false",
-			before: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionFalse,
-			},
-			after: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionFalse,
-			},
-			expectEvent: false,
+		expectEvent: true,
+	}, {
+		name: "true to true",
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
 		},
-		{
-			name:  "true to nil",
-			after: nil,
-			before: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			},
-			expectEvent: true,
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
 		},
-		{
-			name:   "nil to true",
-			before: nil,
-			after: &apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			},
-			expectEvent: true,
+		expectEvent: false,
+	}, {
+		name: "false to false",
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
 		},
-	}
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionFalse,
+		},
+		expectEvent: false,
+	}, {
+		name:  "true to nil",
+		after: nil,
+		before: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		},
+		expectEvent: true,
+	}, {
+		name:   "nil to true",
+		before: nil,
+		after: &apis.Condition{
+			Type:   apis.ConditionSucceeded,
+			Status: corev1.ConditionTrue,
+		},
+		expectEvent: true,
+	}}
 
 	for _, ts := range testcases {
 		fr := record.NewFakeRecorder(1)

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/apply_test.go
@@ -27,49 +27,46 @@ func TestApplyParameters(t *testing.T) {
 		original *v1alpha1.Pipeline
 		run      *v1alpha1.PipelineRun
 		expected *v1alpha1.Pipeline
-	}{
-		{
-			name: "single parameter",
-			original: tb.Pipeline("test-pipeline", "foo",
-				tb.PipelineSpec(
-					tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
-					tb.PipelineParam("second-param"),
-					tb.PipelineTask("first-task-1", "first-task",
-						tb.PipelineTaskParam("first-task-first-param", "${params.first-param}"),
-						tb.PipelineTaskParam("first-task-second-param", "${params.second-param}"),
-						tb.PipelineTaskParam("first-task-third-param", "static value"),
-					))),
-			run: tb.PipelineRun("test-pipeline-run", "foo",
-				tb.PipelineRunSpec("test-pipeline",
-					tb.PipelineRunParam("second-param", "second-value"))),
-			expected: tb.Pipeline("test-pipeline", "foo",
-				tb.PipelineSpec(
-					tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
-					tb.PipelineParam("second-param"),
-					tb.PipelineTask("first-task-1", "first-task",
-						tb.PipelineTaskParam("first-task-first-param", "default-value"),
-						tb.PipelineTaskParam("first-task-second-param", "second-value"),
-						tb.PipelineTaskParam("first-task-third-param", "static value"),
-					))),
-		},
-		{
-			name: "pipeline parameter nested inside task parameter",
-			original: tb.Pipeline("test-pipeline", "foo",
-				tb.PipelineSpec(
-					tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
-					tb.PipelineTask("first-task-1", "first-task",
-						tb.PipelineTaskParam("first-task-first-param", "${input.workspace.${params.first-param}}"),
-					))),
-			run: tb.PipelineRun("test-pipeline-run", "foo",
-				tb.PipelineRunSpec("test-pipeline")),
-			expected: tb.Pipeline("test-pipeline", "foo",
-				tb.PipelineSpec(
-					tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
-					tb.PipelineTask("first-task-1", "first-task",
-						tb.PipelineTaskParam("first-task-first-param", "${input.workspace.default-value}"),
-					))),
-		},
-	}
+	}{{
+		name: "single parameter",
+		original: tb.Pipeline("test-pipeline", "foo",
+			tb.PipelineSpec(
+				tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
+				tb.PipelineParam("second-param"),
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "${params.first-param}"),
+					tb.PipelineTaskParam("first-task-second-param", "${params.second-param}"),
+					tb.PipelineTaskParam("first-task-third-param", "static value"),
+				))),
+		run: tb.PipelineRun("test-pipeline-run", "foo",
+			tb.PipelineRunSpec("test-pipeline",
+				tb.PipelineRunParam("second-param", "second-value"))),
+		expected: tb.Pipeline("test-pipeline", "foo",
+			tb.PipelineSpec(
+				tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
+				tb.PipelineParam("second-param"),
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "default-value"),
+					tb.PipelineTaskParam("first-task-second-param", "second-value"),
+					tb.PipelineTaskParam("first-task-third-param", "static value"),
+				))),
+	}, {
+		name: "pipeline parameter nested inside task parameter",
+		original: tb.Pipeline("test-pipeline", "foo",
+			tb.PipelineSpec(
+				tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "${input.workspace.${params.first-param}}"),
+				))),
+		run: tb.PipelineRun("test-pipeline-run", "foo",
+			tb.PipelineRunSpec("test-pipeline")),
+		expected: tb.Pipeline("test-pipeline", "foo",
+			tb.PipelineSpec(
+				tb.PipelineParam("first-param", tb.PipelineParamDefault("default-value")),
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "${input.workspace.default-value}"),
+				))),
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ApplyParameters(tt.original, tt.run)

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
@@ -263,171 +263,149 @@ func TestGetNextTasks(t *testing.T) {
 		state        PipelineRunState
 		candidates   map[string]v1alpha1.PipelineTask
 		expectedNext []*ResolvedPipelineRunTask
-	}{
-		{
-			name:         "no-tasks-started-no-candidates",
-			state:        noneStartedState,
-			candidates:   map[string]v1alpha1.PipelineTask{},
-			expectedNext: []*ResolvedPipelineRunTask{},
+	}{{
+		name:         "no-tasks-started-no-candidates",
+		state:        noneStartedState,
+		candidates:   map[string]v1alpha1.PipelineTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "no-tasks-started-one-candidate",
+		state: noneStartedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
 		},
-		{
-			name:  "no-tasks-started-one-candidate",
-			state: noneStartedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0]},
+		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0]},
+	}, {
+		name:  "no-tasks-started-other-candidate",
+		state: noneStartedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask2": pts[1],
 		},
-		{
-			name:  "no-tasks-started-other-candidate",
-			state: noneStartedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{noneStartedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		name:  "no-tasks-started-both-candidates",
+		state: noneStartedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
+			"mytask2": pts[1],
 		},
-		{
-			name:  "no-tasks-started-both-candidates",
-			state: noneStartedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0], noneStartedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0], noneStartedState[1]},
+	}, {
+		name:         "one-task-started-no-candidates",
+		state:        oneStartedState,
+		candidates:   map[string]v1alpha1.PipelineTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-task-started-one-candidate",
+		state: oneStartedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
 		},
-		{
-			name:         "one-task-started-no-candidates",
-			state:        oneStartedState,
-			candidates:   map[string]v1alpha1.PipelineTask{},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-task-started-other-candidate",
+		state: oneStartedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask2": pts[1],
 		},
-		{
-			name:  "one-task-started-one-candidate",
-			state: oneStartedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
+	}, {
+		name:  "one-task-started-both-candidates",
+		state: oneStartedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
+			"mytask2": pts[1],
 		},
-		{
-			name:  "one-task-started-other-candidate",
-			state: oneStartedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
+	}, {
+		name:         "one-task-finished-no-candidates",
+		state:        oneFinishedState,
+		candidates:   map[string]v1alpha1.PipelineTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-task-finished-one-candidate",
+		state: oneFinishedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
 		},
-		{
-			name:  "one-task-started-both-candidates",
-			state: oneStartedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-task-finished-other-candidate",
+		state: oneFinishedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask2": pts[1],
 		},
-		{
-			name:         "one-task-finished-no-candidates",
-			state:        oneFinishedState,
-			candidates:   map[string]v1alpha1.PipelineTask{},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+	}, {
+		name:  "one-task-finished-both-candidate",
+		state: oneFinishedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
+			"mytask2": pts[1],
 		},
-		{
-			name:  "one-task-finished-one-candidate",
-			state: oneFinishedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+	}, {
+		name:         "one-task-failed-no-candidates",
+		state:        oneFailedState,
+		candidates:   map[string]v1alpha1.PipelineTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-task-failed-one-candidate",
+		state: oneFailedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
 		},
-		{
-			name:  "one-task-finished-other-candidate",
-			state: oneFinishedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-task-failed-other-candidate",
+		state: oneFailedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask2": pts[1],
 		},
-		{
-			name:  "one-task-finished-both-candidate",
-			state: oneFinishedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
+	}, {
+		name:  "one-task-failed-both-candidates",
+		state: oneFailedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
+			"mytask2": pts[1],
 		},
-		{
-			name:         "one-task-failed-no-candidates",
-			state:        oneFailedState,
-			candidates:   map[string]v1alpha1.PipelineTask{},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
+	}, {
+		name:         "all-finished-no-candidates",
+		state:        allFinishedState,
+		candidates:   map[string]v1alpha1.PipelineTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "all-finished-one-candidate",
+		state: allFinishedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
 		},
-		{
-			name:  "one-task-failed-one-candidate",
-			state: oneFailedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "all-finished-other-candidate",
+		state: allFinishedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask2": pts[1],
 		},
-		{
-			name:  "one-task-failed-other-candidate",
-			state: oneFailedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "all-finished-both-candidates",
+		state: allFinishedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask1": pts[0],
+			"mytask2": pts[1],
 		},
-		{
-			name:  "one-task-failed-both-candidates",
-			state: oneFailedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "one-cancelled-one-candidate",
+		state: taskCancelled,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[4],
 		},
-		{
-			name:         "all-finished-no-candidates",
-			state:        allFinishedState,
-			candidates:   map[string]v1alpha1.PipelineTask{},
-			expectedNext: []*ResolvedPipelineRunTask{},
-		},
-		{
-			name:  "all-finished-one-candidate",
-			state: allFinishedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
-		},
-		{
-			name:  "all-finished-other-candidate",
-			state: allFinishedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
-		},
-		{
-			name:  "all-finished-both-candidates",
-			state: allFinishedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask1": pts[0],
-				"mytask2": pts[1],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
-		},
-		{
-			name:  "one-cancelled-one-candidate",
-			state: taskCancelled,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[4],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
-		},
-	}
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			next := tc.state.GetNextTasks(tc.candidates)
@@ -499,56 +477,49 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 		state        PipelineRunState
 		candidates   map[string]v1alpha1.PipelineTask
 		expectedNext []*ResolvedPipelineRunTask
-	}{
-		{
-			name:  "tasks-cancelled-no-candidates",
-			state: taskCancelledByStatusState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[4],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+	}{{
+		name:  "tasks-cancelled-no-candidates",
+		state: taskCancelledByStatusState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[4],
 		},
-		{
-			name:  "tasks-cancelled-bySpec-no-candidates",
-			state: taskCancelledBySpecState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[4],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "tasks-cancelled-bySpec-no-candidates",
+		state: taskCancelledBySpecState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[4],
 		},
-		{
-			name:  "tasks-running-no-candidates",
-			state: taskRunningState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[4],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "tasks-running-no-candidates",
+		state: taskRunningState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[4],
 		},
-		{
-			name:  "tasks-succeeded-bySpec-no-candidates",
-			state: taskSucceededState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[4],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "tasks-succeeded-bySpec-no-candidates",
+		state: taskSucceededState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[4],
 		},
-		{
-			name:  "tasks-retried-no-candidates",
-			state: taskRetriedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[3],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "tasks-retried-no-candidates",
+		state: taskRetriedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[3],
 		},
-		{
-			name:  "tasks-retried-one-candidates",
-			state: taskExpectedState,
-			candidates: map[string]v1alpha1.PipelineTask{
-				"mytask5": pts[3],
-			},
-			expectedNext: []*ResolvedPipelineRunTask{taskExpectedState[0]},
+		expectedNext: []*ResolvedPipelineRunTask{},
+	}, {
+		name:  "tasks-retried-one-candidates",
+		state: taskExpectedState,
+		candidates: map[string]v1alpha1.PipelineTask{
+			"mytask5": pts[3],
 		},
-	}
+		expectedNext: []*ResolvedPipelineRunTask{taskExpectedState[0]},
+	}}
 
 	// iterate over *state* to get from candidate and check if TaskRun is there.
 	// Cancelled TaskRun should have a TaskRun cancelled and with a retry but should not retry.
@@ -641,56 +612,47 @@ func TestIsDone(t *testing.T) {
 		state      PipelineRunState
 		expected   bool
 		ptExpected []bool
-	}{
-		{
-			name:       "tasks-cancelled-no-candidates",
-			state:      taskCancelledByStatusState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-		{
-			name:       "tasks-cancelled-bySpec-no-candidates",
-			state:      taskCancelledBySpecState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-		{
-			name:       "tasks-running-no-candidates",
-			state:      taskRunningState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-		{
-			name:       "tasks-succeeded-bySpec-no-candidates",
-			state:      taskSucceededState,
-			expected:   true,
-			ptExpected: []bool{true},
-		},
-		{
-			name:       "tasks-retried-no-candidates",
-			state:      taskRetriedState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-		{
-			name:       "tasks-retried-one-candidates",
-			state:      taskExpectedState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-		{
-			name:       "no-pipelineTask",
-			state:      noPipelineTaskState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-		{
-			name:       "No-taskrun",
-			state:      noTaskRunState,
-			expected:   false,
-			ptExpected: []bool{false},
-		},
-	}
+	}{{
+		name:       "tasks-cancelled-no-candidates",
+		state:      taskCancelledByStatusState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "tasks-cancelled-bySpec-no-candidates",
+		state:      taskCancelledBySpecState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "tasks-running-no-candidates",
+		state:      taskRunningState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "tasks-succeeded-bySpec-no-candidates",
+		state:      taskSucceededState,
+		expected:   true,
+		ptExpected: []bool{true},
+	}, {
+		name:       "tasks-retried-no-candidates",
+		state:      taskRetriedState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "tasks-retried-one-candidates",
+		state:      taskExpectedState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "no-pipelineTask",
+		state:      noPipelineTaskState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "No-taskrun",
+		state:      noTaskRunState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -715,33 +677,27 @@ func TestSuccessfulPipelineTaskNames(t *testing.T) {
 		name          string
 		state         PipelineRunState
 		expectedNames []string
-	}{
-		{
-			name:          "no-tasks-started",
-			state:         noneStartedState,
-			expectedNames: []string{},
-		},
-		{
-			name:          "one-task-started",
-			state:         oneStartedState,
-			expectedNames: []string{},
-		},
-		{
-			name:          "one-task-finished",
-			state:         oneFinishedState,
-			expectedNames: []string{"mytask1"},
-		},
-		{
-			name:          "one-task-failed",
-			state:         oneFailedState,
-			expectedNames: []string{},
-		},
-		{
-			name:          "all-finished",
-			state:         allFinishedState,
-			expectedNames: []string{"mytask1", "mytask2"},
-		},
-	}
+	}{{
+		name:          "no-tasks-started",
+		state:         noneStartedState,
+		expectedNames: []string{},
+	}, {
+		name:          "one-task-started",
+		state:         oneStartedState,
+		expectedNames: []string{},
+	}, {
+		name:          "one-task-finished",
+		state:         oneFinishedState,
+		expectedNames: []string{"mytask1"},
+	}, {
+		name:          "one-task-failed",
+		state:         oneFailedState,
+		expectedNames: []string{},
+	}, {
+		name:          "all-finished",
+		state:         allFinishedState,
+		expectedNames: []string{"mytask1", "mytask2"},
+	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			names := tc.state.SuccessfulPipelineTaskNames()
@@ -767,38 +723,31 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 		name           string
 		state          []*ResolvedPipelineRunTask
 		expectedStatus corev1.ConditionStatus
-	}{
-		{
-			name:           "no-tasks-started",
-			state:          noneStartedState,
-			expectedStatus: corev1.ConditionUnknown,
-		},
-		{
-			name:           "one-task-started",
-			state:          oneStartedState,
-			expectedStatus: corev1.ConditionUnknown,
-		},
-		{
-			name:           "one-task-finished",
-			state:          oneFinishedState,
-			expectedStatus: corev1.ConditionUnknown,
-		},
-		{
-			name:           "one-task-failed",
-			state:          oneFailedState,
-			expectedStatus: corev1.ConditionFalse,
-		},
-		{
-			name:           "all-finished",
-			state:          allFinishedState,
-			expectedStatus: corev1.ConditionTrue,
-		},
-		{
-			name:           "one-retry-needed",
-			state:          taskRetriedState,
-			expectedStatus: corev1.ConditionUnknown,
-		},
-	}
+	}{{
+		name:           "no-tasks-started",
+		state:          noneStartedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "one-task-started",
+		state:          oneStartedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "one-task-finished",
+		state:          oneFinishedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "one-task-failed",
+		state:          oneFailedState,
+		expectedStatus: corev1.ConditionFalse,
+	}, {
+		name:           "all-finished",
+		state:          allFinishedState,
+		expectedStatus: corev1.ConditionTrue,
+	}, {
+		name:           "one-retry-needed",
+		state:          taskRetriedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			c := GetPipelineConditionStatus("somepipelinerun", tc.state, zap.NewNop().Sugar(), &metav1.Time{Time: time.Now()},
@@ -1032,24 +981,21 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *v1alpha1.Pipeline
-	}{
-		{
-			name: "input doesnt exist",
-			p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
-				tb.PipelineTask("mytask1", "task",
-					tb.PipelineTaskInputResource("input1", "git-resource"),
-				),
-			)),
-		},
-		{
-			name: "output doesnt exist",
-			p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
-				tb.PipelineTask("mytask1", "task",
-					tb.PipelineTaskOutputResource("input1", "git-resource"),
-				),
-			)),
-		},
-	}
+	}{{
+		name: "input doesnt exist",
+		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("mytask1", "task",
+				tb.PipelineTaskInputResource("input1", "git-resource"),
+			),
+		)),
+	}, {
+		name: "output doesnt exist",
+		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("mytask1", "task",
+				tb.PipelineTaskOutputResource("input1", "git-resource"),
+			),
+		)),
+	}}
 	providedResources := map[string]v1alpha1.PipelineResourceRef{}
 
 	getTask := func(name string) (v1alpha1.TaskInterface, error) { return task, nil }
@@ -1078,24 +1024,21 @@ func TestResolvePipelineRun_ResourcesDontExist(t *testing.T) {
 	tests := []struct {
 		name string
 		p    *v1alpha1.Pipeline
-	}{
-		{
-			name: "input doesnt exist",
-			p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
-				tb.PipelineTask("mytask1", "task",
-					tb.PipelineTaskInputResource("input1", "git-resource"),
-				),
-			)),
-		},
-		{
-			name: "output doesnt exist",
-			p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
-				tb.PipelineTask("mytask1", "task",
-					tb.PipelineTaskOutputResource("input1", "git-resource"),
-				),
-			)),
-		},
-	}
+	}{{
+		name: "input doesnt exist",
+		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("mytask1", "task",
+				tb.PipelineTaskInputResource("input1", "git-resource"),
+			),
+		)),
+	}, {
+		name: "output doesnt exist",
+		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("mytask1", "task",
+				tb.PipelineTaskOutputResource("input1", "git-resource"),
+			),
+		)),
+	}}
 	providedResources := map[string]v1alpha1.PipelineResourceRef{
 		"git-resource": {
 			Name: "doesnt-exist",

--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -143,12 +143,10 @@ var gcsTaskSpec = &v1alpha1.TaskSpec{
 var paramTaskRun = &v1alpha1.TaskRun{
 	Spec: v1alpha1.TaskRunSpec{
 		Inputs: v1alpha1.TaskRunInputs{
-			Params: []v1alpha1.Param{
-				{
-					Name:  "myimage",
-					Value: "bar",
-				},
-			},
+			Params: []v1alpha1.Param{{
+				Name:  "myimage",
+				Value: "bar",
+			}},
 		},
 	},
 }
@@ -168,12 +166,10 @@ var gitResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 	},
 	Spec: v1alpha1.PipelineResourceSpec{
 		Type: v1alpha1.PipelineResourceTypeGit,
-		Params: []v1alpha1.Param{
-			{
-				Name:  "URL",
-				Value: "https://git-repo",
-			},
-		},
+		Params: []v1alpha1.Param{{
+			Name:  "URL",
+			Value: "https://git-repo",
+		}},
 	},
 })
 
@@ -183,12 +179,10 @@ var imageResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 	},
 	Spec: v1alpha1.PipelineResourceSpec{
 		Type: v1alpha1.PipelineResourceTypeImage,
-		Params: []v1alpha1.Param{
-			{
-				Name:  "URL",
-				Value: "gcr.io/hans/sandwiches",
-			},
-		},
+		Params: []v1alpha1.Param{{
+			Name:  "URL",
+			Value: "gcr.io/hans/sandwiches",
+		}},
 	},
 })
 
@@ -198,16 +192,13 @@ var gcsResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 	},
 	Spec: v1alpha1.PipelineResourceSpec{
 		Type: v1alpha1.PipelineResourceTypeStorage,
-		Params: []v1alpha1.Param{
-			{
-				Name:  "type",
-				Value: "gcs",
-			},
-			{
-				Name:  "location",
-				Value: "theCloud?",
-			},
-		},
+		Params: []v1alpha1.Param{{
+			Name:  "type",
+			Value: "gcs",
+		}, {
+			Name:  "location",
+			Value: "theCloud?",
+		}},
 	},
 })
 
@@ -415,8 +406,7 @@ func TestApplyResources(t *testing.T) {
 		want: applyMutation(gcsTaskSpec, func(spec *v1alpha1.TaskSpec) {
 			spec.Steps[0].Args = []string{"/workspace/outputs/bucket"}
 		}),
-	},
-	}
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			setup()

--- a/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/pod_test.go
@@ -445,31 +445,28 @@ func TestMakeAnnotations(t *testing.T) {
 		taskRun                  *v1alpha1.TaskRun
 		expectedAnnotationSubset map[string]string
 	}
-	for _, c := range []testcase{
-		{
-			desc: "a taskruns annotations are copied to the pod",
-			taskRun: &v1alpha1.TaskRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "a-taskrun",
-					Annotations: map[string]string{
-						"foo": "bar",
-						"baz": "quux",
-					},
+	for _, c := range []testcase{{
+		desc: "a taskruns annotations are copied to the pod",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "a-taskrun",
+				Annotations: map[string]string{
+					"foo": "bar",
+					"baz": "quux",
 				},
 			},
-			expectedAnnotationSubset: map[string]string{
-				"foo": "bar",
-				"baz": "quux",
-			},
 		},
-		{
-			desc:    "initial pod annotations contain the ReadyAnnotation to pause steps until sidecars are ready",
-			taskRun: &v1alpha1.TaskRun{},
-			expectedAnnotationSubset: map[string]string{
-				ReadyAnnotation: "",
-			},
+		expectedAnnotationSubset: map[string]string{
+			"foo": "bar",
+			"baz": "quux",
 		},
-	} {
+	}, {
+		desc:    "initial pod annotations contain the ReadyAnnotation to pause steps until sidecars are ready",
+		taskRun: &v1alpha1.TaskRun{},
+		expectedAnnotationSubset: map[string]string{
+			ReadyAnnotation: "",
+		},
+	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			annos := makeAnnotations(c.taskRun)
 			for k, v := range c.expectedAnnotationSubset {

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -1496,8 +1496,7 @@ func TestReconcileTimeouts(t *testing.T) {
 				Reason:  "TaskRunTimeout",
 				Message: `TaskRun "test-taskrun-timeout" failed to finish within "10s"`,
 			},
-		},
-		{
+		}, {
 			taskRun: tb.TaskRun("test-taskrun-default-timeout-60-minutes", "foo",
 				tb.TaskRunSpec(
 					tb.TaskRunTaskRef(simpleTask.Name),
@@ -1513,8 +1512,7 @@ func TestReconcileTimeouts(t *testing.T) {
 				Reason:  "TaskRunTimeout",
 				Message: `TaskRun "test-taskrun-default-timeout-60-minutes" failed to finish within "1h0m0s"`,
 			},
-		},
-		{
+		}, {
 			taskRun: tb.TaskRun("test-taskrun-nil-timeout-default-60-minutes", "foo",
 				tb.TaskRunSpec(
 					tb.TaskRunTaskRef(simpleTask.Name),
@@ -1531,8 +1529,7 @@ func TestReconcileTimeouts(t *testing.T) {
 				Reason:  "TaskRunTimeout",
 				Message: `TaskRun "test-taskrun-nil-timeout-default-60-minutes" failed to finish within "1h0m0s"`,
 			},
-		},
-	}
+		}}
 
 	for _, tc := range testcases {
 		d := test.Data{
@@ -1589,22 +1586,19 @@ func TestHandlePodCreationError(t *testing.T) {
 		expectedType   apis.ConditionType
 		expectedStatus corev1.ConditionStatus
 		expectedReason string
-	}{
-		{
-			description:    "exceeded quota errors are surfaced in taskrun condition but do not fail taskrun",
-			err:            k8sapierrors.NewForbidden(k8sruntimeschema.GroupResource{Group: "foo", Resource: "bar"}, "baz", errors.New("exceeded quota")),
-			expectedType:   apis.ConditionSucceeded,
-			expectedStatus: corev1.ConditionUnknown,
-			expectedReason: status.ReasonExceededResourceQuota,
-		},
-		{
-			description:    "errors other than exceeded quota fail the taskrun",
-			err:            errors.New("this is a fatal error"),
-			expectedType:   apis.ConditionSucceeded,
-			expectedStatus: corev1.ConditionFalse,
-			expectedReason: status.ReasonCouldntGetTask,
-		},
-	}
+	}{{
+		description:    "exceeded quota errors are surfaced in taskrun condition but do not fail taskrun",
+		err:            k8sapierrors.NewForbidden(k8sruntimeschema.GroupResource{Group: "foo", Resource: "bar"}, "baz", errors.New("exceeded quota")),
+		expectedType:   apis.ConditionSucceeded,
+		expectedStatus: corev1.ConditionUnknown,
+		expectedReason: status.ReasonExceededResourceQuota,
+	}, {
+		description:    "errors other than exceeded quota fail the taskrun",
+		err:            errors.New("this is a fatal error"),
+		expectedType:   apis.ConditionSucceeded,
+		expectedStatus: corev1.ConditionFalse,
+		expectedReason: status.ReasonCouldntGetTask,
+	}}
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
 			c.handlePodCreationError(taskRun, tc.err)

--- a/pkg/reconciler/v1alpha1/taskrun/timeout_check_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/timeout_check_test.go
@@ -37,22 +37,19 @@ func TestCheckTimeout(t *testing.T) {
 		name: "TaskRun not started",
 		taskRun: tb.TaskRun("test-taskrun-not-started", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name),
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{
-		}), tb.TaskRunStartTime(zeroTime))),
+		), tb.TaskRunStatus(tb.Condition(apis.Condition{}), tb.TaskRunStartTime(zeroTime))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun no timeout",
 		taskRun: tb.TaskRun("test-taskrun-no-timeout", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(0),
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{
-		}), tb.TaskRunStartTime(time.Now().Add(-15 * time.Hour)))),
+		), tb.TaskRunStatus(tb.Condition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Hour)))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun timed out",
 		taskRun: tb.TaskRun("test-taskrun-timeout", "foo", tb.TaskRunSpec(
-			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(10 * time.Second),
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{
-		}), tb.TaskRunStartTime(time.Now().Add(-15 * time.Second)))),
+			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(10*time.Second),
+		), tb.TaskRunStatus(tb.Condition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
 		expectedStatus: true,
 	}}
 

--- a/pkg/status/taskrunpod.go
+++ b/pkg/status/taskrunpod.go
@@ -64,8 +64,8 @@ func updateCompletedTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 		})
 	} else {
 		taskRun.Status.SetCondition(&apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionTrue,
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionTrue,
 			Reason:  ReasonSucceeded,
 			Message: "All Steps have completed executing",
 		})
@@ -78,9 +78,9 @@ func updateIncompleteTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 	switch pod.Status.Phase {
 	case corev1.PodRunning:
 		taskRun.Status.SetCondition(&apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionUnknown,
-			Reason: ReasonBuilding,
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  ReasonBuilding,
 			Message: "Not all Steps in the Task have finished executing",
 		})
 	case corev1.PodPending:

--- a/pkg/status/taskrunpod_test.go
+++ b/pkg/status/taskrunpod_test.go
@@ -28,15 +28,15 @@ func TestUpdateStatusFromPod(t *testing.T) {
 		Message: ReasonRunning,
 	}
 	conditionTrue := apis.Condition{
-		Type:   apis.ConditionSucceeded,
-		Status: corev1.ConditionTrue,
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionTrue,
 		Reason:  ReasonSucceeded,
 		Message: "All Steps have completed executing",
 	}
 	conditionBuilding := apis.Condition{
-		Type:   apis.ConditionSucceeded,
-		Status: corev1.ConditionUnknown,
-		Reason: ReasonBuilding,
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionUnknown,
+		Reason:  ReasonBuilding,
 		Message: "Not all Steps in the Task have finished executing",
 	}
 	for _, c := range []struct {

--- a/pkg/system/names_test.go
+++ b/pkg/system/names_test.go
@@ -9,16 +9,13 @@ func Test_GetNamespace(t *testing.T) {
 	testcases := []struct {
 		envVar       string
 		expectEnvVar string
-	}{
-		{
-			envVar:       "",
-			expectEnvVar: DefaultNamespace,
-		},
-		{
-			envVar:       "test",
-			expectEnvVar: "test",
-		},
-	}
+	}{{
+		envVar:       "",
+		expectEnvVar: DefaultNamespace,
+	}, {
+		envVar:       "test",
+		expectEnvVar: "test",
+	}}
 
 	value := os.Getenv(SystemNamespaceEnvVar)
 	defer func() { os.Setenv(SystemNamespaceEnvVar, value) }()

--- a/pkg/templating/templating_test.go
+++ b/pkg/templating/templating_test.go
@@ -35,84 +35,78 @@ func TestValidateVariables(t *testing.T) {
 		name          string
 		args          args
 		expectedError *apis.FieldError
-	}{
-		{
-			name: "valid variable",
-			args: args{
-				input:         "--flag=${inputs.params.baz}",
-				prefix:        "params",
-				contextPrefix: "inputs.",
-				locationName:  "step",
-				path:          "taskspec.steps",
-				vars: map[string]struct{}{
-					"baz": {},
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "multiple variables",
-			args: args{
-				input:         "--flag=${inputs.params.baz} ${input.params.foo}",
-				prefix:        "params",
-				contextPrefix: "inputs.",
-				locationName:  "step",
-				path:          "taskspec.steps",
-				vars: map[string]struct{}{
-					"baz": {},
-					"foo": {},
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "different context and prefix",
-			args: args{
-				input:        "--flag=${something.baz}",
-				prefix:       "something",
-				locationName: "step",
-				path:         "taskspec.steps",
-				vars: map[string]struct{}{
-					"baz": {},
-				},
-			},
-			expectedError: nil,
-		},
-		{
-			name: "undefined variable",
-			args: args{
-				input:         "--flag=${inputs.params.baz}",
-				prefix:        "params",
-				contextPrefix: "inputs.",
-				locationName:  "step",
-				path:          "taskspec.steps",
-				vars: map[string]struct{}{
-					"foo": {},
-				},
-			},
-			expectedError: &apis.FieldError{
-				Message: `non-existent variable in "--flag=${inputs.params.baz}" for step somefield`,
-				Paths:   []string{"taskspec.steps.somefield"},
+	}{{
+		name: "valid variable",
+		args: args{
+			input:         "--flag=${inputs.params.baz}",
+			prefix:        "params",
+			contextPrefix: "inputs.",
+			locationName:  "step",
+			path:          "taskspec.steps",
+			vars: map[string]struct{}{
+				"baz": {},
 			},
 		},
-		{
-			name: "undefined variable and defined variable",
-			args: args{
-				input:         "--flag=${inputs.params.baz} ${input.params.foo}",
-				prefix:        "params",
-				contextPrefix: "inputs.",
-				locationName:  "step",
-				path:          "taskspec.steps",
-				vars: map[string]struct{}{
-					"foo": {},
-				},
-			},
-			expectedError: &apis.FieldError{
-				Message: `non-existent variable in "--flag=${inputs.params.baz} ${input.params.foo}" for step somefield`,
-				Paths:   []string{"taskspec.steps.somefield"},
+		expectedError: nil,
+	}, {
+		name: "multiple variables",
+		args: args{
+			input:         "--flag=${inputs.params.baz} ${input.params.foo}",
+			prefix:        "params",
+			contextPrefix: "inputs.",
+			locationName:  "step",
+			path:          "taskspec.steps",
+			vars: map[string]struct{}{
+				"baz": {},
+				"foo": {},
 			},
 		},
-	}
+		expectedError: nil,
+	}, {
+		name: "different context and prefix",
+		args: args{
+			input:        "--flag=${something.baz}",
+			prefix:       "something",
+			locationName: "step",
+			path:         "taskspec.steps",
+			vars: map[string]struct{}{
+				"baz": {},
+			},
+		},
+		expectedError: nil,
+	}, {
+		name: "undefined variable",
+		args: args{
+			input:         "--flag=${inputs.params.baz}",
+			prefix:        "params",
+			contextPrefix: "inputs.",
+			locationName:  "step",
+			path:          "taskspec.steps",
+			vars: map[string]struct{}{
+				"foo": {},
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: `non-existent variable in "--flag=${inputs.params.baz}" for step somefield`,
+			Paths:   []string{"taskspec.steps.somefield"},
+		},
+	}, {
+		name: "undefined variable and defined variable",
+		args: args{
+			input:         "--flag=${inputs.params.baz} ${input.params.foo}",
+			prefix:        "params",
+			contextPrefix: "inputs.",
+			locationName:  "step",
+			path:          "taskspec.steps",
+			vars: map[string]struct{}{
+				"foo": {},
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: `non-existent variable in "--flag=${inputs.params.baz} ${input.params.foo}" for step somefield`,
+			Paths:   []string{"taskspec.steps.somefield"},
+		},
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := templating.ValidateVariable("somefield", tt.args.input, tt.args.prefix, tt.args.contextPrefix, tt.args.locationName, tt.args.path, tt.args.vars)


### PR DESCRIPTION
# Changes
1. Attempt to make bracket usage consistent across testing. To give some background, in [an earlier PR](https://github.com/tektoncd/pipeline/pull/1074), I wrote some validation tests, and kept the additional tests in line with the existing tests in that file. However, I got [feedback](https://github.com/tektoncd/pipeline/pull/1074#discussion_r303121620) that I should collapse the brackets, so I had to change the existing tests in that file as well to match that formatting. I'm not sure if Tekton has decided on that type of styling rule, but IMO it's probably a good idea to keep them consistent so that users aren't forced to either arbitrarily follow one of the existing styles (increasing the project inconsistency), or refactor the entire existing test file themselves.

2. Adjust taskrunpod files to match gofmt results. When runnning gofmt, those 3 files are the only ones that need adjustment. It's interesting that build-tests didn't see that (I assumed it checked linting but I'm probably wrong). It's possible that that it only checks for differences in the generated files or my computer somehow has a different gofmt version.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) - **No functionality changed**
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) **No user facing changes**
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages) 

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes