### PR TITLE
Check parent task's status when calculating pipelinerun status

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -256,3 +256,18 @@ func (pr *PipelineRun) IsCancelled() bool {
 func (pr *PipelineRun) GetRunKey() string {
 	return fmt.Sprintf("%s/%s/%s", pipelineRunControllerName, pr.Namespace, pr.Name)
 }
+
+// IsTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout
+func (pr *PipelineRun) IsTimedOut() bool {
+	pipelineTimeout := pr.Spec.Timeout
+	startTime := pr.Status.StartTime
+
+	if !startTime.IsZero() && pipelineTimeout != nil {
+		timeout := pipelineTimeout.Duration
+		runtime := time.Since(startTime.Time)
+		if runtime > timeout {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/v1alpha1/pipelinerun/pipelinerun.go
@@ -402,7 +402,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 		}
 	}
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)
-	after := resources.GetPipelineConditionStatus(pr.Name, pipelineState, c.Logger, pr.Status.StartTime, pr.Spec.Timeout)
+	after := resources.GetPipelineConditionStatus(pr, pipelineState, c.Logger, d)
 	pr.Status.SetCondition(after)
 	reconciler.EmitEvent(c.Recorder, before, after, pr)
 

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -132,7 +132,7 @@ func TestPipelineRun(t *testing.T) {
 			if _, err := c.TaskClient.Create(task); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", getName(taskName, index), err)
 			}
-			if _, err := c.PipelineClient.Create(getHelloWorldPipelineWithCondition(index, namespace)); err != nil {
+			if _, err := c.PipelineClient.Create(getPipelineWithFailingCondition(index, namespace)); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", getName(pipelineName, index), err)
 			}
 		},
@@ -534,9 +534,10 @@ func assertAnnotationsMatch(t *testing.T, expectedAnnotations, actualAnnotations
 	}
 }
 
-func getHelloWorldPipelineWithCondition(suffix int, namespace string) *v1alpha1.Pipeline {
+func getPipelineWithFailingCondition(suffix int, namespace string) *v1alpha1.Pipeline {
 	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
 		tb.PipelineTask(task1Name, getName(taskName, suffix), tb.PipelineTaskCondition(cond1Name)),
+		tb.PipelineTask("task2", getName(taskName, suffix), tb.RunAfter(task1Name)),
 	))
 }
 


### PR DESCRIPTION
# Changes

Before conditionals, a pipelinerun was marked successful only
if all tasks were successfully run. Now, a pipelinerun is successful
if all tasks were either successfully run or skipped due to a condition
check failure.

Currently while updating status, we only see if a task's own condition
check failed. This is not sufficient if that task (B) is dependent on another
task (A) using `from` or `runAfter`. If A is skipped due to a condition failure,
task B is not scheduled to be execute, and there are no other tasks left to run.
However, the pipeline status is never updated from `Running` to `Successful`.

To fix this, this commit changes the `GetPipelineConditionStatus` function to
recursively look at a task's parent tasks to see if they are skipped. If any single
parent task is skipped, we skip the task. If all tasks in a pipeline are either
successful or skipped, we update the pipeline run status to successful.
 
Fixes #1173

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
