### PR TITLE
This commit fixes some style issues noticed after #1345 was merged.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
@@ -143,7 +143,7 @@ func (s *BuildGCSResource) GetInputTaskModifier(ts *TaskSpec, sourcePath string)
 			Args:    args,
 		}}}
 
-	volumes, err := getStorageVolumeSpec(s, ts)
+	volumes, err := getStorageVolumeSpec(s, *ts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/pipeline/v1alpha1/cloud_event_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cloud_event_resource.go
@@ -78,10 +78,12 @@ func (s *CloudEventResource) Replacements() map[string]string {
 	}
 }
 
+// GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *CloudEventResource) GetInputTaskModifier(_ *TaskSpec, _ string) (TaskModifier, error) {
 	return &InternalTaskModifier{}, nil
 }
 
+// GetOutputTaskModifier returns a No-op TaskModifier.
 func (s *CloudEventResource) GetOutputTaskModifier(_ *TaskSpec, _ string) (TaskModifier, error) {
 	return &InternalTaskModifier{}, nil
 }

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -142,10 +142,12 @@ func (s ClusterResource) String() string {
 	return string(json)
 }
 
+// GetOutputTaskModifier returns a No-op TaskModifier.
 func (s *ClusterResource) GetOutputTaskModifier(_ *TaskSpec, _ string) (TaskModifier, error) {
 	return &InternalTaskModifier{}, nil
 }
 
+// GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *ClusterResource) GetInputTaskModifier(ts *TaskSpec, path string) (TaskModifier, error) {
 	var envVars []corev1.EnvVar
 	for _, sec := range s.Secrets {

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource.go
@@ -97,6 +97,7 @@ func (s *GCSResource) Replacements() map[string]string {
 	}
 }
 
+// GetOutputTaskModifier returns the TaskModifier to be used when this resource is an output.
 func (s *GCSResource) GetOutputTaskModifier(ts *TaskSpec, path string) (TaskModifier, error) {
 	var args []string
 	if s.TypeDir {
@@ -116,7 +117,7 @@ func (s *GCSResource) GetOutputTaskModifier(ts *TaskSpec, path string) (TaskModi
 		Env:          envVars},
 	}
 
-	volumes, err := getStorageVolumeSpec(s, ts)
+	volumes, err := getStorageVolumeSpec(s, *ts)
 	if err != nil {
 		return nil, err
 	}
@@ -127,6 +128,7 @@ func (s *GCSResource) GetOutputTaskModifier(ts *TaskSpec, path string) (TaskModi
 	}, nil
 }
 
+// GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *GCSResource) GetInputTaskModifier(ts *TaskSpec, path string) (TaskModifier, error) {
 	if path == "" {
 		return nil, xerrors.Errorf("GCSResource: Expect Destination Directory param to be set %s", s.Name)
@@ -150,7 +152,7 @@ func (s *GCSResource) GetInputTaskModifier(ts *TaskSpec, path string) (TaskModif
 			VolumeMounts: secretVolumeMount,
 		}}}
 
-	volumes, err := getStorageVolumeSpec(s, ts)
+	volumes, err := getStorageVolumeSpec(s, *ts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -95,6 +95,7 @@ func (s *GitResource) Replacements() map[string]string {
 	}
 }
 
+// GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *GitResource) GetInputTaskModifier(_ *TaskSpec, path string) (TaskModifier, error) {
 	args := []string{"-url", s.URL,
 		"-revision", s.Revision,
@@ -116,6 +117,7 @@ func (s *GitResource) GetInputTaskModifier(_ *TaskSpec, path string) (TaskModifi
 	}, nil
 }
 
+// GetOutputTaskModifier returns a No-op TaskModifier.
 func (s *GitResource) GetOutputTaskModifier(_ *TaskSpec, _ string) (TaskModifier, error) {
 	return &InternalTaskModifier{}, nil
 }

--- a/pkg/apis/pipeline/v1alpha1/image_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource.go
@@ -74,10 +74,12 @@ func (s *ImageResource) Replacements() map[string]string {
 	}
 }
 
+// GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *ImageResource) GetInputTaskModifier(_ *TaskSpec, _ string) (TaskModifier, error) {
 	return &InternalTaskModifier{}, nil
 }
 
+// GetOutputTaskModifier returns a No-op TaskModifier.
 func (s *ImageResource) GetOutputTaskModifier(_ *TaskSpec, _ string) (TaskModifier, error) {
 	return &InternalTaskModifier{}, nil
 }

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -93,12 +93,14 @@ func (s *PullRequestResource) Replacements() map[string]string {
 	}
 }
 
+// GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *PullRequestResource) GetInputTaskModifier(ts *TaskSpec, sourcePath string) (TaskModifier, error) {
 	return &InternalTaskModifier{
 		StepsToPrepend: s.getSteps("download", sourcePath),
 	}, nil
 }
 
+// GetOutputTaskModifier returns a No-op TaskModifier.
 func (s *PullRequestResource) GetOutputTaskModifier(ts *TaskSpec, sourcePath string) (TaskModifier, error) {
 	return &InternalTaskModifier{
 		StepsToAppend: s.getSteps("upload", sourcePath),

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -67,24 +67,29 @@ type TaskModifier interface {
 	GetVolumes() []v1.Volume
 }
 
+// InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.
 type InternalTaskModifier struct {
 	StepsToPrepend []Step
 	StepsToAppend  []Step
 	Volumes        []v1.Volume
 }
 
+// GetStepsToPrepend returns a set of Steps to prepend to the Task.
 func (tm *InternalTaskModifier) GetStepsToPrepend() []Step {
 	return tm.StepsToPrepend
 }
 
+// GetStepsToPrepend returns a set of Steps to append to the Task.
 func (tm *InternalTaskModifier) GetStepsToAppend() []Step {
 	return tm.StepsToAppend
 }
 
+// GetVolumes returns a set of Volumes to prepend to the Task pod.
 func (tm *InternalTaskModifier) GetVolumes() []v1.Volume {
 	return tm.Volumes
 }
 
+// ApplyTaskModifier applies a modifier to the task by appending and prepending steps and volumes.
 func ApplyTaskModifier(ts *TaskSpec, tm TaskModifier) {
 	steps := tm.GetStepsToPrepend()
 	ts.Steps = append(steps, ts.Steps...)

--- a/pkg/apis/pipeline/v1alpha1/storage_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/storage_resource.go
@@ -58,7 +58,7 @@ func NewStorageResource(r *PipelineResource) (PipelineStorageResourceInterface, 
 	return nil, xerrors.Errorf("StoreResource: Cannot create a storage resource without type %s in spec", r.Name)
 }
 
-func getStorageVolumeSpec(s PipelineStorageResourceInterface, spec *TaskSpec) ([]corev1.Volume, error) {
+func getStorageVolumeSpec(s PipelineStorageResourceInterface, spec TaskSpec) ([]corev1.Volume, error) {
 	var storageVol []corev1.Volume
 	mountedSecrets := map[string]string{}
 


### PR DESCRIPTION
# Changes

This adds missing docstrings to the new interface methods and changes the way
TaskSpec is passed so it can't be mutated.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
