### PR TITLE
Allow entrypoint binary to wait for multiple files

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	"time"
 
@@ -29,7 +30,7 @@ import (
 
 var (
 	ep              = flag.String("entrypoint", "", "Original specified entrypoint to execute")
-	waitFile        = flag.String("wait_file", "", "If specified, file to wait for")
+	waitFiles       = flag.String("wait_file", "", "Comma-separated list of paths to wait for")
 	waitFileContent = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
 	postFile        = flag.String("post_file", "", "If specified, file to write upon completion")
 
@@ -41,7 +42,7 @@ func main() {
 
 	e := entrypoint.Entrypointer{
 		Entrypoint:      *ep,
-		WaitFile:        *waitFile,
+		WaitFiles:       strings.Split(*waitFiles, ","),
 		WaitFileContent: *waitFileContent,
 		PostFile:        *postFile,
 		Args:            flag.Args(),

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -27,9 +27,9 @@ type Entrypointer struct {
 	Entrypoint string
 	// Args are the original specified args, if any.
 	Args []string
-	// WaitFile is the file to wait for. If not specified, execution begins
-	// immediately.
-	WaitFile string
+	// WaitFiles is the set of files to wait for. If empty, execution
+	// begins immediately.
+	WaitFiles []string
 	// WaitFileContent indicates the WaitFile should have non-zero size
 	// before continuing with execution.
 	WaitFileContent bool
@@ -65,10 +65,10 @@ type PostWriter interface {
 // Go optionally waits for a file, runs the command, and writes a
 // post file.
 func (e Entrypointer) Go() error {
-	if e.WaitFile != "" {
-		if err := e.Waiter.Wait(e.WaitFile, e.WaitFileContent); err != nil {
+	for _, f := range e.WaitFiles {
+		if err := e.Waiter.Wait(f, e.WaitFileContent); err != nil {
 			// An error happened while waiting, so we bail
-			// *but* we write postfile to make next steps bail too
+			// *but* we write postfile to make next steps bail too.
 			e.WritePostFile(e.PostFile, err)
 			return err
 		}


### PR DESCRIPTION
# Changes

Enables the `entrypoint` binary to be passed multiple comma-separated paths to its `-wait_file` flag. The binary will wait for _all_ of those paths to exist before proceeding to execute the command.

This is not exposed in the TaskRun API (nor is it expected to be), and the change is fully backward-compatible for existing users of the `entrypoint` image.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
entrypoint image allows multiple comma-separated values for the -wait_file flag
```