### PR TITLE
Add Condition type to webhook and `SchemeBuilder`

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -97,6 +97,7 @@ func main() {
 			v1alpha1.SchemeGroupVersion.WithKind("ClusterTask"):      &v1alpha1.ClusterTask{},
 			v1alpha1.SchemeGroupVersion.WithKind("TaskRun"):          &v1alpha1.TaskRun{},
 			v1alpha1.SchemeGroupVersion.WithKind("PipelineRun"):      &v1alpha1.PipelineRun{},
+			v1alpha1.SchemeGroupVersion.WithKind("Condition"):        &v1alpha1.Condition{},
 		},
 		Logger:                logger,
 		DisallowUnknownFields: true,

--- a/pkg/apis/pipeline/v1alpha1/condition_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_defaults.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Tekton Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "context"
+
+func (c *Condition) SetDefaults(ctx context.Context) {
+	c.Spec.SetDefaults(ctx)
+}
+
+func (cs *ConditionSpec) SetDefaults(ctx context.Context) {
+}

--- a/pkg/apis/pipeline/v1alpha1/condition_types.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types.go
@@ -27,6 +27,7 @@ import (
 
 // Check that Task may be validated and defaulted.
 var _ apis.Validatable = (*Condition)(nil)
+var _ apis.Defaultable = (*Condition)(nil)
 
 // +genclient
 // +genclient:noStatus

--- a/pkg/apis/pipeline/v1alpha1/register.go
+++ b/pkg/apis/pipeline/v1alpha1/register.go
@@ -48,6 +48,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Task{},
 		&TaskList{},
+		&Condition{},
+		&ConditionList{},
 		&ClusterTask{},
 		&ClusterTaskList{},
 		&TaskRun{},

--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -23,13 +23,13 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 )
 
-// ConditionOp is an operation which modifies a StatusCondition struct.
+// ConditionOp is an operation which modifies a Condition struct.
 type ConditionOp func(*v1alpha1.Condition)
 
 // ConditionSpecOp is an operation which modifies a ConditionSpec struct.
 type ConditionSpecOp func(spec *v1alpha1.ConditionSpec)
 
-// TaskParamOp is an operation which modify a ParamSpec struct.
+// ConditionParamOp is an operation which modify a ParamSpec struct.
 type ConditionParamOp func(*v1alpha1.ParamSpec)
 
 // Condition creates a Condition with default values.


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

To enable webhook validation, Condition has to implement the
`Defaultable` interface even though at the moment there are no
default values.
Also, found that we need to register new types to the SchemeBuilder else
if we cannot create Conditions using the generated client (e.g. for e2e
 tests) since the Kind is not properly set.

Both of these changes should have been a part of the APIs PR for
Conditions. I have an upcoming PR that will update docs for creating new
types with this information.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
