### PR TITLE
Fix and work around timeout handler data races

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -246,7 +246,8 @@ func (pr *PipelineRun) IsCancelled() bool {
 
 // GetRunKey return the pipelinerun key for timeout handler map
 func (pr *PipelineRun) GetRunKey() string {
-	return fmt.Sprintf("%s/%s/%s", pipelineRunControllerName, pr.Namespace, pr.Name)
+	// The address of the pointer is a threadsafe unique identifier for the pipelinerun
+	return fmt.Sprintf("%s/%p", pipelineRunControllerName, pr)
 }
 
 // IsTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -130,13 +131,8 @@ func TestPipelineRunIsCancelled(t *testing.T) {
 }
 
 func TestPipelineRunKey(t *testing.T) {
-	pr := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "prunname",
-			Namespace: "testns",
-		},
-	}
-	expectedKey := "PipelineRun/testns/prunname"
+	pr := tb.PipelineRun("prunname", "testns")
+	expectedKey := fmt.Sprintf("PipelineRun/%p", pr)
 	if pr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, pr.GetRunKey())
 	}

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -291,5 +291,6 @@ func (tr *TaskRun) IsCancelled() bool {
 
 // GetRunKey return the taskrun key for timeout handler map
 func (tr *TaskRun) GetRunKey() string {
-	return fmt.Sprintf("%s/%s/%s", "TaskRun", tr.Namespace, tr.Name)
+	// The address of the pointer is a threadsafe unique identifier for the taskrun
+	return fmt.Sprintf("%s/%p", "TaskRun", tr)
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -112,8 +113,8 @@ func TestTaskRunIsCancelled(t *testing.T) {
 }
 
 func TestTaskRunKey(t *testing.T) {
-	tr := tb.TaskRun("taskrunname", "testns")
-	expectedKey := "TaskRun/testns/taskrunname"
+	tr := tb.TaskRun("taskrunname", "")
+	expectedKey := fmt.Sprintf("TaskRun/%p", tr)
 	if tr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, tr.GetRunKey())
 	}

--- a/test/controller.go
+++ b/test/controller.go
@@ -35,21 +35,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	informersv1alpha1 "github.com/tektoncd/pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
-	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	"knative.dev/pkg/controller"
 )
-
-// GetLogMessages returns a list of all string logs in logs.
-func GetLogMessages(logs *observer.ObservedLogs) []string {
-	messages := []string{}
-	for _, l := range logs.All() {
-		messages = append(messages, l.Message)
-	}
-	return messages
-}
 
 // Data represents the desired state of the system (i.e. existing resources) to seed controllers
 // with.
@@ -86,7 +76,6 @@ type Informers struct {
 // TestAssets holds references to the controller, logs, clients, and informers.
 type TestAssets struct {
 	Controller *controller.Impl
-	Logs       *observer.ObservedLogs
 	Clients    Clients
 }
 


### PR DESCRIPTION
# Changes

This mostly fixes #1124, will still need to update the `gcr.io/tekton-releases/tests/test-runner` to use a newer version of go which can catch this race.

Will re-add logging to the timeout handler in #1307

## Remove logging from timeout handler :pencil2: 

Logging in the timeout handler was added as part of #731 cuz it helped
us debug when the timeout handler didn't work as expected. Unfortunately
it looks like the logger we're using can't be used in multiple go
routines (uber-go/zap#99 may be related).
Removing this logging to fix #1124, hopefully can find a safe way to add
logging back in #1307.

## Make GetRunKey threadsafe :lock: 

GetRunKey is accessed in goroutines via the timeout_handler; accessing
attributes of an object in a goroutine is not threadsafe. This is used
as a key in a map, so for now replacing this with a value that should be
unique but also threadsafe to fix #1124

## Remove unused function :ghost: 

The function `GetLogMessages` isn't used anywhere. I had tried to remove
it to see if it was causing the data race in #1124 - it _isnt_ but still
it's not being used anywhere so why not remove :)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Removes potential race conditions in timeout handler
```