### PR TITLE
Add a warning if git used as an output 🚨

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -217,6 +217,8 @@ the source code to be built by the pipeline. Adding the git resource as an input
 to a Task will clone this repository and allow the Task to perform the required
 actions on the contents of the repo.
 
+_Git resources as outputs will soon not be supported, see https://github.com/tektoncd/pipeline/pull/1109._
+
 To create a git resource using the `PipelineResource` CRD:
 
 ```yaml

--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -81,6 +81,10 @@ func AddOutputResources(
 			return nil, xerrors.Errorf("failed to get output pipeline Resource for task %q resource %v", taskName, boundResource)
 		}
 
+		if resource.GetType() == v1alpha1.PipelineResourceTypeGit {
+			logger.Warn("The Task %s uses a git output: in the next release, support for git outputs will be removed (See #1109)")
+		}
+
 		var sourcePath string
 		if output.TargetPath == "" {
 			sourcePath = filepath.Join(outputDir, boundResource.Name)


### PR DESCRIPTION
# Changes

In #1109 we will be removing support for git as an output. In the
current implementation, git as an output is just a volume that holds the
data from the git repo, and copies it between Tasks (when git as an
output is linked to git as an input). As discussed in #1076, the model
we want for PipelineResources is for them to take the outside world and
represent it on disk when used as an input, and when used as an output,
to update the outside world. In order to do this, what we actually want for a
git output is for it to create a commit the repo it is referencing.
However up until this point folks have been using git resources in the
way that we want Volume Resources to behave #1062, so we want to
transition folks to Volume Resources and away from using git outputs.

Fixes #1283

Since the way for ppl to handle this would be to migrate to the Volume Resource, we can't really merge this until we merge #1062:

/hold

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Backwards compatibility warning:
🚨 Support for the Git Resource as an output will be removed 🚨
Transition to using the Volume Resource (#1062) instead
```