### PR TITLE
Escape label names when writing to disk.

### DIFF
--- a/examples/taskruns/taskrun-github-pr-yaml
+++ b/examples/taskruns/taskrun-github-pr-yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: tekton-pr
+spec:
+  type: pullRequest
+  params:
+  - name: url
+    # I just picked a random PR. The first couple didn't have any interesting comments or labels.
+    value: https://github.com/tektoncd/pipeline/pull/100
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: dump-pr-task
+spec:
+  inputs:
+    resources:
+    - name: pr
+      type: pullRequest
+  steps:
+  - name: dump-workspace
+    image: ubuntu
+    command: ["sh"]
+    args: ["-c", "find $(inputs.resources.pr.path)/* -type f | xargs tail -n +1"]
+  - name: ensure-approved
+    image: ubuntu
+    command: ["/bin/bash"]
+    args:
+    - -c
+    - |
+      if [ -f "$(inputs.resources.pr.path)/labels/approved" ]; then
+        echo "PR is approved!"
+      else
+        echo "PR is not approved!"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: dump-pr-task-run
+spec:
+  inputs:
+    resources:
+    - name: pr
+      resourceRef:
+        name: tekton-pr
+  taskRef:
+    name: dump-pr-task
+---


### PR DESCRIPTION
# Changes

Github/other providers allow labels to contain special characters like /. These
cannot easily be represented as filenames. This commit URL encodes these label
keys, which should provide a safe mechanism for writing these names as files.

I've been unable to find documentation containing an exhaustive list of characters
allowed in labels, but this change works with everything in the Tekton repos.

This PR also includes a sample YAML that ensures a Tekton PR has been approved, which
caught this issue.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

# Release Notes

```
Describe any user facing changes here, or delete this block.

PR filenames are URL-escaped before being written to disk.
```