### PR TITLE
Enhance the cluster resource type a bit.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -39,7 +39,7 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	if rs.Type == PipelineResourceTypeCluster {
-		var usernameFound, cadataFound, nameFound, isInsecure bool
+		var authFound, cadataFound, nameFound, isInsecure bool
 		for _, param := range rs.Params {
 			switch {
 			case strings.EqualFold(param.Name, "URL"):
@@ -47,9 +47,12 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 					return err
 				}
 			case strings.EqualFold(param.Name, "Username"):
-				usernameFound = true
+				authFound = true
 			case strings.EqualFold(param.Name, "CAData"):
+				authFound = true
 				cadataFound = true
+			case strings.EqualFold(param.Name, "Token"):
+				authFound = true
 			case strings.EqualFold(param.Name, "name"):
 				nameFound = true
 			case strings.EqualFold(param.Name, "insecure"):
@@ -61,8 +64,9 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		for _, secret := range rs.SecretParams {
 			switch {
 			case strings.EqualFold(secret.FieldName, "Username"):
-				usernameFound = true
+				authFound = true
 			case strings.EqualFold(secret.FieldName, "CAData"):
+				authFound = true
 				cadataFound = true
 			}
 		}
@@ -70,8 +74,9 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		if !nameFound {
 			return apis.ErrMissingField("name param")
 		}
-		if !usernameFound {
-			return apis.ErrMissingField("username param")
+		// One auth method must be supplied
+		if !(authFound) {
+			return apis.ErrMissingField("username or CAData  or token param")
 		}
 		if !cadataFound && !isInsecure {
 			return apis.ErrMissingField("CAData param")

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -46,15 +46,13 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrInvalidValue("10.10.10", "URL"),
 		},
 		{
-			name: "cluster with missing username",
+			name: "cluster with missing auth",
 			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeCluster,
 				tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
 				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
-				tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
-				tb.PipelineResourceSpecParam("token", "my-token"),
 			)),
-			want: apis.ErrMissingField("username param"),
+			want: apis.ErrMissingField("username or CAData  or token param"),
 		},
 		{
 			name: "cluster with missing name",


### PR DESCRIPTION
I was trying it out with a GKE cluster, and noticed a few issues:
- we require a username for everything, even if we're using CA auth.
- we weren't checking token auth.

This should really be switched to a declarative system where resources can
specify optional params, but that can come as part of the larger refactor.
This makes things a bit nicer tot use in the meantime.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

