### PR TITLE
Increase linter timeout to 3 minutes

### DIFF
--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -28,7 +28,7 @@ export DISABLE_MD_LINTING=1
 source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
 
 function post_build_tests() {
-    golangci-lint run
+    golangci-lint run --deadline 3m
 }
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION
We have had many instances of the build tests failing
due to the linter exceeding the default timeout of 1m.

Fixes #1205 