### PR TITLE
Helpful error message when multiple volumes share name

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -109,7 +109,10 @@ func ValidateVolumes(volumes []corev1.Volume) *apis.FieldError {
 	vols := map[string]struct{}{}
 	for _, v := range volumes {
 		if _, ok := vols[v.Name]; ok {
-			return apis.ErrMultipleOneOf("name")
+			return &apis.FieldError{
+				Message: fmt.Sprintf("multiple volumes with same name %q", v.Name),
+				Paths:   []string{"name"},
+			}
 		}
 		vols[v.Name] = struct{}{}
 	}

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -215,6 +215,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		Inputs  *v1alpha1.Inputs
 		Outputs *v1alpha1.Outputs
 		Steps   []v1alpha1.Step
+		Volumes []corev1.Volume
 	}
 	tests := []struct {
 		name          string
@@ -597,13 +598,29 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Message: `non-existent variable in "$(inputs.params.foo) && $(inputs.params.inexistent)" for step arg[0]`,
 			Paths:   []string{"taskspec.steps.arg[0]"},
 		},
-	}}
+	},
+		{
+			name: "Multiple volumes with same name",
+			fields: fields{
+				Steps: validSteps,
+				Volumes: []corev1.Volume{{
+					Name: "workspace",
+				}, {
+					Name: "workspace",
+				}},
+			},
+			expectedError: apis.FieldError{
+				Message: `multiple volumes with same name "workspace"`,
+				Paths:   []string{"volumes.name"},
+			},
+		}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := &v1alpha1.TaskSpec{
 				Inputs:  tt.fields.Inputs,
 				Outputs: tt.fields.Outputs,
 				Steps:   tt.fields.Steps,
+				Volumes: tt.fields.Volumes,
 			}
 			ctx := context.Background()
 			ts.SetDefaults(ctx)


### PR DESCRIPTION
Fixes #1402 

# Changes

A Task is not allowed to have multiple volumes that share a name. Prior to this commit the error message printed when a name collision occurred was "expected exactly one, got both: name" which doesn't describe the problem clearly.

After this commit the error message is updated to 'multiple volumes with
same name "foo"'. A test case has been added to exercise the new message.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] ~~Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)~~
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
The error message emitted when a Task has multiple volumes with the same name has changed to describe the conflict more clearly.
```