### PR TITLE
Correct a small error in tasks.md readme

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -2,7 +2,7 @@
 
 A `Task` (or a [`ClusterTask`](#clustertask)) is a collection of sequential
 steps you would want to run as part of your continuous integration flow. A task
-will run inside a container on your cluster.
+will run inside a pod on your cluster.
 
 A `Task` declares:
 


### PR DESCRIPTION
*Taken from commit message:*

Tasks run steps, which each have specified container images. The
encompassing task, though, is a pod (not a container). 

The first line of the tasks.md readme says that a task runs inside a container, which contradicts my above understanding of Tekton.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added) **No functionality changed/added**
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

# Release Notes