### PR TITLE
Support multiple SSH keys for the same host

### DIFF
--- a/pkg/credentials/gitcreds/creds.go
+++ b/pkg/credentials/gitcreds/creds.go
@@ -40,7 +40,7 @@ func flags(fs *flag.FlagSet) {
 	basicConfig = basicGitConfig{entries: make(map[string]basicEntry)}
 	fs.Var(&basicConfig, basicAuthFlag, "List of secret=url pairs.")
 
-	sshConfig = sshGitConfig{entries: make(map[string]sshEntry)}
+	sshConfig = sshGitConfig{entries: make(map[string][]sshEntry)}
 	fs.Var(&sshConfig, sshFlag, "List of secret=url pairs.")
 }
 

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -36,7 +36,7 @@ const sshKnownHosts = "known_hosts"
 // As the flag is read, this status is populated.
 // sshGitConfig implements flag.Value
 type sshGitConfig struct {
-	entries map[string]sshEntry
+	entries map[string][]sshEntry
 	// The order we see things, for iterating over the above.
 	order []string
 }
@@ -48,8 +48,9 @@ func (dc *sshGitConfig) String() string {
 	}
 	var urls []string
 	for _, k := range dc.order {
-		v := dc.entries[k]
-		urls = append(urls, fmt.Sprintf("%s=%s", v.secret, k))
+		for _, e := range dc.entries[k] {
+			urls = append(urls, fmt.Sprintf("%s=%s", e.secretName, k))
+		}
 	}
 	return strings.Join(urls, ",")
 }
@@ -59,19 +60,17 @@ func (dc *sshGitConfig) Set(value string) error {
 	if len(parts) != 2 {
 		return xerrors.Errorf("Expect entries of the form secret=url, got: %v", value)
 	}
-	secret := parts[0]
+	secretName := parts[0]
 	url := parts[1]
 
-	if _, ok := dc.entries[url]; ok {
-		return xerrors.Errorf("Multiple entries for url: %v", url)
-	}
-
-	e, err := newSshEntry(url, secret)
+	e, err := newSshEntry(url, secretName)
 	if err != nil {
 		return err
 	}
-	dc.entries[url] = *e
-	dc.order = append(dc.order, url)
+	if _, exists := dc.entries[url]; !exists {
+		dc.order = append(dc.order, url)
+	}
+	dc.entries[url] = append(dc.entries[url], *e)
 	return nil
 }
 
@@ -82,7 +81,7 @@ func (dc *sshGitConfig) Write() error {
 	}
 
 	// Walk each of the entries and for each do three things:
-	//  1. Write out: ~/.ssh/id_{secret} with the secret key
+	//  1. Write out: ~/.ssh/id_{secretName} with the secret key
 	//  2. Compute its part of "~/.ssh/config"
 	//  3. Compute its part of "~/.ssh/known_hosts"
 	var configEntries []string
@@ -95,17 +94,19 @@ func (dc *sshGitConfig) Write() error {
 			host = k
 			port = defaultPort
 		}
-		v := dc.entries[k]
-		if err := v.Write(sshDir); err != nil {
-			return err
-		}
-		configEntries = append(configEntries, fmt.Sprintf(`Host %s
+		configEntry := fmt.Sprintf(`Host %s
     HostName %s
-    IdentityFile %s
     Port %s
-`, host, host, v.path(sshDir), port))
-
-		knownHosts = append(knownHosts, v.knownHosts)
+`, host, host, port)
+		for _, e := range dc.entries[k] {
+			if err := e.Write(sshDir); err != nil {
+				return err
+			}
+			configEntry += fmt.Sprintf(`    IdentityFile %s
+`, e.path(sshDir))
+			knownHosts = append(knownHosts, e.knownHosts)
+		}
+		configEntries = append(configEntries, configEntry)
 	}
 	configPath := filepath.Join(sshDir, "config")
 	configContent := strings.Join(configEntries, "")
@@ -118,13 +119,13 @@ func (dc *sshGitConfig) Write() error {
 }
 
 type sshEntry struct {
-	secret     string
+	secretName string
 	privateKey string
 	knownHosts string
 }
 
 func (be *sshEntry) path(sshDir string) string {
-	return filepath.Join(sshDir, "id_"+be.secret)
+	return filepath.Join(sshDir, "id_"+be.secretName)
 }
 
 func sshKeyScan(domain string) ([]byte, error) {
@@ -142,8 +143,8 @@ func (be *sshEntry) Write(sshDir string) error {
 	return ioutil.WriteFile(be.path(sshDir), []byte(be.privateKey), 0600)
 }
 
-func newSshEntry(u, secret string) (*sshEntry, error) {
-	secretPath := credentials.VolumeName(secret)
+func newSshEntry(u, secretName string) (*sshEntry, error) {
+	secretPath := credentials.VolumeName(secretName)
 
 	pk, err := ioutil.ReadFile(filepath.Join(secretPath, corev1.SSHAuthPrivateKey))
 	if err != nil {
@@ -161,7 +162,7 @@ func newSshEntry(u, secret string) (*sshEntry, error) {
 	knownHosts := string(kh)
 
 	return &sshEntry{
-		secret:     secret,
+		secretName: secretName,
 		privateKey: privateKey,
 		knownHosts: knownHosts,
 	}, nil


### PR DESCRIPTION
Before this change, if users provided two secrets annotated to target the same host, `creds-init` would fail to generate the ssh config.

This use case is entirely valid, to allow users to rotate keys for instance.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Allow multiple SSH-auth secrets annotated for the same host
```
