### PR TITLE
Support Condition only resources in PipelineTask

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -46,6 +46,12 @@ func validateDeclaredResources(ps *PipelineSpec) error {
 				required = append(required, output.Resource)
 			}
 		}
+
+		for _, condition := range t.Conditions {
+			for _, cr := range condition.Resources {
+				required = append(required, cr.Resource)
+			}
+		}
 	}
 
 	provided := make([]string, 0, len(ps.Resources))

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -110,9 +110,20 @@ func TestPipelineSpec_Validate(t *testing.T) {
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskInputResource("some-workspace", "great-resource"),
-				tb.PipelineTaskOutputResource("some-image", "wonderful-resource")),
+				tb.PipelineTaskOutputResource("some-image", "wonderful-resource"),
+				tb.PipelineTaskCondition("some-condition",
+					tb.PipelineTaskConditionResource("some-workspace", "great-resource"))),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("wow-image", "wonderful-resource", tb.From("bar"))),
+		)),
+		failureExpected: false,
+	}, {
+		name: "valid condition only resource",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
+			tb.PipelineTask("bar", "bar-task",
+				tb.PipelineTaskCondition("some-condition",
+					tb.PipelineTaskConditionResource("some-workspace", "great-resource"))),
 		)),
 		failureExpected: false,
 	}, {
@@ -219,6 +230,14 @@ func TestPipelineSpec_Validate(t *testing.T) {
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "missing-resource"),
 				tb.PipelineTaskOutputResource("the-magic-resource", "great-resource")),
+		)),
+		failureExpected: true,
+	}, {
+		name: "invalid condition only resource",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("bar", "bar-task",
+				tb.PipelineTaskCondition("some-condition",
+					tb.PipelineTaskConditionResource("some-workspace", "missing-resource"))),
 		)),
 		failureExpected: true,
 	}, {

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -232,7 +232,7 @@ func PipelineTaskCondition(conditionRef string, ops ...PipelineTaskConditionOp) 
 	}
 }
 
-// PipelineTaskCondition adds a parameter to a PipelineTaskCondition
+// PipelineTaskConditionParam adds a parameter to a PipelineTaskCondition
 func PipelineTaskConditionParam(name, val string) PipelineTaskConditionOp {
 	return func(condition *v1alpha1.PipelineTaskCondition) {
 		if condition.Params == nil {
@@ -241,6 +241,19 @@ func PipelineTaskConditionParam(name, val string) PipelineTaskConditionOp {
 		condition.Params = append(condition.Params, v1alpha1.Param{
 			Name:  name,
 			Value: *ArrayOrString(val),
+		})
+	}
+}
+
+// PipelineTaskConditionResource adds a resource to a PipelineTaskCondition
+func PipelineTaskConditionResource(name, resource string) PipelineTaskConditionOp {
+	return func(condition *v1alpha1.PipelineTaskCondition) {
+		if condition.Resources == nil {
+			condition.Resources = []v1alpha1.PipelineConditionResource{}
+		}
+		condition.Resources = append(condition.Resources, v1alpha1.PipelineConditionResource{
+			Name:     name,
+			Resource: resource,
 		})
 	}
 }

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -41,6 +41,7 @@ func TestPipeline(t *testing.T) {
 			tb.PipelineTaskParam("arrayparam", "array", "value"),
 			tb.PipelineTaskCondition("some-condition-ref",
 				tb.PipelineTaskConditionParam("param-name", "param-value"),
+				tb.PipelineTaskConditionResource("some-resource", "my-only-git-resource"),
 			),
 		),
 		tb.PipelineTask("bar", "chocolate",
@@ -91,6 +92,10 @@ func TestPipeline(t *testing.T) {
 							Type:      "string",
 							StringVal: "param-value",
 						},
+					}},
+					Resources: []v1alpha1.PipelineConditionResource{{
+						Name:     "some-resource",
+						Resource: "my-only-git-resource",
 					}},
 				}},
 			}, {


### PR DESCRIPTION
# Changes

This commit fixes the Pipeline validation logic to account
for resources that are declared in a `PipelineTaskCondition` but
not in a `PipelineTask`. Previously, each resource used in a
`PipelineTaskCondition` also had to be declared in the `PipelineTask`.

Fixes #1263

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
