### PR TITLE
Refactor the Storage resource interface to remove a type switch state…

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
@@ -173,3 +173,7 @@ func getArtifactType(val string) (GCSArtifactType, error) {
 	}
 	return "", xerrors.Errorf("Invalid ArtifactType %s. Should be one of %s", aType, strings.Join(valid, ","))
 }
+
+func (s *BuildGCSResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return getStorageUploadVolumeSpec(s, spec)
+}

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -173,3 +173,7 @@ func (s *ClusterResource) GetDownloadContainerSpec() ([]corev1.Container, error)
 
 	return []corev1.Container{clusterContainer}, nil
 }
+
+func (s *ClusterResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -150,3 +150,7 @@ func (s *GCSResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 			VolumeMounts: secretVolumeMount,
 		}}, nil
 }
+
+func (s *GCSResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return getStorageUploadVolumeSpec(s, spec)
+}

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -120,3 +120,7 @@ func (s *GitResource) SetDestinationDirectory(path string) {
 func (s *GitResource) GetUploadContainerSpec() ([]corev1.Container, error) {
 	return nil, nil
 }
+
+func (s *GitResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/image_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource.go
@@ -101,3 +101,7 @@ func (s ImageResource) String() string {
 	json, _ := json.Marshal(s)
 	return string(json)
 }
+
+func (s *ImageResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -138,3 +138,7 @@ func (s *PullRequestResource) getContainerSpec(mode string) ([]corev1.Container,
 func (s *PullRequestResource) SetDestinationDirectory(dir string) {
 	s.DestinationDir = dir
 }
+
+func (s *PullRequestResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -55,6 +55,7 @@ type PipelineResourceInterface interface {
 	Replacements() map[string]string
 	GetDownloadContainerSpec() ([]corev1.Container, error)
 	GetUploadContainerSpec() ([]corev1.Container, error)
+	GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error)
 	SetDestinationDirectory(string)
 }
 


### PR DESCRIPTION
…ment.

# Changes

Right now the upload phase for artifacts needs to behave differently between
normal resources and storage (GCS, BuildGCS) resources, leading to type switches
in this code.

This refactor moves that logic up into the normal Resource interface, allowing the
logic to remain uniform between the two resource types.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._
