### PR TITLE
Move nopImage and entrypointImage from pkg/… package to cmd/controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 
 	"knative.dev/pkg/injection/sharedmain"
 
+	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun"
 )
@@ -31,12 +32,17 @@ const (
 )
 
 var (
-	nopImage = flag.String("nop-image", "override-with-nop:latest", "The container image used to kill sidecars")
+	entrypointImage = flag.String("entrypoint-image", "override-with-entrypoint:latest",
+		"The container image containing our entrypoint binary.")
+	nopImage = flag.String("nop-image", "override-with-nop:latest",
+		"The container image used to kill sidecars")
 )
 
 func main() {
-	images := map[string]string{
-		"nopImage": *nopImage,
+	flag.Parse()
+	images := reconciler.Images{
+		EntryPointImage: *entrypointImage,
+		NopImage:        *nopImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"flag"
+
 	"knative.dev/pkg/injection/sharedmain"
 
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
@@ -28,9 +30,16 @@ const (
 	ControllerLogKey = "controller"
 )
 
+var (
+	nopImage = flag.String("nop-image", "override-with-nop:latest", "The container image used to kill sidecars")
+)
+
 func main() {
+	images := map[string]string{
+		"nopImage": *nopImage,
+	}
 	sharedmain.Main(ControllerLogKey,
-		taskrun.NewController,
-		pipelinerun.NewController,
+		taskrun.NewController(images),
+		pipelinerun.NewController(images),
 	)
 }

--- a/pkg/reconciler/images.go
+++ b/pkg/reconciler/images.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+// Images holds the images reference for a number of container images used accross tektoncd pipelines
+type Images struct {
+	// EntryPointImage is container image containing our entrypoint binary.
+	EntryPointImage string
+	// NopImage is the container image used to kill sidecars
+	NopImage string
+}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -42,7 +42,7 @@ const (
 	resyncPeriod = 10 * time.Hour
 )
 
-func NewController(images map[string]string) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(images reconciler.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	taskrunresources "github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/system"
@@ -44,8 +45,9 @@ import (
 
 var (
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
-	images                   = map[string]string{
-		"nopImage": "override-with-nop:latest",
+	images                   = reconciler.Images{
+		EntryPointImage: "override-with-entrypoint:latest",
+		NopImage:        "override-with-nop:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -44,6 +44,9 @@ import (
 
 var (
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
+	images                   = map[string]string{
+		"nopImage": "override-with-nop:latest",
+	}
 )
 
 func getRunName(pr *v1alpha1.PipelineRun) string {
@@ -58,11 +61,8 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.TestAssets, func(
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.GetNamespace())
 	ctx, cancel := context.WithCancel(ctx)
 	return test.TestAssets{
-		Controller: NewController(
-			ctx,
-			configMapWatcher,
-		),
-		Clients: c,
+		Controller: NewController(images)(ctx, configMapWatcher),
+		Clients:    c,
 	}, cancel
 }
 

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -79,11 +79,14 @@ type Base struct {
 	// performance benefits, raw logger also preserves type-safety at
 	// the expense of slightly greater verbosity.
 	Logger *zap.SugaredLogger
+
+	// Images contains images to use for certain internal container
+	Images map[string]string
 }
 
 // NewBase instantiates a new instance of Base implementing
 // the common & boilerplate code between our reconcilers.
-func NewBase(opt Options, controllerAgentName string) *Base {
+func NewBase(opt Options, controllerAgentName string, images map[string]string) *Base {
 	// Enrich the logs with controller name
 	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
 
@@ -110,6 +113,7 @@ func NewBase(opt Options, controllerAgentName string) *Base {
 		ConfigMapWatcher:  opt.ConfigMapWatcher,
 		Recorder:          recorder,
 		Logger:            logger,
+		Images:            images,
 	}
 
 	return base

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -81,12 +81,12 @@ type Base struct {
 	Logger *zap.SugaredLogger
 
 	// Images contains images to use for certain internal container
-	Images map[string]string
+	Images Images
 }
 
 // NewBase instantiates a new instance of Base implementing
 // the common & boilerplate code between our reconcilers.
-func NewBase(opt Options, controllerAgentName string, images map[string]string) *Base {
+func NewBase(opt Options, controllerAgentName string, images Images) *Base {
 	// Enrich the logs with controller name
 	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -67,7 +67,7 @@ func TestRecorderOptions(t *testing.T) {
 		Logger:            zap.New(observer).Sugar(),
 		KubeClientSet:     c.Kube,
 		PipelineClientSet: c.Pipeline,
-	}, "test", map[string]string{})
+	}, "test", Images{})
 
 	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.recorderImpl") != 0 {
 		t.Errorf("Expected recorder type '*record.recorderImpl' but actual type is: %s", reflect.TypeOf(b.Recorder).String())
@@ -81,7 +81,7 @@ func TestRecorderOptions(t *testing.T) {
 		KubeClientSet:     c.Kube,
 		PipelineClientSet: c.Pipeline,
 		Recorder:          fr,
-	}, "test", map[string]string{})
+	}, "test", Images{})
 
 	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.FakeRecorder") != 0 {
 		t.Errorf("Expected recorder type '*record.FakeRecorder' but actual type is: %s", reflect.TypeOf(b.Recorder).String())

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -67,7 +67,7 @@ func TestRecorderOptions(t *testing.T) {
 		Logger:            zap.New(observer).Sugar(),
 		KubeClientSet:     c.Kube,
 		PipelineClientSet: c.Pipeline,
-	}, "test")
+	}, "test", map[string]string{})
 
 	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.recorderImpl") != 0 {
 		t.Errorf("Expected recorder type '*record.recorderImpl' but actual type is: %s", reflect.TypeOf(b.Recorder).String())
@@ -81,7 +81,7 @@ func TestRecorderOptions(t *testing.T) {
 		KubeClientSet:     c.Kube,
 		PipelineClientSet: c.Pipeline,
 		Recorder:          fr,
-	}, "test")
+	}, "test", map[string]string{})
 
 	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.FakeRecorder") != 0 {
 		t.Errorf("Expected recorder type '*record.FakeRecorder' but actual type is: %s", reflect.TypeOf(b.Recorder).String())

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -42,7 +42,7 @@ const (
 	resyncPeriod = 10 * time.Hour
 )
 
