### PR TITLE
Accept any sidecar termination reason

### DIFF
--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -64,12 +64,12 @@ func TestSidecarTaskSupport(t *testing.T) {
 				tb.TaskSpec(
 					tb.Step(
 						primaryContainerName,
-						"ubuntu",
+						"busybox:1.31.0-musl",
 						tb.StepCommand(test.stepCommand...),
 					),
 					tb.Sidecar(
 						sidecarContainerName,
-						"ubuntu",
+						"busybox:1.31.0-musl",
 						tb.Command(test.sidecarCommand...),
 					),
 				),

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -122,14 +122,14 @@ func TestSidecarTaskSupport(t *testing.T) {
 			for _, c := range pod.Status.ContainerStatuses {
 				if c.Name == fmt.Sprintf("step-%s", primaryContainerName) {
 					if c.State.Terminated == nil || c.State.Terminated.Reason != "Completed" {
-						t.Errorf("Primary container did not terminate as expected, Terminated state: %v", c.State.Terminated)
+						t.Errorf("Primary container has nil Terminated state or did not complete successfully. Actual Terminated state: %v", c.State.Terminated)
 					} else {
 						primaryTerminated = true
 					}
 				}
 				if c.Name == sidecarContainerName {
-					if c.State.Terminated == nil || (c.State.Terminated.Reason != "Completed" && c.State.Terminated.Reason != "ContainerCannotRun") {
-						t.Errorf("Sidecar container did not terminate as expected, Terminated state: %v", c.State.Terminated)
+					if c.State.Terminated == nil {
+						t.Errorf("Sidecar container has a nil Terminated status but non-nil is expected.")
 					} else {
 						sidecarTerminated = true
 					}


### PR DESCRIPTION
# Changes

Fixes #1253

When a sidecar is forcefully exited by the taskrun controller it may
error out. This happens because the sidecar is terminated by having its
image field rewritten to be tekton's nop container. The nop container is
bare bones and probably doesnt contain the entrypoint command configured
for the sidecar. When this occurs the container will exit with an error
of some kind. On GKE this error's Reason is "ContainerCannotRun" but on
MiniShift/OpenShift the error Reason is "Error".

The sidecar e2e test previously required a termination Reason of
`ContainerCannotRun` or `Completed` but this appears to be too rigid.
Instead the test now considers a sidecar that has been terminated for
any reason to be a success.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).