### PR TITLE
Add support for using S3-compatible APIs instead of GCS by passing through a boto configuration file.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -137,6 +137,8 @@ The GCS storage bucket can be configured using a ConfigMap with the name
   service account json.
 - The bucket is recommended to be configured with a retention policy after which
   files will be deleted.
+- bucket.service.account.field.name: the name of the environment variable to use when specifying the
+  secret path. Defaults to `GOOGLE_APPLICATION_CREDENTIALS`. Set to `BOTO_CONFIG` if using S3 instead of GCS.
 
 Both options provide the same functionality to the pipeline. The choice is based
 on the infrastructure used, for example in some Kubernetes platforms, the

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -43,6 +43,11 @@ const (
 	// the secret key that will have a value with the service account json with access
 	// to the bucket
 	BucketServiceAccountSecretKey = "bucket.service.account.secret.key"
+
+	// BucketServiceAccountFieldName is the name of the configmap entry that specifies
+	// the field name that should be used for the service account.
+	// Valid values: GOOGLE_APPLICATION_CREDENTIALS, BOTO_CONFIG. Defaults to GOOGLE_APPLICATION_CREDENTIALS.
+	BucketServiceAccountFieldName = "bucket.service.account.field.name"
 )
 
 const (

--- a/pkg/apis/pipeline/v1alpha1/secret_volume_mount.go
+++ b/pkg/apis/pipeline/v1alpha1/secret_volume_mount.go
@@ -33,7 +33,7 @@ func getSecretEnvVarsAndVolumeMounts(name, mountPath string, secrets []SecretPar
 
 	allowedFields := map[string]bool{
 		"GOOGLE_APPLICATION_CREDENTIALS": false,
-		"BOTO_CONFIG": false,
+		"BOTO_CONFIG":                    false,
 	}
 
 	for _, secretParam := range secrets {

--- a/pkg/apis/pipeline/v1alpha1/secret_volume_mount.go
+++ b/pkg/apis/pipeline/v1alpha1/secret_volume_mount.go
@@ -29,12 +29,16 @@ func getSecretEnvVarsAndVolumeMounts(name, mountPath string, secrets []SecretPar
 	var (
 		envVars           []corev1.EnvVar
 		secretVolumeMount []corev1.VolumeMount
-		authVar           bool
 	)
 
+	allowedFields := map[string]bool{
+		"GOOGLE_APPLICATION_CREDENTIALS": false,
+		"BOTO_CONFIG": false,
+	}
+
 	for _, secretParam := range secrets {
-		if secretParam.FieldName == "GOOGLE_APPLICATION_CREDENTIALS" && !authVar {
-			authVar = true
+		if authVar, ok := allowedFields[secretParam.FieldName]; ok && !authVar {
+			allowedFields[secretParam.FieldName] = true
 			mountPath := filepath.Join(mountPath, secretParam.SecretName)
 
 			envVars = append(envVars, corev1.EnvVar{

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -312,6 +312,8 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
 			Location: "s3://fake-bucket",
+			BashNoopImage: "override-with-bash-noop:latest",
+			GsutilImage:   "override-with-gsutil-image:latest",
 			Secrets: []v1alpha1.SecretParam{{
 				FieldName:  "BOTO_CONFIG",
 				SecretKey:  "sakey",

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -311,7 +311,7 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		},
 		pipelinerun: pipelinerun,
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
-			Location: "s3://fake-bucket",
+			Location:      "s3://fake-bucket",
 			BashNoopImage: "override-with-bash-noop:latest",
 			GsutilImage:   "override-with-gsutil-image:latest",
 			Secrets: []v1alpha1.SecretParam{{

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -295,6 +295,30 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 			GsutilImage:   "override-with-gsutil-image:latest",
 		},
 		storagetype: "bucket",
+	}, {
+		desc: "valid bucket with boto config",
+		configMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: system.GetNamespace(),
+				Name:      v1alpha1.BucketConfigName,
+			},
+			Data: map[string]string{
+				v1alpha1.BucketLocationKey:              "s3://fake-bucket",
+				v1alpha1.BucketServiceAccountSecretName: "secret1",
+				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				v1alpha1.BucketServiceAccountFieldName:  "BOTO_CONFIG",
+			},
+		},
+		pipelinerun: pipelinerun,
+		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
+			Location: "s3://fake-bucket",
+			Secrets: []v1alpha1.SecretParam{{
+				FieldName:  "BOTO_CONFIG",
+				SecretKey:  "sakey",
+				SecretName: "secret1",
+			}},
+		},
+		storagetype: "bucket",
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			fakekubeclient := fakek8s.NewSimpleClientset(c.configMap)

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -154,6 +154,9 @@ func NewArtifactBucketConfigFromConfigMap(images pipeline.Images) func(configMap
 		if secretName, ok := configMap.Data[v1alpha1.BucketServiceAccountSecretName]; ok {
 			if secretKey, ok := configMap.Data[v1alpha1.BucketServiceAccountSecretKey]; ok {
 				sp.FieldName = "GOOGLE_APPLICATION_CREDENTIALS"
+				if fieldName, ok := configMap.Data[v1alpha1.BucketServiceAccountFieldName]; ok {
+					sp.FieldName = fieldName
+				}
 				sp.SecretName = secretName
 				sp.SecretKey = secretKey
 				c.Secrets = append(c.Secrets, sp)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds support for using S3-compatible APIs instead of GCS with the GCS storage resource.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
It is now possible to use S3-compatible APIs instead of GCS for GCS storage resources.
```
