### PR TITLE
Update README with dogfooding cluster in place of prow

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -24,7 +24,7 @@ To start from scratch and use these Pipelines and Tasks:
 
 ## Create an official release
 
-Official releases are performed from [the `prow` cluster](https://github.com/tektoncd/plumbing#prow)
+Official releases are performed from the `dogfooding` cluster
 [in the `tekton-releases` GCP project](https://github.com/tektoncd/plumbing/blob/master/gcp.md).
 This cluster [already has the correct version of Tekton installed](#install-tekton).
 
@@ -81,7 +81,7 @@ To use [`tkn`](https://github.com/tektoncd/cli) to run the `publish-tekton-pipel
 1. [Connect to the production cluster](https://github.com/tektoncd/plumbing#prow):
 
     ```bash
-    gcloud container clusters get-credentials prow --zone us-central1-a --project tekton-releases
+    gcloud container clusters get-credentials dogfooding --zone us-central1-a --project tekton-releases
     ```
 
 1. Run the `release-pipeline` (assuming you are using the production cluster and


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We now have a dogfooding cluster thanks to the work that afrittoli has
done with our plumbing. The dogfooding cluster can be used for public
releases of Tekton.

This commit replaces mentions of the `prow` cluster with the
`dogfooding` cluster for future release shepherds.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)