### PR TITLE
Parameter variable substitution support for conditionals

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -8,6 +8,7 @@ This document defines `Conditions` and their capabilities.
 
 - [Syntax](#syntax)
   - [Check](#check)
+  - [Parameters](#parameters)
 - [Examples](#examples)
 
 ## Syntax
@@ -32,10 +33,33 @@ following fields:
 ### Check
 
 The `check` field is required. You define a single check to define the body of a `Condition`. The 
-check must specify a container image that adheres to the [container contract](./container-contract.md). The container image 
-runs till completion. The container must exit successfully i.e. with an exit code 0 for the 
-condition evaluation to be successful. All other exit codes are considered to be a condition check
+check must specify a container image that adheres to the [container contract](./container-contract.md). 
+The container image runs till completion. The container must exit successfully i.e. with an exit code 0 
+for the condition evaluation to be successful. All other exit codes are considered to be a condition check
 failure.
+
+### Parameters
+
+A Condition can declare parameters that must be supplied to it during a PipelineRun. Sub-fields
+within the check field can access the parameter values using the templating syntax:
+
+```yaml
+spec:
+  parameters:
+    - name: image
+      default: ubuntu
+  check:
+    image: ${params.image}
+```
+
+Parameters name are limited to alpha-numeric characters, `-` and `_` and can
+only start with alpha characters and `_`. For example, `fooIs-Bar_` is a valid
+parameter name, `barIsBa$` or `0banana` are not.
+ 
+Each declared parameter has a type field, assumed to be string if not provided by the user. 
+The other possible type is array — useful,checking a pushed branch name doesn't match any of 
+multiple protected branch names. When the actual parameter value is supplied, its parsed type 
+is validated against the type field.
 
 ## Examples
 

--- a/examples/pipelineruns/conditional-pipelinerun.yaml
+++ b/examples/pipelineruns/conditional-pipelinerun.yaml
@@ -1,12 +1,17 @@
 apiVersion: tekton.dev/v1alpha1
 kind: Condition
 metadata:
-  name: always-true
+  name: strings-equal
 spec:
+ params:
+   - name: "x"
+     type: string
+   - name: "y"
+     type: string
  check:
     image: alpine
     command: ["/bin/sh"]
-    args: ['-c', 'exit 0']
+    args: ['-c', 'echo "Comparing ${params.x} and ${params.y}" && [ "${params.x}" == "${params.y}" ]']
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -43,12 +48,22 @@ spec:
   resources:
     - name: source-repo
       type: git
+  params:
+    - name: "x"
+      default: "abc"
+    - name: "y"
+      default: "abc"
   tasks:
     - name: list-files-1
       taskRef:
         name: list-files
       conditions:
-        - conditionRef: "always-true"
+        - conditionRef: "strings-equal"
+          params:
+            - name: "x"
+              value: "${params.x}"
+            - name: "y"
+              value: "${params.y}"
       resources:
         inputs:
           - name: workspace

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -633,10 +633,13 @@ func (c *Reconciler) makeConditionCheckContainer(rprt *resources.ResolvedPipelin
 		Spec: v1alpha1.TaskRunSpec{
 			TaskSpec:       rcc.ConditionToTaskSpec(),
 			ServiceAccount: getServiceAccount(pr, rprt.PipelineTask.Name),
-			Timeout:        getTaskRunTimeout(pr),
-			NodeSelector:   pr.Spec.NodeSelector,
-			Tolerations:    pr.Spec.Tolerations,
-			Affinity:       pr.Spec.Affinity,
+			Inputs: v1alpha1.TaskRunInputs{
+				Params: rcc.PipelineTaskCondition.Params,
+			},
+			Timeout:      getTaskRunTimeout(pr),
+			NodeSelector: pr.Spec.NodeSelector,
+			Tolerations:  pr.Spec.Tolerations,
+			Affinity:     pr.Spec.Affinity,
 		}}
 
 	cctr, err := c.PipelineClientSet.TektonV1alpha1().TaskRuns(pr.Namespace).Create(tr)

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/apply.go
@@ -60,14 +60,19 @@ func ApplyReplacements(p *v1alpha1.Pipeline, replacements map[string]string, arr
 	tasks := p.Spec.Tasks
 
 	for i := range tasks {
-		params := tasks[i].Params
-
-		for j := range params {
-			params[j].Value.ApplyReplacements(replacements, arrayReplacements)
+		tasks[i].Params = replaceParamValues(tasks[i].Params, replacements, arrayReplacements)
+		for j := range tasks[i].Conditions {
+			c := tasks[i].Conditions[j]
+			c.Params = replaceParamValues(c.Params, replacements, arrayReplacements)
 		}
-
-		tasks[i].Params = params
 	}
 
 	return p
+}
+
+func replaceParamValues(params []v1alpha1.Param, stringReplacements map[string]string, arrayReplacements map[string][]string) []v1alpha1.Param {
+	for i := range params {
+		params[i].Value.ApplyReplacements(stringReplacements, arrayReplacements)
+	}
+	return params
 }

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution.go
@@ -450,8 +450,8 @@ func resolveConditionChecks(pt *v1alpha1.PipelineTask,
 	taskRunStatus map[string]*v1alpha1.PipelineRunTaskRunStatus,
 	taskRunName string, getTaskRun resources.GetTaskRun, getCondition GetCondition) ([]*ResolvedConditionCheck, error) {
 	rcc := []*ResolvedConditionCheck{}
-	for j := range pt.Conditions {
-		cName := pt.Conditions[j].ConditionRef
+	for _, ptc := range pt.Conditions {
+		cName := ptc.ConditionRef
 		c, err := getCondition(cName)
 		if err != nil {
 			return nil, &ConditionNotFoundError{
@@ -468,9 +468,10 @@ func resolveConditionChecks(pt *v1alpha1.PipelineTask,
 		}
 
 		rcc = append(rcc, &ResolvedConditionCheck{
-			Condition:          c,
-			ConditionCheckName: conditionCheckName,
-			ConditionCheck:     v1alpha1.NewConditionCheck(cctr),
+			Condition:             c,
+			ConditionCheckName:    conditionCheckName,
+			ConditionCheck:        v1alpha1.NewConditionCheck(cctr),
+			PipelineTaskCondition: &ptc,
 		})
 	}
 	return rcc, nil

--- a/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1492,12 +1492,15 @@ func TestResolveConditionChecks(t *testing.T) {
 		},
 		Spec: v1alpha1.TaskRunSpec{},
 	}
+
+	ptc := v1alpha1.PipelineTaskCondition{
+		ConditionRef: "always-true",
+	}
+
 	pts := []v1alpha1.PipelineTask{{
-		Name:    "mytask1",
-		TaskRef: v1alpha1.TaskRef{Name: "task"},
-		Conditions: []v1alpha1.PipelineTaskCondition{{
-			ConditionRef: "always-true",
-		}},
+		Name:       "mytask1",
+		TaskRef:    v1alpha1.TaskRef{Name: "task"},
+		Conditions: []v1alpha1.PipelineTaskCondition{ptc},
 	}}
 	providedResources := map[string]v1alpha1.PipelineResourceRef{}
 
@@ -1529,9 +1532,10 @@ func TestResolveConditionChecks(t *testing.T) {
 				return nil, xerrors.Errorf("getTaskRun called with unexpected name %s", name)
 			},
 			expectedConditionCheck: TaskConditionCheckState{{
-				ConditionCheckName: "pipelinerun-mytask1-9l9zj-always-true-mz4c7",
-				Condition:          &condition,
-				ConditionCheck:     v1alpha1.NewConditionCheck(cc),
+				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-mz4c7",
+				Condition:             &condition,
+				ConditionCheck:        v1alpha1.NewConditionCheck(cc),
+				PipelineTaskCondition: &ptc,
 			}},
 		},
 		{
@@ -1545,8 +1549,9 @@ func TestResolveConditionChecks(t *testing.T) {
 				return nil, xerrors.Errorf("getTaskRun called with unexpected name %s", name)
 			},
 			expectedConditionCheck: TaskConditionCheckState{{
-				ConditionCheckName: "pipelinerun-mytask1-mssqb-always-true-78c5n",
-				Condition:          &condition,
+				ConditionCheckName:    "pipelinerun-mytask1-mssqb-always-true-78c5n",
+				Condition:             &condition,
+				PipelineTaskCondition: &ptc,
 			}},
 		},
 	}
@@ -1626,12 +1631,14 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 		Spec: v1alpha1.TaskRunSpec{},
 	}
 
+	ptc := v1alpha1.PipelineTaskCondition{
+		ConditionRef: "always-true",
+	}
+
 	pts := []v1alpha1.PipelineTask{{
-		Name:    "mytask1",
-		TaskRef: v1alpha1.TaskRef{Name: "task"},
-		Conditions: []v1alpha1.PipelineTaskCondition{{
-			ConditionRef: "always-true",
-		}},
+		Name:       "mytask1",
+		TaskRef:    v1alpha1.TaskRef{Name: "task"},
+		Conditions: []v1alpha1.PipelineTaskCondition{ptc},
 	}}
 	providedResources := map[string]v1alpha1.PipelineResourceRef{}
 
@@ -1674,9 +1681,10 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 		t.Fatalf("Did not expect error when resolving PipelineRun without Conditions: %v", err)
 	}
 	expectedConditionChecks := TaskConditionCheckState{{
-		ConditionCheckName: ccName,
-		Condition:          &condition,
-		ConditionCheck:     v1alpha1.NewConditionCheck(cc),
+		ConditionCheckName:    ccName,
+		Condition:             &condition,
+		ConditionCheck:        v1alpha1.NewConditionCheck(cc),
+		PipelineTaskCondition: &ptc,
 	}}
 
 	if d := cmp.Diff(pipelineState[0].ResolvedConditionChecks, expectedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{})); d != "" {

--- a/pkg/templating/container_replacements.go
+++ b/pkg/templating/container_replacements.go
@@ -1,0 +1,71 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package templating
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+func ApplyContainerReplacements(container *corev1.Container, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+	container.Name = ApplyReplacements(container.Name, stringReplacements)
+	container.Image = ApplyReplacements(container.Image, stringReplacements)
+
+	//Use ApplyArrayReplacements here, as additional args may be added via an array parameter.
+	var newArgs []string
+	for _, a := range container.Args {
+		newArgs = append(newArgs, ApplyArrayReplacements(a, stringReplacements, arrayReplacements)...)
+	}
+	container.Args = newArgs
+
+	for ie, e := range container.Env {
+		container.Env[ie].Value = ApplyReplacements(e.Value, stringReplacements)
+		if container.Env[ie].ValueFrom != nil {
+			if e.ValueFrom.SecretKeyRef != nil {
+				container.Env[ie].ValueFrom.SecretKeyRef.LocalObjectReference.Name = ApplyReplacements(e.ValueFrom.SecretKeyRef.LocalObjectReference.Name, stringReplacements)
+				container.Env[ie].ValueFrom.SecretKeyRef.Key = ApplyReplacements(e.ValueFrom.SecretKeyRef.Key, stringReplacements)
+			}
+			if e.ValueFrom.ConfigMapKeyRef != nil {
+				container.Env[ie].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name = ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name, stringReplacements)
+				container.Env[ie].ValueFrom.ConfigMapKeyRef.Key = ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.Key, stringReplacements)
+			}
+		}
+	}
+
+	for ie, e := range container.EnvFrom {
+		container.EnvFrom[ie].Prefix = ApplyReplacements(e.Prefix, stringReplacements)
+		if e.ConfigMapRef != nil {
+			container.EnvFrom[ie].ConfigMapRef.LocalObjectReference.Name = ApplyReplacements(e.ConfigMapRef.LocalObjectReference.Name, stringReplacements)
+		}
+		if e.SecretRef != nil {
+			container.EnvFrom[ie].SecretRef.LocalObjectReference.Name = ApplyReplacements(e.SecretRef.LocalObjectReference.Name, stringReplacements)
+		}
+	}
+	container.WorkingDir = ApplyReplacements(container.WorkingDir, stringReplacements)
+
+	//Use ApplyArrayReplacements here, as additional commands may be added via an array parameter.
+	var newCommand []string
+	for _, c := range container.Command {
+		newCommand = append(newCommand, ApplyArrayReplacements(c, stringReplacements, arrayReplacements)...)
+	}
+	container.Command = newCommand
+
+	for iv, v := range container.VolumeMounts {
+		container.VolumeMounts[iv].Name = ApplyReplacements(v.Name, stringReplacements)
+		container.VolumeMounts[iv].MountPath = ApplyReplacements(v.MountPath, stringReplacements)
+		container.VolumeMounts[iv].SubPath = ApplyReplacements(v.SubPath, stringReplacements)
+	}
+}

--- a/pkg/templating/container_replacements_test.go
+++ b/pkg/templating/container_replacements_test.go
@@ -1,0 +1,127 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package templating_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/tektoncd/pipeline/pkg/templating"
+)
+
+func TestApplyContainerReplacements(t *testing.T) {
+	replacements := map[string]string{
+		"replace.me": "replaced!",
+	}
+
+	arrayReplacements := map[string][]string{
+		"array.replace.me": {"val1", "val2"},
+	}
+
+	c := corev1.Container{
+		Name:       "${replace.me}",
+		Image:      "${replace.me}",
+		Command:    []string{"${array.replace.me}"},
+		Args:       []string{"${array.replace.me}"},
+		WorkingDir: "${replace.me}",
+		EnvFrom: []corev1.EnvFromSource{{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "${replace.me}",
+				},
+			},
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "${replace.me}",
+				},
+			},
+		}},
+		Env: []corev1.EnvVar{{
+			Name:  "not_me",
+			Value: "${replace.me}",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "${replace.me}",
+					},
+					Key: "${replace.me}",
+				},
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "${replace.me}",
+					},
+					Key: "${replace.me}",
+				},
+			},
+		}},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "${replace.me}",
+			MountPath: "${replace.me}",
+			SubPath:   "${replace.me}",
+		}},
+	}
+
+	expected := corev1.Container{
+		Name:       "replaced!",
+		Image:      "replaced!",
+		Command:    []string{"val1", "val2"},
+		Args:       []string{"val1", "val2"},
+		WorkingDir: "replaced!",
+		EnvFrom: []corev1.EnvFromSource{{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "replaced!",
+				},
+			},
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "replaced!",
+				},
+			},
+		}},
+		Env: []corev1.EnvVar{{
+			Name:  "not_me",
+			Value: "replaced!",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "replaced!",
+					},
+					Key: "replaced!",
+				},
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "replaced!",
+					},
+					Key: "replaced!",
+				},
+			},
+		}},
+		VolumeMounts: []corev1.VolumeMount{{
+			Name:      "replaced!",
+			MountPath: "replaced!",
+			SubPath:   "replaced!",
+		}},
+	}
+	templating.ApplyContainerReplacements(&c, replacements, arrayReplacements)
+	if d := cmp.Diff(expected, c); d != "" {
+		t.Errorf("Container replacements failed: %s", d)
+	}
+
+}

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -21,11 +21,12 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	tb "github.com/tektoncd/pipeline/test/builder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
 func TestPipeline(t *testing.T) {
@@ -38,7 +39,9 @@ func TestPipeline(t *testing.T) {
 		tb.PipelineTask("foo", "banana",
 			tb.PipelineTaskParam("stringparam", "value"),
 			tb.PipelineTaskParam("arrayparam", "array", "value"),
-			tb.PipelineTaskCondition("some-condition-ref"),
+			tb.PipelineTaskCondition("some-condition-ref",
+				tb.PipelineTaskConditionParam("param-name", "param-value"),
+			),
 		),
 		tb.PipelineTask("bar", "chocolate",
 			tb.PipelineTaskRefKind(v1alpha1.ClusterTaskKind),
@@ -80,7 +83,16 @@ func TestPipeline(t *testing.T) {
 					Name:  "arrayparam",
 					Value: *tb.ArrayOrString("array", "value"),
 				}},
-				Conditions: []v1alpha1.PipelineTaskCondition{{ConditionRef: "some-condition-ref"}},
+				Conditions: []v1alpha1.PipelineTaskCondition{{
+					ConditionRef: "some-condition-ref",
+					Params: []v1alpha1.Param{{
+						Name: "param-name",
+						Value: v1alpha1.ArrayOrString{
+							Type:      "string",
+							StringVal: "param-value",
+						},
+					}},
+				}},
 			}, {
 				Name:    "bar",
 				TaskRef: v1alpha1.TaskRef{Name: "chocolate", Kind: v1alpha1.ClusterTaskKind},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add parameter variable substitution support for conditionals 
A Condition's `spec.Check` can refer to its declared parameters using
the ${params.param-name} syntax just like in a Task. Values can be
provided via the pipelinerun's parameters or via default values in the
condition or in the PipelineTaskCondition
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

Part of #1019, #1137 

# Release Notes

```
- Adds the ability to declare and use parameters in a Condition 
whose values can be defined in a pipelinerun. 

```