### PR TITLE
Adds container name to taskrun.status.steps

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -194,7 +194,8 @@ func (tr *TaskRunStatus) InitializeCloudEvents(targets []string) {
 // StepState reports the results of running a step in the Task.
 type StepState struct {
 	corev1.ContainerState
-	Name string `json:"name,omitempty"`
+	Name          string `json:"name,omitempty"`
+	ContainerName string `json:"container,omitempty"`
 }
 
 // CloudEventDelivery is the target of a cloud event along with the state of

--- a/pkg/status/taskrunpod.go
+++ b/pkg/status/taskrunpod.go
@@ -36,6 +36,7 @@ func UpdateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod, resourceLis
 			taskRun.Status.Steps = append(taskRun.Status.Steps, v1alpha1.StepState{
 				ContainerState: *s.State.DeepCopy(),
 				Name:           resources.TrimContainerNamePrefix(s.Name),
+				ContainerName:  s.Name,
 			})
 		}
 	}

--- a/pkg/status/taskrunpod_test.go
+++ b/pkg/status/taskrunpod_test.go
@@ -77,7 +77,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 123,
 					}},
-				Name: "state-name",
+				Name:          "state-name",
+				ContainerName: "step-state-name",
 			}},
 		},
 	}, {
@@ -106,7 +107,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 123,
 					}},
-				Name: "state-name",
+				Name:          "state-name",
+				ContainerName: "step-state-name",
 			}},
 		},
 	}, {
@@ -131,7 +133,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 0,
 					}},
-				Name: "step-push",
+				Name:          "step-push",
+				ContainerName: "step-step-push",
 			}},
 			// We don't actually care about the time, just that it's not nil
 			CompletionTime: &metav1.Time{Time: time.Now()},
@@ -155,7 +158,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				ContainerState: corev1.ContainerState{
 					Running: &corev1.ContainerStateRunning{},
 				},
-				Name: "running-step",
+				Name:          "running-step",
+				ContainerName: "step-running-step",
 			}},
 		},
 	}, {
@@ -189,7 +193,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 123,
 					}},
-				Name: "failure",
+				Name:          "failure",
+				ContainerName: "step-failure",
 			}},
 			// We don't actually care about the time, just that it's not nil
 			CompletionTime: &metav1.Time{Time: time.Now()},
@@ -260,7 +265,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 						Message: "i'm pending",
 					},
 				},
-				Name: "status-name",
+				Name:          "status-name",
+				ContainerName: "step-status-name",
 			}},
 		},
 	}, {
@@ -363,7 +369,8 @@ func TestUpdateStatusFromPod(t *testing.T) {
 				ContainerState: corev1.ContainerState{
 					Running: &corev1.ContainerStateRunning{},
 				},
-				Name: "running-step",
+				Name:          "running-step",
+				ContainerName: "step-running-step",
 			}},
 		},
 	}} {

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -78,7 +78,8 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Completed",
 			},
 		},
-		Name: "hello",
+		Name:          "hello",
+		ContainerName: "step-hello",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -86,7 +87,8 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Error",
 			},
 		},
-		Name: "exit",
+		Name:          "exit",
+		ContainerName: "step-exit",
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
@@ -94,7 +96,8 @@ func TestTaskRunFailure(t *testing.T) {
 				Reason:   "Completed",
 			},
 		},
-		Name: "world",
+		Name:          "world",
+		ContainerName: "step-world",
 	}}
 	ignoreFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreFields); d != "" {


### PR DESCRIPTION



# Changes

Recently while introducing some minor changes in steps status details, it broked some
functionality across CLI, Dashboard and other projects integration.
Maybe because those integration tries to extract some attributes related to the pod base on
TaskRun.Status fields i.e extracting the container name from step's name for
fetching the logs for TaskRun.Status.Steps.

In order to fix the issue, this patch adds container name in step's status. So that
consumer of status API dont need figure internal details based on steps details.

Fixes https://github.com/tektoncd/pipeline/issues/1027
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes

```
Now `container name` is available in `TaskRun.Status.Steps.Container` field
```