### PR TITLE
Made the digest exporter report image digest if there is only one image.

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -289,9 +289,9 @@ To surface the image digest in the output of the `taskRun` the builder tool
 should produce this information in a
 [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/master/image-layout.md)
 `index.json` file. This file should be placed on a location as specified in the
-task definition under the resource `outputImageDir`. Annotations in `index.json`
-will be ignored, and if there are multiple versions of the image, the latest
-will be used.
+task definition under the resource `outputImageDir`. If there is only one image
+in the `index.json` file, the digest of that image is exported; otherwise, the
+digest of the whole image index would be exported.
 
 For example this build-push task defines the `outputImageDir` for the
 `builtImage` resource in `/workspace/buildImage`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Currently the image digest exporter does not implemented the behavior described
in `resources.md`, which says "if there are multiple versions of the image,
the latest will be used." Instead, it reports the digest of `index.json`, which
is an image index. This behavior introduces a usability issue: one of the major
public container registry --- dockerhub --- does not support OCI image indices,
and there are very few tools (if any) that support converting OCI image indices
to docker manifest lists. E.g., skopeo currently only support pushing an OCI image
index that contain only one image. If the index has more than one images, it
requires the user to specify one:
https://github.com/containers/skopeo/issues/107
https://github.com/containers/image/pull/400

Essentially, these limitations make the image digest exporter less useful. To make
it more usable, the exporter could instead implement the following behavior:

1. If there is only one image in `index.json`, report the image's digest.

2. If there are multiple images, report the digest of the full index.

The advantage of this behavior is that, we can immediately use it (in conjunction
of https://github.com/GoogleContainerTools/kaniko/pull/744), yet if multi-image
manifests are more widely supported in the future, the image digest exporter can
still support that without any modification.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```