### PR TITLE
Allow the customization of the storage class for the PVC of pipelines

### DIFF
--- a/config/config-artifact-pvc.yaml
+++ b/config/config-artifact-pvc.yaml
@@ -21,3 +21,5 @@ data:
   # size of the PVC volume
   # size: 5Gi
 
+  # storage class of the PVC volume
+  # storageClassName: storage-class-name

--- a/docs/install.md
+++ b/docs/install.md
@@ -109,6 +109,7 @@ The PVC option can be configured using a ConfigMap with the name
 `config-artifact-pvc` and the following attributes:
 
 - size: the size of the volume (5Gi by default)
+- storageClassName: the storage class of the volume (default storage class by default)
 
 The GCS storage bucket can be configured using a ConfigMap with the name
 `config-artifact-bucket` with the following attributes:

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -41,6 +41,9 @@ const (
 
 	// DefaultPvcSize is the default size of the PVC to create
 	DefaultPvcSize = "5Gi"
+
+	// PvcStorageClassNameKey is the name of the configmap entry that specifies the storage class of the PVC to create
+	PvcStorageClassNameKey = "storageClassName"
 )
 
 // ArtifactStorageInterface is an interface to define the steps to copy
@@ -163,8 +166,10 @@ func createPVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) (*corev1.Persis
 				return nil, xerrors.Errorf("failed to get PVC ConfigMap %s for %q due to error: %w", PvcConfigName, pr.Name, err)
 			}
 			var pvcSizeStr string
+			var pvcStorageClassNameStr string
 			if configMap != nil {
 				pvcSizeStr = configMap.Data[PvcSizeKey]
+				pvcStorageClassNameStr = configMap.Data[PvcStorageClassNameKey]
 			}
 			if pvcSizeStr == "" {
 				pvcSizeStr = DefaultPvcSize
@@ -173,7 +178,14 @@ func createPVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) (*corev1.Persis
 			if err != nil {
 				return nil, xerrors.Errorf("failed to create Persistent Volume spec for %q due to error: %w", pr.Name, err)
 			}
-			pvcSpec := GetPVCSpec(pr, pvcSize)
+			var pvcStorageClassName *string
+			if pvcStorageClassNameStr == "" {
+				pvcStorageClassName = nil
+			} else {
+				pvcStorageClassName = &pvcStorageClassNameStr
+			}
+
+			pvcSpec := GetPVCSpec(pr, pvcSize, pvcStorageClassName)
 			pvc, err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Create(pvcSpec)
 			if err != nil {
 				return nil, xerrors.Errorf("failed to claim Persistent Volume %q due to error: %w", pr.Name, err)
@@ -197,7 +209,7 @@ func deletePVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) error {
 }
 
 // GetPVCSpec returns the PVC to create for a given PipelineRun
-func GetPVCSpec(pr *v1alpha1.PipelineRun, pvcSize resource.Quantity) *corev1.PersistentVolumeClaim {
+func GetPVCSpec(pr *v1alpha1.PipelineRun, pvcSize resource.Quantity, storageClassName *string) *corev1.PersistentVolumeClaim {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       pr.Namespace,
@@ -211,6 +223,7 @@ func GetPVCSpec(pr *v1alpha1.PipelineRun, pvcSize resource.Quantity) *corev1.Per
 					corev1.ResourceStorage: pvcSize,
 				},
 			},
+			StorageClassName: storageClassName,
 		},
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit enables to use storage classes other than the cluster-wide default storage class for the PVC of pipelines. The customization can be defined in the config map config-artifact-pvc.yaml - similar to how the size of the PVC can already be defined. By default, it will fallback to the cluster-wide default storage class. fixes #1101

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Allow the definition of a storage class for the artifact pvc using the ConfigMap `config-artifact-pvc`
```