### PR TITLE
Adds builder for Condition & renames existing one to StatusCondition

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -91,7 +91,7 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 }
 
 func TestTaskRunIsDone(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.Condition(
+	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -29,7 +29,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(1*time.Second),
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown}),
 		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
@@ -38,7 +38,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown}),
 		tb.TaskRunStartTime(time.Now()),
@@ -47,7 +47,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	taskRunRunningNilTimeout := tb.TaskRun("test-taskrun-running-nil-timeout", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunNilTimeout,
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown}),
 		tb.TaskRunStartTime(time.Now()),
@@ -56,7 +56,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	taskRunDone := tb.TaskRun("test-taskrun-completed", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionTrue}),
 	))
@@ -65,7 +65,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunTaskRef(simpleTask.Name),
 		tb.TaskRunCancelled,
 		tb.TaskRunTimeout(1*time.Second),
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown}),
 	))
@@ -270,7 +270,7 @@ func TestWithNoFunc(t *testing.T) {
 	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(2*time.Second),
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown}),
 		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
@@ -308,7 +308,7 @@ func TestSetTaskRunTimer(t *testing.T) {
 	taskRun := tb.TaskRun("test-taskrun-arbitrary-timer", testNs, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(2*time.Second),
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown}),
 		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun_test.go
@@ -381,7 +381,7 @@ func TestUpdateTaskRunsState(t *testing.T) {
 		tb.TaskRunTaskRef("unit-test-task"),
 		tb.TaskRunServiceAccount("test-sa"),
 	), tb.TaskRunStatus(
-		tb.Condition(apis.Condition{Type: apis.ConditionSucceeded}),
+		tb.StatusCondition(apis.Condition{Type: apis.ConditionSucceeded}),
 		tb.StepState(tb.StateTerminated(0)),
 	))
 
@@ -447,7 +447,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
 			tb.TaskRunSpec(tb.TaskRunTaskRef("hello-world")),
 			tb.TaskRunStatus(
-				tb.Condition(apis.Condition{
+				tb.StatusCondition(apis.Condition{
 					Type: apis.ConditionSucceeded,
 				}),
 			),
@@ -888,7 +888,7 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 				tb.TaskRun("hello-world-1", "foo",
 					tb.TaskRunStatus(
 						tb.PodName("my-pod-name"),
-						tb.Condition(apis.Condition{
+						tb.StatusCondition(apis.Condition{
 							Type:   apis.ConditionSucceeded,
 							Status: corev1.ConditionFalse,
 						}),

--- a/pkg/reconciler/v1alpha1/taskrun/cancel_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/cancel_test.go
@@ -43,7 +43,7 @@ func TestCancelTaskRun(t *testing.T) {
 		taskRun: tb.TaskRun("test-taskrun-run-cancelled", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name),
 			tb.TaskRunCancelled,
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{
+		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
 		}))),
@@ -58,7 +58,7 @@ func TestCancelTaskRun(t *testing.T) {
 		taskRun: tb.TaskRun("test-taskrun-run-cancelled", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name),
 			tb.TaskRunCancelled,
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{
+		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
 		}), tb.PodName("foo-is-bar"))),

--- a/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/taskrun_test.go
@@ -1408,7 +1408,7 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 	}
 	taskRun := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name),
