### PR TITLE
Refactor Resource result output, and add support for Git resources.

### DIFF
--- a/cmd/imagedigestexporter/main.go
+++ b/cmd/imagedigestexporter/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"log"
-	"os"
+
+	"github.com/tektoncd/pipeline/pkg/termination"
+	"knative.dev/pkg/logging"
 
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -28,7 +29,7 @@ import (
 
 var (
 	images                 = flag.String("images", "", "List of images resources built by task in json format")
-	terminationMessagePath = flag.String("terminationMessagePath", "", "Location of file containing termination message")
+	terminationMessagePath = flag.String("terminationMessagePath", "/dev/termination-log", "Location of file containing termination message")
 )
 
 /* The input of this go program will be a JSON string with all the output PipelineResources of type
@@ -40,10 +41,12 @@ The output is an array of PipelineResourceResult, ex: [{"name":"image","digest":
 */
 func main() {
 	flag.Parse()
+	logger, _ := logging.NewLogger("", "image-digest-exporter")
+	defer logger.Sync()
 
 	imageResources := []*v1alpha1.ImageResource{}
 	if err := json.Unmarshal([]byte(*images), &imageResources); err != nil {
-		log.Fatalf("Error reading images array: %v", err)
+		logger.Fatalf("Error reading images array: %v", err)
 	}
 
 	output := []v1alpha1.PipelineResourceResult{}
@@ -52,12 +55,12 @@ func main() {
 		if err != nil {
 			// if this image doesn't have a builder that supports index.json file,
 			// then it will be skipped
-			log.Printf("ImageResource %s doesn't have an index.json file: %s", imageResource.Name, err)
+			logger.Infof("ImageResource %s doesn't have an index.json file: %s", imageResource.Name, err)
 			continue
 		}
 		digest, err := GetDigest(ii)
 		if err != nil {
-			log.Fatalf("Unexpected error getting image digest for %s: %v", imageResource.Name, err)
+			logger.Fatalf("Unexpected error getting image digest for %s: %v", imageResource.Name, err)
 		}
 		// We need to write both the old Name/Digest style and the new Key/Value styles.
 		output = append(output, v1alpha1.PipelineResourceResult{
@@ -75,22 +78,5 @@ func main() {
 
 	}
 
-	imagesJSON, err := json.Marshal(output)
-	if err != nil {
-		log.Fatalf("Unexpected error converting images to json %v: %v", output, err)
-	}
-	log.Printf("Image digest exporter output: %s ", string(imagesJSON))
-	f, err := os.OpenFile(*terminationMessagePath, os.O_WRONLY|os.O_CREATE, 0666)
-	if err != nil {
-		log.Fatalf("Unexpected error converting images to json %v: %v", output, err)
-	}
-	defer f.Close()
-
-	_, err = f.Write(imagesJSON)
-	if err != nil {
-		log.Fatalf("Unexpected error converting images to json %v: %v", output, err)
-	}
-	if err := f.Sync(); err != nil {
-		log.Fatalf("Unexpected error converting images to json %v: %v", output, err)
-	}
+	termination.WriteMessage(logger, *terminationMessagePath, output)
 }

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -198,8 +198,7 @@ spec:
 
 When resources are bound inside a TaskRun, they can include extra information in the TaskRun Status.ResourcesResult field.
 This information can be useful for auditing the exact resources used by a TaskRun later.
-Currently the only resource that uses this mechanism is the Image resource, which includes the exact digest
-of an image built by a TaskRun and declared as an output.
+Currently the Image and Git resources use this mechanism.
 
 For an example of what this output looks like:
 
@@ -257,6 +256,17 @@ Params that can be added are the following:
     (branch, tag, commit SHA or ref) to clone. You can use this to control what
     commit [or branch](#using-a-branch) is used. _If no revision is specified,
     the resource will default to `latest` from `master`._
+
+When used as an input, the Git resource includes the exact commit fetched in the `resourceResults`
+section of the `taskRun`'s status object:
+
+```yaml
+resourceResults:
+- key: commit
+  value: 6ed7aad5e8a36052ee5f6079fc91368e362121f7
+  resourceRef:
+    name: skaffold-git
+```
 
 #### Using a fork
 

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -109,6 +109,11 @@ func (s *GitResource) GetInputTaskModifier(_ *TaskSpec, path string) (TaskModifi
 			Command:    []string{"/ko-app/git-init"},
 			Args:       args,
 			WorkingDir: WorkspaceDir,
+			// This is used to populate the ResourceResult status.
+			Env: []corev1.EnvVar{{
+				Name:  "TEKTON_RESOURCE_NAME",
+				Value: s.Name,
+			}},
 		},
 	}
 	return &InternalTaskModifier{

--- a/pkg/apis/pipeline/v1alpha1/git_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource_test.go
@@ -132,6 +132,7 @@ func Test_GitResource_GetDownloadTaskModifier(t *testing.T) {
 			"/test/test",
 		},
 		WorkingDir: "/workspace",
+		Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "git-resource"}},
 	}}}
 
 	if diff := cmp.Diff(want, modifier.GetStepsToPrepend()); diff != "" {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -26,16 +26,21 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func run(logger *zap.SugaredLogger, args ...string) error {
+func run(logger *zap.SugaredLogger, dir string, args ...string) (string, error) {
 	c := exec.Command("git", args...)
 	var output bytes.Buffer
 	c.Stderr = &output
 	c.Stdout = &output
+	// This is the optional working directory. If not set, it defaults to the current
+	// working directory of the process.
+	if dir != "" {
+		c.Dir = dir
+	}
 	if err := c.Run(); err != nil {
 		logger.Errorf("Error running git %v: %v\n%v", args, err, output.String())
-		return err
+		return "", err
 	}
-	return nil
+	return output.String(), nil
 }
 
 // Fetch fetches the specified git repository at the revision into path.
@@ -70,31 +75,39 @@ func Fetch(logger *zap.SugaredLogger, revision, path, url string) error {
 		revision = "master"
 	}
 	if path != "" {
-		if err := run(logger, "init", path); err != nil {
+		if _, err := run(logger, "", "init", path); err != nil {
 			return err
 		}
 		if err := os.Chdir(path); err != nil {
 			return xerrors.Errorf("Failed to change directory with path %s; err: %w", path, err)
 		}
-	} else if err := run(logger, "init"); err != nil {
+	} else if _, err := run(logger, "", "init"); err != nil {
 		return err
 	}
 	trimmedURL := strings.TrimSpace(url)
-	if err := run(logger, "remote", "add", "origin", trimmedURL); err != nil {
+	if _, err := run(logger, "", "remote", "add", "origin", trimmedURL); err != nil {
 		return err
 	}
-	if err := run(logger, "fetch", "--depth=1", "--recurse-submodules=yes", "origin", revision); err != nil {
+	if _, err := run(logger, "", "fetch", "--depth=1", "--recurse-submodules=yes", "origin", revision); err != nil {
 		// Fetch can fail if an old commitid was used so try git pull, performing regardless of error
 		// as no guarantee that the same error is returned by all git servers gitlab, github etc...
-		if err := run(logger, "pull", "--recurse-submodules=yes", "origin"); err != nil {
+		if _, err := run(logger, "", "pull", "--recurse-submodules=yes", "origin"); err != nil {
 			logger.Warnf("Failed to pull origin : %s", err)
 		}
-		if err := run(logger, "checkout", revision); err != nil {
+		if _, err := run(logger, "", "checkout", revision); err != nil {
 			return err
 		}
-	} else if err := run(logger, "reset", "--hard", "FETCH_HEAD"); err != nil {
+	} else if _, err := run(logger, "", "reset", "--hard", "FETCH_HEAD"); err != nil {
 		return err
 	}
 	logger.Infof("Successfully cloned %s @ %s in path %s", trimmedURL, revision, path)
 	return nil
+}
+
+func Commit(logger *zap.SugaredLogger, revision, path string) (string, error) {
+	output, err := run(logger, path, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSuffix(output, "\n"), nil
 }

--- a/pkg/reconciler/taskrun/resources/image_exporter_test.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
 
 func TestAddOutputImageDigestExporter(t *testing.T) {
@@ -96,12 +95,10 @@ func TestAddOutputImageDigestExporter(t *testing.T) {
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name: "step1",
 		}}, {Container: corev1.Container{
-			Name:    "image-digest-exporter-9l9zj",
-			Image:   "override-with-imagedigest-exporter-image:latest",
-			Command: []string{"/ko-app/imagedigestexporter"},
-			Args: []string{"-images", fmt.Sprintf("[{\"name\":\"source-image-1\",\"type\":\"image\",\"url\":\"gcr.io/some-image-1\",\"digest\":\"\",\"OutputImageDir\":\"%s\"}]", currentDir),
-				"-terminationMessagePath", "/builder/home/image-outputs/termination-log"},
-			TerminationMessagePath:   TerminationMessagePath,
+			Name:                     "image-digest-exporter-9l9zj",
+			Image:                    "override-with-imagedigest-exporter-image:latest",
+			Command:                  []string{"/ko-app/imagedigestexporter"},
+			Args:                     []string{"-images", fmt.Sprintf("[{\"name\":\"source-image-1\",\"type\":\"image\",\"url\":\"gcr.io/some-image-1\",\"digest\":\"\",\"OutputImageDir\":\"%s\"}]", currentDir)},
 			TerminationMessagePolicy: "FallbackToLogsOnError",
 		}}},
 	}, {
@@ -168,12 +165,10 @@ func TestAddOutputImageDigestExporter(t *testing.T) {
 		}}, {Container: corev1.Container{
 			Name: "step2",
 		}}, {Container: corev1.Container{
-			Name:    "image-digest-exporter-9l9zj",
-			Image:   "override-with-imagedigest-exporter-image:latest",
-			Command: []string{"/ko-app/imagedigestexporter"},
-			Args: []string{"-images", fmt.Sprintf("[{\"name\":\"source-image-1\",\"type\":\"image\",\"url\":\"gcr.io/some-image-1\",\"digest\":\"\",\"OutputImageDir\":\"%s\"}]", currentDir),
-				"-terminationMessagePath", "/builder/home/image-outputs/termination-log"},
-			TerminationMessagePath:   TerminationMessagePath,
+			Name:                     "image-digest-exporter-9l9zj",
+			Image:                    "override-with-imagedigest-exporter-image:latest",
+			Command:                  []string{"/ko-app/imagedigestexporter"},
+			Args:                     []string{"-images", fmt.Sprintf("[{\"name\":\"source-image-1\",\"type\":\"image\",\"url\":\"gcr.io/some-image-1\",\"digest\":\"\",\"OutputImageDir\":\"%s\"}]", currentDir)},
 			TerminationMessagePolicy: "FallbackToLogsOnError",
 		}}},
 	}} {
@@ -206,297 +201,6 @@ func TestAddOutputImageDigestExporter(t *testing.T) {
 			}
 
 			if d := cmp.Diff(c.task.Spec.Steps, c.wantSteps); d != "" {
-				t.Fatalf("post build steps mismatch: %s", d)
-			}
-		})
-	}
-}
-
-func TestUpdateTaskRunStatus_withValidJson(t *testing.T) {
-	for _, c := range []struct {
-		desc    string
-		podLog  []byte
-		taskRun *v1alpha1.TaskRun
-		want    []v1alpha1.PipelineResourceResult
-	}{{
-		desc:   "image resource updated",
-		podLog: []byte("[{\"name\":\"source-image\",\"digest\":\"sha256:1234\"}]"),
-		taskRun: &v1alpha1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun-run-output-steps",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskRunSpec{
-				Inputs: v1alpha1.TaskRunInputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source-image",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-image-1",
-							},
-						},
-					}},
-				},
-				Outputs: v1alpha1.TaskRunOutputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source-image",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-image-1",
-							},
-						},
-					}},
-				},
-			},
-		},
-		want: []v1alpha1.PipelineResourceResult{{
-			Name:   "source-image",
-			Digest: "sha256:1234",
-		}},
-	}} {
-		t.Run(c.desc, func(t *testing.T) {
-			names.TestingSeed()
-			c.taskRun.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			})
-			err := UpdateTaskRunStatusWithResourceResult(c.taskRun, c.podLog)
-			if err != nil {
-				t.Errorf("UpdateTaskRunStatusWithResourceResult failed with error: %s", err)
-			}
-			if d := cmp.Diff(c.taskRun.Status.ResourcesResult, c.want); d != "" {
-				t.Errorf("post build steps mismatch: %s", d)
-			}
-		})
-	}
-}
-
-func TestUpdateTaskRunStatus_withInvalidJson(t *testing.T) {
-	for _, c := range []struct {
-		desc    string
-		podLog  []byte
-		taskRun *v1alpha1.TaskRun
-		want    []v1alpha1.PipelineResourceResult
-	}{{
-		desc:   "image resource exporter with malformed json output",
-		podLog: []byte("extralogscamehere[{\"name\":\"source-image\",\"digest\":\"sha256:1234\"}]"),
-		taskRun: &v1alpha1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun-run-output-steps",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskRunSpec{
-				Inputs: v1alpha1.TaskRunInputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source-image",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-image-1",
-							},
-						},
-					}},
-				},
-				Outputs: v1alpha1.TaskRunOutputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source-image",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-image-1",
-							},
-						},
-					}},
-				},
-			},
-		},
-		want: nil,
-	}, {
-		desc:   "task with no image resource ",
-		podLog: []byte(""),
-		taskRun: &v1alpha1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun-run-output-steps",
-				Namespace: "marshmallow",
-			},
-		},
-		want: nil,
-	}} {
-		t.Run(c.desc, func(t *testing.T) {
-			names.TestingSeed()
-			c.taskRun.Status.SetCondition(&apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionTrue,
-			})
-			err := UpdateTaskRunStatusWithResourceResult(c.taskRun, c.podLog)
-			if err == nil {
-				t.Error("UpdateTaskRunStatusWithResourceResult expected to fail with error")
-			}
-			if d := cmp.Diff(c.taskRun.Status.ResourcesResult, c.want); d != "" {
-				t.Errorf("post build steps mismatch: %s", d)
-			}
-		})
-	}
-}
-
-func TestTaskRunHasOutputImageResource(t *testing.T) {
-	for _, c := range []struct {
-		desc       string
-		task       *v1alpha1.Task
-		taskRun    *v1alpha1.TaskRun
-		wantResult bool
-	}{{
-		desc: "image resource as output",
-		task: &v1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "task1",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskSpec{
-				Inputs: &v1alpha1.Inputs{
-					Resources: []v1alpha1.TaskResource{{
-						ResourceDeclaration: v1alpha1.ResourceDeclaration{
-							Name: "source-image",
-							Type: "image",
-						}}},
-				},
-				Outputs: &v1alpha1.Outputs{
-					Resources: []v1alpha1.TaskResource{{
-						ResourceDeclaration: v1alpha1.ResourceDeclaration{
-							Name: "source-image",
-							Type: "image",
-						}}},
-				},
-				Steps: []v1alpha1.Step{{Container: corev1.Container{
-					Name: "step1",
-				}}},
-			},
-		},
-		taskRun: &v1alpha1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun-run-output-steps",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskRunSpec{
-				Inputs: v1alpha1.TaskRunInputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source-image",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-image-1",
-							},
-						},
-					}},
-				},
-				Outputs: v1alpha1.TaskRunOutputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source-image",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-image-1",
-							},
-						},
-					}},
-				},
-			},
-		},
-		wantResult: true,
-	}, {
-		desc: "task with no image resource",
-		task: &v1alpha1.Task{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "task1",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskSpec{
-				Inputs: &v1alpha1.Inputs{
-					Resources: []v1alpha1.TaskResource{{
-						ResourceDeclaration: v1alpha1.ResourceDeclaration{
-							Name: "source",
-							Type: "git",
-						}}},
-				},
-				Outputs: &v1alpha1.Outputs{
-					Resources: []v1alpha1.TaskResource{{
-						ResourceDeclaration: v1alpha1.ResourceDeclaration{
-							Name: "source",
-							Type: "git",
-						}}},
-				},
-			},
-		},
-		taskRun: &v1alpha1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun-run-output-steps",
-				Namespace: "marshmallow",
-			},
-			Spec: v1alpha1.TaskRunSpec{
-				Inputs: v1alpha1.TaskRunInputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-git-1",
-							},
-						},
-					}},
-				},
-				Outputs: v1alpha1.TaskRunOutputs{
-					Resources: []v1alpha1.TaskResourceBinding{{
-						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-							Name: "source",
-							ResourceRef: v1alpha1.PipelineResourceRef{
-								Name: "source-git-1",
-							},
-						},
-					}},
-				},
-			},
-		},
-		wantResult: false,
-	}} {
-		t.Run(c.desc, func(t *testing.T) {
-			gr := func(name string) (*v1alpha1.PipelineResource, error) {
-				var r *v1alpha1.PipelineResource
-				if name == "source-image-1" {
-					r = &v1alpha1.PipelineResource{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "source-image-1",
-							Namespace: "marshmallow",
-						},
-						Spec: v1alpha1.PipelineResourceSpec{
-							Type: "image",
-							Params: []v1alpha1.ResourceParam{{
-								Name:  "url",
-								Value: "gcr.io/some-image-1",
-							}, {
-								Name:  "digest",
-								Value: "",
-							}, {
-								Name:  "OutputImageDir",
-								Value: "/workspace/source-image-1/index.json",
-							}},
-						},
-					}
-				} else if name == "source-git-1" {
-					r = &v1alpha1.PipelineResource{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "source-git-1",
-							Namespace: "marshmallow",
-						},
-						Spec: v1alpha1.PipelineResourceSpec{
-							Type: "git",
-							Params: []v1alpha1.ResourceParam{{
-								Name:  "url",
-								Value: "github.com/repo",
-							},
-							},
-						},
-					}
-				}
-				return r, nil
-			}
-			result := TaskRunHasOutputImageResource(gr, c.taskRun)
-
-			if d := cmp.Diff(result, c.wantResult); d != "" {
 				t.Fatalf("post build steps mismatch: %s", d)
 			}
 		})

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -322,6 +322,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "master", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
+				Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "the-git"}},
 			}}},
 		},
 	}, {
@@ -357,6 +358,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
+				Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"}},
 			}}},
 		},
 	}, {
@@ -399,12 +401,14 @@ func TestAddResourceToTask(t *testing.T) {
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
+				Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"}},
 			}}, {Container: corev1.Container{
 				Name:       "git-source-the-git-with-branch-9l9zj",
 				Image:      "override-with-git:latest",
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/git-duplicate-space"},
 				WorkingDir: "/workspace",
+				Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"}},
 			}}},
 		},
 	}, {
@@ -440,6 +444,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "master", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
+				Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "the-git"}},
 			}}},
 		},
 	}, {
@@ -475,6 +480,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Command:    []string{"/ko-app/git-init"},
 				Args:       []string{"-url", "https://github.com/grafeas/kritis", "-revision", "branch", "-path", "/workspace/gitspace"},
 				WorkingDir: "/workspace",
+				Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"}},
 			}}},
 		},
 	}, {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -18,6 +18,7 @@ package taskrun
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -55,7 +56,6 @@ const (
 
 	// imageDigestExporterContainerName defines the name of the container that will collect the
 	// built images digest
-	imageDigestExporterContainerName = "step-image-digest-exporter"
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.
@@ -312,7 +312,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 
 	status.SortTaskRunStepOrder(tr.Status.Steps, taskSpec.Steps)
 
-	updateTaskRunResourceResult(tr, pod, c.resourceLister, c.Logger)
+	updateTaskRunResourceResult(tr, pod, c.Logger)
 
 	after := tr.Status.GetCondition(apis.ConditionSucceeded)
 
@@ -358,17 +358,29 @@ func (c *Reconciler) handlePodCreationError(tr *v1alpha1.TaskRun, err error) {
 	c.Logger.Errorf("Failed to create build pod for task %q: %v", tr.Name, err)
 }
 
-func updateTaskRunResourceResult(taskRun *v1alpha1.TaskRun, pod *corev1.Pod, resourceLister listers.PipelineResourceLister, logger *zap.SugaredLogger) {
-	if resources.TaskRunHasOutputImageResource(resourceLister.PipelineResources(taskRun.Namespace).Get, taskRun) && taskRun.IsSuccessful() {
+func updateTaskRunResourceResult(taskRun *v1alpha1.TaskRun, pod *corev1.Pod, logger *zap.SugaredLogger) {
+	if taskRun.IsSuccessful() {
 		for _, cs := range pod.Status.ContainerStatuses {
-			if strings.HasPrefix(cs.Name, imageDigestExporterContainerName) {
-				err := resources.UpdateTaskRunStatusWithResourceResult(taskRun, []byte(cs.State.Terminated.Message))
-				if err != nil {
-					logger.Errorf("Error getting output from image-digest-exporter for %s/%s: %s", taskRun.Name, taskRun.Namespace, err)
+			if cs.State.Terminated != nil {
+				msg := cs.State.Terminated.Message
+				if msg != "" {
+					if err := updateTaskRunStatusWithResourceResult(taskRun, []byte(msg)); err != nil {
+						logger.Infof("No resource result from %s for %s/%s: %s", cs.Name, taskRun.Name, taskRun.Namespace, err)
+					}
 				}
 			}
 		}
 	}
+}
+
+// updateTaskRunStatusWithResourceResult if there is an update to the outout image resource, add to taskrun status result
+func updateTaskRunStatusWithResourceResult(taskRun *v1alpha1.TaskRun, logContent []byte) error {
+	results := []v1alpha1.PipelineResourceResult{}
+	if err := json.Unmarshal(logContent, &results); err != nil {
+		return xerrors.Errorf("Failed to unmarshal output image exporter JSON output: %w", err)
+	}
+	taskRun.Status.ResourcesResult = append(taskRun.Status.ResourcesResult, results...)
+	return nil
 }
 
 func (c *Reconciler) updateStatus(taskrun *v1alpha1.TaskRun) (*v1alpha1.TaskRun, error) {

--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package termination
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"go.uber.org/zap"
+)
+
+func WriteMessage(logger *zap.SugaredLogger, path string, pro []v1alpha1.PipelineResourceResult) {
+	jsonOutput, err := json.Marshal(pro)
+	if err != nil {
+		logger.Fatalf("Error marshaling json: %s", err)
+	}
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		log.Fatalf("Unexpected error converting output to json %v: %v", pro, err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(jsonOutput)
+	if err != nil {
+		logger.Fatalf("Unexpected error converting output to json %v: %v", pro, err)
+	}
+	if err := f.Sync(); err != nil {
+		logger.Fatalf("Unexpected error converting output to json %v: %v", pro, err)
+	}
+}

--- a/test/builder/container.go
+++ b/test/builder/container.go
@@ -132,13 +132,6 @@ func EphemeralStorage(val string) ResourceListOp {
 	}
 }
 
-// TerminationMessagePath sets the source of the termination message.
-func TerminationMessagePath(terminationMessagePath string) ContainerOp {
-	return func(c *corev1.Container) {
-		c.TerminationMessagePath = terminationMessagePath
-	}
-}
-
 // TerminationMessagePolicy sets the policy of the termination message.
 func TerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) ContainerOp {
 	return func(c *corev1.Container) {


### PR DESCRIPTION
# Changes

This change builds upon #1406, and logs the exact Git commit used by a Git input
to the ResourceResults field.

Some other cleanups are included:
- Removing custom TerminationMessagePath from the Image resource. The default is fine.
- Test cleanup.
- A new helper to write termination messages from resource containers.

And finally, this adds a new environment variable to the git resource steps, indicating the
name of the resource instance they are running as. We should make this more generic and apply
it to all resource steps as part of the extensiblity refactor.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The 'Git' PipelineResource now populates the taskRun.status.resourcesResult field with the commit used.
```
