### PR TITLE
Declare expected volumes explicitly 🗣️

### DIFF
--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -188,6 +188,14 @@ func TestValidOutputResources(t *testing.T) {
 				MountPath: "/pvc",
 			}},
 		}}},
+		wantVolumes: []corev1.Volume{{
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
+			},
+		}},
 	}, {
 		name: "git resource in output only",
 		desc: "git resource declared as output with pipelinerun owner reference",
@@ -253,6 +261,14 @@ func TestValidOutputResources(t *testing.T) {
 				MountPath: "/pvc",
 			}},
 		}}},
+		wantVolumes: []corev1.Volume{{
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
+			},
+		}},
 	}, {
 		name: "image resource in output with pipelinerun with owner",
 		desc: "image resource declared as output with pipelinerun owner reference should not generate any steps",
@@ -300,7 +316,14 @@ func TestValidOutputResources(t *testing.T) {
 			Command: []string{"/ko-app/bash"},
 			Args:    []string{"-args", "mkdir -p /workspace/output/source-workspace"},
 		}}},
-		wantVolumes: nil,
+		wantVolumes: []corev1.Volume{{
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
+			},
+		}},
 	}, {
 		name: "git resource in output",
 		desc: "git resource declared in output without pipelinerun owner reference",
@@ -352,7 +375,7 @@ func TestValidOutputResources(t *testing.T) {
 				Namespace: "marshmallow",
 				OwnerReferences: []metav1.OwnerReference{{
 					Kind: "PipelineRun",
-					Name: "pipelinerun-parent",
+					Name: "pipelinerun",
 				}},
 			},
 			Spec: v1alpha1.TaskRunSpec{
@@ -414,14 +437,14 @@ func TestValidOutputResources(t *testing.T) {
 				Image:        "override-with-bash-noop:latest",
 				Command:      []string{"/ko-app/bash"},
 				Args:         []string{"-args", "mkdir -p pipeline-task-path"},
-				VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-parent-pvc", MountPath: "/pvc"}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-pvc", MountPath: "/pvc"}},
 			}},
 			{Container: corev1.Container{
 				Name:         "source-copy-source-gcs-mssqb",
 				Image:        "override-with-bash-noop:latest",
 				Command:      []string{"/ko-app/bash"},
 				Args:         []string{"-args", "cp -r /workspace/output/source-workspace/. pipeline-task-path"},
-				VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-parent-pvc", MountPath: "/pvc"}},
+				VolumeMounts: []corev1.VolumeMount{{Name: "pipelinerun-pvc", MountPath: "/pvc"}},
 			}},
 			{Container: corev1.Container{
 				Name:  "upload-source-gcs-78c5n",
@@ -442,8 +465,15 @@ func TestValidOutputResources(t *testing.T) {
 			Name: "volume-source-gcs-sname",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{SecretName: "sname"},
+			}}, {
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
 			},
-		}},
+		},
+		},
 	}, {
 		name: "storage resource as output",
 		desc: "storage resource defined only in output with pipeline ownder reference",
@@ -523,8 +553,15 @@ func TestValidOutputResources(t *testing.T) {
 			Name: "volume-source-gcs-sname",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{SecretName: "sname"},
+			}}, {
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
 			},
-		}},
+		},
+		},
 	}, {
 		name: "storage resource as output with no owner",
 		desc: "storage resource defined only in output without pipelinerun reference",
@@ -696,6 +733,14 @@ func TestValidOutputResources(t *testing.T) {
 			Command: []string{"/ko-app/bash"},
 			Args:    []string{"-args", "mkdir -p /workspace/output/source-workspace"},
 		}}},
+		wantVolumes: []corev1.Volume{{
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
+			},
+		}},
 	}, {
 		name: "Resource with TargetPath as output",
 		desc: "Resource with TargetPath defined only in output",
@@ -743,6 +788,14 @@ func TestValidOutputResources(t *testing.T) {
 			Command: []string{"/ko-app/bash"},
 			Args:    []string{"-args", "mkdir -p /workspace"},
 		}}},
+		wantVolumes: []corev1.Volume{{
+			Name: "pipelinerun-pvc",
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "pipelinerun-pvc",
+				},
+			},
+		}},
 	}, {
 		desc: "image output resource with no steps",
 		taskRun: &v1alpha1.TaskRun{
@@ -799,19 +852,6 @@ func TestValidOutputResources(t *testing.T) {
 					t.Fatalf("post build steps mismatch: %s", d)
 				}
 
-				if c.taskRun.GetPipelineRunPVCName() != "" {
-					c.wantVolumes = append(
-						c.wantVolumes,
-						corev1.Volume{
-							Name: c.taskRun.GetPipelineRunPVCName(),
-							VolumeSource: corev1.VolumeSource{
-								PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-									ClaimName: c.taskRun.GetPipelineRunPVCName(),
-								},
-							},
-						},
-					)
-				}
 				if d := cmp.Diff(got.Volumes, c.wantVolumes); d != "" {
 					t.Fatalf("post build steps volumes mismatch: %s", d)
 				}


### PR DESCRIPTION
# Changes

The test was dynamically adding the expected PVC volumes. This created
two problems:
1. If there was a bug in the logic that was adding them dynamically, we
   we could end up covering a bug
2. This made it confusing to try to reason about what the actual
   expected pod structure was. In #1417 I had to make a lot of changes
   to these tests and it was super confusing to look at the expected
   structure and sometimes see no volumes (or even volumes: nil) when
   you knew volumes were supposed to be there (I was scared there was a
   serious bug for a while)

So now the expected state explicitly lists all the volumes it expects.
This also revealed that one test case was using `pipelinerun-parent` as
the name of the parent pipelinerun even though all the rest used just
`pipelinerun` which was also confusing when I was making changes b/c I
initially thought there was some special case where tekton itself would
add "parent" but no.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).