### PR TITLE
Fix #1211 - Remove reference to yqArg in pipeline tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -370,8 +370,6 @@ spec:
       params:
         - name: path
           value: /workspace/source/examples/microservices/leeroy-web/kubernetes/deployment.yaml #configure: may change according to your source
-        - name: yqArg
-          value: "-d1"
         - name: yamlPathToImage
           value: "spec.template.spec.containers[0].image"
 ```
@@ -395,11 +393,6 @@ spec:
       - name: path
         type: string
         description: Path to the manifest to apply
-      - name: yqArg
-        type: string
-        description:
-          Okay this is a hack, but I didn't feel right hard-coding `-d1` down
-          below
       - name: yamlPathToImage
         type: string
         description:
@@ -411,7 +404,6 @@ spec:
       args:
         - "w"
         - "-i"
-        - "$(inputs.params.yqArg)"
         - "$(inputs.params.path)"
         - "$(inputs.params.yamlPathToImage)"
         - "$(inputs.resources.image.url)"


### PR DESCRIPTION
In the source yaml https://github.com/GoogleContainerTools/skaffold/blob/master/examples/microservices/leeroy-web/kubernetes/deployment.yaml the yaml file changed and removed the first yaml doc for service. 
this change makes the tutorial fail. removing reference to yqArg since deployment.yaml has only one document now.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
docs/tutorial.md
Removed reference to `yqArg` in pipeline tutorial

Fixes issue #1211 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- Bug fixes : the documentation for pipeline tutorial will not work with out this fix

```