### PR TITLE
Adding support to enable pipelineSpec

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -33,7 +33,7 @@ following fields:
     `PipelineRun` resource object, for example a `name`.
   - [`spec`][kubernetes-overview] - Specifies the configuration information for
     your `PipelineRun` resource object.
-    - `pipelineRef` - Specifies the [`Pipeline`](pipelines.md) you want to run.
+    - [`pipelineRef` or `pipelineSpec`](#specifiying-a-pipeline) - Specifies the [`Pipeline`](pipelines.md) you want to run.
 - Optional:
 
   - [`resources`](#resources) - Specifies which
@@ -54,6 +54,48 @@ following fields:
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
+
+### Specifying a pipeline
+
+Since a `PipelineRun` is an invocation of a [`Pipeline`](pipelines.md), you must sepcify
+what `Pipeline` to invoke.
+
+You can do this by providing a reference to an existing `Pipeline`:
+
+```yaml
+spec:
+  pipelineRef:
+    name: myPipeline
+
+```
+
+Or you can embed the spec of the `Pipeline` directly in the `PipelineRun`:
+
+```yaml
+spec:
+  pipelineSpec:
+    tasks:
+    - name: task1
+      taskRef:
+        name: myTask
+```
+
+[Here](../examples/pipelineruns/pipelinerun-with-pipelinespec.yaml) is a sample `PipelineRun` to display different
+greetings while embedding the spec of the `Pipeline` directly in the `PipelineRun`.
+
+
+After creating such `PipelineRun`, logs from a pod displaying morning greetings:
+
+```bash
+kubectl logs $(kubectl get pods -o name | grep pipelinerun-echo-greetings-echo-good-morning)
+Good Morning, Bob!
+```
+
+And logs from a pod displaying morning greetings:
+```bash
+kubectl logs $(kubectl get pods -o name | grep pipelinerun-echo-greetings-echo-good-night)
+Good Night, Bob!
+```
 
 ### Resources
 

--- a/examples/pipelineruns/pipelinerun-with-pipelinespec.yaml
+++ b/examples/pipelineruns/pipelinerun-with-pipelinespec.yaml
@@ -1,0 +1,54 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-echo-message
+spec:
+  inputs:
+    params:
+      - name: MESSAGE
+        type: string
+        default: "Hello World"
+  steps:
+    - name: echo
+      image: ubuntu
+      command:
+        - echo
+      args:
+        - "$(inputs.params.MESSAGE)"
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-echo-greetings
+spec:
+  pipelineSpec:
+    params:
+      - name: MORNING_GREETINGS
+        description: "morning greetings, default is Good Morning!"
+        type: string
+        default: "Good Morning!"
+      - name: NIGHT_GREETINGS
+        description: "Night greetings, default is Good Night!"
+        type: string
+        default: "Good Night!"
+    tasks:
+      # Task to display morning greetings
+      - name: echo-good-morning
+        taskRef:
+          name: task-echo-message
+        params:
+          - name: MESSAGE
+            value: $(params.MORNING_GREETINGS)
+      # Task to display night greetings
+      - name: echo-good-night
+        taskRef:
+          name: task-echo-message
+        params:
+          - name: MESSAGE
+            value: $(params.NIGHT_GREETINGS)
+  params:
+    - name: MORNING_GREETINGS
+      value: "Good Morning, Bob!"
+    - name: NIGHT_GREETINGS
+      value: "Good Night, Bob!"

--- a/pkg/apis/pipeline/v1alpha1/pipeline_interface.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_interface.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// PipelineInterface is implemented by Pipeline and ClusterPipeline
+type PipelineInterface interface {
+	PipelineMetadata() metav1.ObjectMeta
+	PipelineSpec() PipelineSpec
+	Copy() PipelineInterface
+}

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -73,6 +73,18 @@ type Pipeline struct {
 	Status PipelineStatus `json:"status"`
 }
 
+func (p *Pipeline) PipelineMetadata() metav1.ObjectMeta {
+	return p.ObjectMeta
+}
+
+func (p *Pipeline) PipelineSpec() PipelineSpec {
+	return p.Spec
+}
+
+func (p *Pipeline) Copy() PipelineInterface {
+	return p.DeepCopy()
+}
+
 // PipelineTask defines a task in a Pipeline, passing inputs from both
 // Params and from the output of previous tasks.
 type PipelineTask struct {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -44,7 +44,10 @@ var _ apis.Defaultable = (*PipelineRun)(nil)
 
 // PipelineRunSpec defines the desired state of PipelineRun
 type PipelineRunSpec struct {
-	PipelineRef PipelineRef `json:"pipelineRef"`
+	// +optional
+	PipelineRef PipelineRef `json:"pipelineRef,omitempty"`
+	// +optional
+	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 	// Resources is a list of bindings specifying which actual instances of
 	// PipelineResources to use for the resources the Pipeline has declared
 	// it needs.

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -983,6 +983,11 @@ func (in *PipelineRunList) DeepCopyObject() runtime.Object {
 func (in *PipelineRunSpec) DeepCopyInto(out *PipelineRunSpec) {
 	*out = *in
 	out.PipelineRef = in.PipelineRef
+	if in.PipelineSpec != nil {
+		in, out := &in.PipelineSpec, &out.PipelineSpec
+		*out = new(PipelineSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make([]PipelineResourceBinding, len(*in))

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ApplyParameters applies the params from a PipelineRun.Params to a PipelineSpec.
-func ApplyParameters(p *v1alpha1.Pipeline, pr *v1alpha1.PipelineRun) *v1alpha1.Pipeline {
+func ApplyParameters(p *v1alpha1.PipelineSpec, pr *v1alpha1.PipelineRun) *v1alpha1.PipelineSpec {
 	// This assumes that the PipelineRun inputs have been validated against what the Pipeline requests.
 
 	// stringReplacements is used for standard single-string stringReplacements, while arrayReplacements contains arrays
@@ -32,7 +32,7 @@ func ApplyParameters(p *v1alpha1.Pipeline, pr *v1alpha1.PipelineRun) *v1alpha1.P
 	arrayReplacements := map[string][]string{}
 
 	// Set all the default stringReplacements
-	for _, p := range p.Spec.Params {
+	for _, p := range p.Params {
 		if p.Default != nil {
 			if p.Default.Type == v1alpha1.ParamTypeString {
 				stringReplacements[fmt.Sprintf("params.%s", p.Name)] = p.Default.StringVal
@@ -54,10 +54,10 @@ func ApplyParameters(p *v1alpha1.Pipeline, pr *v1alpha1.PipelineRun) *v1alpha1.P
 }
 
 // ApplyReplacements replaces placeholders for declared parameters with the specified replacements.
-func ApplyReplacements(p *v1alpha1.Pipeline, replacements map[string]string, arrayReplacements map[string][]string) *v1alpha1.Pipeline {
+func ApplyReplacements(p *v1alpha1.PipelineSpec, replacements map[string]string, arrayReplacements map[string][]string) *v1alpha1.PipelineSpec {
 	p = p.DeepCopy()
 
-	tasks := p.Spec.Tasks
+	tasks := p.Tasks
 
 	for i := range tasks {
 		tasks[i].Params = replaceParamValues(tasks[i].Params, replacements, arrayReplacements)

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -132,8 +132,8 @@ func TestApplyParameters(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ApplyParameters(tt.original, tt.run)
-			if d := cmp.Diff(got, tt.expected); d != "" {
+			got := ApplyParameters(&tt.original.Spec, tt.run)
+			if d := cmp.Diff(got, &tt.expected.Spec); d != "" {
 				t.Errorf("ApplyParameters() got diff %s", d)
 			}
 		})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -169,7 +169,7 @@ func (state PipelineRunState) SuccessfulPipelineTaskNames() []string {
 // GetTaskRun is a function that will retrieve the TaskRun name.
 type GetTaskRun func(name string) (*v1alpha1.TaskRun, error)
 
-// GetResourcesFromBindings will retreive all Resources bound in PipelineRun pr and return a map
+// GetResourcesFromBindings will retrieve all Resources bound in PipelineRun pr and return a map
 // from the declared name of the PipelineResource (which is how the PipelineResource will
 // be referred to in the PipelineRun) to the PipelineResource, obtained via getResource.
 func GetResourcesFromBindings(pr *v1alpha1.PipelineRun, getResource resources.GetResource) (map[string]*v1alpha1.PipelineResource, error) {
@@ -185,9 +185,9 @@ func GetResourcesFromBindings(pr *v1alpha1.PipelineRun, getResource resources.Ge
 }
 
 // ValidateResourceBindings validate that the PipelineResources declared in Pipeline p are bound in PipelineRun.
-func ValidateResourceBindings(p *v1alpha1.Pipeline, pr *v1alpha1.PipelineRun) error {
-	required := make([]string, 0, len(p.Spec.Resources))
-	for _, resource := range p.Spec.Resources {
+func ValidateResourceBindings(p *v1alpha1.PipelineSpec, pr *v1alpha1.PipelineRun) error {
+	required := make([]string, 0, len(p.Resources))
+	for _, resource := range p.Resources {
 		required = append(required, resource.Name)
 	}
 	provided := make([]string, 0, len(pr.Spec.Resources))

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1074,6 +1074,23 @@ func TestGetResourcesFromBindings(t *testing.T) {
 	}
 }
 
+func TestGetResourcesFromBindings_Missing(t *testing.T) {
+	//p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	//	tb.PipelineDeclaredResource("git-resource", "git"),
+	//	tb.PipelineDeclaredResource("image-resource", "image"),
+	//))
+	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
+	))
+	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
+		return nil, fmt.Errorf("Request for unexpected resource %s", name)
+	}
+	_, err := GetResourcesFromBindings(pr, getResource)
+	if err == nil {
+		t.Fatalf("Expected error indicating `image-resource` was missing but got no error")
+	}
+}
+
 func TestGetResourcesFromBindings_ErrorGettingResource(t *testing.T) {
 	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
@@ -1820,7 +1837,7 @@ func TestValidateResourceBindings(t *testing.T) {
 	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
-	err := ValidateResourceBindings(p, pr)
+	err := ValidateResourceBindings(&p.Spec, pr)
 	if err != nil {
 		t.Fatalf("didn't expect error getting resources from bindings but got: %v", err)
 	}
@@ -1834,7 +1851,7 @@ func TestValidateResourceBindings_Missing(t *testing.T) {
 	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
-	err := ValidateResourceBindings(p, pr)
+	err := ValidateResourceBindings(&p.Spec, pr)
 	if err == nil {
 		t.Fatalf("Expected error indicating `image-resource` was missing but got no error")
 	}
@@ -1848,7 +1865,7 @@ func TestGetResourcesFromBindings_Extra(t *testing.T) {
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 		tb.PipelineRunResourceBinding("image-resource", tb.PipelineResourceBindingRef("sweet-resource2")),
 	))
-	err := ValidateResourceBindings(p, pr)
+	err := ValidateResourceBindings(&p.Spec, pr)
 	if err == nil {
 		t.Fatalf("Expected error indicating `image-resource` was extra but got no error")
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"golang.org/x/xerrors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetPipeline is a function used to retrieve Pipelines.
+type GetPipeline func(string) (v1alpha1.PipelineInterface, error)
+
+// GetPipelineData will retrieve the Pipeline metadata and Spec associated with the
+// provided PipelineRun. This can come from a reference Pipeline or from the PipelineRun's
+// metadata and embedded PipelineSpec.
+func GetPipelineData(pipelineRun *v1alpha1.PipelineRun, getPipeline GetPipeline) (*metav1.ObjectMeta, *v1alpha1.PipelineSpec, error) {
+	pipelineMeta := metav1.ObjectMeta{}
+	pipelineSpec := v1alpha1.PipelineSpec{}
+	switch {
+	case pipelineRun.Spec.PipelineRef.Name != "":
+		// Get related pipeline for pipelinerun
+		t, err := getPipeline(pipelineRun.Spec.PipelineRef.Name)
+		if err != nil {
+			return nil, nil, xerrors.Errorf("error when listing pipelines for pipelineRun %s: %w", pipelineRun.Name, err)
+		}
+		pipelineMeta = t.PipelineMetadata()
+		pipelineSpec = t.PipelineSpec()
+	case pipelineRun.Spec.PipelineSpec != nil:
+		pipelineMeta = pipelineRun.ObjectMeta
+		pipelineSpec = *pipelineRun.Spec.PipelineSpec
+	default:
+		return nil, nil, xerrors.Errorf("PipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
+	}
+	return &pipelineMeta, &pipelineSpec, nil
+}

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"golang.org/x/xerrors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetPipelineSpec_Ref(t *testing.T) {
+	pipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "orchestrate",
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Tasks: []v1alpha1.PipelineTask{{
+				Name: "mytask",
+				TaskRef: v1alpha1.TaskRef{
+					Name: "mytask",
+				},
+			}},
+		},
+	}
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mypipelinerun",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "orchestrate",
+			},
+		},
+	}
+	gt := func(n string) (v1alpha1.PipelineInterface, error) { return pipeline, nil }
+	pipelineMeta, pipelineSpec, err := GetPipelineData(pr, gt)
+
+	if err != nil {
+		t.Fatalf("Did not expect error getting pipeline spec but got: %s", err)
+	}
+
+	if pipelineMeta.Name != "orchestrate" {
+		t.Errorf("Expected pipeline name to be `orchestrate` but was %q", pipelineMeta.Name)
+	}
+
+	if len(pipelineSpec.Tasks) != 1 || pipelineSpec.Tasks[0].Name != "mytask" {
+		t.Errorf("Pipeline Spec not resolved as expected, expected referenced Pipeline spec but got: %v", pipelineSpec)
+	}
+}
+
+func TestGetPipelineSpec_Embedded(t *testing.T) {
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mypipelinerun",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineSpec: &v1alpha1.PipelineSpec{
+				Tasks: []v1alpha1.PipelineTask{{
+					Name: "mytask",
+					TaskRef: v1alpha1.TaskRef{
+						Name: "mytask",
+					},
+				}},
+			},
+		},
+	}
+	gt := func(n string) (v1alpha1.PipelineInterface, error) { return nil, xerrors.New("shouldn't be called") }
+	pipelineMeta, pipelineSpec, err := GetPipelineData(pr, gt)
+
+	if err != nil {
+		t.Fatalf("Did not expect error getting pipeline spec but got: %s", err)
+	}
+
+	if pipelineMeta.Name != "mypipelinerun" {
+		t.Errorf("Expected pipeline name for embedded pipeline to default to name of pipeline run but was %q", pipelineMeta.Name)
+	}
+
+	if len(pipelineSpec.Tasks) != 1 || pipelineSpec.Tasks[0].Name != "mytask" {
+		t.Errorf("Pipeline Spec not resolved as expected, expected embedded Pipeline spec but got: %v", pipelineSpec)
+	}
+}
+
+func TestGetPipelineSpec_Invalid(t *testing.T) {
+	tr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mypipelinerun",
+		},
+	}
+	gt := func(n string) (v1alpha1.PipelineInterface, error) { return nil, xerrors.New("shouldn't be called") }
+	_, _, err := GetPipelineData(tr, gt)
+	if err == nil {
+		t.Fatalf("Expected error resolving spec with no embedded or referenced pipeline spec but didn't get error")
+	}
+}
+
+func TestGetPipelineSpec_Error(t *testing.T) {
+	tr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mypipelinerun",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: v1alpha1.PipelineRef{
+				Name: "orchestrate",
+			},
+		},
+	}
+	gt := func(n string) (v1alpha1.PipelineInterface, error) { return nil, xerrors.New("something went wrong") }
+	_, _, err := GetPipelineData(tr, gt)
+	if err == nil {
+		t.Fatalf("Expected error when unable to find referenced Pipeline but got none")
+	}
+}

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -22,10 +22,10 @@ import (
 )
 
 // Validate that parameters in PipelineRun override corresponding parameters in Pipeline of the same type.
-func ValidateParamTypesMatching(p *v1alpha1.Pipeline, pr *v1alpha1.PipelineRun) error {
+func ValidateParamTypesMatching(p *v1alpha1.PipelineSpec, pr *v1alpha1.PipelineRun) error {
 	// Build a map of parameter names/types declared in p.
 	paramTypes := make(map[string]v1alpha1.ParamType)
-	for _, param := range p.Spec.Params {
+	for _, param := range p.Params {
 		paramTypes[param.Name] = param.Type
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -73,7 +73,7 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateParamTypesMatching(tc.p, tc.pr)
+			err := ValidateParamTypesMatching(&tc.p.Spec, tc.pr)
 			if (!tc.errorExpected) && (err != nil) {
 				t.Errorf("Pipeline.Validate() returned error: %v", err)
 			}
@@ -115,7 +115,7 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateParamTypesMatching(tc.p, tc.pr); err == nil {
+			if err := ValidateParamTypesMatching(&tc.p.Spec, tc.pr); err == nil {
 				t.Errorf("Expected to see error when validating PipelineRun/Pipeline param types but saw none")
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Its now possible to embed the whole pipeline specification into Pipeline Run
using pipelineSpec, for example:

```yaml
apiVersion: tekton.dev/v1alpha1
kind: PipelineRun
metadata:
  name: pipelinerun-echo-greetings
spec:
  pipelineRef:
    name: pipeline-echo-greetings
```

Can be specified as:

```yaml
apiVersion: tekton.dev/v1alpha1
kind: PipelineRun
metadata:
  name: pipelinerun-echo-greetings
spec:
  pipelineSpec:
    tasks:
    - name: echo-good-morning
    ...
    params:
    ...
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) and [TaskRun](../tekton/publish-run.yaml) to build and release this image

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS)
and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS),
and they must first be added
[in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```