### PR TITLE
Add validation when applying task modifiers 🧐

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/resource_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	prependStep = corev1.Container{
+		Name:    "prepend-step",
+		Image:   "dummy",
+		Command: []string{"doit"},
+		Args:    []string{"stuff", "things"},
+	}
+	appendStep = corev1.Container{
+		Name:    "append-step",
+		Image:   "dummy",
+		Command: []string{"doit"},
+		Args:    []string{"other stuff", "other things"},
+	}
+	volume = corev1.Volume{
+		Name: "magic-volume",
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "some-claim"},
+		},
+	}
+)
+
+type TestTaskModifier struct{}
+
+func (tm *TestTaskModifier) GetStepsToPrepend() []v1alpha1.Step {
+	return []v1alpha1.Step{{
+		Container: prependStep,
+	}}
+}
+
+func (tm *TestTaskModifier) GetStepsToAppend() []v1alpha1.Step {
+	return []v1alpha1.Step{{
+		Container: appendStep,
+	}}
+}
+
+func (tm *TestTaskModifier) GetVolumes() []corev1.Volume {
+	return []corev1.Volume{volume}
+}
+
+func TestApplyTaskModifier(t *testing.T) {
+	testcases := []struct {
+		name string
+		ts   v1alpha1.TaskSpec
+	}{{
+		name: "success",
+		ts:   v1alpha1.TaskSpec{},
+	}, {
+		name: "identical volume already added",
+		ts: v1alpha1.TaskSpec{
+			// Trying to add the same Volume that has already been added shouldn't be an error
+			// and it should not be added twice
+			Volumes: []corev1.Volume{volume},
+		},
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := v1alpha1.ApplyTaskModifier(&tc.ts, &TestTaskModifier{}); err != nil {
+				t.Fatalf("Did not expect error modifying TaskSpec but got %v", err)
+			}
+
+			expectedTaskSpec := v1alpha1.TaskSpec{
+				Steps: []v1alpha1.Step{{
+					Container: prependStep,
+				}, {
+					Container: appendStep,
+				}},
+				Volumes: []corev1.Volume{
+					volume,
+				},
+			}
+
+			if d := cmp.Diff(expectedTaskSpec, tc.ts); d != "" {
+				t.Errorf("TaskSpec was not modified as expected (-want, +got): %s", d)
+			}
+		})
+	}
+}
+
+func TestApplyTaskModifier_AlreadyAdded(t *testing.T) {
+	testcases := []struct {
+		name string
+		ts   v1alpha1.TaskSpec
+	}{{
+		name: "prepend already added",
+		ts: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: prependStep}},
+		},
+	}, {
+		name: "append already added",
+		ts: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: appendStep}},
+		},
+	}, {
+		name: "both steps already added",
+		ts: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: prependStep}, {Container: appendStep}},
+		},
+	}, {
+		name: "both steps already added reverse order",
+		ts: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: appendStep}, {Container: prependStep}},
+		},
+	}, {
+		name: "volume with same name but diff content already added",
+		ts: v1alpha1.TaskSpec{
+			Volumes: []corev1.Volume{{
+				Name: "magic-volume",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			}},
+		},
+	}}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := v1alpha1.ApplyTaskModifier(&tc.ts, &TestTaskModifier{}); err == nil {
+				t.Errorf("Expected error when applying values already added but got none")
+			}
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/taskrun/resources/input_resources.go
@@ -113,7 +113,9 @@ func AddInputResource(
 			if err != nil {
 				return nil, err
 			}
-			v1alpha1.ApplyTaskModifier(taskSpec, modifier)
+			if err := v1alpha1.ApplyTaskModifier(taskSpec, modifier); err != nil {
+				return nil, xerrors.Errorf("Unabled to apply Resource %s: %w", boundResource.Name, err)
+			}
 		}
 	}
 

--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -108,7 +108,9 @@ func AddOutputResources(
 		if err != nil {
 			return nil, err
 		}
-		v1alpha1.ApplyTaskModifier(taskSpec, modifier)
+		if err := v1alpha1.ApplyTaskModifier(taskSpec, modifier); err != nil {
+			return nil, xerrors.Errorf("Unabled to apply Resource %s: %w", boundResource.Name, err)
+		}
 
 		if as.GetType() == v1alpha1.ArtifactStoragePVCType {
 			if pvcName == "" {


### PR DESCRIPTION
# Changes

Task modifiers for PipelineResources add pre and post steps and
sometimes Volumes to a pod spec. Adding a step or a volume that already
exists will create a pod that cannot run so this commit adds validation:
- If a modifier tries to add a step that already exists (i.e. the name
  is the same) that's an error
- If a modifier tries to add a volume that already exists but the volume
  it references is the same, we assume that two resources need the same
  volume, so it's not an error, but we only add it wonce
- If a modifier tries to add a volume that already exists but the volume
  it references is different, that means two resources need different
  volumes but we cant add both since the names are the same, so that's
  an error

I encountered a problem with this while working on #1417 (which we
decided not to merge) where I tried to use two VolumeResources and there
was a bug where they both had the same name, so the pod was not
schedulable. I had to work backwards from the error that the pod was
invalid and thought it would be much more handy to get the error
earlier, so I added this.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
If the implementation of a PipelineResource tries to add steps or volumes that already exist, execution will fail before the pod is created.
```
