### PR TITLE
Refactor input resource volume handling to remove a type switch state…

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
@@ -177,3 +177,7 @@ func getArtifactType(val string) (GCSArtifactType, error) {
 func (s *BuildGCSResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
 	return getStorageUploadVolumeSpec(s, spec)
 }
+
+func (s *BuildGCSResource) GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return getStorageUploadVolumeSpec(s, spec)
+}

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -177,3 +177,7 @@ func (s *ClusterResource) GetDownloadContainerSpec() ([]corev1.Container, error)
 func (s *ClusterResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
 	return nil, nil
 }
+
+func (s *ClusterResource) GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -154,3 +154,7 @@ func (s *GCSResource) GetDownloadContainerSpec() ([]corev1.Container, error) {
 func (s *GCSResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
 	return getStorageUploadVolumeSpec(s, spec)
 }
+
+func (s *GCSResource) GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return getStorageUploadVolumeSpec(s, spec)
+}

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -124,3 +124,7 @@ func (s *GitResource) GetUploadContainerSpec() ([]corev1.Container, error) {
 func (s *GitResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
 	return nil, nil
 }
+
+func (s *GitResource) GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/image_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource.go
@@ -105,3 +105,7 @@ func (s ImageResource) String() string {
 func (s *ImageResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
 	return nil, nil
 }
+
+func (s *ImageResource) GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -142,3 +142,7 @@ func (s *PullRequestResource) SetDestinationDirectory(dir string) {
 func (s *PullRequestResource) GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
 	return nil, nil
 }
+
+func (s *PullRequestResource) GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error) {
+	return nil, nil
+}

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -56,6 +56,7 @@ type PipelineResourceInterface interface {
 	GetDownloadContainerSpec() ([]corev1.Container, error)
 	GetUploadContainerSpec() ([]corev1.Container, error)
 	GetUploadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error)
+	GetDownloadVolumeSpec(spec *TaskSpec) ([]corev1.Volume, error)
 	SetDestinationDirectory(string)
 }
 


### PR DESCRIPTION
…ment.

# Changes

This change refactors the way input resources attach volumes to their steps.
Previously, there was a special-cased switch statement for Storage type resources.
This made the logic for resources hard to follow, and spread across the codebase. This
change refactors that by moving it up into the general Resource interface.

This is another follow-on to https://github.com/tektoncd/pipeline/pull/1135

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._