### PR TITLE
Add support for comment and label manifests.

### DIFF
--- a/cmd/pullrequest-init/disk.go
+++ b/cmd/pullrequest-init/disk.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -39,6 +41,10 @@ import (
 // /workspace/<resource>/base.json
 
 // Filenames for labels and statuses are URL encoded for safety.
+
+const (
+	manifestPath = ".MANIFEST"
+)
 
 // ToDisk converts a PullRequest object to an on-disk representation at the specified path.
 func ToDisk(pr *PullRequest, path string) error {
@@ -80,28 +86,54 @@ func ToDisk(pr *PullRequest, path string) error {
 }
 
 func commentsToDisk(path string, comments []*Comment) error {
+	// Create a manifest to keep track of the comments that existed when the
+	// resource was initialized. This is used to verify that a comment that
+	// doesn't exist on disk was actually deleted by the user and not newly
+	// created during upload.
+	f, err := os.Create(filepath.Join(path, manifestPath))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	manifest := bufio.NewWriter(f)
+
 	for _, c := range comments {
-		commentPath := filepath.Join(path, strconv.FormatInt(c.ID, 10)+".json")
+		id := strconv.FormatInt(c.ID, 10)
+		commentPath := filepath.Join(path, id+".json")
 		b, err := json.Marshal(c)
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(commentPath, b, 0700); err != nil {
+		if err := ioutil.WriteFile(commentPath, b, 0600); err != nil {
+			return err
+		}
+		if _, err := manifest.WriteString(fmt.Sprintf("%s\n", id)); err != nil {
 			return err
 		}
 	}
-	return nil
+	return manifest.Flush()
 }
 
 func labelsToDisk(path string, labels []*Label) error {
+	f, err := os.Create(filepath.Join(path, manifestPath))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	manifest := bufio.NewWriter(f)
+
 	for _, l := range labels {
 		name := url.QueryEscape(l.Text)
 		labelPath := filepath.Join(path, name)
-		if err := ioutil.WriteFile(labelPath, []byte{}, 0700); err != nil {
+		if err := ioutil.WriteFile(labelPath, []byte{}, 0600); err != nil {
 			return err
 		}
+		if _, err := manifest.WriteString(fmt.Sprintf("%s\n", l.Text)); err != nil {
+			return err
+		}
+
 	}
-	return nil
+	return manifest.Flush()
 }
 
 func statusToDisk(path string, statuses []*Status) error {
@@ -127,57 +159,81 @@ func refToDisk(name, path string, r *GitReference) error {
 	return ioutil.WriteFile(filepath.Join(path, name+".json"), b, 0700)
 }
 
+// Manifest is a list of sub-resources that exist within the PR resource to
+// determine whether an item existed when the resource was initialized.
+type Manifest map[string]bool
+
 // FromDisk outputs a PullRequest object from an on-disk representation at the specified path.
-func FromDisk(path string) (*PullRequest, error) {
+func FromDisk(path string) (*PullRequest, map[string]Manifest, error) {
 	labelsPath := filepath.Join(path, "labels")
 	commentsPath := filepath.Join(path, "comments")
 	statusesPath := filepath.Join(path, "status")
 
 	pr := PullRequest{}
+	manifests := make(map[string]Manifest)
 
 	var err error
+	var manifest Manifest
 
-	// Start with comments
-	pr.Comments, err = commentsFromDisk(commentsPath)
+	pr.Comments, manifest, err = commentsFromDisk(commentsPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	manifests["comments"] = manifest
 
-	// Now Labels
-	pr.Labels, err = labelsFromDisk(labelsPath)
+	pr.Labels, manifest, err = labelsFromDisk(labelsPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	manifests["labels"] = manifest
 
-	// Now statuses
 	pr.Statuses, err = statusesFromDisk(statusesPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-
-	// Finally refs
 
 	pr.Base, err = refFromDisk(path, "base.json")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pr.Head, err = refFromDisk(path, "head.json")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &pr, nil
+	return &pr, manifests, nil
 }
 
-func commentsFromDisk(path string) ([]*Comment, error) {
-	fis, err := ioutil.ReadDir(path)
+func manifestFromDisk(path string) (map[string]bool, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
+
+	out := make(map[string]bool)
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		out[s.Text()] = true
+	}
+	if s.Err() != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func commentsFromDisk(path string) ([]*Comment, Manifest, error) {
+	fis, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, nil, err
+	}
 	comments := []*Comment{}
 	for _, fi := range fis {
+		if fi.Name() == manifestPath {
+			continue
+		}
 		b, err := ioutil.ReadFile(filepath.Join(path, fi.Name()))
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		comment := Comment{}
 		if err := json.Unmarshal(b, &comment); err != nil {
@@ -186,23 +242,38 @@ func commentsFromDisk(path string) ([]*Comment, error) {
 		}
 		comments = append(comments, &comment)
 	}
-	return comments, nil
+
+	manifest, err := manifestFromDisk(filepath.Join(path, manifestPath))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return comments, manifest, nil
 }
 
-func labelsFromDisk(path string) ([]*Label, error) {
+func labelsFromDisk(path string) ([]*Label, Manifest, error) {
 	fis, err := ioutil.ReadDir(path)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	labels := []*Label{}
 	for _, fi := range fis {
+		if fi.Name() == manifestPath {
+			continue
+		}
 		text, err := url.QueryUnescape(fi.Name())
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		labels = append(labels, &Label{Text: text})
 	}
-	return labels, nil
+
+	manifest, err := manifestFromDisk(filepath.Join(path, manifestPath))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return labels, manifest, nil
 }
 
 func statusesFromDisk(path string) ([]*Status, error) {

--- a/cmd/pullrequest-init/main.go
+++ b/cmd/pullrequest-init/main.go
@@ -52,11 +52,11 @@ func main() {
 
 	case "upload":
 		logger.Info("RUNNING UPLOAD!")
-		pr, err := FromDisk(*path)
+		pr, manifests, err := FromDisk(*path)
 		if err != nil {
 			logger.Fatal(err)
 		}
-		if err := client.Upload(ctx, pr); err != nil {
+		if err := client.Upload(ctx, pr, manifests); err != nil {
 			logger.Fatal(err)
 		}
 	}


### PR DESCRIPTION
# Changes

Introduces `.MANIFEST` files to comment and label directories to keep
track of sub-resources when the PullRequest resource is initialized.
This allows us to keep track of what resources the user explicitly
deleted, and not accidentally overwrite new comments/lables that were
introduced during execution.

Minor changes included:
* Changed fake GitHub server to make copies of PullRequests to avoid
  pointer collision across tests.
* Changed uploadLabels to Add/Delete labels explicitly instead of
  replacing all.

Change manifest path to .MANIFEST to avoid collisions.

Fixes #1286 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
- Fixes bug where PullRequestResource could accidentally delete newly created upsteam resources in certain race conditions.
```
