### PR TITLE
Have cmd/bash image actually use bash

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,6 +1,6 @@
 baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
-  github.com/tektoncd/pipeline/cmd/bash: busybox # image should have shell in $PATH
-  github.com/tektoncd/pipeline/cmd/entrypoint: busybox # image should have shell in $PATH
+  github.com/tektoncd/pipeline/cmd/bash: bash # image must have `bash` in $PATH
+  github.com/tektoncd/pipeline/cmd/entrypoint: busybox  # image must have `cp` in $PATH
   github.com/tektoncd/pipeline/cmd/gsutil: google/cloud-sdk:alpine # image should have gsutil in $PATH

--- a/cmd/bash/main.go
+++ b/cmd/bash/main.go
@@ -26,7 +26,7 @@ args: ['-args', 'ARGUMENTS_FOR_SHELL_COMMAND']
 For help, run `man sub-command`
 ```
 image: github.com/tektoncd/pipeline/cmd/bash
-args: ['-args', `man`,`mkdir`]
+args: ['-args', 'man mkdir']
 ```
 
 For example:
@@ -34,8 +34,11 @@ Following example executes shell sub-command `mkdir`
 
 ```
 image: github.com/tektoncd/pipeline/cmd/bash
-args:  ['-args', 'mkdir', '-p', '/workspace/gcs-dir']
+args:  ['-args', 'mkdir -p /workspace/gcs-dir']
 ```
+
+Be sure not to pass multiple args to `-args`, only a single quoted string to
+execute. Passing further args will cause the image to raise an error.
 */
 
 package main