-	), tb.TaskRunStatus(tb.Condition(*taskSt)))
+	), tb.TaskRunStatus(tb.StatusCondition(*taskSt)))
 	d := test.Data{
 		TaskRuns: []*v1alpha1.TaskRun{
 			taskRun,
@@ -1437,7 +1437,7 @@ func TestReconcileOnCancelledTaskRun(t *testing.T) {
 	taskRun := tb.TaskRun("test-taskrun-run-cancelled", "foo", tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name),
 		tb.TaskRunCancelled,
-	), tb.TaskRunStatus(tb.Condition(apis.Condition{
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 		Type:   apis.ConditionSucceeded,
 		Status: corev1.ConditionUnknown,
 	})))
@@ -1483,7 +1483,7 @@ func TestReconcileTimeouts(t *testing.T) {
 					tb.TaskRunTaskRef(simpleTask.Name),
 					tb.TaskRunTimeout(10*time.Second),
 				),
-				tb.TaskRunStatus(tb.Condition(apis.Condition{
+				tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionUnknown}),
 					tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
@@ -1499,7 +1499,7 @@ func TestReconcileTimeouts(t *testing.T) {
 				tb.TaskRunSpec(
 					tb.TaskRunTaskRef(simpleTask.Name),
 				),
-				tb.TaskRunStatus(tb.Condition(apis.Condition{
+				tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionUnknown}),
 					tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
@@ -1516,7 +1516,7 @@ func TestReconcileTimeouts(t *testing.T) {
 					tb.TaskRunTaskRef(simpleTask.Name),
 					tb.TaskRunNilTimeout,
 				),
-				tb.TaskRunStatus(tb.Condition(apis.Condition{
+				tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionUnknown}),
 					tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
@@ -1558,7 +1558,7 @@ func TestHandlePodCreationError(t *testing.T) {
 		tb.TaskRunTaskRef(simpleTask.Name),
 	), tb.TaskRunStatus(
 		tb.TaskRunStartTime(time.Now()),
-		tb.Condition(apis.Condition{
+		tb.StatusCondition(apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
 		}),

--- a/pkg/reconciler/v1alpha1/taskrun/timeout_check_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/timeout_check_test.go
@@ -37,19 +37,19 @@ func TestCheckTimeout(t *testing.T) {
 		name: "TaskRun not started",
 		taskRun: tb.TaskRun("test-taskrun-not-started", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name),
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{}), tb.TaskRunStartTime(zeroTime))),
+		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(zeroTime))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun no timeout",
 		taskRun: tb.TaskRun("test-taskrun-no-timeout", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(0),
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Hour)))),
+		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Hour)))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun timed out",
 		taskRun: tb.TaskRun("test-taskrun-timeout", "foo", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(10*time.Second),
-		), tb.TaskRunStatus(tb.Condition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
+		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
 		expectedStatus: true,
 	}}
 

--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -1,0 +1,100 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package builder
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// ConditionOp is an operation which modifies a StatusCondition struct.
+type ConditionOp func(*v1alpha1.Condition)
+
+// ConditionSpecOp is an operation which modifies a ConditionSpec struct.
+type ConditionSpecOp func(spec *v1alpha1.ConditionSpec)
+
+// TaskParamOp is an operation which modify a ParamSpec struct.
+type ConditionParamOp func(*v1alpha1.ParamSpec)
+
+// Condition creates a Condition with default values.
+// Any number of Condition modifiers can be passed to transform it.
+func Condition(name, namespace string, ops ...ConditionOp) *v1alpha1.Condition {
+	condition := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, op := range ops {
+		op(condition)
+	}
+	return condition
+}
+
+// ConditionSpec creates a ConditionSpec with default values.
+// Any number of ConditionSpec modifiers can be passed to transform it.
+func ConditionSpec(ops ...ConditionSpecOp) ConditionOp {
+	return func(Condition *v1alpha1.Condition) {
+		ConditionSpec := &Condition.Spec
+		for _, op := range ops {
+			op(ConditionSpec)
+		}
+		Condition.Spec = *ConditionSpec
+	}
+}
+
+// ConditionSpecCheck adds a Container, with the specified name and image, to the Condition Spec Check.
+// Any number of Container modifiers can be passed to transform it.
+func ConditionSpecCheck(image string, ops ...ContainerOp) ConditionSpecOp {
+	return func(spec *v1alpha1.ConditionSpec) {
+		c := &corev1.Container{
+			Image: image,
+		}
+		for _, op := range ops {
+			op(c)
+		}
+		spec.Check = *c
+	}
+}
+
+// ParamSpec adds a param, with specified name, to the Spec.
+// Any number of ParamSpec modifiers can be passed to transform it.
+func ConditionParam(name string, ops ...ConditionParamOp) ConditionSpecOp {
+	return func(ps *v1alpha1.ConditionSpec) {
+		pp := &v1alpha1.ParamSpec{Name: name}
+		for _, op := range ops {
+			op(pp)
+		}
+		ps.Params = append(ps.Params, *pp)
+	}
+}
+
+// ConditionParamDescription sets the description to the ParamSpec.
+func ConditionParamDescription(desc string) ConditionParamOp {
+	return func(pp *v1alpha1.ParamSpec) {
+		pp.Description = desc
+	}
+}
+
+// ConditionParamDefault sets the default value to the ParamSpec.
+func ConditionParamDefault(value string) ConditionParamOp {
+	return func(pp *v1alpha1.ParamSpec) {
+		pp.Default = value
+	}
+}

