### PR TITLE
Provide a way to specify default service accounts

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -37,3 +37,7 @@ data:
     # default-timeout-minutes contains the default number of
     # minutes to use for TaskRun and PipelineRun, if none is specified.
     default-timeout-minutes: "60"  # 60 minutes
+
+    # default-service-account contains the default service account name
+    # to use for TaskRun and PipelineRun, if none is specified.
+    default-service-account: "default"

--- a/docs/install.md
+++ b/docs/install.md
@@ -144,6 +144,25 @@ creation of a persistent volume could be slower than uploading/downloading files
 to a bucket, or if the the cluster is running in multiple zones, the access to
 the persistent volume can fail.
 
+### Overriding  default ServiceAccount used for TaskRun and PipelineRun
+
+The ConfigMap `config-defaults` can be used to override default service account
+e.g. to override the default service account (`default`) to `tekton` apply the
+following
+
+```yaml
+
+### config-defaults.yaml
+apiVersion: v1
+kind: ConfigMap
+data:
+  default-service-account: "tekton"
+
+```
+
+*NOTE:* The `_example` key contains of the keys that can be overriden and their
+default values.
+
 ## Custom Releases
 
 The [release Task](./../tekton/README.md) can be used for creating a custom

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -40,8 +40,9 @@ following fields:
     [`PipelineResources`](resources.md) to use for this `PipelineRun`.
   - [`serviceAccount`](#service-account) - Specifies a `ServiceAccount` resource
     object that enables your build to run with the defined authentication
-    information.
-  - [`serviceAccounts`](#service-accounts) - Specifies a list of `ServiceAccount` 
+    information. When a `ServiceAccount` isn't specified, the `default-service-account`
+    specified in the configmap - config-defaults will be applied.
+  - [`serviceAccounts`](#service-accounts) - Specifies a list of `ServiceAccount`
     and `PipelineTask` pairs that enable you to overwrite `ServiceAccount` for concrete `PipelineTask`.
   - [`timeout`] - Specifies timeout after which the `PipelineRun` will fail. If the value of
     `timeout` is empty, the default timeout will be applied. If the value is set to 0,
@@ -118,10 +119,10 @@ spec:
 Specifies the `name` of a `ServiceAccount` resource object. Use the
 `serviceAccount` field to run your `Pipeline` with the privileges of the
 specified service account. If no `serviceAccount` field is specified, your
-resulting `TaskRuns` run using the
+resulting `TaskRuns` run using the service account specified in the ConfigMap
+`configmap-defaults` which if absent will default to
 [`default` service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server)
-that is in the
-[namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+that is in the [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
 of the `TaskRun` resource object.
 
 For examples and more information about specifying service accounts, see the
@@ -129,8 +130,8 @@ For examples and more information about specifying service accounts, see the
 
 ### Service Accounts
 
-Specifies the list of `ServiceAccount` and `PipelineTask` pairs. Specified 
-`PipelineTask` will be run with configured `ServiceAccount`, 
+Specifies the list of `ServiceAccount` and `PipelineTask` pairs. Specified
+`PipelineTask` will be run with configured `ServiceAccount`,
 overwriting [`serviceAccount`](#service-account) configuration, for example:
 
 ```yaml

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -46,7 +46,8 @@ following fields:
 
   - [`serviceAccount`](#service-account) - Specifies a `ServiceAccount` resource
     object that enables your build to run with the defined authentication
-    information.
+    information. When a `ServiceAccount` isn't specified, the `default-service-account`
+    specified in the configmap - config-defaults will be applied.
   - [`inputs`] - Specifies [input parameters](#input-parameters) and
     [input resources](#providing-resources)
   - [`outputs`] - Specifies [output resources](#providing-resources)
@@ -157,10 +158,10 @@ default, if `default-timeout-minutes` is set to 0.
 Specifies the `name` of a `ServiceAccount` resource object. Use the
 `serviceAccount` field to run your `Task` with the privileges of the specified
 service account. If no `serviceAccount` field is specified, your `Task` runs
-using the
+using the  service account specified in the ConfigMap `configmap-defaults`
+which if absent will default to
 [`default` service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server)
-that is in the
-[namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
+that is in the [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/)
 of the `TaskRun` resource object.
 
 For examples and more information about specifying service accounts, see the

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -30,17 +30,20 @@ const (
 	DefaultTimeoutMinutes    = 60
 	NoTimeoutDuration        = 0 * time.Minute
 	defaultTimeoutMinutesKey = "default-timeout-minutes"
+	defaultServiceAccountKey = "default-service-account"
 )
 
 // Defaults holds the default configurations
 // +k8s:deepcopy-gen=true
 type Defaults struct {
 	DefaultTimeoutMinutes int
+	DefaultServiceAccount string
 }
 
 // Equals returns true if two Configs are identical
 func (cfg *Defaults) Equals(other *Defaults) bool {
-	return other.DefaultTimeoutMinutes == cfg.DefaultTimeoutMinutes
+	return other.DefaultTimeoutMinutes == cfg.DefaultTimeoutMinutes &&
+		other.DefaultServiceAccount == cfg.DefaultServiceAccount
 }
 
 // NewDefaultsFromMap returns a Config given a map corresponding to a ConfigMap
@@ -54,6 +57,10 @@ func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 			return nil, fmt.Errorf("failed parsing tracing config %q", defaultTimeoutMinutesKey)
 		}
 		tc.DefaultTimeoutMinutes = int(timeout)
+	}
+
+	if defaultServiceAccount, ok := cfgMap[defaultServiceAccountKey]; ok {
+		tc.DefaultServiceAccount = defaultServiceAccount
 	}
 
 	return &tc, nil

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -26,6 +26,7 @@ import (
 func TestNewDefaultsFromConfigMap(t *testing.T) {
 	expectedConfig := &Defaults{
 		DefaultTimeoutMinutes: 50,
+		DefaultServiceAccount: "tekton",
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigName, expectedConfig)
 }

--- a/pkg/apis/config/testdata/config-defaults.yaml
+++ b/pkg/apis/config/testdata/config-defaults.yaml
@@ -19,3 +19,4 @@ metadata:
   namespace: tekton-pipelines
 data:
   default-timeout-minutes: "50"
+  default-service-account: "tekton"

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
@@ -42,4 +42,9 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 		}
 		prs.Timeout = timeout
 	}
+
+	defaultSA := cfg.Defaults.DefaultServiceAccount
+	if prs.ServiceAccount == "" && defaultSA != "" {
+		prs.ServiceAccount = defaultSA
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
@@ -123,6 +123,33 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			})
 			return s.ToContext(ctx)
 		},
+	}, {
+		name: "PipelineRef default config context with sa",
+		in: &v1alpha1.PipelineRun{
+			Spec: v1alpha1.PipelineRunSpec{
+				PipelineRef: v1alpha1.PipelineRef{Name: "foo"},
+			},
+		},
+		want: &v1alpha1.PipelineRun{
+			Spec: v1alpha1.PipelineRunSpec{
+				PipelineRef:    v1alpha1.PipelineRef{Name: "foo"},
+				Timeout:        &metav1.Duration{Duration: 5 * time.Minute},
+				ServiceAccount: "tekton",
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.DefaultsConfigName,
+				},
+				Data: map[string]string{
+					"default-timeout-minutes": "5",
+					"default-service-account": "tekton",
+				},
+			})
+			return s.ToContext(ctx)
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -46,4 +46,9 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 		}
 		trs.Timeout = timeout
 	}
+
+	defaultSA := cfg.Defaults.DefaultServiceAccount
+	if trs.ServiceAccount == "" && defaultSA != "" {
+		trs.ServiceAccount = defaultSA
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -146,6 +146,33 @@ func TestTaskRunDefaulting(t *testing.T) {
 			})
 			return s.ToContext(ctx)
 		},
+	}, {
+		name: "TaskRef default config context with SA",
+		in: &v1alpha1.TaskRun{
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{Name: "foo"},
+			},
+		},
+		want: &v1alpha1.TaskRun{
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef:        &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				Timeout:        &metav1.Duration{Duration: 5 * time.Minute},
+				ServiceAccount: "tekton",
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.DefaultsConfigName,
+				},
+				Data: map[string]string{
+					"default-timeout-minutes": "5",
+					"default-service-account": "tekton",
+				},
+			})
+			return s.ToContext(ctx)
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR allows defaults service-account (configurable though the configmap)
to be set  when none is specified in a PipelineRun.

Fixes: #1213
Signed-off-by: Sunil Thaha <sthaha@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [🙅‍♂ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
If pipeline controllers are deployed with a config-map that has `default-service-account` key set to a non-empty string, pipeline-runs that do not specify a ServiceAccount will be modified (mutated) to  the value of the `default-service-account`. 

```