### PR TITLE
Fix export comments

### DIFF
--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -32,9 +32,9 @@ const (
 	// PipelineRunLabelKey is used as the label identifier for a PipelineRun
 	PipelineRunLabelKey = "/pipelineRun"
 
-	// PipelineRunLabelKey is used as the label identifier for a PipelineTask
+	// PipelineTaskLabelKey is used as the label identifier for a PipelineTask
 	PipelineTaskLabelKey = "/pipelineTask"
 
-	// ConditionCheck is used as the label identifier for a ConditionCheck
+	// ConditionCheckKey is used as the label identifier for a ConditionCheck
 	ConditionCheckKey = "/conditionCheck"
 )


### PR DESCRIPTION
Signed-off-by: cappyzawa <cappyzawa@yahoo.ne.jp>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This is non-impact PR.
I found mismatches of export comment when I was reading code.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API
changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md)
are included, [additive
changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes)
must be approved by at least two
[OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards
incompatible
changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes)
must be approved by [more than 50% of the
OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must
first be added [in a backwards compatible
way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
