### PR TITLE
Remove "Building" status reason

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1363,8 +1363,8 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 	if d := cmp.Diff(newTr.Status.GetCondition(apis.ConditionSucceeded), &apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionUnknown,
-		Message: "Running",
 		Reason:  "Running",
+		Message: "Not all Steps in the Task have finished executing",
 	}, ignoreLastTransitionTime); d != "" {
 		t.Fatalf("-got, +want: %v", d)
 	}

--- a/pkg/status/taskrunpod.go
+++ b/pkg/status/taskrunpod.go
@@ -40,7 +40,7 @@ func UpdateStatusFromPod(taskRun *v1alpha1.TaskRun, pod *corev1.Pod, resourceLis
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
 			Reason:  ReasonRunning,
-			Message: ReasonRunning,
+			Message: "Not all Steps in the Task have finished executing",
 		})
 	}
 
@@ -98,7 +98,7 @@ func updateIncompleteTaskRun(taskRun *v1alpha1.TaskRun, pod *corev1.Pod) {
 		taskRun.Status.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Reason:  ReasonBuilding,
+			Reason:  ReasonRunning,
 			Message: "Not all Steps in the Task have finished executing",
 		})
 	case corev1.PodPending:

--- a/pkg/status/taskrunpod_test.go
+++ b/pkg/status/taskrunpod_test.go
@@ -41,19 +41,13 @@ func TestUpdateStatusFromPod(t *testing.T) {
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionUnknown,
 		Reason:  ReasonRunning,
-		Message: ReasonRunning,
+		Message: "Not all Steps in the Task have finished executing",
 	}
 	conditionTrue := apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionTrue,
 		Reason:  ReasonSucceeded,
 		Message: "All Steps have completed executing",
-	}
-	conditionBuilding := apis.Condition{
-		Type:    apis.ConditionSucceeded,
-		Status:  corev1.ConditionUnknown,
-		Reason:  ReasonBuilding,
-		Message: "Not all Steps in the Task have finished executing",
 	}
 	for _, c := range []struct {
 		desc      string
@@ -176,7 +170,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 		},
 		want: v1alpha1.TaskRunStatus{
 			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionBuilding},
+				Conditions: []apis.Condition{conditionRunning},
 			},
 			Steps: []v1alpha1.StepState{{
 				ContainerState: corev1.ContainerState{
@@ -390,7 +384,7 @@ func TestUpdateStatusFromPod(t *testing.T) {
 		},
 		want: v1alpha1.TaskRunStatus{
 			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionBuilding},
+				Conditions: []apis.Condition{conditionRunning},
 			},
 			Steps: []v1alpha1.StepState{{
 				ContainerState: corev1.ContainerState{

--- a/pkg/status/taskrunreasons.go
+++ b/pkg/status/taskrunreasons.go
@@ -33,10 +33,6 @@ const (
 	// is just starting to be reconciled
 	ReasonRunning = "Running"
 
-	// reasonBuilding indicates that the reason for the in-progress status is that the TaskRun
-	// is just being built
-	ReasonBuilding = "Building"
-
 	// reasonTimedOut indicates that the TaskRun has taken longer than its configured timeout
 	ReasonTimedOut = "TaskRunTimeout"
 


### PR DESCRIPTION
# Changes

This was a vestige of the days when Tekton (née "build pipelines") was
focused on "building" instead of arbitrary "task execution".

Fixes #815 

# Submitter Checklist

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
