### PR TITLE
Use ubuntu images for sidecar tests

### DIFF
--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -64,12 +64,12 @@ func TestSidecarTaskSupport(t *testing.T) {
 				tb.TaskSpec(
 					tb.Step(
 						primaryContainerName,
-						"busybox:1.31.0-musl",
+						"ubuntu",
 						tb.StepCommand(test.stepCommand...),
 					),
 					tb.Sidecar(
 						sidecarContainerName,
-						"busybox:1.31.0-musl",
+						"ubuntu",
 						tb.Command(test.sidecarCommand...),
 					),
 				),


### PR DESCRIPTION
Sidecar tests were failing on our CI when using the busybox images, switching it
to ubuntu image 'fix' it.

I tried a few other way to fix it properly (change the paths, change loop to
sleep infinity etc...) with no success.

Closes #1253

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ✔️   ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ 🤷‍♂ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ✔️  ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


