### PR TITLE
Add test for a default empty value parameter.

### DIFF
--- a/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/v1alpha1/taskrun/resources/apply_test.go
@@ -552,6 +552,21 @@ func TestApplyParameters(t *testing.T) {
 		want: applyMutation(simpleTaskSpec, func(spec *v1alpha1.TaskSpec) {
 			spec.Steps[0].Image = "mydefault"
 		}),
+	}, {
+		name: "with empty string default parameter",
+		args: args{
+			ts: simpleTaskSpec,
+			tr: &v1alpha1.TaskRun{},
+			dp: []v1alpha1.ParamSpec{
+				{
+					Name:    "myimage",
+					Default: builder.ArrayOrString(""),
+				},
+			},
+		},
+		want: applyMutation(simpleTaskSpec, func(spec *v1alpha1.TaskSpec) {
+			spec.Steps[0].Image = ""
+		}),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
@vdemeester pointed out that #1080 fixes a previous issue where default
empty string parameters weren't working properly. Add a test to ensure
this new functionality remains.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) **(not user facing)**
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

# Release Notes