### PR TITLE
Add a warning when the same resource is used as an input and an output.

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/output_resource.go
@@ -98,7 +98,10 @@ func AddOutputResources(
 		// if resource is declared in input then copy outputs to pvc
 		// To build copy step it needs source path(which is targetpath of input resourcemap) from task input source
 		sourcePath := inputResourceMap[boundResource.Name]
-		if sourcePath == "" {
+		if sourcePath != "" {
+			logger.Warn(`This task uses the same resource as an input and output. The behavior of this will change in a future release.
+		See https://github.com/tektoncd/pipeline/issues/1118 for more information.`)
+		} else {
 			if output.TargetPath == "" {
 				sourcePath = filepath.Join(outputDir, boundResource.Name)
 			} else {


### PR DESCRIPTION
# Changes

In the future, we will be changing the behavior of this. Outputs will
always be copied from the /workspace/outputs directory, rather than
sometimes copying them from the input.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
We now warn when the same resource is used as an input and an output of the same Task. This will still be a supported case, but the behavior on where files are expected to be will change in a future release.

Outputs must be placed into the /workspace/outputs directory and Tekton will no longer copy them from the input directory automatically.
```