### PR TITLE
Randomly generate script heredoc to prevent collisions

### DIFF
--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -32,6 +32,15 @@ spec:
         #!/usr/bin/env bash
         /workspace/hello
 
+    - name: contains-eof
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        cat > file << EOF
+        this file has some contents
+        EOF
+        cat file
+
     - name: node
       image: node
       script: |

--- a/pkg/reconciler/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/taskrun/resources/pod_test.go
@@ -512,15 +512,15 @@ print("Hello from Python")`,
 				TTY:     true,
 				Args: []string{"-args", `tmpfile="/builder/scripts/script-0-mssqb"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'EOF'
+cat > ${tmpfile} << 'script-heredoc-randomly-generated-78c5n'
 echo hello from step one
-EOF
-tmpfile="/builder/scripts/script-1-78c5n"
+script-heredoc-randomly-generated-78c5n
+tmpfile="/builder/scripts/script-1-6nl7g"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'EOF'
+cat > ${tmpfile} << 'script-heredoc-randomly-generated-j2tds'
 #!/usr/bin/env python
 print("Hello from Python")
-EOF
+script-heredoc-randomly-generated-j2tds
 `},
 				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 			}},
@@ -543,7 +543,7 @@ EOF
 				Name:         "step-two",
 				Image:        "image",
 				Command:      []string{"entrypointer"},
-				Args:         []string{"wait-file", "out-file", "-entrypoint", "/builder/scripts/script-1-78c5n"},
+				Args:         []string{"wait-file", "out-file", "-entrypoint", "/builder/scripts/script-1-6nl7g"},
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{{Name: "i-have-a-volume-mount"}}, append(implicitVolumeMounts, scriptsVolumeMount)...),
 				WorkingDir:   workspaceDir,


### PR DESCRIPTION
Followup PR from #1432 

This reserves a randomly generated string like `script-heredoc-randomly-generated-myxlp` such that if a user's script happens to collide with that randomly generated string their TaskRun will fail.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Randomly generate step script heredocs to prevent collisions
```
