### PR TITLE
WIP: Initial implementation of step scripts

### DIFF
--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: step-script
+spec:
+  taskSpec:
+    steps:
+    - image: ubuntu
+      env:
+      - name: FOO
+        value: foooooooo
+      script:
+      - '#!/bin/bash'
+      - 'set -euxo pipefail'
+      - 'echo "Hello from Bash!"'
+      # Environment variables are available.
+      - 'echo FOO is ${FOO}'
+      # Multiline strings work.
+      - |
+        for i in {1..10}; do
+          echo line $i
+        done
+    - image: node
+      script:
+      - '#!/usr/bin/env node'
+      - 'console.log("Hello from Node!")'
+    - image: python
+      script:
+      - '#!/usr/bin/env python3'
+      - 'print("Hello from Python!")'
+    - image: perl
+      script:
+      - '#!/usr/bin/perl'
+      - 'print "Hello from Perl!"'

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -66,6 +66,15 @@ type TaskSpec struct {
 // provided by Container.
 type Step struct {
 	corev1.Container
+
+	// Script is a list of commands to run in sequence inside the
+	// container.
+	//
+	// If any script invocation fails, the step fails without executing
+	// the rest.
+	//
+	// If Script is not empty, the Step cannot have an Command or Args.
+	Script []string `json:"script,omitempty"`
 }
 
 // Check that Task may be validated and defaulted.

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -124,6 +124,13 @@ func validateSteps(steps []Step) *apis.FieldError {
 			return apis.ErrMissingField("Image")
 		}
 
+		if len(s.Script) > 0 && (len(s.Args) > 0 || len(s.Command) > 0) {
+			return &apis.FieldError{
+				Message: "script cannot be used with args or command",
+				Paths:   []string{"script"},
+			}
+		}
+
 		if s.Name == "" {
 			continue
 		}

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1432,6 +1432,11 @@ func (in *SecretParam) DeepCopy() *SecretParam {
 func (in *Step) DeepCopyInto(out *Step) {
 	*out = *in
 	in.Container.DeepCopyInto(&out.Container)
+	if in.Script != nil {
+		in, out := &in.Script, &out.Script
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
This adds a `script` field to the `Step` type which, when specified,
results in a temporary generated executable script file being generated
and invoked containing the specified script items.

The result is an easier-to-use scripting option for users who just want
to invoke simple scripts. Generated scripts should be an implpementation
detail and will not persist between steps.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [notyet] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Support "script mode" for steps, which allows users to specify simple scripts inline in their YAML definition.
```
