### PR TITLE
Update v0.6.0 docs to include fixed tutorial 🤒

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Tekton Pipelines are **Typed**:
 | Version | Docs | Examples |
 | ------- | ---- | -------- |
 | [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
-| [v0.6.0](https://github.com/tektoncd/pipeline/releases/tag/v0.6.0) | [Docs @ v0.6.0](https://github.com/tektoncd/pipeline/tree/v0.6.0/docs#tekton-pipelines) | [Examples @ v0.6.0](https://github.com/tektoncd/pipeline/tree/v0.6.0/examples#examples) |
+| [v0.6.0](https://github.com/tektoncd/pipeline/releases/tag/v0.6.0) | [Docs @ v0.6.0](https://github.com/tektoncd/pipeline/tree/release-v0.6.x/docs#tekton-pipelines) | [Examples @ v0.6.0](https://github.com/tektoncd/pipeline/tree/v0.6.0/examples#examples) |
 | [v0.5.2](https://github.com/tektoncd/pipeline/releases/tag/v0.5.2) | [Docs @ v0.5.2](https://github.com/tektoncd/pipeline/tree/v0.5.2/docs#tekton-pipelines) | [Examples @ v0.5.2](https://github.com/tektoncd/pipeline/tree/v0.5.2/examples#examples) |
 | [v0.5.1](https://github.com/tektoncd/pipeline/releases/tag/v0.5.1) | [Docs @ v0.5.1](https://github.com/tektoncd/pipeline/tree/v0.5.1/docs#tekton-pipelines) | [Examples @ v0.5.1](https://github.com/tektoncd/pipeline/tree/v0.5.1/examples#examples) |
 | [v0.5.0](https://github.com/tektoncd/pipeline/releases/tag/v0.5.0) | [Docs @ v0.5.0](https://github.com/tektoncd/pipeline/tree/v0.5.0/docs#tekton-pipelines) | [Examples @ v0.5.0](https://github.com/tektoncd/pipeline/tree/v0.5.0/examples#examples) |


### PR DESCRIPTION
# Changes

In #1199 @moficodes reported that the tutorial wasn't working which was
b/c in #1172 when I updated the braces, I only half updated the tutorial
example. I wanted to fix this for the v0.6.0 docs as well, but since the
released binary and yaml files don't need an update, it didn't make
sense to me to create v0.6.1 for this (and leave the v0.6.0 docs
broken!) so I created a 0.6 branch and cherry picked the docs fix into
it only, and am now updating the README to point at that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).