### PR TITLE
Remove Docker Edge requirement from tutorial

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -544,18 +544,15 @@ the status of individual Task runs are shown.
 
 Tekton Pipelines is known to work with:
 
-- [Docker for Desktop](https://www.docker.com/products/docker-desktop): a
-  version that uses Kubernetes 1.11 or higher. At the time of this document,
-  this requires the _edge_ version of Docker to be installed. A known good
-  configuration specifies six CPUs, 10 GB of memory and 2 GB of swap space
-- The following
-  [prerequisites](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements)
+- [Docker for Desktop](https://www.docker.com/products/docker-desktop). A known good
+  configuration specifies six CPUs, 10 GB of memory and 2 GB of swap space. 
+- These [prerequisites](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements).
 - Setting `host.docker.local:5000` as an insecure registry with Docker for
   Desktop (set via preferences or configuration, see the
-  [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/)
+  [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/).
   for details)
 - Passing `--insecure` as an argument to Kaniko tasks lets us push to an
-  insecure registry
+  insecure registry.
 - Running a local (insecure) Docker registry: this can be run with
 
 `docker run -d -p 5000:5000 --name registry-srv -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Removed Docker Edge requirement from the Tutorial as per https://github.com/tektoncd/pipeline/issues/1384

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
