### PR TITLE
Refactor Resource interface a bit to simplify directory passing.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cloud_event_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cloud_event_resource.go
@@ -81,17 +81,13 @@ func (s *CloudEventResource) Replacements() map[string]string {
 }
 
 // GetUploadContainerSpec returns nothing as the cloud event is sent by the controller once the POD execution is completed
-func (s *CloudEventResource) GetUploadContainerSpec() ([]corev1.Container, error) {
+func (s *CloudEventResource) GetUploadContainerSpec(_ string) ([]corev1.Container, error) {
 	return nil, nil
 }
 
 // GetDownloadContainerSpec returns nothing, cloud events cannot be used as input resource
-func (s *CloudEventResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
+func (s *CloudEventResource) GetDownloadContainerSpec(_ string) ([]corev1.Container, error) {
 	return nil, nil
-}
-
-// SetDestinationDirectory required by the interface but not really used
-func (s *CloudEventResource) SetDestinationDirectory(path string) {
 }
 
 // GetUploadVolumeSpec - no upload from volume for CloudEvent resource

--- a/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go
@@ -94,7 +94,7 @@ func Test_CloudEventDownloadContainerSpec(t *testing.T) {
 		TargetURI: "http://fake-uri",
 		Type:      v1alpha1.PipelineResourceTypeCloudEvent,
 	}
-	d, e := r.GetDownloadContainerSpec()
+	d, e := r.GetDownloadContainerSpec("")
 	if d != nil {
 		t.Errorf("Did not expect a download container for CloudEventResource")
 	}
@@ -109,7 +109,7 @@ func Test_CloudEventUploadContainerSpec(t *testing.T) {
 		TargetURI: "http://fake-uri",
 		Type:      v1alpha1.PipelineResourceTypeCloudEvent,
 	}
-	d, e := r.GetUploadContainerSpec()
+	d, e := r.GetUploadContainerSpec("")
 	if d != nil {
 		t.Errorf("Did not expect an upload container for CloudEventResource")
 	}

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -138,13 +138,11 @@ func (s ClusterResource) String() string {
 	return string(json)
 }
 
-func (s *ClusterResource) GetUploadContainerSpec() ([]corev1.Container, error) {
+func (s *ClusterResource) GetUploadContainerSpec(_ string) ([]corev1.Container, error) {
 	return nil, nil
 }
 
-func (s *ClusterResource) SetDestinationDirectory(path string) {
-}
-func (s *ClusterResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
+func (s *ClusterResource) GetDownloadContainerSpec(sourcePath string) ([]corev1.Container, error) {
 	var envVars []corev1.EnvVar
 	for _, sec := range s.Secrets {
 		ev := corev1.EnvVar{

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -156,7 +156,7 @@ func Test_ClusterResource_GetDownloadContainerSpec(t *testing.T) {
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotContainers, err := tc.clusterResource.GetDownloadContainerSpec()
+			gotContainers, err := tc.clusterResource.GetDownloadContainerSpec("")
 			if tc.wantErr && err == nil {
 				t.Fatalf("Expected error to be %t but got %v:", tc.wantErr, err)
 			}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -35,11 +35,10 @@ var (
 // GCSResource is a GCS endpoint from which to get artifacts which is required
 // by a Build/Task for context (e.g. a archive from which to build an image).
 type GCSResource struct {
-	Name           string               `json:"name"`
-	Type           PipelineResourceType `json:"type"`
-	Location       string               `json:"location"`
-	TypeDir        bool                 `json:"typeDir"`
-	DestinationDir string               `json:"destinationDir"`
+	Name     string               `json:"name"`
+	Type     PipelineResourceType `json:"type"`
+	Location string               `json:"location"`
+	TypeDir  bool                 `json:"typeDir"`
 	//Secret holds a struct to indicate a field name and corresponding secret name to populate it
 	Secrets []SecretParam `json:"secrets"`
 }
@@ -95,24 +94,18 @@ func (s *GCSResource) Replacements() map[string]string {
 		"name":     s.Name,
 		"type":     string(s.Type),
 		"location": s.Location,
-		"path":     s.DestinationDir,
 	}
 }
 
-// SetDestinationDirectory sets the destination directory at runtime like where is the resource going to be copied to
-func (s *GCSResource) SetDestinationDirectory(destDir string) { s.DestinationDir = destDir }
-
 // GetUploadContainerSpec gets container spec for gcs resource to be uploaded like
 // set environment variable from secret params and set volume mounts for those secrets
-func (s *GCSResource) GetUploadContainerSpec() ([]corev1.Container, error) {
-	if s.DestinationDir == "" {
-		return nil, xerrors.Errorf("GCSResource: Expect Destination Directory param to be set: %s", s.Name)
-	}
+func (s *GCSResource) GetUploadContainerSpec(sourcePath string) ([]corev1.Container, error) {
+
 	var args []string
 	if s.TypeDir {
-		args = []string{"-args", fmt.Sprintf("rsync -d -r %s %s", s.DestinationDir, s.Location)}
+		args = []string{"-args", fmt.Sprintf("rsync -d -r %s %s", sourcePath, s.Location)}
 	} else {
-		args = []string{"-args", fmt.Sprintf("cp %s %s", filepath.Join(s.DestinationDir, "*"), s.Location)}
+		args = []string{"-args", fmt.Sprintf("cp %s %s", filepath.Join(sourcePath, "*"), s.Location)}
 	}
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts(s.Name, gcsSecretVolumeMountPath, s.Secrets)
@@ -128,20 +121,20 @@ func (s *GCSResource) GetUploadContainerSpec() ([]corev1.Container, error) {
 }
 
 // GetDownloadContainerSpec returns an array of container specs to download gcs storage object
-func (s *GCSResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
-	if s.DestinationDir == "" {
+func (s *GCSResource) GetDownloadContainerSpec(sourcePath string) ([]corev1.Container, error) {
+	if sourcePath == "" {
 		return nil, xerrors.Errorf("GCSResource: Expect Destination Directory param to be set %s", s.Name)
 	}
 	var args []string
 	if s.TypeDir {
-		args = []string{"-args", fmt.Sprintf("rsync -d -r %s %s", s.Location, s.DestinationDir)}
+		args = []string{"-args", fmt.Sprintf("rsync -d -r %s %s", s.Location, sourcePath)}
 	} else {
-		args = []string{"-args", fmt.Sprintf("cp %s %s", s.Location, s.DestinationDir)}
+		args = []string{"-args", fmt.Sprintf("cp %s %s", s.Location, sourcePath)}
 	}
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts(s.Name, gcsSecretVolumeMountPath, s.Secrets)
 	return []corev1.Container{
-		CreateDirContainer(s.Name, s.DestinationDir), {
+		CreateDirContainer(s.Name, sourcePath), {
 			Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("fetch-%s", s.Name)),
 			Image:        *gsutilImage,
 			Command:      []string{"/ko-app/gsutil"},

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -117,7 +117,6 @@ func Test_GCSGetReplacements(t *testing.T) {
 		"name":     "gcs-resource",
 		"type":     "gcs",
 		"location": "gs://fake-bucket",
-		"path":     "",
 	}
 	if d := cmp.Diff(gcsResource.Replacements(), expectedReplacementMap); d != "" {
 		t.Errorf("GCS Replacement map mismatch: %s", d)
@@ -156,10 +155,9 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 	}{{
 		name: "valid download protected buckets",
 		gcsResource: &v1alpha1.GCSResource{
-			Name:           "gcs-valid",
-			Location:       "gs://some-bucket",
-			DestinationDir: "/workspace",
-			TypeDir:        true,
+			Name:     "gcs-valid",
+			Location: "gs://some-bucket",
+			TypeDir:  true,
 			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
@@ -188,9 +186,8 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 	}, {
 		name: "duplicate secret mount paths",
 		gcsResource: &v1alpha1.GCSResource{
-			Name:           "gcs-valid",
-			Location:       "gs://some-bucket",
-			DestinationDir: "/workspace",
+			Name:     "gcs-valid",
+			Location: "gs://some-bucket",
 			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "fieldName",
@@ -220,17 +217,10 @@ func Test_GetDownloadContainerSpec(t *testing.T) {
 				MountPath: "/var/secret/secretName",
 			}},
 		}},
-	}, {
-		name: "invalid no destination directory set",
-		gcsResource: &v1alpha1.GCSResource{
-			Name:     "gcs-invalid",
-			Location: "gs://some-bucket",
-		},
-		wantErr: true,
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotContainers, err := tc.gcsResource.GetDownloadContainerSpec()
+			gotContainers, err := tc.gcsResource.GetDownloadContainerSpec("/workspace")
 			if tc.wantErr && err == nil {
 				t.Fatalf("Expected error to be %t but got %v:", tc.wantErr, err)
 			}
@@ -252,10 +242,9 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 	}{{
 		name: "valid upload to protected buckets with directory paths",
 		gcsResource: &v1alpha1.GCSResource{
-			Name:           "gcs-valid",
-			Location:       "gs://some-bucket",
-			DestinationDir: "/workspace/",
-			TypeDir:        true,
+			Name:     "gcs-valid",
+			Location: "gs://some-bucket",
+			TypeDir:  true,
 			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
@@ -276,9 +265,8 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 	}, {
 		name: "duplicate secret mount paths",
 		gcsResource: &v1alpha1.GCSResource{
-			Name:           "gcs-valid",
-			Location:       "gs://some-bucket",
-			DestinationDir: "/workspace",
+			Name:     "gcs-valid",
+			Location: "gs://some-bucket",
 			Secrets: []v1alpha1.SecretParam{{
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
@@ -305,10 +293,9 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 	}, {
 		name: "valid upload to protected buckets with single file",
 		gcsResource: &v1alpha1.GCSResource{
-			Name:           "gcs-valid",
-			Location:       "gs://some-bucket",
-			DestinationDir: "/workspace/",
-			TypeDir:        false,
+			Name:     "gcs-valid",
+			Location: "gs://some-bucket",
+			TypeDir:  false,
 		},
 		wantContainers: []corev1.Container{{
 			Name:    "upload-gcs-valid-mssqb",
@@ -316,17 +303,10 @@ func Test_GetUploadContainerSpec(t *testing.T) {
 			Command: []string{"/ko-app/gsutil"},
 			Args:    []string{"-args", "cp /workspace/* gs://some-bucket"},
 		}},
-	}, {
-		name: "invalid upload with no source directory path",
-		gcsResource: &v1alpha1.GCSResource{
-			Name:     "gcs-invalid",
-			Location: "gs://some-bucket",
-		},
-		wantErr: true,
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotContainers, err := tc.gcsResource.GetUploadContainerSpec()
+			gotContainers, err := tc.gcsResource.GetUploadContainerSpec("/workspace/")
 			if tc.wantErr && err == nil {
 				t.Fatalf("Expected error to be %t but got %v:", tc.wantErr, err)
 			}

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -43,8 +43,7 @@ type GitResource struct {
 	// Git revision (branch, tag, commit SHA or ref) to clone.  See
 	// https://git-scm.com/docs/gitrevisions#_specifying_revisions for more
 	// information.
-	Revision   string `json:"revision"`
-	TargetPath string
+	Revision string `json:"revision"`
 }
 
 // NewGitResource creates a new git resource to pass to a Task
@@ -93,16 +92,15 @@ func (s *GitResource) Replacements() map[string]string {
 		"type":     string(s.Type),
 		"url":      s.URL,
 		"revision": s.Revision,
-		"path":     s.TargetPath,
 	}
 }
 
-func (s *GitResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
+func (s *GitResource) GetDownloadContainerSpec(sourcePath string) ([]corev1.Container, error) {
 	args := []string{"-url", s.URL,
 		"-revision", s.Revision,
 	}
 
-	args = append(args, []string{"-path", s.TargetPath}...)
+	args = append(args, []string{"-path", sourcePath}...)
 
 	return []corev1.Container{{
 		Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(gitSource + "-" + s.Name),
@@ -113,11 +111,7 @@ func (s *GitResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 	}}, nil
 }
 
-func (s *GitResource) SetDestinationDirectory(path string) {
-	s.TargetPath = path
-}
-
-func (s *GitResource) GetUploadContainerSpec() ([]corev1.Container, error) {
+func (s *GitResource) GetUploadContainerSpec(sourcePath string) ([]corev1.Container, error) {
 	return nil, nil
 }
 

--- a/pkg/apis/pipeline/v1alpha1/git_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource_test.go
@@ -100,11 +100,10 @@ func Test_Valid_NewGitResource(t *testing.T) {
 
 func Test_GitResource_Replacements(t *testing.T) {
 	r := &v1alpha1.GitResource{
-		Name:       "git-resource",
-		Type:       v1alpha1.PipelineResourceTypeGit,
-		URL:        "git@github.com:test/test.git",
-		Revision:   "master",
-		TargetPath: "/test/test",
+		Name:     "git-resource",
+		Type:     v1alpha1.PipelineResourceTypeGit,
+		URL:      "git@github.com:test/test.git",
+		Revision: "master",
 	}
 
 	want := map[string]string{
@@ -112,7 +111,6 @@ func Test_GitResource_Replacements(t *testing.T) {
 		"type":     string(v1alpha1.PipelineResourceTypeGit),
 		"url":      "git@github.com:test/test.git",
 		"revision": "master",
-		"path":     "/test/test",
 	}
 
 	got := r.Replacements()
@@ -126,11 +124,10 @@ func Test_GitResource_GetDownloadContainerSpec(t *testing.T) {
 	names.TestingSeed()
 
 	r := &v1alpha1.GitResource{
-		Name:       "git-resource",
-		Type:       v1alpha1.PipelineResourceTypeGit,
-		URL:        "git@github.com:test/test.git",
-		Revision:   "master",
-		TargetPath: "/test/test",
+		Name:     "git-resource",
+		Type:     v1alpha1.PipelineResourceTypeGit,
+		URL:      "git@github.com:test/test.git",
+		Revision: "master",
 	}
 
 	want := []corev1.Container{{
@@ -148,7 +145,7 @@ func Test_GitResource_GetDownloadContainerSpec(t *testing.T) {
 		WorkingDir: "/workspace",
 	}}
 
-	got, err := r.GetDownloadContainerSpec()
+	got, err := r.GetDownloadContainerSpec("/test/test")
 	if err != nil {
 		t.Fatalf("Unexpected error getting DownloadContainerSpec: %s", err)
 	}

--- a/pkg/apis/pipeline/v1alpha1/image_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource.go
@@ -76,17 +76,13 @@ func (s *ImageResource) Replacements() map[string]string {
 }
 
 // GetUploadContainerSpec returns the spec for the upload container
-func (s *ImageResource) GetUploadContainerSpec() ([]corev1.Container, error) {
+func (s *ImageResource) GetUploadContainerSpec(_ string) ([]corev1.Container, error) {
 	return nil, nil
 }
 
 // GetDownloadContainerSpec returns the spec for the download container
-func (s *ImageResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
+func (s *ImageResource) GetDownloadContainerSpec(sourcePath string) ([]corev1.Container, error) {
 	return nil, nil
-}
-
-// SetDestinationDirectory sets the destination for the resource
-func (s *ImageResource) SetDestinationDirectory(path string) {
 }
 
 // GetOutputImageDir return the path to get the index.json file

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -42,7 +42,6 @@ type PullRequestResource struct {
 	Name string               `json:"name"`
 	Type PipelineResourceType `json:"type"`
 
-	DestinationDir string `json:"destinationDir"`
 	// GitHub URL pointing to the pull request.
 	// Example: https://github.com/owner/repo/pulls/1
 	URL string `json:"url"`
@@ -94,16 +93,16 @@ func (s *PullRequestResource) Replacements() map[string]string {
 	}
 }
 
-func (s *PullRequestResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
-	return s.getContainerSpec("download")
+func (s *PullRequestResource) GetDownloadContainerSpec(sourcePath string) ([]corev1.Container, error) {
+	return s.getContainerSpec("download", sourcePath)
 }
 
-func (s *PullRequestResource) GetUploadContainerSpec() ([]corev1.Container, error) {
-	return s.getContainerSpec("upload")
+func (s *PullRequestResource) GetUploadContainerSpec(sourcePath string) ([]corev1.Container, error) {
+	return s.getContainerSpec("upload", sourcePath)
 }
 
-func (s *PullRequestResource) getContainerSpec(mode string) ([]corev1.Container, error) {
-	args := []string{"-url", s.URL, "-path", s.DestinationDir, "-mode", mode}
+func (s *PullRequestResource) getContainerSpec(mode string, sourcePath string) ([]corev1.Container, error) {
+	args := []string{"-url", s.URL, "-path", sourcePath, "-mode", mode}
 
 	evs := []corev1.EnvVar{}
 	for _, sec := range s.Secrets {
@@ -132,11 +131,6 @@ func (s *PullRequestResource) getContainerSpec(mode string) ([]corev1.Container,
 		WorkingDir: WorkspaceDir,
 		Env:        evs,
 	}}, nil
-}
-
-// SetDestinationDirectory sets the destination directory at runtime like where is the resource going to be copied to
-func (s *PullRequestResource) SetDestinationDirectory(dir string) {
-	s.DestinationDir = dir
 }
 
 func (s *PullRequestResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -63,26 +63,26 @@ type testcase struct {
 	out []corev1.Container
 }
 
+const workspace = "/workspace"
+
 func containerTestCases(mode string) []testcase {
 	return []testcase{{
 		in: &v1alpha1.PullRequestResource{
-			Name:           "nocreds",
-			DestinationDir: "/workspace",
-			URL:            "https://example.com",
+			Name: "nocreds",
+			URL:  "https://example.com",
 		},
 		out: []corev1.Container{{
 			Name:       "pr-source-nocreds-9l9zj",
 			Image:      "override-with-pr:latest",
 			WorkingDir: v1alpha1.WorkspaceDir,
 			Command:    []string{"/ko-app/pullrequest-init"},
-			Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode},
+			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode},
 			Env:        []corev1.EnvVar{},
 		}},
 	}, {
 		in: &v1alpha1.PullRequestResource{
-			Name:           "creds",
-			DestinationDir: "/workspace",
-			URL:            "https://example.com",
+			Name: "creds",
+			URL:  "https://example.com",
 			Secrets: []v1alpha1.SecretParam{{
 				FieldName:  "githubToken",
 				SecretName: "github-creds",
@@ -115,7 +115,7 @@ func TestPullRequest_GetDownloadContainerSpec(t *testing.T) {
 
 	for _, tc := range containerTestCases("download") {
 		t.Run(tc.in.GetName(), func(t *testing.T) {
-			got, err := tc.in.GetDownloadContainerSpec()
+			got, err := tc.in.GetDownloadContainerSpec(workspace)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -131,7 +131,7 @@ func TestPullRequest_GetUploadContainerSpec(t *testing.T) {
 
 	for _, tc := range containerTestCases("upload") {
 		t.Run(tc.in.GetName(), func(t *testing.T) {
-			got, err := tc.in.GetUploadContainerSpec()
+			got, err := tc.in.GetUploadContainerSpec(workspace)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -56,11 +56,10 @@ type PipelineResourceInterface interface {
 	GetName() string
 	GetType() PipelineResourceType
 	Replacements() map[string]string
-	GetDownloadContainerSpec() ([]corev1.Container, error)
-	GetUploadContainerSpec() ([]corev1.Container, error)
+	GetDownloadContainerSpec(sourcePath string) ([]corev1.Container, error)
+	GetUploadContainerSpec(sourcePath string) ([]corev1.Container, error)
 	GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error)
 	GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error)
-	SetDestinationDirectory(string)
 }
 
 // SecretParam indicates which secret can be used to populate a field of the resource

--- a/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/input_resources.go
@@ -87,7 +87,6 @@ func AddInputResource(
 			copyStepsFromPrevTasks []corev1.Container
 			dPath                  = destinationPath(input.Name, input.TargetPath)
 		)
-		resource.SetDestinationDirectory(dPath)
 		// if taskrun is fetching resource from previous task then execute copy step instead of fetching new copy
 		// to the desired destination directory, as long as the resource exports output to be copied
 		if allowedOutputResources[resource.GetType()] && taskRun.HasPipelineRunOwnerReference() {
@@ -112,7 +111,7 @@ func AddInputResource(
 			taskSpec.Steps = append(copyStepsFromPrevTasks, taskSpec.Steps...)
 			taskSpec.Volumes = append(taskSpec.Volumes, as.GetSecretsVolumes()...)
 		} else {
-			resourceContainers, err = resource.GetDownloadContainerSpec()
+			resourceContainers, err = resource.GetDownloadContainerSpec(dPath)
 			if err != nil {
 				return nil, xerrors.Errorf("task %q invalid resource download spec: %q; error %w", taskName, boundResource.ResourceRef.Name, err)
 			}

--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -107,9 +107,8 @@ func AddOutputResources(
 				sourcePath = output.TargetPath
 			}
 		}
-		resource.SetDestinationDirectory(sourcePath)
 
-		resourceContainers, err = resource.GetUploadContainerSpec()
+		resourceContainers, err = resource.GetUploadContainerSpec(sourcePath)
 		if err != nil {
 			return nil, xerrors.Errorf("task %q invalid upload spec: %q; error %w", taskName, boundResource.ResourceRef.Name, err)
 		}


### PR DESCRIPTION
# Changes

This change removes the SetDestinationDirectory method from the Resource
interface. This overcomplicated each Resource, and is unnecessary. The
directory resources need to copy/paste from can be simply passed in at container
generation time.

The one side effect of this change is that this path is no longer available at
interpolation time. This should not be needed at interpolation time because it
is completely controlled by the Task definition itself and can be hardcoded.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
The "Path" variable from resources is no longer available for interpolation inside Task definitions. This value is not dynamic and can be simply hardcoded.
```