-func NewController(images map[string]string) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(images reconciler.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)

--- a/pkg/reconciler/taskrun/entrypoint/entrypoint.go
+++ b/pkg/reconciler/taskrun/entrypoint/entrypoint.go
@@ -17,7 +17,6 @@ limitations under the License.
 package entrypoint
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 
@@ -56,10 +55,6 @@ var downwardMount = corev1.VolumeMount{
 	Name:      DownwardMountName,
 	MountPath: DownwardMountPoint,
 }
-var (
-	entrypointImage = flag.String("entrypoint-image", "override-with-entrypoint:latest",
-		"The container image containing our entrypoint binary.")
-)
 
 // Cache is a simple caching mechanism allowing for caching the results of
 // getting the Entrypoint of a container image from a remote registry. The
@@ -96,10 +91,10 @@ func AddToEntrypointCache(c *Cache, sha string, ep []string) {
 // copy the entrypoint binary from the entrypoint image into the
 // volume mounted at MountPoint, so that it can be mounted by
 // subsequent steps and used to capture logs.
-func AddCopyStep(spec *v1alpha1.TaskSpec) {
+func AddCopyStep(entrypointImage string, spec *v1alpha1.TaskSpec) {
 	cp := corev1.Container{
 		Name:    InitContainerName,
-		Image:   *entrypointImage,
+		Image:   entrypointImage,
 		Command: []string{"/bin/sh"},
 		// based on the ko version, the binary could be in one of two different locations
 		Args:         []string{"-c", fmt.Sprintf("cp /ko-app/entrypoint %s", BinaryLocation)},

--- a/pkg/reconciler/taskrun/entrypoint/entrypoint_test.go
+++ b/pkg/reconciler/taskrun/entrypoint/entrypoint_test.go
@@ -461,7 +461,7 @@ func TestAddCopyStep(t *testing.T) {
 	}
 
 	expectedSteps := len(ts.Steps) + 1
-	AddCopyStep(ts)
+	AddCopyStep("override-with-entrypoint:latest", ts)
 	if len(ts.Steps) != 3 {
 		t.Errorf("BuildSpec has the wrong step count: %d should be %d", len(ts.Steps), expectedSteps)
 	}

--- a/pkg/reconciler/taskrun/sidecars/stop.go
+++ b/pkg/reconciler/taskrun/sidecars/stop.go
@@ -17,14 +17,8 @@ limitations under the License.
 package sidecars
 
 import (
-	"flag"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-var (
-	nopImage = flag.String("nop-image", "override-with-nop:latest", "The container image used to kill sidecars")
 )
 
 type GetPod func(string, metav1.GetOptions) (*corev1.Pod, error)
@@ -39,15 +33,15 @@ type UpdatePod func(*corev1.Pod) (*corev1.Pod, error)
 // image, which in turn quickly exits. If the sidecar defines a command then
 // it will exit with a non-zero status. When we check for TaskRun success we
 // have to check for the containers we care about - not the final Pod status.
-func Stop(pod *corev1.Pod, updatePod UpdatePod) error {
+func Stop(pod *corev1.Pod, nopImage string, updatePod UpdatePod) error {
 	updated := false
 	if pod.Status.Phase == corev1.PodRunning {
 		for _, s := range pod.Status.ContainerStatuses {
 			if s.State.Running != nil {
 				for j, c := range pod.Spec.Containers {
-					if c.Name == s.Name && c.Image != *nopImage {
+					if c.Name == s.Name && c.Image != nopImage {
 						updated = true
-						pod.Spec.Containers[j].Image = *nopImage
+						pod.Spec.Containers[j].Image = nopImage
 					}
 				}
 			}

--- a/pkg/reconciler/taskrun/sidecars/stop_test.go
+++ b/pkg/reconciler/taskrun/sidecars/stop_test.go
@@ -24,6 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	nopImage = "nopImage"
+)
+
 // TestStop exercises the Stop() method of the sidecars package.
 // A sidecar is killed by having its container image changed to that of the nop image.
 // This test therefore runs through a series of pod and sidecar configurations,
@@ -47,7 +51,7 @@ func TestStop(t *testing.T) {
 		sidecarState: corev1.ContainerState{
 			Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())},
 		},
-		expectedImage: *nopImage,
+		expectedImage: nopImage,
 	}, {
 		description: "a pending pod should not have its sidecars stopped",
 		podPhase:    corev1.PodPending,
@@ -106,7 +110,7 @@ func TestStop(t *testing.T) {
 				},
 			}
 			updatePod := func(p *corev1.Pod) (*corev1.Pod, error) { return nil, nil }
-			if err := Stop(pod, updatePod); err != nil {
+			if err := Stop(pod, nopImage, updatePod); err != nil {
 				t.Errorf("error stopping sidecar: %v", err)
 			}
 			sidecarIdx := len(pod.Spec.Containers) - 1

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -126,7 +126,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		c.timeoutHandler.Release(tr)
 		pod, err := c.KubeClientSet.CoreV1().Pods(tr.Namespace).Get(tr.Status.PodName, metav1.GetOptions{})
 		if err == nil {
-			err = sidecars.Stop(pod, c.KubeClientSet.CoreV1().Pods(tr.Namespace).Update)
+			err = sidecars.Stop(pod, c.Images["nopImage"], c.KubeClientSet.CoreV1().Pods(tr.Namespace).Update)
 		} else if errors.IsNotFound(err) {
 			return merr.ErrorOrNil()
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -62,6 +62,9 @@ const (
 )
 
 var (
+	images = map[string]string{
+		"nopImage": "override-with-nop:latest",
+	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
 	// Pods are created with a random 3-byte (6 hex character) suffix that we want to ignore in our diffs.
@@ -264,11 +267,8 @@ func getTaskRunController(t *testing.T, d test.Data) (test.TestAssets, func()) {
 	c, _ := test.SeedTestData(t, ctx, d)
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.GetNamespace())
 	return test.TestAssets{
-		Controller: NewController(
-			ctx,
-			configMapWatcher,
-		),
-		Clients: c,
+		Controller: NewController(images)(ctx, configMapWatcher),
+		Clients:    c,
 	}, cancel
 }
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/entrypoint"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources/cloudevent"
@@ -62,8 +63,9 @@ const (
 )
 
 var (
-	images = map[string]string{
-		"nopImage": "override-with-nop:latest",
+	images = reconciler.Images{
+		EntryPointImage: "override-with-entrypoint:latest",
+		NopImage:        "override-with-nop:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
@@ -1422,7 +1424,7 @@ func TestCreateRedirectedTaskSpec(t *testing.T) {
 	observer, _ := observer.New(zap.InfoLevel)
 	entrypointCache, _ := entrypoint.NewCache()
 	c := fakekubeclientset.NewSimpleClientset()
-	ts, err := createRedirectedTaskSpec(c, &task.Spec, tr, entrypointCache, zap.New(observer).Sugar())
+	ts, err := createRedirectedTaskSpec(c, "override-with-entrypoint:latest", &task.Spec, tr, entrypointCache, zap.New(observer).Sugar())
 	if err != nil {
 		t.Errorf("expected createRedirectedTaskSpec to pass: %v", err)
 	}


### PR DESCRIPTION
# Changes

This is part of a set of changes to make sure we don't define CLI
flags in our `pkg/…` packages… so that importing packages from there
do not pollute the cli flags.

This is part of #1309 — submitting this one *alone* to gather early feedback and make sure this is the way to go (aka I am not a fan of the map in this change so far)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
