### PR TITLE
Update PipelineSpec Task validation to prevents errors at runtime

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -139,8 +139,11 @@ spec:
 ### Pipeline Tasks
 
 A `Pipeline` will execute a graph of [`Tasks`](tasks.md) (see
-[ordering](#ordering) for how to express this graph). At a minimum, this
-declaration must include a reference to the [`Task`](tasks.md):
+[ordering](#ordering) for how to express this graph). A valid `Pipeline` 
+declaration must include a reference to at least one [`Task`](tasks.md). Each
+`Task` within a `Pipeline` must have a
+[valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)
+name and task reference, for example:
 
 ```yaml
 tasks:

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -66,6 +66,24 @@ func TestPipeline_Validate(t *testing.T) {
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
+	}, {
+		name: "pipeline spec empty task name",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("", "foo-task"),
+		)),
+		failureExpected: true,
+	}, {
+		name: "pipeline spec invalid task name",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("_foo", "foo-task"),
+		)),
+		failureExpected: true,
+	}, {
+		name: "pipeline spec invalid taskref name",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineTask("foo", "_foo-task"),
+		)),
+		failureExpected: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Currently, if step names are omitted, a duplicate empty value collides in the Pipeline validation. Also, if a Task name uses forbidden characters, pods will fail to be created since it is appended to the name. If the name is omitted (in a single step, which would pass validation) we would get `<PipelineRunName>--<Rand>-<ConditionalRefName>-<Rand>` for a condition pod and `<PipelineRunName>--<Rand>` otherwise, where the double hyphen imply the name should be specified. Further, in the catalog and elsewhere it seems to be a well documented practice to include the name.

This PR adds validation to PipelineSpec Task name and TaskRef name validation to ensure that the name are valid Kubernetes names (revokes empty values). 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Names of Task instances within Pipelines are now validated: they must not be empty, and they must only contain valid characters (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
```
