### PR TITLE
Add links to versioned docs from main README 🔗

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,20 @@ Tekton Pipelines are **Typed**:
 
 - [Installing Tekton Pipelines](docs/install.md)
 - Jump in with [the tutorial!](docs/tutorial.md)
-- [Read about it](/docs/README.md)
-- Look at [some examples](/examples)
+
+### Read the docs
+
+| Version | Docs | Examples |
+| ------- | ---- | -------- |
+| [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
+| [v0.5.2](https://github.com/tektoncd/pipeline/releases/tag/v0.5.2) | [Docs @ v0.5.2](https://github.com/tektoncd/pipeline/tree/v0.5.2/docs#tekton-pipelines) | [Examples @ v0.5.2](https://github.com/tektoncd/pipeline/tree/v0.5.2/examples#examples) |
+| [v0.5.1](https://github.com/tektoncd/pipeline/releases/tag/v0.5.1) | [Docs @ v0.5.1](https://github.com/tektoncd/pipeline/tree/v0.5.1/docs#tekton-pipelines) | [Examples @ v0.5.1](https://github.com/tektoncd/pipeline/tree/v0.5.1/examples#examples) |
+| [v0.5.0](https://github.com/tektoncd/pipeline/releases/tag/v0.5.0) | [Docs @ v0.5.0](https://github.com/tektoncd/pipeline/tree/v0.5.0/docs#tekton-pipelines) | [Examples @ v0.5.0](https://github.com/tektoncd/pipeline/tree/v0.5.0/examples#examples) |
+| [v0.4.0](https://github.com/tektoncd/pipeline/releases/tag/v0.4.0) | [Docs @ v0.4.0](https://github.com/tektoncd/pipeline/tree/v0.4.0/docs#tekton-pipelines) | [Examples @ v0.4.0](https://github.com/tektoncd/pipeline/tree/v0.4.0/examples#examples) |
+| [v0.3.1](https://github.com/tektoncd/pipeline/releases/tag/v0.3.1) | [Docs @ v0.3.1](https://github.com/tektoncd/pipeline/tree/v0.3.1/docs#tekton-pipelines) | [Examples @ v0.3.1](https://github.com/tektoncd/pipeline/tree/v0.3.1/examples#examples) |
+| [v0.3.0](https://github.com/tektoncd/pipeline/releases/tag/v0.3.0) | [Docs @ v0.3.0](https://github.com/tektoncd/pipeline/tree/v0.3.0/docs#tekton-pipelines) | [Examples @ v0.3.0](https://github.com/tektoncd/pipeline/tree/v0.3.0/examples#examples) |
+| [v0.2.0](https://github.com/tektoncd/pipeline/releases/tag/v0.2.0) | [Docs @ v0.2.0](https://github.com/tektoncd/pipeline/tree/v0.2.0/docs#tekton-pipelines) | [Examples @ v0.2.0](https://github.com/tektoncd/pipeline/tree/v0.2.0/examples#examples) |
+| [v0.1.0](https://github.com/tektoncd/pipeline/releases/tag/v0.1.0) | [Docs @ v0.1.0](https://github.com/tektoncd/pipeline/tree/v0.1.0/docs#tekton-pipelines) | [Examples @ v0.1.0](https://github.com/tektoncd/pipeline/tree/v0.1.0/examples#examples) |
 
 _See [our API compatibility policy](api_compatibility_policy.md) for info on the
 stability level of the API._

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -90,6 +90,15 @@ GCP project](https://github.com/tektoncd/plumbing#prow). To release you will wan
    we often just [create the release](#creating-a-new-release) and we skip the bit where we publish
    the ci images (which rarely change anyway). Hashtag lazy manual anti-pattern.
 
+3. Create the new tag and release in GitHub
+   ([see one of way of doing that here](https://github.com/tektoncd/pipeline/issues/530#issuecomment-477409459)).
+   _TODO(#530): Automate as much of this as possible with Tekton._
+
+4. Add an entry to [the README](../README.md) at `HEAD` for docs and examples for the new release
+   ([README.md#read-the-docs](README.md#read-the-docs)).
+
+5. Update the new release in GitHub with the same links to the docs and examples, see
+   [v0.1.0](https://github.com/tektoncd/pipeline/releases/tag/v0.1.0) for example.
 
 ### Run the Pipeline
 


### PR DESCRIPTION
# Changes

For a long time now we've wanted to have versioned docs - the docs you
get when you look at the repo only work for HEAD, which can be different
from our releases.

For example, TWICE today I've seen users try to run our examples with
the new `$()` syntax with `v0.5.2` deployed :( @vdemeester pointed out
we should get versioned docs asap so until we have some cool docs
generated (with versions!) at tekton.dev, I think this might be an okay
stopgap?

This commit adds a table which links to the markdown files associated
with each version. I'm also going to update the releases in GitHub
themselves to contain a link to these docs and examples.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Releases in GitHub now include links to their versioned docs. Links are also found in the README at HEAD.
```