### PR TITLE
Fix workingdir typo in Knative migration guide

### DIFF
--- a/docs/migrating-from-knative-build.md
+++ b/docs/migrating-from-knative-build.md
@@ -31,7 +31,7 @@ Pipeline, and provide additional flexibility and reusability.
 * Input resources must specify a `name`, which is the directory within
   `/workspace` where the resource's source will be placed. So if you specify a
   `git`-type resource named `foo`, the source will be cloned into
-  `/workspace/foo` -- make sure to either set `workingdir: /workspace/foo` in
+  `/workspace/foo` -- make sure to either set `workingDir: /workspace/foo` in
   the Task's `steps`, or at least be aware that source will not be cloned into
   `/workspace` as was the case with Knative Builds. See [Controlling where
   resources are
@@ -98,7 +98,7 @@ spec:
   steps:
   - name: go-test  # <-- the step must specify a name.
     image: golang
-    workingdir: /workspace/source  # <-- set workingdir
+    workingDir: /workspace/source  # <-- set workingdir
     command: ['go', 'test', '${inputs.params.TARGET}']  # <-- specify inputs.params.TARGET
 ```
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes a typo that means `workingDir` is ignored.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ na ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ na ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ y ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
None
```