### PR TITLE
Move nopImage and entrypointImage from pkg/… package to cmd/controller

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -40,15 +40,18 @@ var (
 		"The container image containing our Git binary.")
 	credsImage = flag.String("creds-image", "override-with-creds:latest",
 		"The container image for preparing our Build's credentials.")
+	kubeconfigWriterImage = flag.String("kubeconfig-writer-image", "override-with-kubeconfig-writer:latest",
+		"The container image containing our kubeconfig writer binary.")
 )
 
 func main() {
 	flag.Parse()
 	images := pipeline.Images{
-		EntryPointImage: *entrypointImage,
-		NopImage:        *nopImage,
-		GitImage:        *gitImage,
-		CredsImage:      *credsImage,
+		EntryPointImage:       *entrypointImage,
+		NopImage:              *nopImage,
+		GitImage:              *gitImage,
+		CredsImage:            *credsImage,
+		KubeconfigWriterImage: *kubeconfigWriterImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -38,6 +38,8 @@ var (
 		"The container image used to kill sidecars")
 	gitImage = flag.String("git-image", "override-with-git:latest",
 		"The container image containing our Git binary.")
+	credsImage = flag.String("creds-image", "override-with-creds:latest",
+		"The container image for preparing our Build's credentials.")
 )
 
 func main() {
@@ -46,6 +48,7 @@ func main() {
 		EntryPointImage: *entrypointImage,
 		NopImage:        *nopImage,
 		GitImage:        *gitImage,
+		CredsImage:      *credsImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -46,6 +46,8 @@ var (
 		"The container image containing bash shell")
 	gsutilImage = flag.String("gsutil-image", "override-with-gsutil-image:latest",
 		"The container image containing gsutil")
+	buildGCSFetcherImage = flag.String("build-gcs-fetcher-image", "gcr.io/cloud-builders/gcs-fetcher:latest",
+		"The container image containing our GCS fetcher binary.")
 )
 
 func main() {
@@ -58,6 +60,7 @@ func main() {
 		KubeconfigWriterImage: *kubeconfigWriterImage,
 		BashNoopImage:         *bashNoopImage,
 		GsutilImage:           *gsutilImage,
+		BuildGCSFetcherImage:  *buildGCSFetcherImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -48,6 +48,8 @@ var (
 		"The container image containing gsutil")
 	buildGCSFetcherImage = flag.String("build-gcs-fetcher-image", "gcr.io/cloud-builders/gcs-fetcher:latest",
 		"The container image containing our GCS fetcher binary.")
+	prImage = flag.String("pr-image", "override-with-pr:latest",
+		"The container image containing our PR binary.")
 )
 
 func main() {
@@ -61,6 +63,7 @@ func main() {
 		BashNoopImage:         *bashNoopImage,
 		GsutilImage:           *gsutilImage,
 		BuildGCSFetcherImage:  *buildGCSFetcherImage,
+		PRImage:               *prImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -42,6 +42,8 @@ var (
 		"The container image for preparing our Build's credentials.")
 	kubeconfigWriterImage = flag.String("kubeconfig-writer-image", "override-with-kubeconfig-writer:latest",
 		"The container image containing our kubeconfig writer binary.")
+	bashNoopImage = flag.String("bash-noop-image", "override-with-bash-noop:latest",
+		"The container image containing bash shell")
 )
 
 func main() {
@@ -52,6 +54,7 @@ func main() {
 		GitImage:              *gitImage,
 		CredsImage:            *credsImage,
 		KubeconfigWriterImage: *kubeconfigWriterImage,
+		BashNoopImage:         *bashNoopImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -36,6 +36,8 @@ var (
 		"The container image containing our entrypoint binary.")
 	nopImage = flag.String("nop-image", "override-with-nop:latest",
 		"The container image used to kill sidecars")
+	gitImage = flag.String("git-image", "override-with-git:latest",
+		"The container image containing our Git binary.")
 )
 
 func main() {
@@ -43,6 +45,7 @@ func main() {
 	images := pipeline.Images{
 		EntryPointImage: *entrypointImage,
 		NopImage:        *nopImage,
+		GitImage:        *gitImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,7 +21,7 @@ import (
 
 	"knative.dev/pkg/injection/sharedmain"
 
-	"github.com/tektoncd/pipeline/pkg/reconciler"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun"
 )
@@ -40,7 +40,7 @@ var (
 
 func main() {
 	flag.Parse()
-	images := reconciler.Images{
+	images := pipeline.Images{
 		EntryPointImage: *entrypointImage,
 		NopImage:        *nopImage,
 	}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -50,20 +50,23 @@ var (
 		"The container image containing our GCS fetcher binary.")
 	prImage = flag.String("pr-image", "override-with-pr:latest",
 		"The container image containing our PR binary.")
+	imageDigestExporterImage = flag.String("imagedigest-exporter-image", "override-with-imagedigest-exporter-image:latest",
+		"The container image containing our image digest exporter binary.")
 )
 
 func main() {
 	flag.Parse()
 	images := pipeline.Images{
-		EntryPointImage:       *entrypointImage,
-		NopImage:              *nopImage,
-		GitImage:              *gitImage,
-		CredsImage:            *credsImage,
-		KubeconfigWriterImage: *kubeconfigWriterImage,
-		BashNoopImage:         *bashNoopImage,
-		GsutilImage:           *gsutilImage,
-		BuildGCSFetcherImage:  *buildGCSFetcherImage,
-		PRImage:               *prImage,
+		EntryPointImage:          *entrypointImage,
+		NopImage:                 *nopImage,
+		GitImage:                 *gitImage,
+		CredsImage:               *credsImage,
+		KubeconfigWriterImage:    *kubeconfigWriterImage,
+		BashNoopImage:            *bashNoopImage,
+		GsutilImage:              *gsutilImage,
+		BuildGCSFetcherImage:     *buildGCSFetcherImage,
+		PRImage:                  *prImage,
+		ImageDigestExporterImage: *imageDigestExporterImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -44,6 +44,8 @@ var (
 		"The container image containing our kubeconfig writer binary.")
 	bashNoopImage = flag.String("bash-noop-image", "override-with-bash-noop:latest",
 		"The container image containing bash shell")
+	gsutilImage = flag.String("gsutil-image", "override-with-gsutil-image:latest",
+		"The container image containing gsutil")
 )
 
 func main() {
@@ -55,6 +57,7 @@ func main() {
 		CredsImage:            *credsImage,
 		KubeconfigWriterImage: *kubeconfigWriterImage,
 		BashNoopImage:         *bashNoopImage,
+		GsutilImage:           *gsutilImage,
 	}
 	sharedmain.Main(ControllerLogKey,
 		taskrun.NewController(images),

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package reconciler
+package pipeline
 
 // Images holds the images reference for a number of container images used accross tektoncd pipelines
 type Images struct {
@@ -22,4 +22,6 @@ type Images struct {
 	EntryPointImage string
 	// NopImage is the container image used to kill sidecars
 	NopImage string
+	// GitImage container with Git that we use to implement the Git source step.
+	GitImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -34,4 +34,6 @@ type Images struct {
 	GsutilImage string
 	// BuildGCSFetcherImage is the container image containing our GCS fetcher binary.
 	BuildGCSFetcherImage string
+	// PRImage is the container image that we use to implement the PR source step.
+	PRImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -22,6 +22,6 @@ type Images struct {
 	EntryPointImage string
 	// NopImage is the container image used to kill sidecars
 	NopImage string
-	// GitImage container with Git that we use to implement the Git source step.
+	// GitImage is the container image with Git that we use to implement the Git source step.
 	GitImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -32,4 +32,6 @@ type Images struct {
 	BashNoopImage string
 	// GsutilImage is the container miage containing gsutil.
 	GsutilImage string
+	// BuildGCSFetcherImage is the container image containing our GCS fetcher binary.
+	BuildGCSFetcherImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -20,7 +20,7 @@ package pipeline
 type Images struct {
 	// EntryPointImage is container image containing our entrypoint binary.
 	EntryPointImage string
-	// NopImage is the container image used to kill sidecars
+	// NopImage is the container image used to kill sidecars.
 	NopImage string
 	// GitImage is the container image with Git that we use to implement the Git source step.
 	GitImage string
@@ -28,6 +28,8 @@ type Images struct {
 	CredsImage string
 	// KubeconfigWriterImage is the container image containing our kubeconfig writer binary.
 	KubeconfigWriterImage string
-	// BashNoopImage is the container image containing bash shell
+	// BashNoopImage is the container image containing bash shell.
 	BashNoopImage string
+	// GsutilImage is the container miage containing gsutil.
+	GsutilImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -36,4 +36,6 @@ type Images struct {
 	BuildGCSFetcherImage string
 	// PRImage is the container image that we use to implement the PR source step.
 	PRImage string
+	// ImageDigestExporterImage is the container image containing our image digest exporter binary.
+	ImageDigestExporterImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -26,4 +26,6 @@ type Images struct {
 	GitImage string
 	// CredsImage is the container image used to initialize credentials before the build runs.
 	CredsImage string
+	// KubeconfigWriterImage is the container image containing our kubeconfig writer binary.
+	KubeconfigWriterImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -28,4 +28,6 @@ type Images struct {
 	CredsImage string
 	// KubeconfigWriterImage is the container image containing our kubeconfig writer binary.
 	KubeconfigWriterImage string
+	// BashNoopImage is the container image containing bash shell
+	BashNoopImage string
 }

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -24,4 +24,6 @@ type Images struct {
 	NopImage string
 	// GitImage is the container image with Git that we use to implement the Git source step.
 	GitImage string
+	// CredsImage is the container image used to initialize credentials before the build runs.
+	CredsImage string
 }

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -66,6 +66,7 @@ type ArtifactBucket struct {
 	Secrets  []SecretParam
 
 	BashNoopImage string
+	GsutilImage   string
 }
 
 // GetType returns the type of the artifact storage
@@ -93,7 +94,7 @@ func (b *ArtifactBucket) GetCopyFromStorageToSteps(name, sourcePath, destination
 		},
 	}}, {Container: corev1.Container{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-copy-from-%s", name)),
-		Image:        *gsutilImage,
+		Image:        b.GsutilImage,
 		Command:      []string{"/ko-app/gsutil"},
 		Args:         args,
 		Env:          envVars,
@@ -109,7 +110,7 @@ func (b *ArtifactBucket) GetCopyToStorageFromSteps(name, sourcePath, destination
 
 	return []Step{{Container: corev1.Container{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-copy-to-%s", name)),
-		Image:        *gsutilImage,
+		Image:        b.GsutilImage,
 		Command:      []string{"/ko-app/gsutil"},
 		Args:         args,
 		Env:          envVars,

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -64,6 +64,8 @@ type ArtifactBucket struct {
 	Name     string
 	Location string
 	Secrets  []SecretParam
+
+	BashNoopImage string
 }
 
 // GetType returns the type of the artifact storage
@@ -84,7 +86,7 @@ func (b *ArtifactBucket) GetCopyFromStorageToSteps(name, sourcePath, destination
 
 	return []Step{{Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("artifact-dest-mkdir-%s", name)),
-		Image:   *BashNoopImage,
+		Image:   b.BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " "),

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
@@ -41,6 +41,7 @@ var (
 			SecretKey:  "serviceaccount",
 		}},
 		BashNoopImage: "override-with-bash-noop:latest",
+		GsutilImage:   "override-with-gsutil-image:latest",
 	}
 )
 

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket_test.go
@@ -40,6 +40,7 @@ var (
 			SecretName: secretName,
 			SecretKey:  "serviceaccount",
 		}},
+		BashNoopImage: "override-with-bash-noop:latest",
 	}
 )
 

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 
@@ -26,8 +25,7 @@ import (
 )
 
 var (
-	pvcDir        = "/pvc"
-	BashNoopImage = flag.String("bash-noop-image", "override-with-bash-noop:latest", "The container image containing bash shell")
+	pvcDir = "/pvc"
 )
 
 // ArtifactPVC represents the pvc created by the pipelinerun
@@ -35,6 +33,8 @@ var (
 type ArtifactPVC struct {
 	Name                  string
 	PersistentVolumeClaim *corev1.PersistentVolumeClaim
+
+	BashNoopImage string
 }
 
 // GetType returns the type of the artifact storage
@@ -51,7 +51,7 @@ func (p *ArtifactPVC) StorageBasePath(pr *PipelineRun) string {
 func (p *ArtifactPVC) GetCopyFromStorageToSteps(name, sourcePath, destinationPath string) []Step {
 	return []Step{{Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
-		Image:   *BashNoopImage,
+		Image:   p.BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args:    []string{"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " ")},
 	}}}
@@ -61,7 +61,7 @@ func (p *ArtifactPVC) GetCopyFromStorageToSteps(name, sourcePath, destinationPat
 func (p *ArtifactPVC) GetCopyToStorageFromSteps(name, sourcePath, destinationPath string) []Step {
 	return []Step{{Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-mkdir-%s", name)),
-		Image:   *BashNoopImage,
+		Image:   p.BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " "),
@@ -69,7 +69,7 @@ func (p *ArtifactPVC) GetCopyToStorageFromSteps(name, sourcePath, destinationPat
 		VolumeMounts: []corev1.VolumeMount{GetPvcMount(p.Name)},
 	}}, {Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("source-copy-%s", name)),
-		Image:   *BashNoopImage,
+		Image:   p.BashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args: []string{
 			"-args", strings.Join([]string{"cp", "-r", fmt.Sprintf("%s/.", sourcePath), destinationPath}, " "),
@@ -87,10 +87,10 @@ func GetPvcMount(name string) corev1.VolumeMount {
 }
 
 // CreateDirStep returns a container step to create a dir
-func CreateDirStep(name, destinationPath string) Step {
+func CreateDirStep(bashNoopImage string, name, destinationPath string) Step {
 	return Step{Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("create-dir-%s", strings.ToLower(name))),
-		Image:   *BashNoopImage,
+		Image:   bashNoopImage,
 		Command: []string{"/ko-app/bash"},
 		Args:    []string{"-args", strings.Join([]string{"mkdir", "-p", destinationPath}, " ")},
 	}}

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc_test.go
@@ -30,7 +30,8 @@ func TestPVCGetCopyFromContainerSpec(t *testing.T) {
 	names.TestingSeed()
 
 	pvc := v1alpha1.ArtifactPVC{
-		Name: "pipelinerun-pvc",
+		Name:          "pipelinerun-pvc",
+		BashNoopImage: "override-with-bash-noop:latest",
 	}
 	want := []v1alpha1.Step{{Container: corev1.Container{
 		Name:    "source-copy-workspace-9l9zj",
@@ -49,7 +50,8 @@ func TestPVCGetCopyToContainerSpec(t *testing.T) {
 	names.TestingSeed()
 
 	pvc := v1alpha1.ArtifactPVC{
-		Name: "pipelinerun-pvc",
+		Name:          "pipelinerun-pvc",
+		BashNoopImage: "override-with-bash-noop:latest",
 	}
 	want := []v1alpha1.Step{{Container: corev1.Container{
 		Name:         "source-mkdir-workspace-9l9zj",
@@ -95,7 +97,7 @@ func TestPVCGetMakeStep(t *testing.T) {
 		Command: []string{"/ko-app/bash"},
 		Args:    []string{"-args", "mkdir -p /workspace/destination"},
 	}}
-	got := v1alpha1.CreateDirStep("workspace", "/workspace/destination")
+	got := v1alpha1.CreateDirStep("override-with-bash-noop:latest", "workspace", "/workspace/destination")
 	if d := cmp.Diff(got, want); d != "" {
 		t.Errorf("Diff:\n%s", d)
 	}

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource.go
@@ -75,7 +75,7 @@ type BuildGCSResource struct {
 	BashNoopImage string `json:"-"`
 }
 
-// NewBuildGCSResource creates a new BuildGCS resource to pass to a Task
+//  creates a new BuildGCS resource to pass to a Task
 func NewBuildGCSResource(images pipeline.Images, r *PipelineResource) (*BuildGCSResource, error) {
 	if r.Spec.Type != PipelineResourceTypeStorage {
 		return nil, xerrors.Errorf("BuildGCSResource: Cannot create a BuildGCS resource from a %s Pipeline Resource", r.Spec.Type)

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -34,6 +34,7 @@ var images = pipeline.Images{
 	CredsImage:            "override-with-creds:latest",
 	KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 	BashNoopImage:         "override-with-bash-noop:latest",
+	GsutilImage:           "override-with-gsutil-image:latest",
 }
 
 func Test_Invalid_BuildGCSResource(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -35,6 +35,7 @@ var images = pipeline.Images{
 	KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 	BashNoopImage:         "override-with-bash-noop:latest",
 	GsutilImage:           "override-with-gsutil-image:latest",
+	BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
 }
 
 func Test_Invalid_BuildGCSResource(t *testing.T) {
@@ -105,11 +106,12 @@ func Test_Valid_NewBuildGCSResource(t *testing.T) {
 		tb.PipelineResourceSpecParam("ArtifactType", "Manifest"),
 	))
 	expectedGCSResource := &v1alpha1.BuildGCSResource{
-		Name:          "build-gcs-resource",
-		Location:      "gs://fake-bucket",
-		Type:          v1alpha1.PipelineResourceTypeStorage,
-		ArtifactType:  "Manifest",
-		BashNoopImage: "override-with-bash-noop:latest",
+		Name:                 "build-gcs-resource",
+		Location:             "gs://fake-bucket",
+		Type:                 v1alpha1.PipelineResourceTypeStorage,
+		ArtifactType:         "Manifest",
+		BashNoopImage:        "override-with-bash-noop:latest",
+		BuildGCSFetcherImage: "gcr.io/cloud-builders/gcs-fetcher:latest",
 	}
 
 	r, err := v1alpha1.NewBuildGCSResource(images, pr)
@@ -146,10 +148,11 @@ func Test_BuildGCSGetInputSteps(t *testing.T) {
 	} {
 		t.Run(string(at), func(t *testing.T) {
 			resource := &v1alpha1.BuildGCSResource{
-				Name:          "gcs-valid",
-				Location:      "gs://some-bucket",
-				ArtifactType:  at,
-				BashNoopImage: "override-with-bash-noop:latest",
+				Name:                 "gcs-valid",
+				Location:             "gs://some-bucket",
+				ArtifactType:         at,
+				BashNoopImage:        "override-with-bash-noop:latest",
+				BuildGCSFetcherImage: "gcr.io/cloud-builders/gcs-fetcher:latest",
 			}
 			wantSteps := []v1alpha1.Step{{Container: corev1.Container{
 				Name:    "create-dir-gcs-valid-9l9zj",

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -28,15 +28,16 @@ import (
 )
 
 var images = pipeline.Images{
-	EntryPointImage:       "override-with-entrypoint:latest",
-	NopImage:              "override-with-nop:latest",
-	GitImage:              "override-with-git:latest",
-	CredsImage:            "override-with-creds:latest",
-	KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
-	BashNoopImage:         "override-with-bash-noop:latest",
-	GsutilImage:           "override-with-gsutil-image:latest",
-	BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
-	PRImage:               "override-with-pr:latest",
+	EntryPointImage:          "override-with-entrypoint:latest",
+	NopImage:                 "override-with-nop:latest",
+	GitImage:                 "override-with-git:latest",
+	CredsImage:               "override-with-creds:latest",
+	KubeconfigWriterImage:    "override-with-kubeconfig-writer:latest",
+	BashNoopImage:            "override-with-bash-noop:latest",
+	GsutilImage:              "override-with-gsutil-image:latest",
+	BuildGCSFetcherImage:     "gcr.io/cloud-builders/gcs-fetcher:latest",
+	PRImage:                  "override-with-pr:latest",
+	ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 }
 
 func Test_Invalid_BuildGCSResource(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -36,6 +36,7 @@ var images = pipeline.Images{
 	BashNoopImage:         "override-with-bash-noop:latest",
 	GsutilImage:           "override-with-gsutil-image:latest",
 	BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
+	PRImage:               "override-with-pr:latest",
 }
 
 func Test_Invalid_BuildGCSResource(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -19,17 +19,12 @@ package v1alpha1
 import (
 	b64 "encoding/base64"
 	"encoding/json"
-	"flag"
 	"strconv"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/names"
 	"golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
-)
-
-var (
-	kubeconfigWriterImage = flag.String("kubeconfig-writer-image", "override-with-kubeconfig-writer:latest", "The container image containing our kubeconfig writer binary.")
 )
 
 // ClusterResource represents a cluster configuration (kubeconfig)
@@ -55,15 +50,18 @@ type ClusterResource struct {
 	CAData []byte `json:"cadata"`
 	//Secrets holds a struct to indicate a field name and corresponding secret name to populate it
 	Secrets []SecretParam `json:"secrets"`
+
+	KubeconfigWriterImage string `json:"-"`
 }
 
 // NewClusterResource create a new k8s cluster resource to pass to a pipeline task
-func NewClusterResource(r *PipelineResource) (*ClusterResource, error) {
+func NewClusterResource(kubeconfigWriterImage string, r *PipelineResource) (*ClusterResource, error) {
 	if r.Spec.Type != PipelineResourceTypeCluster {
 		return nil, xerrors.Errorf("ClusterResource: Cannot create a Cluster resource from a %s Pipeline Resource", r.Spec.Type)
 	}
 	clusterResource := ClusterResource{
-		Type: r.Spec.Type,
+		Type:                  r.Spec.Type,
+		KubeconfigWriterImage: kubeconfigWriterImage,
 	}
 	for _, param := range r.Spec.Params {
 		switch {
@@ -166,7 +164,7 @@ func (s *ClusterResource) GetInputTaskModifier(ts *TaskSpec, path string) (TaskM
 	}
 	step := Step{Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("kubeconfig"),
-		Image:   *kubeconfigWriterImage,
+		Image:   s.KubeconfigWriterImage,
 		Command: []string{"/ko-app/kubeconfigwriter"},
 		Args: []string{
 			"-clusterConfig", s.String(),

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -41,11 +41,12 @@ func TestNewClusterResource(t *testing.T) {
 			tb.PipelineResourceSpecParam("token", "my-token"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:   "test_cluster_resource",
-			Type:   v1alpha1.PipelineResourceTypeCluster,
-			URL:    "http://10.10.10.10",
-			CAData: []byte("my-cluster-cert"),
-			Token:  "my-token",
+			Name:                  "test_cluster_resource",
+			Type:                  v1alpha1.PipelineResourceTypeCluster,
+			URL:                   "http://10.10.10.10",
+			CAData:                []byte("my-cluster-cert"),
+			Token:                 "my-token",
+			KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		},
 	}, {
 		desc: "resource with password instead of token",
@@ -58,12 +59,13 @@ func TestNewClusterResource(t *testing.T) {
 			tb.PipelineResourceSpecParam("password", "pass"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:     "test_cluster_resource",
-			Type:     v1alpha1.PipelineResourceTypeCluster,
-			URL:      "http://10.10.10.10",
-			CAData:   []byte("my-cluster-cert"),
-			Username: "user",
-			Password: "pass",
+			Name:                  "test_cluster_resource",
+			Type:                  v1alpha1.PipelineResourceTypeCluster,
+			URL:                   "http://10.10.10.10",
+			CAData:                []byte("my-cluster-cert"),
+			Username:              "user",
+			Password:              "pass",
+			KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		},
 	}, {
 		desc: "set insecure flag to true when there is no cert",
@@ -74,11 +76,12 @@ func TestNewClusterResource(t *testing.T) {
 			tb.PipelineResourceSpecParam("token", "my-token"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:     "test.cluster.resource",
-			Type:     v1alpha1.PipelineResourceTypeCluster,
-			URL:      "http://10.10.10.10",
-			Token:    "my-token",
-			Insecure: true,
+			Name:                  "test.cluster.resource",
+			Type:                  v1alpha1.PipelineResourceTypeCluster,
+			URL:                   "http://10.10.10.10",
+			Token:                 "my-token",
+			Insecure:              true,
+			KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		},
 	}, {
 		desc: "basic cluster resource with namespace",
@@ -91,12 +94,13 @@ func TestNewClusterResource(t *testing.T) {
 			tb.PipelineResourceSpecParam("namespace", "my-namespace"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:      "test_cluster_resource",
-			Type:      v1alpha1.PipelineResourceTypeCluster,
-			URL:       "http://10.10.10.10",
-			CAData:    []byte("my-cluster-cert"),
-			Token:     "my-token",
-			Namespace: "my-namespace",
+			Name:                  "test_cluster_resource",
+			Type:                  v1alpha1.PipelineResourceTypeCluster,
+			URL:                   "http://10.10.10.10",
+			CAData:                []byte("my-cluster-cert"),
+			Token:                 "my-token",
+			Namespace:             "my-namespace",
+			KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		},
 	}, {
 		desc: "basic resource with secrets",
@@ -120,10 +124,11 @@ func TestNewClusterResource(t *testing.T) {
 				SecretKey:  "tokenkey",
 				SecretName: "secret1",
 			}},
+			KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			got, err := v1alpha1.NewClusterResource(c.resource)
+			got, err := v1alpha1.NewClusterResource("override-with-kubeconfig-writer:latest", c.resource)
 			if err != nil {
 				t.Errorf("Test: %q; TestNewClusterResource() error = %v", c.desc, err)
 			}
@@ -145,6 +150,7 @@ func Test_ClusterResource_GetInputTaskModifier(t *testing.T) {
 			SecretKey:  "cadatakey",
 			SecretName: "secret1",
 		}},
+		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 	}
 
 	ts := v1alpha1.TaskSpec{}

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -68,7 +68,7 @@ func Test_Invalid_NewStorageResource(t *testing.T) {
 		),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := v1alpha1.NewStorageResource(tc.pipelineResource)
+			_, err := v1alpha1.NewStorageResource(images, tc.pipelineResource)
 			if err == nil {
 				t.Error("Expected error creating GCS resource")
 			}
@@ -94,9 +94,10 @@ func Test_Valid_NewGCSResource(t *testing.T) {
 			SecretKey:  "secretKey",
 			FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 		}},
+		BashNoopImage: "override-with-bash-noop:latest",
 	}
 
-	gcsRes, err := v1alpha1.NewGCSResource(pr)
+	gcsRes, err := v1alpha1.NewGCSResource(images, pr)
 	if err != nil {
 		t.Fatalf("Unexpected error creating GCS resource: %s", err)
 	}
@@ -128,7 +129,7 @@ func Test_GetParams(t *testing.T) {
 		tb.PipelineResourceSpecParam("type", "gcs"),
 		tb.PipelineResourceSpecSecretParam("test-field-name", "test-secret-name", "test-secret-key"),
 	))
-	gcsResource, err := v1alpha1.NewStorageResource(pr)
+	gcsResource, err := v1alpha1.NewStorageResource(images, pr)
 	if err != nil {
 		t.Fatalf("Error creating storage resource: %s", err.Error())
 	}
@@ -161,6 +162,7 @@ func Test_GetInputSteps(t *testing.T) {
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
 			}},
+			BashNoopImage: "override-with-bash-noop:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "create-dir-gcs-valid-9l9zj",
@@ -195,6 +197,7 @@ func Test_GetInputSteps(t *testing.T) {
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
+			BashNoopImage: "override-with-bash-noop:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "create-dir-gcs-valid-mssqb",

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -95,6 +95,7 @@ func Test_Valid_NewGCSResource(t *testing.T) {
 			FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 		}},
 		BashNoopImage: "override-with-bash-noop:latest",
+		GsutilImage:   "override-with-gsutil-image:latest",
 	}
 
 	gcsRes, err := v1alpha1.NewGCSResource(images, pr)
@@ -163,6 +164,7 @@ func Test_GetInputSteps(t *testing.T) {
 				SecretKey:  "key.json",
 			}},
 			BashNoopImage: "override-with-bash-noop:latest",
+			GsutilImage:   "override-with-gsutil-image:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "create-dir-gcs-valid-9l9zj",
@@ -198,6 +200,7 @@ func Test_GetInputSteps(t *testing.T) {
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
 			BashNoopImage: "override-with-bash-noop:latest",
+			GsutilImage:   "override-with-gsutil-image:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "create-dir-gcs-valid-mssqb",
@@ -251,6 +254,7 @@ func Test_GetOutputTaskModifier(t *testing.T) {
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 				SecretKey:  "key.json",
 			}},
+			GsutilImage: "override-with-gsutil-image:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "upload-gcs-valid-9l9zj",
@@ -277,6 +281,7 @@ func Test_GetOutputTaskModifier(t *testing.T) {
 				SecretName: "secretName",
 				FieldName:  "GOOGLE_APPLICATION_CREDENTIALS",
 			}},
+			GsutilImage: "override-with-gsutil-image:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "upload-gcs-valid-mz4c7",
@@ -294,9 +299,10 @@ func Test_GetOutputTaskModifier(t *testing.T) {
 	}, {
 		name: "valid upload to protected buckets with single file",
 		gcsResource: &v1alpha1.GCSResource{
-			Name:     "gcs-valid",
-			Location: "gs://some-bucket",
-			TypeDir:  false,
+			Name:        "gcs-valid",
+			Location:    "gs://some-bucket",
+			TypeDir:     false,
+			GsutilImage: "override-with-gsutil-image:latest",
 		},
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "upload-gcs-valid-mssqb",

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"flag"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/names"
@@ -29,9 +28,6 @@ const WorkspaceDir = "/workspace"
 
 var (
 	gitSource = "git-source"
-	// The container with Git that we use to implement the Git source step.
-	gitImage = flag.String("git-image", "override-with-git:latest",
-		"The container image containing our Git binary.")
 )
 
 // GitResource is an endpoint from which to get data which is required
@@ -44,16 +40,19 @@ type GitResource struct {
 	// https://git-scm.com/docs/gitrevisions#_specifying_revisions for more
 	// information.
 	Revision string `json:"revision"`
+
+	GitImage string `json:"-"`
 }
 
 // NewGitResource creates a new git resource to pass to a Task
-func NewGitResource(r *PipelineResource) (*GitResource, error) {
+func NewGitResource(gitImage string, r *PipelineResource) (*GitResource, error) {
 	if r.Spec.Type != PipelineResourceTypeGit {
 		return nil, xerrors.Errorf("GitResource: Cannot create a Git resource from a %s Pipeline Resource", r.Spec.Type)
 	}
 	gitResource := GitResource{
-		Name: r.Name,
-		Type: r.Spec.Type,
+		Name:     r.Name,
+		Type:     r.Spec.Type,
+		GitImage: gitImage,
 	}
 	for _, param := range r.Spec.Params {
 		switch {
@@ -106,7 +105,7 @@ func (s *GitResource) GetInputTaskModifier(_ *TaskSpec, path string) (TaskModifi
 	step := Step{
 		Container: corev1.Container{
 			Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(gitSource + "-" + s.Name),
-			Image:      *gitImage,
+			Image:      s.GitImage,
 			Command:    []string{"/ko-app/git-init"},
 			Args:       args,
 			WorkingDir: WorkspaceDir,

--- a/pkg/apis/pipeline/v1alpha1/git_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Test_Invalid_NewGitResource(t *testing.T) {
-	if _, err := v1alpha1.NewGitResource(tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGCS))); err == nil {
+	if _, err := v1alpha1.NewGitResource("override-with-git:latest", tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGCS))); err == nil {
 		t.Error("Expected error creating Git resource")
 	}
 }
@@ -50,6 +50,7 @@ func Test_Valid_NewGitResource(t *testing.T) {
 			Type:     v1alpha1.PipelineResourceTypeGit,
 			URL:      "git@github.com:test/test.git",
 			Revision: "test",
+			GitImage: "override-with-git:latest",
 		},
 	}, {
 		desc: "Without Revision",
@@ -63,10 +64,11 @@ func Test_Valid_NewGitResource(t *testing.T) {
 			Type:     v1alpha1.PipelineResourceTypeGit,
 			URL:      "git@github.com:test/test.git",
 			Revision: "master",
+			GitImage: "override-with-git:latest",
 		},
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
-			got, err := v1alpha1.NewGitResource(tc.pipelineResource)
+			got, err := v1alpha1.NewGitResource("override-with-git:latest", tc.pipelineResource)
 			if err != nil {
 				t.Fatalf("Unexpected error creating Git resource: %s", err)
 			}
@@ -108,6 +110,7 @@ func Test_GitResource_GetDownloadTaskModifier(t *testing.T) {
 		Type:     v1alpha1.PipelineResourceTypeGit,
 		URL:      "git@github.com:test/test.git",
 		Revision: "master",
+		GitImage: "override-with-git:latest",
 	}
 
 	ts := v1alpha1.TaskSpec{}

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 
@@ -28,12 +27,6 @@ import (
 const (
 	prSource       = "pr-source"
 	githubTokenEnv = "githubToken"
-)
-
-var (
-	// The container that we use to implement the PR source step.
-	prImage = flag.String("pr-image", "override-with-pr:latest",
-		"The container image containing our PR binary.")
 )
 
 // PullRequestResource is an endpoint from which to get data which is required
@@ -47,10 +40,12 @@ type PullRequestResource struct {
 	URL string `json:"url"`
 	// Secrets holds a struct to indicate a field name and corresponding secret name to populate it.
 	Secrets []SecretParam `json:"secrets"`
+
+	PRImage string `json:"-"`
 }
 
 // NewPullRequestResource create a new git resource to pass to a Task
-func NewPullRequestResource(r *PipelineResource) (*PullRequestResource, error) {
+func NewPullRequestResource(prImage string, r *PipelineResource) (*PullRequestResource, error) {
 	if r.Spec.Type != PipelineResourceTypePullRequest {
 		return nil, fmt.Errorf("PipelineResource: Cannot create a PR resource from a %s Pipeline Resource", r.Spec.Type)
 	}
@@ -58,6 +53,7 @@ func NewPullRequestResource(r *PipelineResource) (*PullRequestResource, error) {
 		Name:    r.Name,
 		Type:    r.Spec.Type,
 		Secrets: r.Spec.SecretParams,
+		PRImage: prImage,
 	}
 	for _, param := range r.Spec.Params {
 		if strings.EqualFold(param.Name, "URL") {
@@ -129,7 +125,7 @@ func (s *PullRequestResource) getSteps(mode string, sourcePath string) []Step {
 
 	return []Step{{Container: corev1.Container{
 		Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(prSource + "-" + s.Name),
-		Image:      *prImage,
+		Image:      s.PRImage,
 		Command:    []string{"/ko-app/pullrequest-init"},
 		Args:       args,
 		WorkingDir: WorkspaceDir,

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -34,7 +34,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 		tb.PipelineResourceSpecParam("url", url),
 		tb.PipelineResourceSpecSecretParam("githubToken", "test-secret-key", "test-secret-name"),
 	))
-	got, err := v1alpha1.NewPullRequestResource(pr)
+	got, err := v1alpha1.NewPullRequestResource("override-with-pr:latest", pr)
 	if err != nil {
 		t.Fatalf("Error creating storage resource: %s", err.Error())
 	}
@@ -44,6 +44,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 		Type:    v1alpha1.PipelineResourceTypePullRequest,
 		URL:     url,
 		Secrets: pr.Spec.SecretParams,
+		PRImage: "override-with-pr:latest",
 	}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Error(diff)
@@ -52,7 +53,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 
 func TestPullRequest_NewResource_error(t *testing.T) {
 	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
-	if _, err := v1alpha1.NewPullRequestResource(pr); err == nil {
+	if _, err := v1alpha1.NewPullRequestResource("override-with-pr:latest", pr); err == nil {
 		t.Error("NewPullRequestResource() want error, got nil")
 	}
 }
@@ -67,8 +68,9 @@ const workspace = "/workspace"
 func containerTestCases(mode string) []testcase {
 	return []testcase{{
 		in: &v1alpha1.PullRequestResource{
-			Name: "nocreds",
-			URL:  "https://example.com",
+			Name:    "nocreds",
+			URL:     "https://example.com",
+			PRImage: "override-with-pr:latest",
 		},
 		out: []v1alpha1.Step{{Container: corev1.Container{
 			Name:       "pr-source-nocreds-9l9zj",
@@ -87,6 +89,7 @@ func containerTestCases(mode string) []testcase {
 				SecretName: "github-creds",
 				SecretKey:  "token",
 			}},
+			PRImage: "override-with-pr:latest",
 		},
 		out: []v1alpha1.Step{{Container: corev1.Container{
 			Name:       "pr-source-creds-mz4c7",

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"golang.org/x/xerrors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -196,10 +197,10 @@ type ResourceDeclaration struct {
 }
 
 // ResourceFromType returns a PipelineResourceInterface from a PipelineResource's type.
-func ResourceFromType(r *PipelineResource) (PipelineResourceInterface, error) {
+func ResourceFromType(r *PipelineResource, images pipeline.Images) (PipelineResourceInterface, error) {
 	switch r.Spec.Type {
 	case PipelineResourceTypeGit:
-		return NewGitResource(r)
+		return NewGitResource(images.GitImage, r)
 	case PipelineResourceTypeImage:
 		return NewImageResource(r)
 	case PipelineResourceTypeCluster:

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -206,7 +206,7 @@ func ResourceFromType(r *PipelineResource, images pipeline.Images) (PipelineReso
 	case PipelineResourceTypeCluster:
 		return NewClusterResource(images.KubeconfigWriterImage, r)
 	case PipelineResourceTypeStorage:
-		return NewStorageResource(r)
+		return NewStorageResource(images, r)
 	case PipelineResourceTypePullRequest:
 		return NewPullRequestResource(r)
 	case PipelineResourceTypeCloudEvent:

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -208,7 +208,7 @@ func ResourceFromType(r *PipelineResource, images pipeline.Images) (PipelineReso
 	case PipelineResourceTypeStorage:
 		return NewStorageResource(images, r)
 	case PipelineResourceTypePullRequest:
-		return NewPullRequestResource(r)
+		return NewPullRequestResource(images.PRImage, r)
 	case PipelineResourceTypeCloudEvent:
 		return NewCloudEventResource(r)
 	}

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -204,7 +204,7 @@ func ResourceFromType(r *PipelineResource, images pipeline.Images) (PipelineReso
 	case PipelineResourceTypeImage:
 		return NewImageResource(r)
 	case PipelineResourceTypeCluster:
-		return NewClusterResource(r)
+		return NewClusterResource(images.KubeconfigWriterImage, r)
 	case PipelineResourceTypeStorage:
 		return NewStorageResource(r)
 	case PipelineResourceTypePullRequest:

--- a/pkg/apis/pipeline/v1alpha1/storage_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/storage_resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"golang.org/x/xerrors"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -38,7 +39,7 @@ type PipelineStorageResourceInterface interface {
 	GetSecretParams() []SecretParam
 }
 
-func NewStorageResource(r *PipelineResource) (PipelineStorageResourceInterface, error) {
+func NewStorageResource(images pipeline.Images, r *PipelineResource) (PipelineStorageResourceInterface, error) {
 	if r.Spec.Type != PipelineResourceTypeStorage {
 		return nil, xerrors.Errorf("StoreResource: Cannot create a storage resource from a %s Pipeline Resource", r.Spec.Type)
 	}
@@ -47,9 +48,9 @@ func NewStorageResource(r *PipelineResource) (PipelineStorageResourceInterface, 
 		if strings.EqualFold(param.Name, "type") {
 			switch {
 			case strings.EqualFold(param.Value, string(PipelineResourceTypeGCS)):
-				return NewGCSResource(r)
+				return NewGCSResource(images, r)
 			case strings.EqualFold(param.Value, string(PipelineResourceTypeBuildGCS)):
-				return NewBuildGCSResource(r)
+				return NewBuildGCSResource(images, r)
 			default:
 				return nil, xerrors.Errorf("%s is an invalid or unimplemented PipelineStorageResource", param.Value)
 			}

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -35,15 +35,16 @@ import (
 
 var (
 	images = pipeline.Images{
-		EntryPointImage:       "override-with-entrypoint:latest",
-		NopImage:              "override-with-nop:latest",
-		GitImage:              "override-with-git:latest",
-		CredsImage:            "override-with-creds:latest",
-		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
-		BashNoopImage:         "override-with-bash-noop:latest",
-		GsutilImage:           "override-with-gsutil-image:latest",
-		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
-		PRImage:               "override-with-pr:latest",
+		EntryPointImage:          "override-with-entrypoint:latest",
+		NopImage:                 "override-with-nop:latest",
+		GitImage:                 "override-with-git:latest",
+		CredsImage:               "override-with-creds:latest",
+		KubeconfigWriterImage:    "override-with-kubeconfig-writer:latest",
+		BashNoopImage:            "override-with-bash-noop:latest",
+		GsutilImage:              "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:     "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:                  "override-with-pr:latest",
+		ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 	}
 	pipelinerun = &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -43,6 +43,7 @@ var (
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
 		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:               "override-with-pr:latest",
 	}
 	pipelinerun = &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -42,6 +42,7 @@ var (
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
 	}
 	pipelinerun = &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -41,6 +41,7 @@ var (
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
+		GsutilImage:           "override-with-gsutil-image:latest",
 	}
 	pipelinerun = &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -216,6 +217,7 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 				SecretName: "secret1",
 			}},
 			BashNoopImage: "override-with-bash-noop:latest",
+			GsutilImage:   "override-with-gsutil-image:latest",
 		},
 		storagetype: "bucket",
 	}, {
@@ -287,6 +289,7 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
 			Location:      "gs://fake-bucket",
 			BashNoopImage: "override-with-bash-noop:latest",
+			GsutilImage:   "override-with-gsutil-image:latest",
 		},
 		storagetype: "bucket",
 	}} {
@@ -411,7 +414,7 @@ func TestInitializeArtifactStorageWithoutConfigMap(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(pvc, expectedArtifactPVC, cmpopts.IgnoreUnexported(resource.Quantity{})); diff != "" {
-		t.Fatalf("want %v, but got %v", expectedArtifactPVC, pvc)
+		t.Fatalf("-want +got: %s", diff)
 	}
 }
 
@@ -442,6 +445,7 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 				SecretName: "secret1",
 			}},
 			BashNoopImage: "override-with-bash-noop:latest",
+			GsutilImage:   "override-with-gsutil-image:latest",
 		},
 	}, {
 		desc: "location empty",
@@ -498,7 +502,7 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(artifactStorage, c.expectedArtifactStorage); diff != "" {
-				t.Fatalf("want %v, but got %v", c.expectedArtifactStorage, artifactStorage)
+				t.Fatalf("-want +got: %s", diff)
 			}
 		})
 	}
@@ -518,7 +522,7 @@ func TestGetArtifactStorageWithoutConfigMap(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(pvc, expectedArtifactPVC); diff != "" {
-		t.Fatalf("want %v, but got %v", expectedArtifactPVC, pvc)
+		t.Fatalf("-want +got: %s", diff)
 	}
 }
 
@@ -554,7 +558,7 @@ func TestGetArtifactStorageWithPvcConfigMap(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(artifactStorage, c.expectedArtifactStorage); diff != "" {
-				t.Fatalf("want %v, but got %v", c.expectedArtifactStorage, artifactStorage)
+				t.Fatalf("-want +got: %s", diff)
 			}
 		})
 	}

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/system"
 	"go.uber.org/zap"
@@ -58,7 +59,7 @@ type ArtifactStorageInterface interface {
 
 // InitializeArtifactStorage will check if there is there is a
 // bucket configured or create a PVC
-func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
+func InitializeArtifactStorage(images pipeline.Images, pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
 	shouldCreatePVC, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
@@ -69,10 +70,10 @@ func InitializeArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface,
 		if err != nil {
 			return nil, err
 		}
-		return &v1alpha1.ArtifactPVC{Name: pr.Name, PersistentVolumeClaim: pvc}, nil
+		return &v1alpha1.ArtifactPVC{Name: pr.Name, PersistentVolumeClaim: pvc, BashNoopImage: images.BashNoopImage}, nil
 	}
 
-	return NewArtifactBucketConfigFromConfigMap(configMap)
+	return NewArtifactBucketConfigFromConfigMap(images)(configMap)
 }
 
 // CleanupArtifactStorage will delete the PipelineRun's artifact storage PVC if it exists. The PVC is created for using
@@ -121,40 +122,44 @@ func NeedsPVC(configMap *corev1.ConfigMap, err error, logger *zap.SugaredLogger)
 
 // GetArtifactStorage returns the storage interface to enable
 // consumer code to get a container step for copy to/from storage
-func GetArtifactStorage(prName string, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
+func GetArtifactStorage(images pipeline.Images, prName string, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
 	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
 	pvc, err := NeedsPVC(configMap, err, logger)
 	if err != nil {
 		return nil, xerrors.Errorf("couldn't determine if PVC was needed from config map: %w", err)
 	}
 	if pvc {
-		return &v1alpha1.ArtifactPVC{Name: prName}, nil
+		return &v1alpha1.ArtifactPVC{Name: prName, BashNoopImage: images.BashNoopImage}, nil
 	}
-	return NewArtifactBucketConfigFromConfigMap(configMap)
+	return NewArtifactBucketConfigFromConfigMap(images)(configMap)
 }
 
 // NewArtifactBucketConfigFromConfigMap creates a Bucket from the supplied ConfigMap
-func NewArtifactBucketConfigFromConfigMap(configMap *corev1.ConfigMap) (*v1alpha1.ArtifactBucket, error) {
-	c := &v1alpha1.ArtifactBucket{}
+func NewArtifactBucketConfigFromConfigMap(images pipeline.Images) func(configMap *corev1.ConfigMap) (*v1alpha1.ArtifactBucket, error) {
+	return func(configMap *corev1.ConfigMap) (*v1alpha1.ArtifactBucket, error) {
+		c := &v1alpha1.ArtifactBucket{
+			BashNoopImage: images.BashNoopImage,
+		}
 
-	if configMap.Data == nil {
+		if configMap.Data == nil {
+			return c, nil
+		}
+		if location, ok := configMap.Data[v1alpha1.BucketLocationKey]; !ok {
+			c.Location = ""
+		} else {
+			c.Location = location
+		}
+		sp := v1alpha1.SecretParam{}
+		if secretName, ok := configMap.Data[v1alpha1.BucketServiceAccountSecretName]; ok {
+			if secretKey, ok := configMap.Data[v1alpha1.BucketServiceAccountSecretKey]; ok {
+				sp.FieldName = "GOOGLE_APPLICATION_CREDENTIALS"
+				sp.SecretName = secretName
+				sp.SecretKey = secretKey
+				c.Secrets = append(c.Secrets, sp)
+			}
+		}
 		return c, nil
 	}
-	if location, ok := configMap.Data[v1alpha1.BucketLocationKey]; !ok {
-		c.Location = ""
-	} else {
-		c.Location = location
-	}
-	sp := v1alpha1.SecretParam{}
-	if secretName, ok := configMap.Data[v1alpha1.BucketServiceAccountSecretName]; ok {
-		if secretKey, ok := configMap.Data[v1alpha1.BucketServiceAccountSecretKey]; ok {
-			sp.FieldName = "GOOGLE_APPLICATION_CREDENTIALS"
-			sp.SecretName = secretName
-			sp.SecretKey = secretKey
-			c.Secrets = append(c.Secrets, sp)
-		}
-	}
-	return c, nil
 }
 
 func createPVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) (*corev1.PersistentVolumeClaim, error) {

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -139,6 +139,7 @@ func NewArtifactBucketConfigFromConfigMap(images pipeline.Images) func(configMap
 	return func(configMap *corev1.ConfigMap) (*v1alpha1.ArtifactBucket, error) {
 		c := &v1alpha1.ArtifactBucket{
 			BashNoopImage: images.BashNoopImage,
+			GsutilImage:   images.GsutilImage,
 		}
 
 		if configMap.Data == nil {

--- a/pkg/reconciler/pipelinerun/config/store.go
+++ b/pkg/reconciler/pipelinerun/config/store.go
@@ -19,6 +19,7 @@ package config
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/artifacts"
 	"knative.dev/pkg/configmap"
@@ -42,17 +43,20 @@ func ToContext(ctx context.Context, c *Config) context.Context {
 // +k8s:deepcopy-gen=false
 type Store struct {
 	*configmap.UntypedStore
+
+	images pipeline.Images
 }
 
-func NewStore(logger configmap.Logger) *Store {
+func NewStore(images pipeline.Images, logger configmap.Logger) *Store {
 	return &Store{
 		UntypedStore: configmap.NewUntypedStore(
 			"pipelinerun",
 			logger,
 			configmap.Constructors{
-				v1alpha1.BucketConfigName: artifacts.NewArtifactBucketConfigFromConfigMap,
+				v1alpha1.BucketConfigName: artifacts.NewArtifactBucketConfigFromConfigMap(images),
 			},
 		),
+		images: images,
 	}
 }
 
@@ -65,7 +69,8 @@ func (s *Store) Load() *Config {
 	if ep == nil {
 		return &Config{
 			ArtifactBucket: &v1alpha1.ArtifactBucket{
-				Location: "",
+				Location:      "",
+				BashNoopImage: s.images.BashNoopImage,
 			},
 		}
 	}

--- a/pkg/reconciler/pipelinerun/config/store.go
+++ b/pkg/reconciler/pipelinerun/config/store.go
@@ -71,6 +71,7 @@ func (s *Store) Load() *Config {
 			ArtifactBucket: &v1alpha1.ArtifactBucket{
 				Location:      "",
 				BashNoopImage: s.images.BashNoopImage,
+				GsutilImage:   s.images.GsutilImage,
 			},
 		}
 	}

--- a/pkg/reconciler/pipelinerun/config/store_test.go
+++ b/pkg/reconciler/pipelinerun/config/store_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/artifacts"
 	logtesting "knative.dev/pkg/logging/testing"
 
@@ -28,19 +29,19 @@ import (
 )
 
 func TestStoreLoadWithContext(t *testing.T) {
-	store := NewStore(logtesting.TestLogger(t))
+	store := NewStore(pipeline.Images{}, logtesting.TestLogger(t))
 	bucketConfig := test.ConfigMapFromTestFile(t, "config-artifact-bucket")
 	store.OnConfigChanged(bucketConfig)
 
 	config := FromContext(store.ToContext(context.Background()))
 
-	expected, _ := artifacts.NewArtifactBucketConfigFromConfigMap(bucketConfig)
+	expected, _ := artifacts.NewArtifactBucketConfigFromConfigMap(pipeline.Images{})(bucketConfig)
 	if diff := cmp.Diff(expected, config.ArtifactBucket); diff != "" {
 		t.Errorf("Unexpected controller config (-want, +got): %v", diff)
 	}
 }
 func TestStoreImmutableConfig(t *testing.T) {
-	store := NewStore(logtesting.TestLogger(t))
+	store := NewStore(pipeline.Images{}, logtesting.TestLogger(t))
 	store.OnConfigChanged(test.ConfigMapFromTestFile(t, "config-artifact-bucket"))
 
 	config := store.Load()

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	clustertaskinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/clustertask"
 	conditioninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/condition"
@@ -42,7 +43,7 @@ const (
 	resyncPeriod = 10 * time.Hour
 )
 
-func NewController(images reconciler.Images) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -94,7 +94,7 @@ func NewController(images pipeline.Images) func(context.Context, configmap.Watch
 		})
 
 		c.Logger.Info("Setting up ConfigMap receivers")
-		c.configStore = config.NewStore(c.Logger.Named("config-store"))
+		c.configStore = config.NewStore(images, c.Logger.Named("config-store"))
 		c.configStore.WatchConfigs(opt.ConfigMapWatcher)
 
 		return impl

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -393,7 +393,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	rprts := pipelineState.GetNextTasks(candidateTasks)
 
 	var as artifacts.ArtifactStorageInterface
-	if as, err = artifacts.InitializeArtifactStorage(pr, c.KubeClientSet, c.Logger); err != nil {
+	if as, err = artifacts.InitializeArtifactStorage(c.Images, pr, c.KubeClientSet, c.Logger); err != nil {
 		c.Logger.Infof("PipelineRun failed to initialize artifact storage %s", pr.Name)
 		return err
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -48,6 +48,7 @@ var (
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
 		GitImage:        "override-with-git:latest",
+		CredsImage:      "override-with-creds:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -52,6 +52,7 @@ var (
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -50,6 +50,7 @@ var (
 		GitImage:              "override-with-git:latest",
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
+		BashNoopImage:         "override-with-bash-noop:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -47,6 +47,7 @@ var (
 	images                   = pipeline.Images{
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
+		GitImage:        "override-with-git:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -53,6 +53,7 @@ var (
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
 		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:               "override-with-pr:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -51,6 +51,7 @@ var (
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
+		GsutilImage:           "override-with-gsutil-image:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -45,15 +45,16 @@ import (
 var (
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
 	images                   = pipeline.Images{
-		EntryPointImage:       "override-with-entrypoint:latest",
-		NopImage:              "override-with-nop:latest",
-		GitImage:              "override-with-git:latest",
-		CredsImage:            "override-with-creds:latest",
-		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
-		BashNoopImage:         "override-with-bash-noop:latest",
-		GsutilImage:           "override-with-gsutil-image:latest",
-		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
-		PRImage:               "override-with-pr:latest",
+		EntryPointImage:          "override-with-entrypoint:latest",
+		NopImage:                 "override-with-nop:latest",
+		GitImage:                 "override-with-git:latest",
+		CredsImage:               "override-with-creds:latest",
+		KubeconfigWriterImage:    "override-with-kubeconfig-writer:latest",
+		BashNoopImage:            "override-with-bash-noop:latest",
+		GsutilImage:              "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:     "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:                  "override-with-pr:latest",
+		ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -45,10 +45,11 @@ import (
 var (
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
 	images                   = pipeline.Images{
-		EntryPointImage: "override-with-entrypoint:latest",
-		NopImage:        "override-with-nop:latest",
-		GitImage:        "override-with-git:latest",
-		CredsImage:      "override-with-creds:latest",
+		EntryPointImage:       "override-with-entrypoint:latest",
+		NopImage:              "override-with-nop:latest",
+		GitImage:              "override-with-git:latest",
+		CredsImage:            "override-with-creds:latest",
+		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 	}
 )
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	taskrunresources "github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/system"
@@ -45,7 +44,7 @@ import (
 
 var (
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
-	images                   = reconciler.Images{
+	images                   = pipeline.Images{
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1628,7 +1628,7 @@ func TestResolveConditionChecks(t *testing.T) {
 				t.Fatalf("Did not expect error when resolving PipelineRun without Conditions: %v", err)
 			}
 
-			if d := cmp.Diff(tc.expectedConditionCheck, pipelineState[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{})); d != "" {
+			if d := cmp.Diff(tc.expectedConditionCheck, pipelineState[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{}, ResolvedConditionCheck{})); d != "" {
 				t.Fatalf("ConditionChecks did not resolve as expected for case %s (-want, +got) : %s", tc.name, d)
 			}
 		})
@@ -1747,7 +1747,7 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 		ResolvedResources:     providedResources,
 	}}
 
-	if d := cmp.Diff(expectedConditionChecks, pipelineState[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{})); d != "" {
+	if d := cmp.Diff(expectedConditionChecks, pipelineState[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{}, ResolvedConditionCheck{})); d != "" {
 		t.Fatalf("ConditionChecks did not resolve as expected (-want, +got): %s", d)
 	}
 }
@@ -1822,7 +1822,7 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 					PipelineTaskCondition: &ptc,
 					ResolvedResources:     tc.expected,
 				}}
-				if d := cmp.Diff(expectedConditionChecks, pipelineState[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{})); d != "" {
+				if d := cmp.Diff(expectedConditionChecks, pipelineState[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{}, ResolvedConditionCheck{})); d != "" {
 					t.Fatalf("ConditionChecks did not resolve as expected (-want, +got): %s", d)
 				}
 			}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -19,6 +19,7 @@ package reconciler
 import (
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	pipelineScheme "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
 	"go.uber.org/zap"
@@ -81,12 +82,12 @@ type Base struct {
 	Logger *zap.SugaredLogger
 
 	// Images contains images to use for certain internal container
-	Images Images
+	Images pipeline.Images
 }
 
 // NewBase instantiates a new instance of Base implementing
 // the common & boilerplate code between our reconcilers.
-func NewBase(opt Options, controllerAgentName string, images Images) *Base {
+func NewBase(opt Options, controllerAgentName string, images pipeline.Images) *Base {
 	// Enrich the logs with controller name
 	logger := opt.Logger.Named(controllerAgentName).With(zap.String(logkey.ControllerType, controllerAgentName))
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	"github.com/tektoncd/pipeline/test"
@@ -67,7 +68,7 @@ func TestRecorderOptions(t *testing.T) {
 		Logger:            zap.New(observer).Sugar(),
 		KubeClientSet:     c.Kube,
 		PipelineClientSet: c.Pipeline,
-	}, "test", Images{})
+	}, "test", pipeline.Images{})
 
 	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.recorderImpl") != 0 {
 		t.Errorf("Expected recorder type '*record.recorderImpl' but actual type is: %s", reflect.TypeOf(b.Recorder).String())
@@ -81,7 +82,7 @@ func TestRecorderOptions(t *testing.T) {
 		KubeClientSet:     c.Kube,
 		PipelineClientSet: c.Pipeline,
 		Recorder:          fr,
-	}, "test", Images{})
+	}, "test", pipeline.Images{})
 
 	if strings.Compare(reflect.TypeOf(b.Recorder).String(), "*record.FakeRecorder") != 0 {
 		t.Errorf("Expected recorder type '*record.FakeRecorder' but actual type is: %s", reflect.TypeOf(b.Recorder).String())

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	clustertaskinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/clustertask"
@@ -42,7 +43,7 @@ const (
 	resyncPeriod = 10 * time.Hour
 )
 
-func NewController(images reconciler.Images) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -34,6 +34,7 @@ var images = pipeline.Images{
 	GitImage:              "override-with-git:latest",
 	CredsImage:            "override-with-creds:latest",
 	KubeconfigWriterImage: "override-with-kubeconfig-writer-image:latest",
+	BashNoopImage:         "override-with-bash-noop:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -35,6 +35,7 @@ var images = pipeline.Images{
 	CredsImage:            "override-with-creds:latest",
 	KubeconfigWriterImage: "override-with-kubeconfig-writer-image:latest",
 	BashNoopImage:         "override-with-bash-noop:latest",
+	GsutilImage:           "override-with-gsutil-image:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -37,6 +37,7 @@ var images = pipeline.Images{
 	BashNoopImage:         "override-with-bash-noop:latest",
 	GsutilImage:           "override-with-gsutil-image:latest",
 	BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
+	PRImage:               "override-with-pr:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -20,12 +20,19 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var images = pipeline.Images{
+	EntryPointImage: "override-with-entrypoint:latest",
+	NopImage:        "override-with-nop:latest",
+	GitImage:        "override-with-git:latest",
+}
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{
 	Inputs: &v1alpha1.Inputs{
@@ -317,7 +324,7 @@ var gitResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 			Value: "https://git-repo",
 		}},
 	},
-})
+}, images)
 
 var imageResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 	ObjectMeta: metav1.ObjectMeta{
@@ -330,7 +337,7 @@ var imageResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 			Value: "gcr.io/hans/sandwiches",
 		}},
 	},
-})
+}, images)
 
 var gcsResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 	ObjectMeta: metav1.ObjectMeta{
@@ -346,7 +353,7 @@ var gcsResource, _ = v1alpha1.ResourceFromType(&v1alpha1.PipelineResource{
 			Value: "theCloud?",
 		}},
 	},
-})
+}, images)
 
 func applyMutation(ts *v1alpha1.TaskSpec, f func(*v1alpha1.TaskSpec)) *v1alpha1.TaskSpec {
 	ts = ts.DeepCopy()

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -29,10 +29,11 @@ import (
 )
 
 var images = pipeline.Images{
-	EntryPointImage: "override-with-entrypoint:latest",
-	NopImage:        "override-with-nop:latest",
-	GitImage:        "override-with-git:latest",
-	CredsImage:      "override-with-creds:latest",
+	EntryPointImage:       "override-with-entrypoint:latest",
+	NopImage:              "override-with-nop:latest",
+	GitImage:              "override-with-git:latest",
+	CredsImage:            "override-with-creds:latest",
+	KubeconfigWriterImage: "override-with-kubeconfig-writer-image:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -29,15 +29,16 @@ import (
 )
 
 var images = pipeline.Images{
-	EntryPointImage:       "override-with-entrypoint:latest",
-	NopImage:              "override-with-nop:latest",
-	GitImage:              "override-with-git:latest",
-	CredsImage:            "override-with-creds:latest",
-	KubeconfigWriterImage: "override-with-kubeconfig-writer-image:latest",
-	BashNoopImage:         "override-with-bash-noop:latest",
-	GsutilImage:           "override-with-gsutil-image:latest",
-	BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
-	PRImage:               "override-with-pr:latest",
+	EntryPointImage:          "override-with-entrypoint:latest",
+	NopImage:                 "override-with-nop:latest",
+	GitImage:                 "override-with-git:latest",
+	CredsImage:               "override-with-creds:latest",
+	KubeconfigWriterImage:    "override-with-kubeconfig-writer-image:latest",
+	BashNoopImage:            "override-with-bash-noop:latest",
+	GsutilImage:              "override-with-gsutil-image:latest",
+	BuildGCSFetcherImage:     "gcr.io/cloud-builders/gcs-fetcher:latest",
+	PRImage:                  "override-with-pr:latest",
+	ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -36,6 +36,7 @@ var images = pipeline.Images{
 	KubeconfigWriterImage: "override-with-kubeconfig-writer-image:latest",
 	BashNoopImage:         "override-with-bash-noop:latest",
 	GsutilImage:           "override-with-gsutil-image:latest",
+	BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -32,6 +32,7 @@ var images = pipeline.Images{
 	EntryPointImage: "override-with-entrypoint:latest",
 	NopImage:        "override-with-nop:latest",
 	GitImage:        "override-with-git:latest",
+	CredsImage:      "override-with-creds:latest",
 }
 
 var simpleTaskSpec = &v1alpha1.TaskSpec{

--- a/pkg/reconciler/taskrun/resources/image_exporter.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"encoding/json"
-	"flag"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/names"
@@ -28,12 +27,9 @@ import (
 
 const TerminationMessagePath = "/builder/home/image-outputs/termination-log"
 
-var (
-	imageDigestExporterImage = flag.String("imagedigest-exporter-image", "override-with-imagedigest-exporter-image:latest", "The container image containing our image digest exporter binary.")
-)
-
 // AddOutputImageDigestExporter add a step to check the index.json for all output images
 func AddOutputImageDigestExporter(
+	imageDigestExporterImage string,
 	tr *v1alpha1.TaskRun,
 	taskSpec *v1alpha1.TaskSpec,
 	gr GetResource,
@@ -76,7 +72,7 @@ func AddOutputImageDigestExporter(
 			}
 
 			augmentedSteps = append(augmentedSteps, taskSpec.Steps...)
-			augmentedSteps = append(augmentedSteps, imageDigestExporterStep(imagesJSON))
+			augmentedSteps = append(augmentedSteps, imageDigestExporterStep(imageDigestExporterImage, imagesJSON))
 
 			taskSpec.Steps = augmentedSteps
 		}
@@ -95,10 +91,10 @@ func UpdateTaskRunStatusWithResourceResult(taskRun *v1alpha1.TaskRun, logContent
 	return nil
 }
 
-func imageDigestExporterStep(imagesJSON []byte) v1alpha1.Step {
+func imageDigestExporterStep(imageDigestExporterImage string, imagesJSON []byte) v1alpha1.Step {
 	return v1alpha1.Step{Container: corev1.Container{
 		Name:    names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("image-digest-exporter"),
-		Image:   *imageDigestExporterImage,
+		Image:   imageDigestExporterImage,
 		Command: []string{"/ko-app/imagedigestexporter"},
 		Args: []string{
 			"-images", string(imagesJSON),

--- a/pkg/reconciler/taskrun/resources/image_exporter_test.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter_test.go
@@ -200,7 +200,7 @@ func TestAddOutputImageDigestExporter(t *testing.T) {
 					},
 				}, nil
 			}
-			err := AddOutputImageDigestExporter(c.taskRun, &c.task.Spec, gr)
+			err := AddOutputImageDigestExporter("override-with-imagedigest-exporter-image:latest", c.taskRun, &c.task.Spec, gr)
 			if err != nil {
 				t.Fatalf("Failed to declare output resources for test %q: error %v", c.desc, err)
 			}

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -40,6 +40,7 @@ var (
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
 		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:               "override-with-pr:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -38,6 +38,7 @@ var (
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
+		GsutilImage:           "override-with-gsutil-image:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -32,10 +32,11 @@ import (
 
 var (
 	images = pipeline.Images{
-		EntryPointImage: "override-with-entrypoint:latest",
-		NopImage:        "override-with-nop:latest",
-		GitImage:        "override-with-git:latest",
-		CredsImage:      "override-with-creds:latest",
+		EntryPointImage:       "override-with-entrypoint:latest",
+		NopImage:              "override-with-nop:latest",
+		GitImage:              "override-with-git:latest",
+		CredsImage:            "override-with-creds:latest",
+		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -37,6 +37,7 @@ var (
 		GitImage:              "override-with-git:latest",
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
+		BashNoopImage:         "override-with-bash-noop:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger
@@ -738,7 +739,7 @@ func TestAddResourceToTask(t *testing.T) {
 			setUp(t)
 			names.TestingSeed()
 			fakekubeclient := fakek8s.NewSimpleClientset()
-			got, err := AddInputResource(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, mockResolveTaskResources(c.taskRun), logger)
+			got, err := AddInputResource(fakekubeclient, images, c.task.Name, &c.task.Spec, c.taskRun, mockResolveTaskResources(c.taskRun), logger)
 			if (err != nil) != c.wantErr {
 				t.Errorf("Test: %q; AddInputResource() error = %v, WantErr %v", c.desc, err, c.wantErr)
 			}
@@ -920,7 +921,7 @@ func TestStorageInputResource(t *testing.T) {
 			names.TestingSeed()
 			setUp(t)
 			fakekubeclient := fakek8s.NewSimpleClientset()
-			got, err := AddInputResource(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, mockResolveTaskResources(c.taskRun), logger)
+			got, err := AddInputResource(fakekubeclient, images, c.task.Name, &c.task.Spec, c.taskRun, mockResolveTaskResources(c.taskRun), logger)
 			if (err != nil) != c.wantErr {
 				t.Errorf("Test: %q; AddInputResource() error = %v, WantErr %v", c.desc, err, c.wantErr)
 			}
@@ -1050,7 +1051,7 @@ func TestAddStepsToTaskWithBucketFromConfigMap(t *testing.T) {
 					},
 				},
 			)
-			got, err := AddInputResource(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, mockResolveTaskResources(c.taskRun), logger)
+			got, err := AddInputResource(fakekubeclient, images, c.task.Name, &c.task.Spec, c.taskRun, mockResolveTaskResources(c.taskRun), logger)
 			if err != nil {
 				t.Errorf("Test: %q; AddInputResource() error = %v", c.desc, err)
 			}

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -32,15 +32,16 @@ import (
 
 var (
 	images = pipeline.Images{
-		EntryPointImage:       "override-with-entrypoint:latest",
-		NopImage:              "override-with-nop:latest",
-		GitImage:              "override-with-git:latest",
-		CredsImage:            "override-with-creds:latest",
-		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
-		BashNoopImage:         "override-with-bash-noop:latest",
-		GsutilImage:           "override-with-gsutil-image:latest",
-		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
-		PRImage:               "override-with-pr:latest",
+		EntryPointImage:          "override-with-entrypoint:latest",
+		NopImage:                 "override-with-nop:latest",
+		GitImage:                 "override-with-git:latest",
+		CredsImage:               "override-with-creds:latest",
+		KubeconfigWriterImage:    "override-with-kubeconfig-writer:latest",
+		BashNoopImage:            "override-with-bash-noop:latest",
+		GsutilImage:              "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:     "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:                  "override-with-pr:latest",
+		ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -35,6 +35,7 @@ var (
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
 		GitImage:        "override-with-git:latest",
+		CredsImage:      "override-with-creds:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/test/names"
@@ -30,6 +31,11 @@ import (
 )
 
 var (
+	images = pipeline.Images{
+		EntryPointImage: "override-with-entrypoint:latest",
+		NopImage:        "override-with-nop:latest",
+		GitImage:        "override-with-git:latest",
+	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger
 
@@ -200,7 +206,7 @@ func setUp(t *testing.T) {
 	}}
 	inputResourceInterfaces = make(map[string]v1alpha1.PipelineResourceInterface)
 	for _, r := range rs {
-		ri, _ := v1alpha1.ResourceFromType(r)
+		ri, _ := v1alpha1.ResourceFromType(r, images)
 		inputResourceInterfaces[r.Name] = ri
 	}
 }
@@ -1067,7 +1073,7 @@ func mockResolveTaskResources(taskRun *v1alpha1.TaskRun) map[string]v1alpha1.Pip
 					Name: r.Name,
 				},
 				Spec: *r.ResourceSpec,
-			})
+			}, images)
 			resolved[r.Name] = i
 		default:
 			resolved[r.Name] = nil

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -39,6 +39,7 @@ var (
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
 	}
 	inputResourceInterfaces map[string]v1alpha1.PipelineResourceInterface
 	logger                  *zap.SugaredLogger

--- a/pkg/reconciler/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/taskrun/resources/input_resources.go
@@ -45,6 +45,7 @@ func getBoundResource(resourceName string, boundResources []v1alpha1.TaskResourc
 // 3. If resource has paths declared then fresh copy of resource is not fetched
 func AddInputResource(
 	kubeclient kubernetes.Interface,
+	images pipeline.Images,
 	taskName string,
 	taskSpec *v1alpha1.TaskSpec,
 	taskRun *v1alpha1.TaskRun,
@@ -64,7 +65,7 @@ func AddInputResource(
 	if prNameFromLabel == "" {
 		prNameFromLabel = pvcName
 	}
-	as, err := artifacts.GetArtifactStorage(prNameFromLabel, kubeclient, logger)
+	as, err := artifacts.GetArtifactStorage(images, prNameFromLabel, kubeclient, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func AddInputResource(
 					for _, s := range cpSteps {
 						s.VolumeMounts = []corev1.VolumeMount{v1alpha1.GetPvcMount(pvcName)}
 						copyStepsFromPrevTasks = append(copyStepsFromPrevTasks,
-							v1alpha1.CreateDirStep(boundResource.Name, dPath),
+							v1alpha1.CreateDirStep(images.BashNoopImage, boundResource.Name, dPath),
 							s)
 					}
 				} else {

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -93,7 +93,7 @@ func outputResourceSetup(t *testing.T) {
 
 	outputResources = make(map[string]v1alpha1.PipelineResourceInterface)
 	for _, r := range rs {
-		ri, _ := v1alpha1.ResourceFromType(r)
+		ri, _ := v1alpha1.ResourceFromType(r, images)
 		outputResources[r.Name] = ri
 	}
 }
@@ -1174,7 +1174,7 @@ func resolveOutputResources(taskRun *v1alpha1.TaskRun) map[string]v1alpha1.Pipel
 					Name: r.Name,
 				},
 				Spec: *r.ResourceSpec,
-			})
+			}, images)
 			resolved[r.Name] = i
 		}
 	}

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -789,7 +789,7 @@ func TestValidOutputResources(t *testing.T) {
 			names.TestingSeed()
 			outputResourceSetup(t)
 			fakekubeclient := fakek8s.NewSimpleClientset()
-			got, err := AddOutputResources(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, resolveOutputResources(c.taskRun), logger)
+			got, err := AddOutputResources(fakekubeclient, images, c.task.Name, &c.task.Spec, c.taskRun, resolveOutputResources(c.taskRun), logger)
 			if err != nil {
 				t.Fatalf("Failed to declare output resources for test name %q ; test description %q: error %v", c.name, c.desc, err)
 			}
@@ -1005,7 +1005,7 @@ func TestValidOutputResourcesWithBucketStorage(t *testing.T) {
 					},
 				},
 			)
-			got, err := AddOutputResources(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, resolveOutputResources(c.taskRun), logger)
+			got, err := AddOutputResources(fakekubeclient, images, c.task.Name, &c.task.Spec, c.taskRun, resolveOutputResources(c.taskRun), logger)
 			if err != nil {
 				t.Fatalf("Failed to declare output resources for test name %q ; test description %q: error %v", c.name, c.desc, err)
 			}
@@ -1153,7 +1153,7 @@ func TestInvalidOutputResources(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			outputResourceSetup(t)
 			fakekubeclient := fakek8s.NewSimpleClientset()
-			_, err := AddOutputResources(fakekubeclient, c.task.Name, &c.task.Spec, c.taskRun, resolveOutputResources(c.taskRun), logger)
+			_, err := AddOutputResources(fakekubeclient, images, c.task.Name, &c.task.Spec, c.taskRun, resolveOutputResources(c.taskRun), logger)
 			if (err != nil) != c.wantErr {
 				t.Fatalf("Test AddOutputResourceSteps %v : error%v", c.desc, err)
 			}

--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -184,7 +184,7 @@ func makeWorkingDirScript(workingDirs map[string]bool) string {
 	return script
 }
 
-func makeWorkingDirInitializer(steps []v1alpha1.Step) *v1alpha1.Step {
+func makeWorkingDirInitializer(bashNoopImage string, steps []v1alpha1.Step) *v1alpha1.Step {
 	workingDirs := make(map[string]bool)
 	for _, step := range steps {
 		workingDirs[step.WorkingDir] = true
@@ -193,7 +193,7 @@ func makeWorkingDirInitializer(steps []v1alpha1.Step) *v1alpha1.Step {
 	if script := makeWorkingDirScript(workingDirs); script != "" {
 		return &v1alpha1.Step{Container: corev1.Container{
 			Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(containerPrefix + workingDirInit),
-			Image:        *v1alpha1.BashNoopImage,
+			Image:        bashNoopImage,
 			Command:      []string{"/ko-app/bash"},
 			Args:         []string{"-args", script},
 			VolumeMounts: implicitVolumeMounts,
@@ -206,14 +206,14 @@ func makeWorkingDirInitializer(steps []v1alpha1.Step) *v1alpha1.Step {
 
 // initOutputResourcesDefaultDir checks if there are any output image resources expecting a default path
 // and creates an init container to create that folder
-func initOutputResourcesDefaultDir(taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec) []v1alpha1.Step {
+func initOutputResourcesDefaultDir(bashNoopImage string, taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec) []v1alpha1.Step {
 	var makeDirSteps []v1alpha1.Step
 	if len(taskRun.Spec.Outputs.Resources) > 0 {
 		for _, r := range taskRun.Spec.Outputs.Resources {
 			for _, o := range taskSpec.Outputs.Resources {
 				if o.Name == r.Name {
 					if strings.HasPrefix(o.OutputImageDir, v1alpha1.TaskOutputImageDefaultDir) {
-						s := v1alpha1.CreateDirStep("default-image-output", fmt.Sprintf("%s/%s", v1alpha1.TaskOutputImageDefaultDir, r.Name))
+						s := v1alpha1.CreateDirStep(bashNoopImage, "default-image-output", fmt.Sprintf("%s/%s", v1alpha1.TaskOutputImageDefaultDir, r.Name))
 						s.VolumeMounts = append(s.VolumeMounts, implicitVolumeMounts...)
 						makeDirSteps = append(makeDirSteps, s)
 					}
@@ -243,19 +243,19 @@ func TryGetPod(taskRunStatus v1alpha1.TaskRunStatus, gp GetPod) (*corev1.Pod, er
 
 // MakePod converts TaskRun and TaskSpec objects to a Pod which implements the taskrun specified
 // by the supplied CRD.
-func MakePod(credsImage string, taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec, kubeclient kubernetes.Interface) (*corev1.Pod, error) {
-	cred, secrets, err := makeCredentialInitializer(credsImage, taskRun.Spec.ServiceAccount, taskRun.Namespace, kubeclient)
+func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec, kubeclient kubernetes.Interface) (*corev1.Pod, error) {
+	cred, secrets, err := makeCredentialInitializer(images.CredsImage, taskRun.Spec.ServiceAccount, taskRun.Namespace, kubeclient)
 	if err != nil {
 		return nil, err
 	}
 	initSteps := []v1alpha1.Step{*cred}
 	var podSteps []v1alpha1.Step
 
-	if workingDir := makeWorkingDirInitializer(taskSpec.Steps); workingDir != nil {
+	if workingDir := makeWorkingDirInitializer(images.BashNoopImage, taskSpec.Steps); workingDir != nil {
 		initSteps = append(initSteps, *workingDir)
 	}
 
-	initSteps = append(initSteps, initOutputResourcesDefaultDir(taskRun, taskSpec)...)
+	initSteps = append(initSteps, initOutputResourcesDefaultDir(images.BashNoopImage, taskRun, taskSpec)...)
 
 	maxIndicesByResource := findMaxResourceRequest(taskSpec.Steps, corev1.ResourceCPU, corev1.ResourceMemory, corev1.ResourceEphemeralStorage)
 

--- a/pkg/reconciler/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/taskrun/resources/pod_test.go
@@ -39,7 +39,8 @@ var (
 	resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0
 	})
-	credsImage = "override-with-creds:latest"
+	credsImage    = "override-with-creds:latest"
+	bashNoopImage = "override-with-bash-noop:latest"
 )
 
 func TestTryGetPod(t *testing.T) {
@@ -305,7 +306,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 			}, {
 				Name:         containerPrefix + workingDirInit + "-mz4c7",
-				Image:        *v1alpha1.BashNoopImage,
+				Image:        bashNoopImage,
 				Command:      []string{"/ko-app/bash"},
 				Args:         []string{"-args", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
 				Env:          implicitEnvVars,
@@ -408,7 +409,7 @@ func TestMakePod(t *testing.T) {
 				},
 				Spec: c.trs,
 			}
-			got, err := MakePod(credsImage, tr, c.ts, cs)
+			got, err := MakePod(images, tr, c.ts, cs)
 			if err != c.wantErr {
 				t.Fatalf("MakePod: %v", err)
 			}
@@ -641,7 +642,7 @@ func TestInitOutputResourcesDefaultDir(t *testing.T) {
 		},
 		Spec: trs,
 	}
-	got, err := MakePod(credsImage, tr, ts, cs)
+	got, err := MakePod(images, tr, ts, cs)
 	if err != nil {
 		t.Fatalf("MakePod: %v", err)
 	}

--- a/pkg/reconciler/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/taskrun/resources/pod_test.go
@@ -39,6 +39,7 @@ var (
 	resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0
 	})
+	credsImage = "override-with-creds:latest"
 )
 
 func TestTryGetPod(t *testing.T) {
@@ -140,7 +141,7 @@ func TestMakePod(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        *credsImage,
+				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
@@ -179,7 +180,7 @@ func TestMakePod(t *testing.T) {
 			RestartPolicy:      corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
 				Name:    containerPrefix + credsInit + "-mz4c7",
-				Image:   *credsImage,
+				Image:   credsImage,
 				Command: []string{"/ko-app/creds-init"},
 				Args: []string{
 					"-basic-docker=multi-creds=https://docker.io",
@@ -222,7 +223,7 @@ func TestMakePod(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        *credsImage,
+				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
@@ -260,7 +261,7 @@ func TestMakePod(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        *credsImage,
+				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
@@ -296,7 +297,7 @@ func TestMakePod(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        *credsImage,
+				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
@@ -344,7 +345,7 @@ func TestMakePod(t *testing.T) {
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
 				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        *credsImage,
+				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
 				Env:          implicitEnvVars,
@@ -407,7 +408,7 @@ func TestMakePod(t *testing.T) {
 				},
 				Spec: c.trs,
 			}
-			got, err := MakePod(tr, c.ts, cs)
+			got, err := MakePod(credsImage, tr, c.ts, cs)
 			if err != c.wantErr {
 				t.Fatalf("MakePod: %v", err)
 			}
@@ -581,7 +582,7 @@ func TestInitOutputResourcesDefaultDir(t *testing.T) {
 		RestartPolicy: corev1.RestartPolicyNever,
 		InitContainers: []corev1.Container{{
 			Name:         containerPrefix + credsInit + "-9l9zj",
-			Image:        *credsImage,
+			Image:        credsImage,
 			Command:      []string{"/ko-app/creds-init"},
 			Args:         []string{},
 			Env:          implicitEnvVars,
@@ -640,7 +641,7 @@ func TestInitOutputResourcesDefaultDir(t *testing.T) {
 		},
 		Spec: trs,
 	}
-	got, err := MakePod(tr, ts, cs)
+	got, err := MakePod(credsImage, tr, ts, cs)
 	if err != nil {
 		t.Fatalf("MakePod: %v", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -436,13 +436,13 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTask
 		return nil, err
 	}
 
-	ts, err = resources.AddInputResource(c.KubeClientSet, rtr.TaskName, ts, tr, inputResources, c.Logger)
+	ts, err = resources.AddInputResource(c.KubeClientSet, c.Images, rtr.TaskName, ts, tr, inputResources, c.Logger)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a build for taskrun: %s due to input resource error %v", tr.Name, err)
 		return nil, err
 	}
 
-	ts, err = resources.AddOutputResources(c.KubeClientSet, rtr.TaskName, ts, tr, outputResources, c.Logger)
+	ts, err = resources.AddOutputResources(c.KubeClientSet, c.Images, rtr.TaskName, ts, tr, outputResources, c.Logger)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a build for taskrun: %s due to output resource error %v", tr.Name, err)
 		return nil, err
@@ -464,7 +464,7 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTask
 	ts = resources.ApplyResources(ts, inputResources, "inputs")
 	ts = resources.ApplyResources(ts, outputResources, "outputs")
 
-	pod, err := resources.MakePod(c.Images.CredsImage, tr, *ts, c.KubeClientSet)
+	pod, err := resources.MakePod(c.Images, tr, *ts, c.KubeClientSet)
 	if err != nil {
 		return nil, xerrors.Errorf("translating Build to Pod: %w", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -430,7 +430,7 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTask
 
 	// Get actual resource
 
-	err = resources.AddOutputImageDigestExporter(tr, ts, c.resourceLister.PipelineResources(tr.Namespace).Get)
+	err = resources.AddOutputImageDigestExporter(c.Images.ImageDigestExporterImage, tr, ts, c.resourceLister.PipelineResources(tr.Namespace).Get)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a build for taskrun: %s due to output image resource error %v", tr.Name, err)
 		return nil, err

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -417,12 +417,12 @@ func (c *Reconciler) updateReady(pod *corev1.Pod) error {
 // TODO(dibyom): Refactor resource setup/substitution logic to its own function in the resources package
 func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTaskResources) (*corev1.Pod, error) {
 	ts := rtr.TaskSpec.DeepCopy()
-	inputResources, err := resourceImplBinding(rtr.Inputs)
+	inputResources, err := resourceImplBinding(rtr.Inputs, c.Images)
 	if err != nil {
 		c.Logger.Errorf("Failed to initialize input resources: %v", err)
 		return nil, err
 	}
-	outputResources, err := resourceImplBinding(rtr.Outputs)
+	outputResources, err := resourceImplBinding(rtr.Outputs, c.Images)
 	if err != nil {
 		c.Logger.Errorf("Failed to initialize output resources: %v", err)
 		return nil, err
@@ -549,10 +549,10 @@ func isExceededResourceQuotaError(err error) bool {
 }
 
 // resourceImplBinding maps pipeline resource names to the actual resource type implementations
-func resourceImplBinding(resources map[string]*v1alpha1.PipelineResource) (map[string]v1alpha1.PipelineResourceInterface, error) {
+func resourceImplBinding(resources map[string]*v1alpha1.PipelineResource, images pipeline.Images) (map[string]v1alpha1.PipelineResourceInterface, error) {
 	p := make(map[string]v1alpha1.PipelineResourceInterface)
 	for rName, r := range resources {
-		i, err := v1alpha1.ResourceFromType(r)
+		i, err := v1alpha1.ResourceFromType(r, images)
 		if err != nil {
 			return nil, xerrors.Errorf("failed to create resource %s : %v with error: %w", rName, r, err)
 		}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -464,7 +464,7 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTask
 	ts = resources.ApplyResources(ts, inputResources, "inputs")
 	ts = resources.ApplyResources(ts, outputResources, "outputs")
 
-	pod, err := resources.MakePod(tr, *ts, c.KubeClientSet)
+	pod, err := resources.MakePod(c.Images.CredsImage, tr, *ts, c.KubeClientSet)
 	if err != nil {
 		return nil, xerrors.Errorf("translating Build to Pod: %w", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -66,6 +66,7 @@ var (
 	images = pipeline.Images{
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
+		GitImage:        "override-with-git:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -72,6 +72,7 @@ var (
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
 		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:               "override-with-pr:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -70,6 +70,7 @@ var (
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
+		GsutilImage:           "override-with-gsutil-image:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -64,15 +64,16 @@ const (
 
 var (
 	images = pipeline.Images{
-		EntryPointImage:       "override-with-entrypoint:latest",
-		NopImage:              "override-with-nop:latest",
-		GitImage:              "override-with-git:latest",
-		CredsImage:            "override-with-creds:latest",
-		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
-		BashNoopImage:         "override-with-bash-noop:latest",
-		GsutilImage:           "override-with-gsutil-image:latest",
-		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
-		PRImage:               "override-with-pr:latest",
+		EntryPointImage:          "override-with-entrypoint:latest",
+		NopImage:                 "override-with-nop:latest",
+		GitImage:                 "override-with-git:latest",
+		CredsImage:               "override-with-creds:latest",
+		KubeconfigWriterImage:    "override-with-kubeconfig-writer:latest",
+		BashNoopImage:            "override-with-bash-noop:latest",
+		GsutilImage:              "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:     "gcr.io/cloud-builders/gcs-fetcher:latest",
+		PRImage:                  "override-with-pr:latest",
+		ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -64,10 +64,11 @@ const (
 
 var (
 	images = pipeline.Images{
-		EntryPointImage: "override-with-entrypoint:latest",
-		NopImage:        "override-with-nop:latest",
-		GitImage:        "override-with-git:latest",
-		CredsImage:      "override-with-creds:latest",
+		EntryPointImage:       "override-with-entrypoint:latest",
+		NopImage:              "override-with-nop:latest",
+		GitImage:              "override-with-git:latest",
+		CredsImage:            "override-with-creds:latest",
+		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -69,6 +69,7 @@ var (
 		GitImage:              "override-with-git:latest",
 		CredsImage:            "override-with-creds:latest",
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
+		BashNoopImage:         "override-with-bash-noop:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
@@ -1501,7 +1502,7 @@ func makePod(taskRun *v1alpha1.TaskRun, task *v1alpha1.Task) (*corev1.Pod, error
 	// specify the Pod we want to exist directly, and not call MakePod from
 	// the build. This will break the cycle and allow us to simply use
 	// clients normally.
-	return resources.MakePod("override-with-creds:latest", taskRun, task.Spec, fakekubeclientset.NewSimpleClientset(&corev1.ServiceAccount{
+	return resources.MakePod(images, taskRun, task.Spec, fakekubeclientset.NewSimpleClientset(&corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
 			Namespace: taskRun.Namespace,

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -71,6 +71,7 @@ var (
 		KubeconfigWriterImage: "override-with-kubeconfig-writer:latest",
 		BashNoopImage:         "override-with-bash-noop:latest",
 		GsutilImage:           "override-with-gsutil-image:latest",
+		BuildGCSFetcherImage:  "gcr.io/cloud-builders/gcs-fetcher:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/entrypoint"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources/cloudevent"
@@ -64,7 +63,7 @@ const (
 )
 
 var (
-	images = reconciler.Images{
+	images = pipeline.Images{
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -67,6 +67,7 @@ var (
 		EntryPointImage: "override-with-entrypoint:latest",
 		NopImage:        "override-with-nop:latest",
 		GitImage:        "override-with-git:latest",
+		CredsImage:      "override-with-creds:latest",
 	}
 	entrypointCache          *entrypoint.Cache
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
@@ -1499,7 +1500,7 @@ func makePod(taskRun *v1alpha1.TaskRun, task *v1alpha1.Task) (*corev1.Pod, error
 	// specify the Pod we want to exist directly, and not call MakePod from
 	// the build. This will break the cycle and allow us to simply use
 	// clients normally.
-	return resources.MakePod(taskRun, task.Spec, fakekubeclientset.NewSimpleClientset(&corev1.ServiceAccount{
+	return resources.MakePod("override-with-creds:latest", taskRun, task.Spec, fakekubeclientset.NewSimpleClientset(&corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
 			Namespace: taskRun.Namespace,


### PR DESCRIPTION
# Changes

This is part of a set of changes to make sure we don't define CLI
flags in our `pkg/…` packages… so that importing packages from there
do not pollute the cli flags.

Follow-up of #1348, Closes #1309

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
