### PR TITLE
Modify the behvior of the PullRequest resource when used as an output…

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -100,8 +100,10 @@ func (s *PullRequestResource) GetInputTaskModifier(ts *TaskSpec, sourcePath stri
 }
 
 func (s *PullRequestResource) GetOutputTaskModifier(ts *TaskSpec, sourcePath string) (TaskModifier, error) {
+	// When used as an output, the PR resource should initially fill the output directory with the PR contents.
 	return &InternalTaskModifier{
-		StepsToAppend: s.getSteps("upload", sourcePath),
+		StepsToPrepend: s.getSteps("download", sourcePath),
+		StepsToAppend:  s.getSteps("upload", sourcePath),
 	}, nil
 }
 


### PR DESCRIPTION
… to prefill the directory.

# Changes

When used as an output on an existing PullRequest, the resource will now prefill the output directory.
This behavior change will prevent users from accidentally deleting comments, labels and statuses from
a PullRequest if they forget to copy the information over from the input directory before making modifications.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The PullRequest resource now pre-fills the output directory when it is used as an Output.
```