--- a/test/builder/condition_test.go
+++ b/test/builder/condition_test.go
@@ -1,0 +1,59 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package builder_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+)
+
+func TestCondition(t *testing.T) {
+	condition := tb.Condition("cond-name", "foo",
+		tb.ConditionSpec(tb.ConditionSpecCheck("ubuntu", tb.Command("exit 0")),
+			tb.ConditionParam("param-1",
+				tb.ConditionParamDefault("default"),
+				tb.ConditionParamDescription("desc"))),
+	)
+
+	expected := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cond-name",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{
+				Image:   "ubuntu",
+				Command: []string{"exit 0"},
+			},
+			Params: []v1alpha1.ParamSpec{{
+				Name:        "param-1",
+				Description: "desc",
+				Default:     "default",
+			}},
+		},
+	}
+
+	if d := cmp.Diff(expected, condition); d != "" {
+		t.Fatalf("Condition diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -378,7 +378,7 @@ func PipelineRunStatus(ops ...PipelineRunStatusOp) PipelineRunOp {
 	}
 }
 
-// PipelineRunStatusCondition adds a Condition to the TaskRunStatus.
+// PipelineRunStatusCondition adds a StatusCondition to the TaskRunStatus.
 func PipelineRunStatusCondition(condition apis.Condition) PipelineRunStatusOp {
 	return func(s *v1alpha1.PipelineRunStatus) {
 		s.Conditions = append(s.Conditions, condition)

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -311,8 +311,8 @@ func PodName(name string) TaskRunStatusOp {
 	}
 }
 
-// Condition adds a Condition to the TaskRunStatus.
-func Condition(condition apis.Condition) TaskRunStatusOp {
+// StatusCondition adds a StatusCondition to the TaskRunStatus.
+func StatusCondition(condition apis.Condition) TaskRunStatusOp {
 	return func(s *v1alpha1.TaskRunStatus) {
 		s.Conditions = append(s.Conditions, condition)
 	}

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -162,7 +162,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 		),
 		tb.TaskRunStatus(
 			tb.PodName("my-pod-name"),
-			tb.Condition(apis.Condition{Type: apis.ConditionSucceeded}),
+			tb.StatusCondition(apis.Condition{Type: apis.ConditionSucceeded}),
 			tb.StepState(tb.StateTerminated(127)),
 		),
 	)

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -41,7 +41,7 @@ func TestWaitForTaskRunStateSucceed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{
 			tb.TaskRun("foo", waitNamespace, tb.TaskRunStatus(
-				tb.Condition(success),
+				tb.StatusCondition(success),
 			)),
 		},
 	}
@@ -56,7 +56,7 @@ func TestWaitForTaskRunStateFailed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{
 			tb.TaskRun("foo", waitNamespace, tb.TaskRunStatus(
-				tb.Condition(failure),
+				tb.StatusCondition(failure),
 			)),
 		},
 	}


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There was already a function called `Condition` for building a TaskRun's
status in the `builder` process. I renamed that to `StatusCondition`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._
