### PR TITLE
Add checking insecure flag when creating pipeline resources.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -37,7 +38,7 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	if rs.Type == PipelineResourceTypeCluster {
-		var usernameFound, cadataFound, nameFound bool
+		var usernameFound, cadataFound, nameFound, isInsecure bool
 		for _, param := range rs.Params {
 			switch {
 			case strings.EqualFold(param.Name, "URL"):
@@ -50,6 +51,9 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 				cadataFound = true
 			case strings.EqualFold(param.Name, "name"):
 				nameFound = true
+			case strings.EqualFold(param.Name, "insecure"):
+				b, _ := strconv.ParseBool(param.Value)
+				isInsecure = b
 			}
 		}
 
@@ -68,7 +72,7 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		if !usernameFound {
 			return apis.ErrMissingField("username param")
 		}
-		if !cadataFound {
+		if !cadataFound && !isInsecure {
 			return apis.ErrMissingField("CAData param")
 		}
 	}

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -129,16 +129,39 @@ func TestResourceValidation_Invalid(t *testing.T) {
 }
 
 func TestClusterResourceValidation_Valid(t *testing.T) {
-	res := tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
-		v1alpha1.PipelineResourceTypeCluster,
-		tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
-		tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
-		tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
-		tb.PipelineResourceSpecParam("username", "admin"),
-		tb.PipelineResourceSpecParam("token", "my-token"),
-	))
-	if err := res.Validate(context.Background()); err != nil {
-		t.Errorf("Unexpected PipelineRun.Validate() error = %v", err)
+	tests := []struct {
+		name string
+		res  *v1alpha1.PipelineResource
+	}{
+		{
+			name: "success validate",
+			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeCluster,
+				tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+				tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
+				tb.PipelineResourceSpecParam("username", "admin"),
+				tb.PipelineResourceSpecParam("token", "my-token"),
+			)),
+		},
+		{
+			name: "specify insecure without cadata",
+			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+				v1alpha1.PipelineResourceTypeCluster,
+				tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
+				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
+				tb.PipelineResourceSpecParam("username", "admin"),
+				tb.PipelineResourceSpecParam("token", "my-token"),
+				tb.PipelineResourceSpecParam("insecure", "true"),
+			)),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.res.Validate(context.Background()); err != nil {
+				t.Errorf("Unexpected PipelineRun.Validate() error = %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This is for https://github.com/tektoncd/pipeline/issues/1314.
when creating ```ClusterResource``` insecure flag is not checked currently.
so this PR added checking insecure flag and if this is true, user can create ```ClusterResource``` without cadata.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
If insecure flag is true, user can create ClusterResource without cadata.
```
