### PR TITLE
[WIP] Allows to refer a Task from different namespace in PipelineRun 🌳🕊️

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -199,7 +199,9 @@ type PipelineTaskOutputResource struct {
 type TaskRef struct {
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
 	Name string `json:"name,omitempty"`
-	// TaskKind inficates the kind of the task, namespaced or cluster scoped.
+	// Namespace indicates task namespaces.
+	Namespace string `json:"namespace,omitempty"`
+	// TaskKind indicates the kind of the task, namespaced or cluster scoped.
 	Kind TaskKind `json:"kind,omitempty"`
 	// API version of the referent
 	// +optional

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -508,7 +508,7 @@ func (c *Reconciler) createTaskRun(rprt *resources.ResolvedPipelineRunTask, pr *
 		return c.PipelineClientSet.TektonV1alpha1().TaskRuns(pr.Namespace).UpdateStatus(tr)
 	}
 
-	taskNS := pr.Namespace
+	taskNS := ""
 	if rprt.PipelineTask.TaskRef.Namespace != "" {
 		taskNS = rprt.PipelineTask.TaskRef.Namespace
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1576,7 +1576,7 @@ func TestReconcileWithTask_InOtherNamespace(t *testing.T) {
 	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(prName, "foo",
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
-			tb.PipelineRunServiceAccount("test-sa"),
+			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
 	ts := []*v1alpha1.Task{tb.Task("hello-world", "other")}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -245,13 +245,18 @@ func ResolvePipelineRun(
 		// Find the Task that this PipelineTask is using
 		var t v1alpha1.TaskInterface
 		var err error
+
 		if pt.TaskRef.Kind == v1alpha1.ClusterTaskKind {
 			t, err = getClusterTask(pt.TaskRef.Name)
-		} else if pt.TaskRef.Namespace != "" {
-			t, err = getTask(pt.TaskRef.Namespace, pt.TaskRef.Name)
 		} else {
-			t, err = getTask(pipelineRun.Namespace, pt.TaskRef.Name)
+			ns := pipelineRun.Namespace
+			if pt.TaskRef.Namespace != "" {
+				ns = pt.TaskRef.Namespace
+			}
+
+			t, err = getTask(ns, pt.TaskRef.Name)
 		}
+
 		if err != nil {
 			return nil, &TaskNotFoundError{
 				Name: pt.TaskRef.Name,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -247,8 +247,10 @@ func ResolvePipelineRun(
 		var err error
 		if pt.TaskRef.Kind == v1alpha1.ClusterTaskKind {
 			t, err = getClusterTask(pt.TaskRef.Name)
+		} else if pt.TaskRef.Namespace != "" {
+			t, err = getTask(pt.TaskRef.Namespace, pt.TaskRef.Name)
 		} else {
-			t, err = getTask(pt.TaskRef.Name)
+			t, err = getTask(pipelineRun.Namespace, pt.TaskRef.Name)
 		}
 		if err != nil {
 			return nil, &TaskNotFoundError{

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GetTask is a function used to retrieve Tasks.
-type GetTask func(string) (v1alpha1.TaskInterface, error)
+type GetTask func(string, string) (v1alpha1.TaskInterface, error)
 type GetTaskRun func(string) (*v1alpha1.TaskRun, error)
 
 // GetClusterTask is a function that will retrieve the Task from name and namespace.
@@ -38,7 +38,11 @@ func GetTaskData(taskRun *v1alpha1.TaskRun, getTask GetTask) (*metav1.ObjectMeta
 	switch {
 	case taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Name != "":
 		// Get related task for taskrun
-		t, err := getTask(taskRun.Spec.TaskRef.Name)
+		ns := taskRun.Namespace
+		if taskRun.Spec.TaskRef.Namespace != "" {
+			ns = taskRun.Spec.TaskRef.Namespace
+		}
+		t, err := getTask(ns, taskRun.Spec.TaskRef.Name)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("error when listing tasks for taskRun %s: %w", taskRun.Name, err)
 		}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -171,7 +171,7 @@ func (c *Reconciler) getTaskFunc(tr *v1alpha1.TaskRun) (resources.GetTask, v1alp
 	var gtFunc resources.GetTask
 	kind := v1alpha1.NamespacedTaskKind
 	if tr.Spec.TaskRef != nil && tr.Spec.TaskRef.Kind == v1alpha1.ClusterTaskKind {
-		gtFunc = func(name string) (v1alpha1.TaskInterface, error) {
+		gtFunc = func(namespace, name string) (v1alpha1.TaskInterface, error) {
 			t, err := c.clusterTaskLister.Get(name)
 			if err != nil {
 				return nil, err
@@ -180,8 +180,8 @@ func (c *Reconciler) getTaskFunc(tr *v1alpha1.TaskRun) (resources.GetTask, v1alp
 		}
 		kind = v1alpha1.ClusterTaskKind
 	} else {
-		gtFunc = func(name string) (v1alpha1.TaskInterface, error) {
-			t, err := c.taskLister.Tasks(tr.Namespace).Get(name)
+		gtFunc = func(namesapce, name string) (v1alpha1.TaskInterface, error) {
+			t, err := c.taskLister.Tasks(namesapce).Get(name)
 			if err != nil {
 				return nil, err
 			}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -143,6 +143,24 @@ func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
 	}
 }
 
+// PipelineTaskWithNamespace adds a PipelineTask, with specified name and task name with given namespace,  // to the PipelineSpec.
+// Any number of PipelineTask modifier can be passed to transform it.
+func PipelineTaskWithNamespace(name, taskName, namespace string, ops ...PipelineTaskOp) PipelineSpecOp {
+	return func(ps *v1alpha1.PipelineSpec) {
+		pTask := &v1alpha1.PipelineTask{
+			Name: name,
+			TaskRef: v1alpha1.TaskRef{
+				Name:      taskName,
+				Namespace: namespace,
+			},
+		}
+		for _, op := range ops {
+			op(pTask)
+		}
+		ps.Tasks = append(ps.Tasks, *pTask)
+	}
+}
+
 func Retries(retries int) PipelineTaskOp {
 	return func(pt *v1alpha1.PipelineTask) {
 		pt.Retries = retries


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Sometimes users don't want to copy-paste Task from one namespace to others.
One such use case could be enabling Task from Task catalog. Every time
duplicating the same Task in more than one namespace could become
maintenance nightmare.

This patch allows referencing a Task from a different namespace in TaskRun's
and PipelineRun's spec.TaskRef`. Hence this would allow the user to install the
Task once in the namespace. (Now not sure about its overlap with ClusterTask)

Fixes https://github.com/tektoncd/pipeline/issues/1409
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

Adds the new field in `TaskRef` fied in `PipelineTask` and `TaskRun` specs.

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

Users can refer a Task from different namespace in PipelineRun anaskRun spec.
```
e.g.
apiVersion: tekton.dev/v1alpha1
kind: Pipeline
metadata:
  name: echo-hello-world-pipeline
  namesapce: default
spec:
  tasks:
    - name: hello-world
      taskRef:
        name: echo-hello-world
        namespace: other


```
