### PR TITLE
Implement step scripts

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -129,7 +129,7 @@ The `steps` field is required. You define one or more `steps` fields to define
 the body of a `Task`.
 
 If multiple `steps` are defined, they will be executed in the same order as they
-are defined, if the `Task` is invoked by a [TaskRun](taskruns.md).
+are defined, if the `Task` is invoked by a [`TaskRun`](taskruns.md).
 
 Each `steps` in a `Task` must specify a container image that adheres to the
 [container contract](./container-contract.md). For each of the `steps` fields,
@@ -145,6 +145,67 @@ or container images that you define:
   will only request the resources necessary to execute any single container
   image in the Task, rather than requesting the sum of all of the container
   image's resource requests.
+
+#### Step Script
+
+To simplify executing scripts inside a container, a step can specify a `script`.
+If this field is present, the step cannot specify `command` or `args`.
+
+When specified, a `script` gets invoked as if it were the contents of a file in
+the container. Scripts should start with a
+[shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line to declare what
+tool should be used to interpret the script. That tool must then also be
+available within the step's container.
+
+This allows you to execute a Bash script, if the image includes `bash`:
+
+```yaml
+steps:
+- image: ubuntu  # contains bash
+  script: |
+    #!/usr/bin/env bash
+    echo "Hello from Bash!"
+```
+
+...or to execute a Python script, if the image includes `python`:
+
+```yaml
+steps:
+- image: python  # contains python
+  script: |
+    #!/usr/bin/env python3
+    print("Hello from Python!")
+```
+
+...or to execute a Node script, if the image includes `node`:
+
+```yaml
+steps:
+- image: node  # contains node
+  script: |
+    #!/usr/bin/env node
+    console.log("Hello from Node!")
+```
+
+This also simplifies executing script files in the workspace:
+
+```yaml
+steps:
+- image: ubuntu
+  script: |
+    #!/usr/bin/env bash
+    /workspace/my-script.sh  # provided by an input resource
+```
+
+...or in the container image:
+
+```yaml
+steps:
+- image: my-image  # contains /bin/my-binary
+  script: |
+    #!/usr/bin/env bash
+    /bin/my-binary
+```
 
 ### Inputs
 

--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: step-script-
+spec:
+  taskSpec:
+    steps:
+    - name: bash
+      image: ubuntu
+      env:
+      - name: FOO
+        value: foooooooo
+      script: |
+        #!/usr/bin/env bash
+        set -euxo pipefail
+        echo "Hello from Bash!"
+        echo FOO is ${FOO}
+        echo substring is ${FOO:2:4}
+        for i in {1..10}; do
+          echo line $i
+        done
+
+    - name: place-file
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        echo "echo Hello from script file" > /workspace/hello
+        chmod +x /workspace/hello
+    - name: run-file
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        /workspace/hello
+
+    - name: node
+      image: node
+      script: |
+        #!/usr/bin/env node
+        console.log("Hello from Node!")
+
+    - name: python
+      image: python
+      script: |
+        #!/usr/bin/env python3
+        print("Hello from Python!")
+
+    - name: perl
+      image: perl
+      script: |
+        #!/usr/bin/perl
+        print "Hello from Perl!"

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -16,7 +16,8 @@ limitations under the License.
 
 package pipeline
 
-// Images holds the images reference for a number of container images used accross tektoncd pipelines
+// Images holds the images reference for a number of container images used
+// across tektoncd pipelines.
 type Images struct {
 	// EntryPointImage is container image containing our entrypoint binary.
 	EntryPointImage string

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -66,6 +66,11 @@ type TaskSpec struct {
 // provided by Container.
 type Step struct {
 	corev1.Container
+
+	// Script is the contents of an executable file to execute.
+	//
+	// If Script is not empty, the Step cannot have an Command or Args.
+	Script string `json:"script,omitempty"`
 }
 
 // Check that Task may be validated and defaulted.

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -127,6 +127,21 @@ func validateSteps(steps []Step) *apis.FieldError {
 			return apis.ErrMissingField("Image")
 		}
 
+		if s.Script != "" {
+			if len(s.Args) > 0 || len(s.Command) > 0 {
+				return &apis.FieldError{
+					Message: "script cannot be used with args or command",
+					Paths:   []string{"script"},
+				}
+			}
+			if !strings.HasPrefix(strings.TrimSpace(s.Script), "#!") {
+				return &apis.FieldError{
+					Message: "script must start with a shebang (#!)",
+					Paths:   []string{"script"},
+				}
+			}
+		}
+
 		if s.Name == "" {
 			continue
 		}


### PR DESCRIPTION
Fixes #781 

This adds a `Script` field to the `Step` type which, when specified, results in a temporary generated executable script file being invoked containing the specified script contents.

The result is an easy-to-use scripting option for users who just want to invoke simple scripts inside containers. Details of generated scripts should be considered an implementation detail, and should not be relied upon by users.

This implementation is based on feedback from @skaegi to generate files and invoke them, rather than hijacking the step's args to run the script using `sh`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Support step scripts for easier scripting inside container executions
```
