### PR TITLE
Add managed-by label to Pods created from TaskRuns

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -37,17 +37,18 @@ data:
 
     # metrics.backend-destination field specifies the system metrics destination.
     # It supports either prometheus (the default) or stackdriver.
-    # Note: Using stackdriver will incur additional charges
+    # Note: Using Stackdriver will incur additional charges.
     metrics.backend-destination: prometheus
 
-    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # metrics.stackdriver-project-id field specifies the Stackdriver project ID. This
     # field is optional. When running on GCE, application default credentials will be
-    # used if this field is not provided.
+    # used and metrics will be sent to the cluster's project if this field is
+    # not provided.
     metrics.stackdriver-project-id: "<your stackdriver project id>"
 
-    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
-    # Stackdriver using "global" resource type and custom metric type if the
-    # metrics are not supported by "knative_revision" resource type. Setting this
-    # flag to "true" could cause extra Stackdriver charge.
-    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed
+    # to send metrics to Stackdriver using "global" resource type and custom
+    # metric type. Setting this flag to "true" could cause extra Stackdriver
+    # charge.  If metrics.backend-destination is not Stackdriver, this is
+    # ignored.
     metrics.allow-stackdriver-custom-metrics: "false"

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -16,6 +16,9 @@ kind: Deployment
 metadata:
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: controller
 spec:
   replicas: 1
   template:
@@ -24,6 +27,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: tekton-pipelines-controller
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: controller
     spec:
       serviceAccountName: tekton-pipelines-controller
       containers:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: webhook-controller
 spec:
   replicas: 1
   template:
@@ -25,6 +28,8 @@ spec:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: tekton-pipelines-webhook
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: webhook-controller
     spec:
       serviceAccountName: tekton-pipelines-controller
       containers:

--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -47,6 +47,10 @@ import (
 const (
 	workspaceDir = "/workspace"
 	homeDir      = "/builder/home"
+
+	taskRunLabelKey     = pipeline.GroupName + pipeline.TaskRunLabelKey
+	ManagedByLabelKey   = "app.kubernetes.io/managed-by"
+	ManagedByLabelValue = "tekton-pipelines"
 )
 
 // These are effectively const, but Go doesn't have such an annotation.
@@ -387,10 +391,18 @@ func IsContainerStep(name string) bool {
 // makeLabels constructs the labels we will propagate from TaskRuns to Pods.
 func makeLabels(s *v1alpha1.TaskRun) map[string]string {
 	labels := make(map[string]string, len(s.ObjectMeta.Labels)+1)
+	// NB: Set this *before* passing through TaskRun labels. If the TaskRun
+	// has a managed-by label, it should override this default.
+
+	// Copy through the TaskRun's labels to the underlying Pod's.
+	labels[ManagedByLabelKey] = ManagedByLabelValue
 	for k, v := range s.ObjectMeta.Labels {
 		labels[k] = v
 	}
-	labels[pipeline.GroupName+pipeline.TaskRunLabelKey] = s.Name
+
+	// NB: Set this *after* passing through TaskRun Labels. If the TaskRun
+	// specifies this label, it should be overridden by this value.
+	labels[taskRunLabelKey] = s.Name
 	return labels
 }
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -431,6 +431,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-run-success"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -462,6 +463,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-with-sa"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-sa-run-success"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-sa-run-success",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -494,6 +496,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-task-with-substitution"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-substitution"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-substitution",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -584,6 +587,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-output-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-input-output"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-input-output",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -716,6 +720,7 @@ func TestReconcile(t *testing.T) {
 		wantPod: tb.Pod("test-taskrun-with-taskspec-pod-123456", "foo",
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-taskspec"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-taskspec",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -763,6 +768,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-cluster-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-cluster-task"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-cluster-task",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -793,6 +799,7 @@ func TestReconcile(t *testing.T) {
 		wantPod: tb.Pod("test-taskrun-with-resource-spec-pod-123456", "foo",
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-resource-spec"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-resource-spec",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -841,6 +848,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodLabel("TaskRunLabel", "TaskRunValue"),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-labels"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-labels",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -873,6 +881,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("TaskRunAnnotation", "TaskRunValue"),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-annotations"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-annotations",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -904,6 +913,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-task-env"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-task-env"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-task-env",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1")),
 			tb.PodSpec(
@@ -936,6 +946,7 @@ func TestReconcile(t *testing.T) {
 		wantPod: tb.Pod("test-taskrun-with-resource-requests-pod-123456", "foo",
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-resource-requests"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-resource-requests",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(
@@ -1004,6 +1015,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation("tekton.dev/ready", ""),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-pod"),
+			tb.PodLabel(resources.ManagedByLabelKey, resources.ManagedByLabelValue),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-pod",
 				tb.OwnerReferenceAPIVersion(currentApiVersion)),
 			tb.PodSpec(


### PR DESCRIPTION
# Changes

Also annotate the controllers' Deployments and created Pods with labels
denoting their purpose.

This is a Kubernetes best practice
(https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
and will allow operators to understand at a high level where these Pods
come from.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._


# Release Notes

```
Label Pods created to run TaskRuns with `managed-by` to denote Tekton created them.
```