### PR TITLE
Annotate TargetPath and OutputImageDir with omitempty

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -122,10 +122,10 @@ type TaskResource struct {
 	// TargetPath is the path in workspace directory where the task resource
 	// will be copied.
 	// +optional
-	TargetPath string `json:"targetPath"`
+	TargetPath string `json:"targetPath,omitempty"`
 	// Path to the index.json file for output container images.
 	// +optional
-	OutputImageDir string `json:"outputImageDir"`
+	OutputImageDir string `json:"outputImageDir,omitempty"`
 }
 
 // Outputs allow a task to declare what data the Build/Task will be producing,


### PR DESCRIPTION
# Changes

This omits them from YAML output if the value isn't specified. Before
this change, YAMLs would print `outputImageDir: ""` if it was
unspecified.

# Submitter Checklist

- [ y ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ n/a ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ y ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)