### PR TITLE
Fix nightly script docker push 🤕🐳

### DIFF
--- a/hack/nightly.sh
+++ b/hack/nightly.sh
@@ -21,4 +21,4 @@ set -o pipefail
 export KO_DOCKER_REPO="gcr.io/tekton-nightly"
   # Build the base image for creds-init and git images.
 docker build -t "${KO_DOCKER_REPO}/github.com/tektoncd/pipeline/base" -f images/Dockerfile images/
-docker push "${KO_DOCKER_REPO/github.com/tektoncd/pipeline/base}"
+docker push "${KO_DOCKER_REPO}/github.com/tektoncd/pipeline/base"


### PR DESCRIPTION
# Changes

The bash variable was wrong 😓 — somehow I missed that in the previous fix :man_facepalming: 

/cc @ImJasonH @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
