### PR TITLE
Use a local registry in build-push-kaniko

### DIFF
--- a/examples/taskruns/build-push-kaniko.yaml
+++ b/examples/taskruns/build-push-kaniko.yaml
@@ -6,23 +6,7 @@ spec:
   type: image
   params:
   - name: url
-    value: gcr.io/christiewilson-catfactory/leeroy-web # Replace this URL with $KO_DOCKER_REPO
----
-# This demo modifies the cluster (deploys to it) you must use a service
-# account with permission to admin the cluster (or make your default user an admin
-# of the `default` namespace with default-cluster-admin.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: default-cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: default
-roleRef:
-  kind: ClusterRole
-  name: cluster-admin
-  apiGroup: rbac.authorization.k8s.io
+    value: localhost:5000/leeroy-web
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -60,16 +44,15 @@ spec:
   steps:
   - name: build-and-push
     image: gcr.io/kaniko-project/executor:v0.9.0
-    # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
-    env:
-    - name: "DOCKER_CONFIG"
-      value: "/builder/home/.docker/"
     command:
     - /kaniko/executor
     args:
     - --dockerfile=$(inputs.params.pathToDockerFile)
     - --destination=$(outputs.resources.builtImage.url)
     - --context=$(inputs.params.pathToContext)
+  sidecars:
+    - image: registry
+      name: registry
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun


### PR DESCRIPTION
This is a first step in making our E2E tests more portable and less
dependent on resources outside of the k8s cluster they run into.

This changes the build-push-kaniko taskrun example.
There is a lot of infra setup required to make sure that the service
account used by test is able to push to a registry. The test script
replaces the image URL in the resource with the content of the
KO_DOCKER_REPO environment variable. If that is a gcr.io url then
the service account must be setup for access to it.

The updated version runs a local registry as a sidecar in the pod.
The task now can push to localhost:5000. The port is not exposed
outside of the pod so there is no risk of interference with other
tests.

Partially fixes #1372

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
