### PR TITLE
Add sidecars to Tasks

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -646,14 +646,6 @@ container which runs alongside your workloads to provide ancillary support.
 Typical examples of the sidecar pattern are logging daemons, services to
 update files on a shared volume, and network proxies.
 
-Tekton doesn't provide a mechanism to specify sidecars for Task steps
-but it's still possible for sidecars to be added to your Pods:
-[Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/)
-provide cluster admins a mechanism to inject sidecar containers as Pods launch.
-As a concrete example this is one possible method [used by Istio](https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#automatic-sidecar-injection)
-to inject an envoy proxy in to pods so that they can be included as part of
-Istio's service mesh.
-
 Tekton will happily work with sidecars injected into a TaskRun's
 pods but the behaviour is a bit nuanced: When TaskRun's steps are complete
 any sidecar containers running inside the Pod will be terminated. In

--- a/examples/taskruns/task-sidecar-dind.yaml
+++ b/examples/taskruns/task-sidecar-dind.yaml
@@ -1,0 +1,40 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: dind-sidecar-taskrun-1
+spec:
+  taskSpec:
+    steps:
+      - image: docker
+        name: client
+        workingDir: /workspace
+        command:
+          - /bin/sh
+          - -c
+          - |
+            cat > Dockerfile << EOF
+            FROM ubuntu
+            RUN apt-get update
+            ENTRYPOINT ["echo", "hello"]
+            EOF
+            docker build -t hello . && docker run hello
+            docker images
+        volumeMounts:
+          - mountPath: /var/run/
+            name: dind-socket
+    sidecars:
+      - image: docker:18.05-dind
+        name: server
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - mountPath: /var/lib/docker
+            name: dind-storage
+          - mountPath: /var/run/
+            name: dind-socket
+
+    volumes:
+      - name: dind-storage
+        emptyDir: {}
+      - name: dind-socket
+        emptyDir: {}

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -56,6 +56,10 @@ type TaskSpec struct {
 	// StepTemplate can be used as the basis for all step containers within the
 	// Task, so that the steps inherit settings on the base container.
 	StepTemplate *corev1.Container `json:"stepTemplate,omitempty"`
+
+	// Sidecars are run alongside the Task's step containers. They begin before
+	// the steps start and end after the steps complete.
+	Sidecars []corev1.Container `json:"sidecars,omitempty"`
 }
 
 // Step embeds the Container type, which allows it to include fields not

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1818,6 +1818,13 @@ func (in *TaskSpec) DeepCopyInto(out *TaskSpec) {
 		*out = new(v1.Container)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Sidecars != nil {
+		in, out := &in.Sidecars, &out.Sidecars
+		*out = make([]v1.Container, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller.go
@@ -89,8 +89,6 @@ func SendCloudEvents(tr *v1alpha1.TaskRun, ceclient CEClient, logger *zap.Sugare
 	}
 	if merr != nil && merr.Len() > 0 {
 		logger.Errorf("Failed to send %d cloud events for TaskRun %s", merr.Len(), tr.Name)
-		// Return all send error
-		return merr
 	}
-	return merr
+	return merr.ErrorOrNil()
 }

--- a/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller_test.go
@@ -114,7 +114,7 @@ func TestSendCloudEvents(t *testing.T) {
 				SendSuccessfully: true,
 			}
 			err := SendCloudEvents(tc.taskRun, NewFakeClient(&successfulBehaviour), logger)
-			if err == nil {
+			if err != nil {
 				t.Fatalf("Unexpected error sending cloud events: %v", err)
 			}
 			opts := GetCloudEventDeliveryCompareOptions()

--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -327,6 +327,9 @@ func MakePod(taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec, kubeclient k
 	for _, s := range mergedPodSteps {
 		mergedPodContainers = append(mergedPodContainers, s.Container)
 	}
+	if len(taskSpec.Sidecars) > 0 {
+		mergedPodContainers = append(mergedPodContainers, taskSpec.Sidecars...)
+	}
 
 	podTemplate := v1alpha1.CombinedPodTemplate(taskRun.Spec.PodTemplate, taskRun.Spec.NodeSelector, taskRun.Spec.Tolerations, taskRun.Spec.Affinity)
 

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -154,6 +154,19 @@ func Step(name, image string, ops ...StepOp) TaskSpecOp {
 	}
 }
 
+func Sidecar(name, image string, ops ...ContainerOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		c := corev1.Container{
+			Name:  name,
+			Image: image,
+		}
+		for _, op := range ops {
+			op(&c)
+		}
+		spec.Sidecars = append(spec.Sidecars, c)
+	}
+}
+
 // TaskStepTemplate adds a base container for all steps in the task.
 func TaskStepTemplate(ops ...ContainerOp) TaskSpecOp {
 	return func(spec *v1alpha1.TaskSpec) {

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -1,0 +1,144 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	sidecarTaskName      = "sidecar-test-task"
+	sidecarTaskRunName   = "sidecar-test-task-run"
+	sidecarContainerName = "sidecar-container"
+	primaryContainerName = "primary"
+)
+
+// TestSidecarTaskSupport checks whether support for sidecars is working
+// as expected by running a Task with a Sidecar defined and confirming
+// that both the primary and sidecar containers terminate.
+func TestSidecarTaskSupport(t *testing.T) {
+	tests := []struct {
+		desc           string
+		stepCommand    []string
+		sidecarCommand []string
+	}{{
+		desc:           "A sidecar that runs forever is terminated when Steps complete",
+		stepCommand:    []string{"echo", "\"hello world\""},
+		sidecarCommand: []string{"sh", "-c", "while [[ true ]] ; do echo \"hello from sidecar\" ; done"},
+	}, {
+		desc:           "A sidecar that terminates early does not cause problems running Steps",
+		stepCommand:    []string{"echo", "\"hello world\""},
+		sidecarCommand: []string{"echo", "\"hello from sidecar\""},
+	}}
+
+	clients, namespace := setup(t)
+
+	for i, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			sidecarTaskName := fmt.Sprintf("%s-%d", sidecarTaskName, i)
+			sidecarTaskRunName := fmt.Sprintf("%s-%d", sidecarTaskRunName, i)
+			task := tb.Task(sidecarTaskName, namespace,
+				tb.TaskSpec(
+					tb.Step(
+						primaryContainerName,
+						"busybox:1.31.0-musl",
+						tb.StepCommand(test.stepCommand...),
+					),
+					tb.Sidecar(
+						sidecarContainerName,
+						"busybox:1.31.0-musl",
+						tb.Command(test.sidecarCommand...),
+					),
+				),
+			)
+
+			taskRun := tb.TaskRun(sidecarTaskRunName, namespace,
+				tb.TaskRunSpec(tb.TaskRunTaskRef(sidecarTaskName),
+					tb.TaskRunTimeout(1*time.Minute),
+				),
+			)
+
+			t.Logf("Creating Task %q", sidecarTaskName)
+			if _, err := clients.TaskClient.Create(task); err != nil {
+				t.Errorf("Failed to create Task %q: %v", sidecarTaskName, err)
+			}
+
+			t.Logf("Creating TaskRun %q", sidecarTaskRunName)
+			if _, err := clients.TaskRunClient.Create(taskRun); err != nil {
+				t.Errorf("Failed to create TaskRun %q: %v", sidecarTaskRunName, err)
+			}
+
+			var podName string
+			if err := WaitForTaskRunState(clients, sidecarTaskRunName, func(tr *v1alpha1.TaskRun) (bool, error) {
+				podName = tr.Status.PodName
+				return TaskRunSucceed(sidecarTaskRunName)(tr)
+			}, "TaskRunSucceed"); err != nil {
+				t.Errorf("Error waiting for TaskRun %q to finish: %v", sidecarTaskRunName, err)
+			}
+
+			if err := WaitForPodState(clients, podName, namespace, func(pod *corev1.Pod) (bool, error) {
+				terminatedCount := 0
+				for _, c := range pod.Status.ContainerStatuses {
+					if c.State.Terminated != nil {
+						terminatedCount++
+					}
+				}
+				return terminatedCount == 2, nil
+			}, "PodContainersTerminated"); err != nil {
+				t.Errorf("Error waiting for Pod %q to terminate both the primary and sidecar containers: %v", podName, err)
+			}
+
+			pod, err := clients.KubeClient.Kube.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("Error getting TaskRun pod: %v", err)
+			}
+
+			primaryTerminated := false
+			sidecarTerminated := false
+
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == fmt.Sprintf("step-%s", primaryContainerName) {
+					if c.State.Terminated == nil || c.State.Terminated.Reason != "Completed" {
+						t.Errorf("Primary container did not terminate as expected, Terminated state: %v", c.State.Terminated)
+					} else {
+						primaryTerminated = true
+					}
+				}
+				if c.Name == sidecarContainerName {
+					if c.State.Terminated == nil || (c.State.Terminated.Reason != "Completed" && c.State.Terminated.Reason != "ContainerCannotRun") {
+						t.Errorf("Sidecar container did not terminate as expected, Terminated state: %v", c.State.Terminated)
+					} else {
+						sidecarTerminated = true
+					}
+				}
+			}
+
+			if !primaryTerminated || !sidecarTerminated {
+				t.Errorf("Either the primary or sidecar containers did not terminate")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Closes https://github.com/tektoncd/pipeline/issues/980

This commit adds user-defined sidecars to the TaskSpec. A sidecar is a
container intended to provide some auxiliary support to a pod's primary
containers. An example usecase is a mock API server for your app to hit
during testing.

This commit doesn't introduce any extra lifecycle management beyond that
added in #936 - sidecars will be stopped without any warning or cleanup
time. At the moment I'm thinking of leaving this as-is until the sidecars
KEP reaches general availability in Kubernetes.

Design doc: https://docs.google.com/document/d/1OiV75sIqwo77QbASiItBVFVsM5gWgxvtpuc4fLcbjBs/edit

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Tasks can now define a list of sidecar containers to run alongside their steps
```