@@ -56,7 +59,11 @@ func main() {
 	flag.Parse()
 	logger, _ := logging.NewLogger("", "shell_command")
 	defer logger.Sync()
-	cmd := exec.Command("sh", "-c", *args)
+	if len(flag.Args()) > 0 {
+		logger.Fatalf("Extra args were provided, and would be ignored: %v", flag.Args())
+	}
+
+	cmd := exec.Command("bash", "-c", *args)
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
 		logger.Fatalf("Error executing command %q ; error %s; cmd_output %s", strings.Join(cmd.Args, " "), err.Error(), stdoutStderr)

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -46,9 +46,9 @@ func main() {
 		WaitFileContent: *waitFileContent,
 		PostFile:        *postFile,
 		Args:            flag.Args(),
-		Waiter:          &RealWaiter{},
-		Runner:          &RealRunner{},
-		PostWriter:      &RealPostWriter{},
+		Waiter:          &realWaiter{},
+		Runner:          &realRunner{},
+		PostWriter:      &realPostWriter{},
 	}
 	if err := e.Go(); err != nil {
 		switch t := err.(type) {

--- a/cmd/entrypoint/post_writer.go
+++ b/cmd/entrypoint/post_writer.go
@@ -7,12 +7,12 @@ import (
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
 )
 
-// RealPostWriter actually writes files.
-type RealPostWriter struct{}
+// realPostWriter actually writes files.
+type realPostWriter struct{}
 
-var _ entrypoint.PostWriter = (*RealPostWriter)(nil)
+var _ entrypoint.PostWriter = (*realPostWriter)(nil)
 
-func (*RealPostWriter) Write(file string) {
+func (*realPostWriter) Write(file string) {
 	if file == "" {
 		return
 	}

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -10,12 +10,12 @@ import (
 // TODO(jasonhall): Test that original exit code is propagated and that
 // stdout/stderr are collected -- needs e2e tests.
 
-// RealRunner actually runs commands.
-type RealRunner struct{}
+// realRunner actually runs commands.
+type realRunner struct{}
 
-var _ entrypoint.Runner = (*RealRunner)(nil)
+var _ entrypoint.Runner = (*realRunner)(nil)
 
-func (*RealRunner) Run(args ...string) error {
+func (*realRunner) Run(args ...string) error {
 	if len(args) == 0 {
 		return nil
 	}

--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -8,10 +8,10 @@ import (
 	"golang.org/x/xerrors"
 )
 
-// RealWaiter actually waits for files, by polling.
-type RealWaiter struct{}
+// realWaiter actually waits for files, by polling.
+type realWaiter struct{}
 
-var _ entrypoint.Waiter = (*RealWaiter)(nil)
+var _ entrypoint.Waiter = (*realWaiter)(nil)
 
 // Wait watches a file and returns when either a) the file exists and, if
 // the expectContent argument is true, the file has non-zero size or b) there
@@ -22,7 +22,7 @@ var _ entrypoint.Waiter = (*RealWaiter)(nil)
 //
 // If a file of the same name with a ".err" extension exists then this Wait
 // will end with a skipError.
-func (*RealWaiter) Wait(file string, expectContent bool) error {
+func (*realWaiter) Wait(file string, expectContent bool) error {
 	if file == "" {
 		return nil
 	}

--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -32,7 +32,7 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 		t.Errorf("error creating temp file: %v", err)
 	}
 	os.Remove(tmp.Name())
-	rw := RealWaiter{}
+	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
 		err := rw.Wait(tmp.Name(), false)
@@ -55,7 +55,7 @@ func TestRealWaiterWaitWithFile(t *testing.T) {
 		t.Errorf("error creating temp file: %v", err)
 	}
 	defer os.Remove(tmp.Name())
-	rw := RealWaiter{}
+	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
 		err := rw.Wait(tmp.Name(), false)
@@ -78,7 +78,7 @@ func TestRealWaiterWaitMissingContent(t *testing.T) {
 		t.Errorf("error creating temp file: %v", err)
 	}
 	defer os.Remove(tmp.Name())
-	rw := RealWaiter{}
+	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
 		err := rw.Wait(tmp.Name(), true)
@@ -101,7 +101,7 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 		t.Errorf("error creating temp file: %v", err)
 	}
 	defer os.Remove(tmp.Name())
-	rw := RealWaiter{}
+	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
 		err := rw.Wait(tmp.Name(), true)

--- a/pkg/reconciler/taskrun/entrypoint/entrypoint_test.go
+++ b/pkg/reconciler/taskrun/entrypoint/entrypoint_test.go
@@ -74,7 +74,7 @@ func TestRewriteSteps(t *testing.T) {
 		t.Errorf("failed to get resources: %v", err)
 	}
 	for _, input := range inputs {
-		if len(input.Command) == 0 || input.Command[0] != BinaryLocation {
+		if len(input.Command) == 0 || input.Command[0] != binaryLocation {
 			t.Errorf("command incorrectly set: %q", input.Command)
 		}
 		found := false

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -194,14 +194,12 @@ var (
 		Name: "downward",
 		VolumeSource: corev1.VolumeSource{
 			DownwardAPI: &corev1.DownwardAPIVolumeSource{
-				Items: []corev1.DownwardAPIVolumeFile{
-					{
-						Path: "ready",
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.annotations['tekton.dev/ready']",
-						},
+				Items: []corev1.DownwardAPIVolumeFile{{
+					Path: "ready",
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.annotations['tekton.dev/ready']",
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -245,8 +243,8 @@ var (
 
 	getPlaceToolsInitContainer = func(ops ...tb.ContainerOp) tb.PodSpecOp {
 		actualOps := []tb.ContainerOp{
-			tb.Command("/bin/sh"),
-			tb.Args("-c", fmt.Sprintf("cp /ko-app/entrypoint %s", entrypointLocation)),
+			tb.Command("cp", "/ko-app/entrypoint", entrypointLocation),
+			tb.Args(),
 			tb.WorkingDir(workspaceDir),
 			tb.EnvVar("HOME", "/builder/home"),
 			tb.VolumeMount("tools", "/builder/tools"),


### PR DESCRIPTION
- Base cmd/bash image on `bash` (based on `alpine`), run specified args with `bash -c`
- Fail cmd/bash if extra args are passed -- these would have been ignored previously
- Fix examples for cmd/bash that passed extra args
- Update entrypoint image to be based on busybox, since it only needs `cp`
- Un-export unnecessarily exported types in entrypoint cmd and pkgs

Fixes #1445

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Base cmd/bash image on an image containing bash, and actually use bash to execute specified args.
```

/assign sbwsg 