### PR TITLE
Cloud event message format

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/cloudevent/cloudevent_test.go
@@ -39,7 +39,7 @@ const (
 	defaultEventID                = "event1234"
 	defaultEventSourceURI         = "/taskrun/1234"
 	invalidEventSourceURI         = "htt%23p://_invalid_URI##"
-	defaultEventType              = TektonTaskRunUnknown
+	defaultEventType              = TektonTaskRunUnknownV1
 	taskRunName                   = "faketaskrunname"
 	invalidConditionSuccessStatus = "foobar"
 )
@@ -138,15 +138,15 @@ func TestSendTaskRunCloudEvent(t *testing.T) {
 	}{{
 		desc:          "send a cloud event with unknown status taskrun",
 		taskRun:       getTaskRunByCondition(corev1.ConditionUnknown),
-		wantEventType: TektonTaskRunUnknown,
+		wantEventType: TektonTaskRunUnknownV1,
 	}, {
 		desc:          "send a cloud event with successful status taskrun",
 		taskRun:       getTaskRunByCondition(corev1.ConditionTrue),
-		wantEventType: TektonTaskRunSuccessful,
+		wantEventType: TektonTaskRunSuccessfulV1,
 	}, {
 		desc:          "send a cloud event with unknown status taskrun",
 		taskRun:       getTaskRunByCondition(corev1.ConditionFalse),
-		wantEventType: TektonTaskRunFailed,
+		wantEventType: TektonTaskRunFailedV1,
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			logger, _ := logging.NewLogger("", "")
@@ -163,7 +163,7 @@ func TestSendTaskRunCloudEvent(t *testing.T) {
 				if diff := cmp.Diff(string(c.wantEventType), gotEventType); diff != "" {
 					t.Errorf("Wrong Event Type (-want +got) = %s", diff)
 				}
-				wantData, _ := json.Marshal(c.taskRun)
+				wantData, _ := json.Marshal(NewTektonCloudEventData(c.taskRun))
 				gotData, err := event.DataBytes()
 				if err != nil {
 					t.Fatalf("Could not get data from event %v: %v", event, err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enhance the format of the Cloud Event sent by Tekton

Move TaskRun to a TaskRun field in the payload to prepare for extra data we may want to add in the future without breaking existing consumers.

Add a version number to the message types so that if at some point we want to start sending a new format of message we can match it to a new version.

Docs (with example) will be added in the PR on top.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

The format of cloud events sent by Tekton has been changed. 

Moved TaskRun to a TaskRun field in the payload to prepare for extra data we may want to add in the future without breaking existing consumers. Added a version number to the message types so that if at some point we want to start sending a new format of message we can match it to a new version.