### PR TITLE
Add namespace to cluster resource.

### DIFF
--- a/cmd/kubeconfigwriter/main.go
+++ b/cmd/kubeconfigwriter/main.go
@@ -81,8 +81,9 @@ func createKubeconfigFile(resource *v1alpha1.ClusterResource, logger *zap.Sugare
 		Password: pass,
 	}
 	context := &clientcmdapi.Context{
-		Cluster:  resource.Name,
-		AuthInfo: resource.Username,
+		Cluster:   resource.Name,
+		AuthInfo:  resource.Username,
+		Namespace: resource.Namespace,
 	}
 	c := clientcmdapi.NewConfig()
 	c.Clusters[resource.Name] = cluster

--- a/cmd/kubeconfigwriter/main.go
+++ b/cmd/kubeconfigwriter/main.go
@@ -81,8 +81,9 @@ func createKubeconfigFile(resource *v1alpha1.ClusterResource, logger *zap.Sugare
 		Password: pass,
 	}
 	context := &clientcmdapi.Context{
-		Cluster:   resource.Name,
-		AuthInfo:  resource.Username,
+		Cluster:  resource.Name,
+		AuthInfo: resource.Username,
+		// Namespace isn't written to kubeconfig if this is empty
 		Namespace: resource.Namespace,
 	}
 	c := clientcmdapi.NewConfig()

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -356,7 +356,7 @@ The Cluster resource has the following parameters:
 -   `url` (required): Host url of the master node
 -   `username` (required): the user with access to the cluster
 -   `password`: to be used for clusters with basic auth
--   `namespace`: The namespace to be given to the target namespace
+-   `namespace`: The namespace to target in the cluster
 -   `token`: to be used for authentication, if present will be used ahead of the
     password
 -   `insecure`: to indicate server should be accessed without verifying the TLS

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -356,6 +356,7 @@ The Cluster resource has the following parameters:
 -   `url` (required): Host url of the master node
 -   `username` (required): the user with access to the cluster
 -   `password`: to be used for clusters with basic auth
+-   `namespace`: The namespace to be given to the target namespace
 -   `token`: to be used for authentication, if present will be used ahead of the
     password
 -   `insecure`: to indicate server should be accessed without verifying the TLS

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -41,8 +41,9 @@ type ClusterResource struct {
 	URL      string `json:"url"`
 	Revision string `json:"revision"`
 	// Server requires Basic authentication
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	Namespace string `json:"namespace"`
 	// Server requires Bearer authentication. This client will not attempt to use
 	// refresh tokens for an OAuth2 flow.
 	// Token overrides userame and password
@@ -74,6 +75,8 @@ func NewClusterResource(r *PipelineResource) (*ClusterResource, error) {
 			clusterResource.Revision = param.Value
 		case strings.EqualFold(param.Name, "Username"):
 			clusterResource.Username = param.Value
+		case strings.EqualFold(param.Name, "Namespace"):
+			clusterResource.Namespace = param.Value
 		case strings.EqualFold(param.Name, "Password"):
 			clusterResource.Password = param.Value
 		case strings.EqualFold(param.Name, "Token"):
@@ -121,15 +124,16 @@ func (s *ClusterResource) GetURL() string {
 // Replacements is used for template replacement on a ClusterResource inside of a Taskrun.
 func (s *ClusterResource) Replacements() map[string]string {
 	return map[string]string{
-		"name":     s.Name,
-		"type":     string(s.Type),
-		"url":      s.URL,
-		"revision": s.Revision,
-		"username": s.Username,
-		"password": s.Password,
-		"token":    s.Token,
-		"insecure": strconv.FormatBool(s.Insecure),
-		"cadata":   string(s.CAData),
+		"name":      s.Name,
+		"type":      string(s.Type),
+		"url":       s.URL,
+		"revision":  s.Revision,
+		"username":  s.Username,
+		"password":  s.Password,
+		"namespace": s.Namespace,
+		"token":     s.Token,
+		"insecure":  strconv.FormatBool(s.Insecure),
+		"cadata":    string(s.CAData),
 	}
 }
 

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -81,6 +81,24 @@ func TestNewClusterResource(t *testing.T) {
 			Insecure: true,
 		},
 	}, {
+		desc: "basic cluster resource with namespace",
+		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+			v1alpha1.PipelineResourceTypeCluster,
+			tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+			tb.PipelineResourceSpecParam("token", "my-token"),
+			tb.PipelineResourceSpecParam("namespace", "my-namespace"),
+		)),
+		want: &v1alpha1.ClusterResource{
+			Name:      "test_cluster_resource",
+			Type:      v1alpha1.PipelineResourceTypeCluster,
+			URL:       "http://10.10.10.10",
+			CAData:    []byte("my-cluster-cert"),
+			Token:     "my-token",
+			Namespace: "my-namespace",
+		},
+	}, {
 		desc: "basic resource with secrets",
 		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -150,7 +150,7 @@ func Test_ClusterResource_GetDownloadSteps(t *testing.T) {
 		Name:    "kubeconfig-9l9zj",
 		Image:   "override-with-kubeconfig-writer:latest",
 		Command: []string{"/ko-app/kubeconfigwriter"},
-		Args:    []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
+		Args:    []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
 		Env: []corev1.EnvVar{{
 			Name: "CADATA",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -132,6 +132,9 @@ func setUp(t *testing.T) {
 				Name:  "Url",
 				Value: "http://10.10.10.10",
 			}, {
+				Name:  "Namespace",
+				Value: "namespace1",
+			}, {
 				Name: "CAdata",
 				// echo "my-ca-cert" | base64
 				Value: "bXktY2EtY2VydAo=",
@@ -639,7 +642,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Image:   "override-with-kubeconfig-writer:latest",
 				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args: []string{
-					"-clusterConfig", `{"name":"cluster3","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":"bXktY2EtY2VydAo=","secrets":null}`,
+					"-clusterConfig", `{"name":"cluster3","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"namespace1","token":"","Insecure":false,"cadata":"bXktY2EtY2VydAo=","secrets":null}`,
 				},
 			}}},
 		},
@@ -681,7 +684,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Image:   "override-with-kubeconfig-writer:latest",
 				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args: []string{
-					"-clusterConfig", `{"name":"cluster2","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`,
+					"-clusterConfig", `{"name":"cluster2","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`,
 				},
 				Env: []corev1.EnvVar{{
 					ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
Signed-off-by: cappyzawa <cappyzawa@yahoo.ne.jp>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

I expect this to reduce args passed to `kubectl apply`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Enable to use `namespace` in ClusterResource params.
```