### PR TITLE
Remove the custom "name" parameter from cluster resources.

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -552,8 +552,6 @@ cluster. The kubeconfig will be placed in
 
 The Cluster resource has the following parameters:
 
--   `name` (required): The name to be given to the target cluster, will be used
-    in the kubeconfig and also as part of the path to the kubeconfig file
 -   `url` (required): Host url of the master node
 -   `username` (required): the user with access to the cluster
 -   `password`: to be used for clusters with basic auth
@@ -687,8 +685,6 @@ spec:
   params:
     - name: url
       value: https://<ip address determined above>
-    - name: name
-      value: mycluster
   secrets:
     - fieldName: cadata
       secretName: cluster-ca-data

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -62,6 +62,7 @@ func NewClusterResource(kubeconfigWriterImage string, r *PipelineResource) (*Clu
 	clusterResource := ClusterResource{
 		Type:                  r.Spec.Type,
 		KubeconfigWriterImage: kubeconfigWriterImage,
+		Name:                  r.Name,
 	}
 	for _, param := range r.Spec.Params {
 		switch {

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
+	logging "knative.dev/pkg/logging"
 )
 
 var _ apis.Validatable = (*PipelineResource)(nil)
@@ -74,8 +75,9 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 			}
 		}
 
-		if !nameFound {
-			return apis.ErrMissingField("name param")
+		if nameFound {
+			logging.FromContext(ctx).Warn(
+				"The name parameter on the cluster resource is deprecated. Support will be removed in a future release")
 		}
 		// One auth method must be supplied
 		if !(authFound) {

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -55,16 +55,6 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrMissingField("username or CAData  or token param"),
 		},
 		{
-			name: "cluster with missing name",
-			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
-				v1alpha1.PipelineResourceTypeCluster,
-				tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
-				tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
-				tb.PipelineResourceSpecParam("token", "my-token"),
-			)),
-			want: apis.ErrMissingField("name param"),
-		},
-		{
 			name: "cluster with missing cadata",
 			res: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeCluster,


### PR DESCRIPTION
# Changes

This is redundant with the Name that Tasks already declare on Resources.
The name is used both to name the cluster in the kubeconfig and to set the
path for the kubeconfig. Using a name on the resource itself means Tasks can't
know where to expect this file.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The 'name' parameter to the cluster resource is now deprecated. Please use the standard name parameter on the Task Resource binding instead.
```
