### PR TITLE
Set defaults for Tasks embedded in TaskRuns

### DIFF
--- a/examples/pipelineruns/conditional-pipelinerun.yaml
+++ b/examples/pipelineruns/conditional-pipelinerun.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   params:
     - name: "path"
-      type: string
   resources:
     - name: workspace
       type: git

--- a/examples/taskruns/steptemplate-env-merge.yaml
+++ b/examples/taskruns/steptemplate-env-merge.yaml
@@ -19,14 +19,11 @@ spec:
       params:
       - name: FOO
         description: FOO variable
-        type: string
       - name: BAR
         description: BAR variable
-        type: string
       - name: FOOBAR
         description: FOOBAR variable
         default: foobar
-        type: string
     steps:
       # Test the environment variables are set in the task
       - name: foo

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -51,4 +51,9 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	if trs.ServiceAccountName == "" && defaultSA != "" {
 		trs.ServiceAccountName = defaultSA
 	}
+
+	// If this taskrun has an embedded task, apply the usual task defaults
+	if trs.TaskSpec != nil {
+		trs.TaskSpec.SetDefaults(ctx)
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -34,40 +34,58 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 		desc string
 		trs  *v1alpha1.TaskRunSpec
 		want *v1alpha1.TaskRunSpec
-	}{
-		{
-			desc: "taskref is nil",
-			trs: &v1alpha1.TaskRunSpec{
-				TaskRef: nil,
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
-			},
-			want: &v1alpha1.TaskRunSpec{
-				TaskRef: nil,
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+	}{{
+		desc: "taskref is nil",
+		trs: &v1alpha1.TaskRunSpec{
+			TaskRef: nil,
+			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+		},
+		want: &v1alpha1.TaskRunSpec{
+			TaskRef: nil,
+			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+		},
+	}, {
+		desc: "taskref kind is empty",
+		trs: &v1alpha1.TaskRunSpec{
+			TaskRef: &v1alpha1.TaskRef{},
+			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+		},
+		want: &v1alpha1.TaskRunSpec{
+			TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.NamespacedTaskKind},
+			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+		},
+	}, {
+		desc: "timeout is nil",
+		trs: &v1alpha1.TaskRunSpec{
+			TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
+		},
+		want: &v1alpha1.TaskRunSpec{
+			TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
+			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+		},
+	}, {
+		desc: "embedded taskSpec",
+		trs: &v1alpha1.TaskRunSpec{
+			TaskSpec: &v1alpha1.TaskSpec{
+				Inputs: &v1alpha1.Inputs{
+					Params: []v1alpha1.ParamSpec{{
+						Name: "param-name",
+					}},
+				},
 			},
 		},
-		{
-			desc: "taskref kind is empty",
-			trs: &v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{},
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+		want: &v1alpha1.TaskRunSpec{
+			TaskSpec: &v1alpha1.TaskSpec{
+				Inputs: &v1alpha1.Inputs{
+					Params: []v1alpha1.ParamSpec{{
+						Name: "param-name",
+						Type: v1alpha1.ParamTypeString,
+					}},
+				},
 			},
-			want: &v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
-			},
+			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
-		{
-			desc: "timeout is nil",
-			trs: &v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
-			},
-			want: &v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-			},
-		},
-	}
+	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()


### PR DESCRIPTION
# Changes

Partially fixes #1427 

Previously, we were not setting defaults for Tasks
that were embedded inside TaskRuns. So, these tasks
always had to have the default set manually e.g. the
`type` field for each input `param`. If they were not set,
the webhook would deny creating the resource.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
