### PR TITLE
Make cmp.Diff want vs got usage clear 🚰

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation_test.go
@@ -119,8 +119,8 @@ func TestResourceValidation_Invalid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.res.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), tt.want.Error()); d != "" {
-				t.Errorf("PipelineResource.Validate/%s (-want, +got) = %v", tt.name, d)
+			if d := cmp.Diff(tt.want.Error(), err.Error()); d != "" {
+				t.Errorf("Didn't get expected error for %s (-want, +got) = %v", tt.name, d)
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -968,8 +968,8 @@ func TestStorageInputResource(t *testing.T) {
 			if (err != nil) != c.wantErr {
 				t.Errorf("Test: %q; AddInputResource() error = %v, WantErr %v", c.desc, err, c.wantErr)
 			}
-			if d := cmp.Diff(got, c.want); d != "" {
-				t.Errorf("Diff:\n%s", d)
+			if d := cmp.Diff(c.want, got); d != "" {
+				t.Errorf("Didn't get expected Task spec (-want, +got): %s", d)
 			}
 		})
 	}
@@ -1209,8 +1209,8 @@ func TestAddStepsToTaskWithBucketFromConfigMap(t *testing.T) {
 			if err != nil {
 				t.Errorf("Test: %q; AddInputResource() error = %v", c.desc, err)
 			}
-			if d := cmp.Diff(got, c.want); d != "" {
-				t.Errorf("Diff:\n%s", d)
+			if d := cmp.Diff(c.want, got); d != "" {
+				t.Errorf("Didn't get expected TaskSpec (-want, +got): %s", d)
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -795,8 +795,8 @@ func TestValidOutputResources(t *testing.T) {
 			}
 
 			if got != nil {
-				if d := cmp.Diff(got.Steps, c.wantSteps); d != "" {
-					t.Fatalf("post build steps mismatch: %s", d)
+				if d := cmp.Diff(c.wantSteps, got.Steps); d != "" {
+					t.Fatalf("post build steps mismatch (-want, +got): %s", d)
 				}
 
 				if c.taskRun.GetPipelineRunPVCName() != "" {
@@ -812,8 +812,8 @@ func TestValidOutputResources(t *testing.T) {
 						},
 					)
 				}
-				if d := cmp.Diff(got.Volumes, c.wantVolumes); d != "" {
-					t.Fatalf("post build steps volumes mismatch: %s", d)
+				if d := cmp.Diff(c.wantVolumes, got.Volumes); d != "" {
+					t.Fatalf("post build steps volumes mismatch (-want, +got): %s", d)
 				}
 			}
 		})
@@ -1010,8 +1010,8 @@ func TestValidOutputResourcesWithBucketStorage(t *testing.T) {
 				t.Fatalf("Failed to declare output resources for test name %q ; test description %q: error %v", c.name, c.desc, err)
 			}
 			if got != nil {
-				if d := cmp.Diff(got.Steps, c.wantSteps); d != "" {
-					t.Fatalf("post build steps mismatch: %s", d)
+				if d := cmp.Diff(c.wantSteps, got.Steps); d != "" {
+					t.Fatalf("post build steps mismatch (-want, got): %s", d)
 				}
 			}
 		})


### PR DESCRIPTION
# Changes

While working on #1417 (which we decided not to go ahead with) I made a
_lot_ of unit tests fail. B/c I was changing how steps were added (for
the volume resource) these failures were often in the middle of big
diffs. It turns out we were inconsistent about how we used cmp.Diff:
anything that is in the first argument but not in the second gets a `-`
before it, anything that is in the second argument but not in the first
gets a `+`, which is why the example at
https://godoc.org/github.com/google/go-cmp/cmp#Diff passes these
arguments as `cmp.Diff(want, got)`. If we reverse them, which many of
our tests did, the results are counter intuitive: the "extra" stuff gets
a `-` and the missing stuff gets a `+`. It seems like a small thing but
it's really hard to wrap your head around! So this commit takes a bunch
of these tests (not all of them, just the ones I was touchin in #1417)
and:
- Makes them consistently pass `(want, got)`
- Annotates the failure message with a legend for `-` and `+`
- Adds more details to the messages when applicable so you know what the
  diff is that you're looking at

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).