### PR TITLE
Support runtimeClassName in pod templates

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -216,6 +216,9 @@ allows to customize some Pod specific field per `Task` execution, aka
 - `volumes`: list of volumes that can be mounted by containers
   belonging to the pod. This lets the user of a Task define which type
   of volume to use for a Task `volumeMount`
+- `runtimeClassName`: the name of a
+  [runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
+  to use to run the pod.
 
 In the following example, the Task is defined with a `volumeMount`
 (`my-cache`), that is provided by the PipelineRun, using a

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -186,7 +186,10 @@ allows to customize some Pod specific field per `Task` execution, aka
 - `volumes`: list of volumes that can be mounted by containers
   belonging to the pod. This lets the user of a Task define which type
   of volume to use for a Task `volumeMount`
-  
+- `runtimeClassName`: the name of a
+  [runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
+  to use to run the pod.
+
 In the following example, the Task is defined with a `volumeMount`
 (`my-cache`), that is provided by the TaskRun, using a
 PersistenceVolumeClaim. The Pod will also run as a non-root user.

--- a/pkg/apis/pipeline/v1alpha1/pod.go
+++ b/pkg/apis/pipeline/v1alpha1/pod.go
@@ -45,4 +45,14 @@ type PodTemplate struct {
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes
 	// +optional
 	Volumes []corev1.Volume `json:"volumes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
+
+	// RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
+	// group, which should be used to run this pod. If no RuntimeClass resource
+	// matches the named class, the pod will not be run. If unset or empty, the
+	// "legacy" RuntimeClass will be used, which is an implicit class with an
+	// empty definition that uses the default runtime handler.
+	// More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+	// This is a beta feature as of Kubernetes v1.14.
+	// +optional
+	RuntimeClassName *string `json:"runtimeClassName,omitempty" protobuf:"bytes,2,opt,name=runtimeClassName"`
 }

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1379,6 +1379,11 @@ func (in *PodTemplate) DeepCopyInto(out *PodTemplate) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.RuntimeClassName != nil {
+		in, out := &in.RuntimeClassName, &out.RuntimeClassName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -355,6 +355,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 			Tolerations:        taskRun.Spec.PodTemplate.Tolerations,
 			Affinity:           taskRun.Spec.PodTemplate.Affinity,
 			SecurityContext:    taskRun.Spec.PodTemplate.SecurityContext,
+			RuntimeClassName:   taskRun.Spec.PodTemplate.RuntimeClassName,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change adds support for the Kubernetes 1.12+ [runtime class](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/runtime-class.md) feature by adding the `runtimeClassName` field to pod templates and propagating that to the underlying pod spec.

At Puppet, we're using Tekton in a fully untrusted environment (i.e., letting arbitrary users run containers à la GitHub Actions). We'd like to use gVisor (GKE Sandbox) as an additional layer of security as we approach a GA release of our product.

As a quick demo, here's the output of `dmesg | tail -n20` using the legacy runtime and the gVisor runtime:
```
$ kubectl create -f dmesg.yaml 
taskrun.tekton.dev/dmesg-l8mzl created
$ tkn taskrun logs dmesg-l8mzl
[test] [16123.188072] audit: type=1327 audit(1569736337.381:1603): proctitle=69707461626C65732D726573746F7265002D2D6E6F666C757368002D2D636F756E74657273
[test] [16138.666823] IPv6: ADDRCONF(NETDEV_UP): eth0: link is not ready
[test] [16138.672706] IPv6: ADDRCONF(NETDEV_UP): vethf7b1349a: link is not ready
[test] [16138.672713] IPv6: ADDRCONF(NETDEV_CHANGE): vethf7b1349a: link becomes ready
[test] [16138.672750] IPv6: ADDRCONF(NETDEV_CHANGE): eth0: link becomes ready
[test] [16138.673023] mybridge: port 11(vethf7b1349a) entered blocking state
[test] [16138.673024] mybridge: port 11(vethf7b1349a) entered disabled state
[test] [16138.673212] device vethf7b1349a entered promiscuous mode
[test] [16138.673232] mybridge: port 11(vethf7b1349a) entered blocking state
[test] [16138.673233] mybridge: port 11(vethf7b1349a) entered forwarding state
[test] [16138.673293] audit: type=1700 audit(1569736352.866:1604): dev=vethf7b1349a prom=256 old_prom=0 auid=4294967295 uid=0 gid=0 ses=4294967295
[test] [16138.681523] audit: type=1300 audit(1569736352.866:1604): arch=c000003e syscall=44 success=yes exit=40 a0=4 a1=c4200a81e0 a2=28 a3=0 items=0 ppid=5173 pid=11202 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="bridge" exe="/opt/cni/bin/bridge" subj=kernel key=(null)
[test] [16138.681697] audit: type=1327 audit(1569736352.866:1604): proctitle="/opt/cni/bin/bridge"
[test] [16140.578679] audit: type=1325 audit(1569736354.772:1605): table=nat family=2 entries=192
[test] [16140.578702] audit: type=1300 audit(1569736354.772:1605): arch=c000003e syscall=54 success=yes exit=0 a0=4 a1=0 a2=40 a3=16ed3a0 items=0 ppid=11202 pid=11303 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="iptables" exe="/usr/sbin/xtables-multi" subj=kernel key=(null)
[test] [16140.578714] audit: type=1327 audit(1569736354.772:1605): proctitle=2F7573722F7362696E2F69707461626C6573002D74006E6174002D4E00434E492D316239346435666165393737663166303835626262646535002D2D77616974
[test] [16140.590522] audit: type=1325 audit(1569736354.783:1606): table=nat family=2 entries=194
[test] [16140.590893] audit: type=1300 audit(1569736354.783:1606): arch=c000003e syscall=54 success=yes exit=0 a0=4 a1=0 a2=40 a3=1a3cb50 items=0 ppid=11202 pid=11305 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="iptables" exe="/usr/sbin/xtables-multi" subj=kernel key=(null)
[test] [16140.591663] audit: type=1327 audit(1569736354.783:1606): proctitle=2F7573722F7362696E2F69707461626C6573002D74006E6174002D4100434E492D316239346435666165393737663166303835626262646535002D640031302E312E302E302F3136002D6A00414343455054002D6D00636F6D6D656E74002D2D636F6D6D656E74006E616D653A2022726B742E6B756265726E657465732E696F
[test] [16140.598676] audit: type=1325 audit(1569736354.792:1607): table=nat family=2 entries=195

$ kubectl create -f dmesg-gvisor.yaml
taskrun.tekton.dev/dmesg-trgrx created
$ tkn taskrun logs dmesg-trgrx
[test] [   0.000000] Starting gVisor...
[test] [   0.106358] Rewriting operating system in Javascript...
[test] [   0.297406] Checking naughty and nice process list...
[test] [   0.532869] Searching for socket adapter...
[test] [   0.904946] Letting the watchdogs out...
[test] [   1.275319] Granting licence to kill(2)...
[test] [   1.497669] Synthesizing system calls...
[test] [   1.566194] Consulting tar man page...
[test] [   1.591064] Waiting for children...
[test] [   1.982031] Forking spaghetti code...
[test] [   2.442056] Searching for needles in stacks...
[test] [   2.626892] Ready!

```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

- Support the `runtimeClassName` field in pod templates