### PR TITLE
Remove support for ${} syntax 🗑️

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -91,9 +91,7 @@ parameters can be passed to the `Pipeline` from a `PipelineRun`.
 
 Input parameters in the form of `$(params.foo)` are replaced inside of the
 [`PipelineTask` parameters' values](#pipeline-tasks) (see also
-[variable substitution](tasks.md#variable-substitution)). _As with
-[variable substitution](tasks.md#variable-substitution), the deprecated syntax
-`${params.foo}` will be supported until [#1170](https://github.com/tektoncd/pipeline/issues/1170)._
+[variable substitution](tasks.md#variable-substitution)).
 
 The following `Pipeline` declares an input parameter called 'context', and uses
 it in the `PipelineTask`'s parameter. The `description` and `default` fields for

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -86,9 +86,6 @@ The `path` key is pre-defined and refers to the local path to a resource on the 
 $(inputs.resouces.<name>.path)
 ```
 
-_The deprecated syntax `${}`, e.g. `${inputs.params.<name>}` will be supported
-until [#1170](https://github.com/tektoncd/pipeline/issues/1170)._
-
 ### Controlling where resources are mounted
 
 The optional field `targetPath` can be used to initialize a resource in specific

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -400,9 +400,6 @@ $(inputs.params.<name>)
 
 Param values from resources can also be accessed using [variable substitution](./resources.md#variable-substitution)
 
-_The deprecated syntax `${}`, e.g. `${inputs.params.<name>}` will be supported
-until [#1170](https://github.com/tektoncd/pipeline/issues/1170)._
-
 #### Variable Substitution with Parameters of Type `Array`
 
 Referenced parameters of type `array` will expand to insert the array elements in the reference string's spot.

--- a/pkg/apis/pipeline/v1alpha1/param_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/param_types_test.go
@@ -128,42 +128,6 @@ func TestArrayOrString_ApplyReplacements(t *testing.T) {
 			arrayReplacements:  map[string][]string{"arraykey": {}},
 		},
 		expectedOutput: builder.ArrayOrString("firstvalue", "lastvalue"),
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated string replacements on string",
-		args: args{
-			input:              builder.ArrayOrString("astring${some} asdf ${anotherkey}"),
-			stringReplacements: map[string]string{"some": "value", "anotherkey": "value"},
-			arrayReplacements:  map[string][]string{"arraykey": {"array", "value"}, "sdfdf": {"asdf", "sdfsd"}},
-		},
-		expectedOutput: builder.ArrayOrString("astringvalue asdf value"),
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated single array replacement",
-		args: args{
-			input:              builder.ArrayOrString("firstvalue", "${arraykey}", "lastvalue"),
-			stringReplacements: map[string]string{"some": "value", "anotherkey": "value"},
-			arrayReplacements:  map[string][]string{"arraykey": {"array", "value"}, "sdfdf": {"asdf", "sdfsd"}},
-		},
-		expectedOutput: builder.ArrayOrString("firstvalue", "array", "value", "lastvalue"),
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated multiple array replacement",
-		args: args{
-			input:              builder.ArrayOrString("firstvalue", "${arraykey}", "lastvalue", "${sdfdf}"),
-			stringReplacements: map[string]string{"some": "value", "anotherkey": "value"},
-			arrayReplacements:  map[string][]string{"arraykey": {"array", "value"}, "sdfdf": {"asdf", "sdfsd"}},
-		},
-		expectedOutput: builder.ArrayOrString("firstvalue", "array", "value", "lastvalue", "asdf", "sdfsd"),
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated empty array replacement",
-		args: args{
-			input:              builder.ArrayOrString("firstvalue", "${arraykey}", "lastvalue"),
-			stringReplacements: map[string]string{"some": "value", "anotherkey": "value"},
-			arrayReplacements:  map[string][]string{"arraykey": {}},
-		},
-		expectedOutput: builder.ArrayOrString("firstvalue", "lastvalue"),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -153,35 +153,6 @@ func TestPipelineSpec_Validate(t *testing.T) {
 		)),
 		failureExpected: false,
 	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated valid parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeString),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "${baz} and ${foo-is-baz}")),
-		)),
-		failureExpected: false,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated valid array parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "${baz}", "and", "${foo-is-baz}")),
-		)),
-		failureExpected: false,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated pipeline parameter nested in task parameter",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "${input.workspace.${baz}}")),
-		)),
-		failureExpected: false,
-	}, {
 		name: "duplicate tasks",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
@@ -303,67 +274,6 @@ func TestPipelineSpec_Validate(t *testing.T) {
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz)", "last")),
-		)),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated not defined parameter variable",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskParam("a-param", "${params.does-not-exist}")))),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "not defined parameter variable with defined",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("foo", v1alpha1.ParamTypeString, tb.ParamSpecDefault("something")),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskParam("a-param", "${params.foo} and ${params.does-not-exist}")))),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated invalid parameter type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", "invalidtype", tb.ParamSpecDefault("some", "default")),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "${baz}", "and", "${foo-is-baz}")),
-		)),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated array parameter mismatching default type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("astring")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "arrayelement", "${baz}")),
-		)),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated string parameter mismatching default type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "arrayelement", "${baz}")),
-		)),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated array parameter used as string",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "${params.baz}")),
-		)),
-		failureExpected: true,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated array parameter string template not isolated",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "first", "value: ${params.baz}", "last")),
 		)),
 		failureExpected: true,
 	}, {

--- a/pkg/apis/pipeline/v1alpha1/step_replacements_test.go
+++ b/pkg/apis/pipeline/v1alpha1/step_replacements_test.go
@@ -34,45 +34,45 @@ func TestApplyStepReplacements(t *testing.T) {
 	}
 
 	s := v1alpha1.Step{Container: corev1.Container{
-		Name:       "${replace.me}",
-		Image:      "${replace.me}",
-		Command:    []string{"${array.replace.me}"},
-		Args:       []string{"${array.replace.me}"},
-		WorkingDir: "${replace.me}",
+		Name:       "$(replace.me)",
+		Image:      "$(replace.me)",
+		Command:    []string{"$(array.replace.me)"},
+		Args:       []string{"$(array.replace.me)"},
+		WorkingDir: "$(replace.me)",
 		EnvFrom: []corev1.EnvFromSource{{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "${replace.me}",
+					Name: "$(replace.me)",
 				},
 			},
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "${replace.me}",
+					Name: "$(replace.me)",
 				},
 			},
 		}},
 		Env: []corev1.EnvVar{{
 			Name:  "not_me",
-			Value: "${replace.me}",
+			Value: "$(replace.me)",
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "${replace.me}",
+						Name: "$(replace.me)",
 					},
-					Key: "${replace.me}",
+					Key: "$(replace.me)",
 				},
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "${replace.me}",
+						Name: "$(replace.me)",
 					},
-					Key: "${replace.me}",
+					Key: "$(replace.me)",
 				},
 			},
 		}},
 		VolumeMounts: []corev1.VolumeMount{{
-			Name:      "${replace.me}",
-			MountPath: "${replace.me}",
-			SubPath:   "${replace.me}",
+			Name:      "$(replace.me)",
+			MountPath: "$(replace.me)",
+			SubPath:   "$(replace.me)",
 		}},
 	}}
 
@@ -126,7 +126,7 @@ func TestApplyStepReplacements(t *testing.T) {
 
 func TestApplyStepReplacements_NotDefined(t *testing.T) {
 	s := v1alpha1.Step{Container: corev1.Container{
-		Name: "${params.not.defined}",
+		Name: "$(params.not.defined)",
 	}}
 	replacements := map[string]string{
 		"replace.me": "replaced!",
@@ -137,7 +137,7 @@ func TestApplyStepReplacements_NotDefined(t *testing.T) {
 	}
 
 	expected := v1alpha1.Step{Container: corev1.Container{
-		Name: "${params.not.defined}",
+		Name: "$(params.not.defined)",
 	}}
 	v1alpha1.ApplyStepReplacements(&s, replacements, arrayReplacements)
 	if d := cmp.Diff(s, expected); d != "" {

--- a/pkg/apis/pipeline/v1alpha1/substitution_test.go
+++ b/pkg/apis/pipeline/v1alpha1/substitution_test.go
@@ -109,82 +109,6 @@ func TestValidateVariables(t *testing.T) {
 			Message: `non-existent variable in "--flag=$(inputs.params.baz) $(input.params.foo)" for step somefield`,
 			Paths:   []string{"taskspec.steps.somefield"},
 		},
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated valid variable",
-		args: args{
-			input:         "--flag=${inputs.params.baz}",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
-			vars: map[string]struct{}{
-				"baz": {},
-			},
-		},
-		expectedError: nil,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated multiple variables",
-		args: args{
-			input:         "--flag=${inputs.params.baz} ${input.params.foo}",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
-			vars: map[string]struct{}{
-				"baz": {},
-				"foo": {},
-			},
-		},
-		expectedError: nil,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated different context and prefix",
-		args: args{
-			input:        "--flag=${something.baz}",
-			prefix:       "something",
-			locationName: "step",
-			path:         "taskspec.steps",
-			vars: map[string]struct{}{
-				"baz": {},
-			},
-		},
-		expectedError: nil,
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated undefined variable",
-		args: args{
-			input:         "--flag=${inputs.params.baz}",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
-			vars: map[string]struct{}{
-				"foo": {},
-			},
-		},
-		expectedError: &apis.FieldError{
-			Message: `non-existent variable in "--flag=${inputs.params.baz}" for step somefield`,
-			Paths:   []string{"taskspec.steps.somefield"},
-		},
-	}, {
-		// TODO(#1170): Remove support for ${} syntax
-		name: "deprecated undefined variable and defined variable",
-		args: args{
-			input:         "--flag=${inputs.params.baz} ${input.params.foo}",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
-			vars: map[string]struct{}{
-				"foo": {},
-			},
-		},
-		expectedError: &apis.FieldError{
-			Message: `non-existent variable in "--flag=${inputs.params.baz} ${input.params.foo}" for step somefield`,
-			Paths:   []string{"taskspec.steps.somefield"},
-		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := v1alpha1.ValidateVariable("somefield", tc.args.input, tc.args.prefix, tc.args.contextPrefix, tc.args.locationName, tc.args.path, tc.args.vars)
@@ -217,7 +141,7 @@ func TestApplyReplacements(t *testing.T) {
 		{
 			name: "single replacement requested",
 			args: args{
-				input:        "this is ${a} string",
+				input:        "this is $(a) string",
 				replacements: map[string]string{"a": "not a"},
 			},
 			expectedOutput: "this is not a string",
@@ -225,7 +149,7 @@ func TestApplyReplacements(t *testing.T) {
 		{
 			name: "single replacement requested multiple matches",
 			args: args{
-				input:        "this ${is} a string ${is} a string",
+				input:        "this $(is) a string $(is) a string",
 				replacements: map[string]string{"is": "a"},
 			},
 			expectedOutput: "this a a string a a string",
@@ -233,7 +157,7 @@ func TestApplyReplacements(t *testing.T) {
 		{
 			name: "multiple replacements requested",
 			args: args{
-				input:        "this ${is} a ${string} ${is} a ${string}",
+				input:        "this $(is) a $(string) $(is) a $(string)",
 				replacements: map[string]string{"is": "a", "string": "sstring"},
 			},
 			expectedOutput: "this a a sstring a a sstring",
@@ -286,7 +210,7 @@ func TestApplyArrayReplacements(t *testing.T) {
 	}, {
 		name: "multiple replacements only string replacement possible",
 		args: args{
-			input:              "${string}rep${lacement}${string}",
+			input:              "$(string)rep$(lacement)$(string)",
 			stringReplacements: map[string]string{"string": "word", "lacement": "lacements"},
 			arrayReplacements:  map[string][]string{"ace": {"replacement", "a"}, "string": {"1", "2"}},
 		},
@@ -294,7 +218,7 @@ func TestApplyArrayReplacements(t *testing.T) {
 	}, {
 		name: "array replacement",
 		args: args{
-			input:              "${match}",
+			input:              "$(match)",
 			stringReplacements: map[string]string{"string": "word", "lacement": "lacements"},
 			arrayReplacements:  map[string][]string{"ace": {"replacement", "a"}, "match": {"1", "2"}},
 		},

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -39,8 +39,7 @@ func TestApplyParameters(t *testing.T) {
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
 				tb.PipelineTask("first-task-1", "first-task",
 					tb.PipelineTaskParam("first-task-first-param", "$(params.first-param)"),
-					// TODO(#1170): Remove support for ${} syntax
-					tb.PipelineTaskParam("first-task-second-param", "${params.second-param}"),
+					tb.PipelineTaskParam("first-task-second-param", "$(params.second-param)"),
 					tb.PipelineTaskParam("first-task-third-param", "static value"),
 				))),
 		run: tb.PipelineRun("test-pipeline-run", "foo",
@@ -63,8 +62,7 @@ func TestApplyParameters(t *testing.T) {
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineTask("first-task-1", "first-task",
 					tb.PipelineTaskParam("first-task-first-param", "$(input.workspace.$(params.first-param))"),
-					// TODO(#1170): Remove support for ${} syntax
-					tb.PipelineTaskParam("first-task-second-param", "${input.workspace.${params.second-param}}"),
+					tb.PipelineTaskParam("first-task-second-param", "$(input.workspace.$(params.second-param))"),
 				))),
 		run: tb.PipelineRun("test-pipeline-run", "foo",
 			tb.PipelineRunSpec("test-pipeline")),
@@ -74,7 +72,7 @@ func TestApplyParameters(t *testing.T) {
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineTask("first-task-1", "first-task",
 					tb.PipelineTaskParam("first-task-first-param", "$(input.workspace.default-value)"),
-					tb.PipelineTaskParam("first-task-second-param", "${input.workspace.default-value}"),
+					tb.PipelineTaskParam("first-task-second-param", "$(input.workspace.default-value)"),
 				))),
 	}, {
 		name: "parameters in task condition",
@@ -85,8 +83,7 @@ func TestApplyParameters(t *testing.T) {
 				tb.PipelineTask("first-task-1", "first-task",
 					tb.PipelineTaskCondition("task-condition",
 						tb.PipelineTaskConditionParam("cond-first-param", "$(params.first-param)"),
-						// TODO(#1170): Remove support for ${} syntax
-						tb.PipelineTaskConditionParam("cond-second-param", "${params.second-param}"),
+						tb.PipelineTaskConditionParam("cond-second-param", "$(params.second-param)"),
 					),
 				))),
 		run: tb.PipelineRun("test-pipeline-run", "foo",
@@ -114,8 +111,7 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-first-param", "firstelement", "$(params.first-param)"),
 					tb.PipelineTaskParam("first-task-second-param", "first", "$(params.second-param)"),
 					tb.PipelineTaskParam("first-task-third-param", "static value"),
-					// TODO(#1170): Remove support for ${} syntax
-					tb.PipelineTaskParam("first-task-fourth-param", "first", "${params.fourth-param}"),
+					tb.PipelineTaskParam("first-task-fourth-param", "first", "$(params.fourth-param)"),
 				))),
 		run: tb.PipelineRun("test-pipeline-run", "foo",
 			tb.PipelineRunSpec("test-pipeline",

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -107,9 +107,9 @@ func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() (*v1alpha1.TaskSpec, er
 		})
 	}
 
-	// convert param strings of type ${params.x} to ${inputs.params.x}
+	// convert param strings of type $(params.x) to $(inputs.params.x)
 	convertParamTemplates(&t.Steps[0], rcc.Condition.Spec.Params)
-	// convert resource strings of type ${resources.name.key} to ${inputs.resources.name.key}
+	// convert resource strings of type $(resources.name.key) to $(inputs.resources.name.key)
 	err := ApplyResourceSubstitution(&t.Steps[0], rcc.ResolvedResources, rcc.Condition.Spec.Resources)
 
 	if err != nil {
@@ -119,7 +119,7 @@ func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() (*v1alpha1.TaskSpec, er
 	return t, nil
 }
 
-// Replaces all instances of ${params.x} in the container to ${inputs.params.x} for each param name
+// Replaces all instances of $(params.x) in the container to $(inputs.params.x) for each param name
 func convertParamTemplates(step *v1alpha1.Step, params []v1alpha1.ParamSpec) {
 	replacements := make(map[string]string)
 	for _, p := range params {

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -55,20 +55,17 @@ var simpleTaskSpec = &v1alpha1.TaskSpec{
 		Image: "quux",
 		Args:  []string{"$(outputs.resources.imageToUse.url)"},
 	}}, {Container: corev1.Container{
-		Name: "foo",
-		// TODO(#1170): Remove support for ${} syntax
-		Image: "${inputs.params.myimage}",
+		Name:  "foo",
+		Image: "$(inputs.params.myimage)",
 	}}, {Container: corev1.Container{
-		Name:  "baz",
-		Image: "bat",
-		// TODO(#1170): Remove support for ${} syntax
-		WorkingDir: "${inputs.resources.workspace.path}",
-		Args:       []string{"${inputs.resources.workspace.url}"},
+		Name:       "baz",
+		Image:      "bat",
+		WorkingDir: "$(inputs.resources.workspace.path)",
+		Args:       []string{"$(inputs.resources.workspace.url)"},
 	}}, {Container: corev1.Container{
 		Name:  "qux",
 		Image: "quux",
-		// TODO(#1170): Remove support for ${} syntax
-		Args: []string{"${outputs.resources.imageToUse.url}"},
+		Args:  []string{"$(outputs.resources.imageToUse.url)"},
 	}}},
 }
 
@@ -88,12 +85,11 @@ var envTaskSpec = &v1alpha1.TaskSpec{
 				},
 			},
 		}, {
-			// TODO(#1170): Remove support for ${} syntax
 			Name: "baz",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{Name: "secret-${inputs.params.FOO}"},
-					Key:                  "secret-key-${inputs.params.FOO}",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "secret-$(inputs.params.FOO)"},
+					Key:                  "secret-key-$(inputs.params.FOO)",
 				},
 			},
 		}},
@@ -103,10 +99,9 @@ var envTaskSpec = &v1alpha1.TaskSpec{
 				LocalObjectReference: corev1.LocalObjectReference{Name: "config-$(inputs.params.FOO)"},
 			},
 		}, {
-			// TODO(#1170): Remove support for ${} syntax
-			Prefix: "prefix-1-${inputs.params.FOO}",
+			Prefix: "prefix-1-$(inputs.params.FOO)",
 			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{Name: "secret-${inputs.params.FOO}"},
+				LocalObjectReference: corev1.LocalObjectReference{Name: "secret-$(inputs.params.FOO)"},
 			},
 		}},
 	}}},
@@ -737,11 +732,10 @@ func TestVolumeReplacement(t *testing.T) {
 			}},
 		},
 	}, {
-		// TODO(#1170): Remove support for ${} syntax
 		name: "deprecated volume replacement",
 		ts: &v1alpha1.TaskSpec{
 			Volumes: []corev1.Volume{{
-				Name: "${foo}",
+				Name: "$(foo)",
 			}},
 		},
 		repl: map[string]string{"foo": "bar"},
@@ -751,15 +745,14 @@ func TestVolumeReplacement(t *testing.T) {
 			}},
 		},
 	}, {
-		// TODO(#1170): Remove support for ${} syntax
 		name: "deprecated volume configmap",
 		ts: &v1alpha1.TaskSpec{
 			Volumes: []corev1.Volume{{
-				Name: "${name}",
+				Name: "$(name)",
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "${configmapname}",
+							Name: "$(configmapname)",
 						},
 					},
 				}},
@@ -782,14 +775,13 @@ func TestVolumeReplacement(t *testing.T) {
 			},
 		},
 	}, {
-		// TODO(#1170): Remove support for ${} syntax
 		name: "deprecated volume secretname",
 		ts: &v1alpha1.TaskSpec{
 			Volumes: []corev1.Volume{{
-				Name: "${name}",
+				Name: "$(name)",
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "${secretname}",
+						SecretName: "$(secretname)",
 					},
 				}},
 			},
@@ -809,14 +801,13 @@ func TestVolumeReplacement(t *testing.T) {
 			},
 		},
 	}, {
-		// TODO(#1170): Remove support for ${} syntax
 		name: "deprecated volume PVC name",
 		ts: &v1alpha1.TaskSpec{
 			Volumes: []corev1.Volume{{
-				Name: "${name}",
+				Name: "$(name)",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "${FOO}",
+						ClaimName: "$(FOO)",
 					},
 				},
 			}},

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -122,8 +122,7 @@ var (
 			"--my-arg=$(inputs.params.myarg)",
 			"--my-arg-with-default=$(inputs.params.myarghasdefault)",
 			"--my-arg-with-default2=$(inputs.params.myarghasdefault2)",
-			// TODO(#1170): Remove support for ${} syntax
-			"--my-additional-arg=${outputs.resources.myimage.url}",
+			"--my-additional-arg=$(outputs.resources.myimage.url)",
 		)),
 		tb.Step("myothercontainer", "myotherimage", tb.StepCommand("/mycmd"), tb.StepArgs(
 			"--my-other-arg=$(inputs.resources.workspace.url)",

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -56,7 +56,7 @@ func TestDAGPipelineRun(t *testing.T) {
 		),
 		tb.TaskOutputs(tb.OutputsResource("repo", v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("echo-text", "busybox", tb.StepCommand("echo"), tb.StepArgs("$(inputs.params.text)")),
-		tb.Step("ln", "busybox", tb.StepCommand("ln"), tb.StepArgs("-s", "${inputs.resources.repo.path}", "${outputs.resources.repo.path}")),
+		tb.Step("ln", "busybox", tb.StepCommand("ln"), tb.StepArgs("-s", "$(inputs.resources.repo.path)", "$(outputs.resources.repo.path)")),
 	))
 	if _, err := c.TaskClient.Create(echoTask); err != nil {
 		t.Fatalf("Failed to create echo Task: %s", err)

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -100,8 +100,7 @@ func TestPipelineRun(t *testing.T) {
 				// Reference build: https://github.com/knative/build/tree/master/test/docker-basic
 				tb.Step("config-docker", "quay.io/rhpipeline/skopeo:alpine",
 					tb.StepCommand("skopeo"),
-					// TODO(#1170): This test is using a mix of ${} and $() syntax to make sure both work.
-					tb.StepArgs("copy", "${inputs.params.path}", "$(inputs.params.dest)"),
+					tb.StepArgs("copy", "$(inputs.params.path)", "$(inputs.params.dest)"),
 				),
 			))
 			if _, err := c.TaskClient.Create(task); err != nil {
@@ -234,9 +233,7 @@ func getHelloWorldPipelineWithSingularTask(suffix int, namespace string) *v1alph
 		tb.PipelineParamSpec("path", v1alpha1.ParamTypeString),
 		tb.PipelineParamSpec("dest", v1alpha1.ParamTypeString),
 		tb.PipelineTask(task1Name, getName(taskName, suffix),
-			tb.PipelineTaskParam("path", "${params.path}"),
-			// TODO(#1170): This test is using a mix of ${} and $() syntax to make sure both work.
-			// In the next release we will remove support for $() entirely.
+			tb.PipelineTaskParam("path", "$(params.path)"),
 			tb.PipelineTaskParam("dest", "$(params.dest)")),
 	))
 }
@@ -254,18 +251,14 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo stuff > $(outputs.resources.workspace.path)/stuff"),
 			),
 			tb.Step("write-data-task-0-step-1", "ubuntu", tb.StepCommand("/bin/bash"),
-				// TODO(#1170): This test is using a mix of ${} and $() syntax to make sure both work.
-				// In the next release we will remove support for $() entirely.
-				tb.StepArgs("-c", "echo other > ${outputs.resources.workspace.path}/other"),
+				tb.StepArgs("-c", "echo other > $(outputs.resources.workspace.path)/other"),
 			),
 		)),
 		tb.Task("check-create-files-exists", namespace, tb.TaskSpec(
 			tb.TaskInputs(inWorkspaceResource),
 			tb.TaskOutputs(outWorkspaceResource),
 			tb.Step("read-from-task-0", "ubuntu", tb.StepCommand("/bin/bash"),
-				// TODO(#1170): This test is using a mix of ${} and $() syntax to make sure both work.
-				// In the next release we will remove support for $() entirely.
-				tb.StepArgs("-c", "[[ stuff == $(cat ${inputs.resources.workspace.path}/stuff) ]]"),
+				tb.StepArgs("-c", "[[ stuff == $(cat $(inputs.resources.workspace.path)/stuff) ]]"),
 			),
 			tb.Step("write-data-task-1", "ubuntu", tb.StepCommand("/bin/bash"),
 				tb.StepArgs("-c", "echo something > $(outputs.resources.workspace.path)/something"),
@@ -289,9 +282,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "[[ something == $(cat $(inputs.resources.workspace.path)/something) ]]"),
 			),
 			tb.Step("read-from-task-1", "ubuntu", tb.StepCommand("/bin/bash"),
-				// TODO(#1170): This test is using a mix of ${} and $() syntax to make sure both work.
-				// In the next release we will remove support for $() entirely.
-				tb.StepArgs("-c", "[[ else == $(cat ${inputs.resources.workspace.path}/else) ]]"),
+				tb.StepArgs("-c", "[[ else == $(cat $(inputs.resources.workspace.path)/else) ]]"),
 			),
 		)),
 	}


### PR DESCRIPTION
# Changes

In #850 we decided that to make our syntax more similar to k8s style
syntax, we will use $() for variable substitution instead of ${}. In a
later iteration we may also want to make it so that anything that can be
acesssed as a variable is also available as an env var to the running
container, but that is TBD.

In #1172 we added support for the new syntax, $(), and continued support
for ${}, which was released in 0.6. This commit removes support for
${}.

Fixes #1170

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Backwards incompatible change:
🚨Support for ${} syntax removed in favor of $() 🚨
${} syntax will no longer perform variable replacement, $() must be used instead
```