### PR TITLE
Add support for specifiying "0" as no-timeout for PipelineRuns.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -257,6 +259,9 @@ func (pr *PipelineRun) IsTimedOut() bool {
 
 	if !startTime.IsZero() && pipelineTimeout != nil {
 		timeout := pipelineTimeout.Duration
+		if timeout == config.NoTimeoutDuration {
+			return false
+		}
 		runtime := time.Since(startTime.Time)
 		if runtime > timeout {
 			return true

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -192,7 +192,13 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 		timeout:   25 * time.Hour,
 		starttime: time.Now().AddDate(0, 0, -1),
 		expected:  false,
-	}}
+	}, {
+		name:      "notimeoutspecified",
+		timeout:   0 * time.Second,
+		starttime: time.Now().AddDate(0, 0, -1),
+		expected:  false,
+	},
+	}
 
 	for _, tc := range tcs {
 		t.Run(t.Name(), func(t *testing.T) {


### PR DESCRIPTION
# Changes

This was already done in #1040 for TaskRuns, but PipelineRuns seem to have been missed.
This fixes #1339 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix a bug with PipelineRuns timing out immediately when a timeout of 0 is specified.
```
