### PR TITLE
Actually make the cluster resource work with GKE.

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -550,6 +550,8 @@ The Cluster resource has the following parameters:
     certificate.
 -   `cadata` (required): holds PEM-encoded bytes (typically read from a root
     certificates bundle).
+-   `authProvider`: specifies an optional kubectl auth provider to use. For more information, see:
+    [the kubectl docs](https://manpages.debian.org/unstable/kubernetes-client/kubectl-config-set-credentials.1.en.html).
 
 Note: Since only one authentication technique is allowed per user, either a
 `token` or a `password` should be provided, if both are provided, the `password`
@@ -641,7 +643,7 @@ spec:
 ```
 
 To use the `cluster` resource with Google Kubernetes Engine, you should use the `cadata` authentication
-mechanism.
+mechanism, and specify the "gcp" authProvider parameter.
 
 To determine the caData, you can use the following `gcloud` commands:
 
@@ -673,6 +675,8 @@ spec:
       value: https://<ip address determined above>
     - name: name
       value: mycluster
+    - name: authProvider
+      value: gcp
   secrets:
     - fieldName: cadata
       secretName: cluster-ca-data

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -39,6 +39,8 @@ type ClusterResource struct {
 	Username  string `json:"username"`
 	Password  string `json:"password"`
 	Namespace string `json:"namespace"`
+	// AuthProvider corresponds to a custom kubectl auth provider
+	AuthProvider string `json:"authProvider"`
 	// Server requires Bearer authentication. This client will not attempt to use
 	// refresh tokens for an OAuth2 flow.
 	// Token overrides userame and password
@@ -79,6 +81,8 @@ func NewClusterResource(kubeconfigWriterImage string, r *PipelineResource) (*Clu
 			clusterResource.Password = param.Value
 		case strings.EqualFold(param.Name, "Token"):
 			clusterResource.Token = param.Value
+		case strings.EqualFold(param.Name, "AuthProvider"):
+			clusterResource.AuthProvider = param.Value
 		case strings.EqualFold(param.Name, "Insecure"):
 			b, _ := strconv.ParseBool(param.Value)
 			clusterResource.Insecure = b

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -158,7 +158,7 @@ func Test_ClusterResource_GetInputTaskModifier(t *testing.T) {
 		Name:    "kubeconfig-9l9zj",
 		Image:   "override-with-kubeconfig-writer:latest",
 		Command: []string{"/ko-app/kubeconfigwriter"},
-		Args:    []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
+		Args:    []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","authProvider":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
 		Env: []corev1.EnvVar{{
 			Name: "CADATA",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -718,7 +718,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Image:   "override-with-kubeconfig-writer:latest",
 				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args: []string{
-					"-clusterConfig", `{"name":"cluster3","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"namespace1","token":"","Insecure":false,"cadata":"bXktY2EtY2VydAo=","secrets":null}`,
+					"-clusterConfig", `{"name":"cluster3","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"namespace1","authProvider":"","token":"","Insecure":false,"cadata":"bXktY2EtY2VydAo=","secrets":null}`,
 				},
 			}}},
 		},
@@ -762,7 +762,7 @@ func TestAddResourceToTask(t *testing.T) {
 				Image:   "override-with-kubeconfig-writer:latest",
 				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args: []string{
-					"-clusterConfig", `{"name":"cluster2","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`,
+					"-clusterConfig", `{"name":"cluster2","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","authProvider":"","token":"","Insecure":false,"cadata":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`,
 				},
 				Env: []corev1.EnvVar{{
 					ValueFrom: &corev1.EnvVarSource{

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -79,6 +79,7 @@ func getClusterResource(namespace, name, sname string) *v1alpha1.PipelineResourc
 		tb.PipelineResourceSpecParam("Url", "https://1.1.1.1"),
 		tb.PipelineResourceSpecParam("username", "test-user"),
 		tb.PipelineResourceSpecParam("password", "test-password"),
+		tb.PipelineResourceSpecParam("authProvider", "foo"),
 		tb.PipelineResourceSpecSecretParam("cadata", sname, "cadatakey"),
 		tb.PipelineResourceSpecSecretParam("token", sname, "tokenkey"),
 	))
@@ -133,11 +134,12 @@ func getClusterConfigMap(namespace, name string) *corev1.ConfigMap {
 			Namespace: namespace,
 			Name:      name,
 		},
+		// The certificate-authority-data value is just 'ca-cert' base64 encoded.
 		Data: map[string]string{
 			"test.data": `apiVersion: v1
 clusters:
 - cluster:
-    certificate-authority-data: WTJFdFkyVnlkQW89
+    certificate-authority-data: Y2EtY2VydAo=
     server: https://1.1.1.1
   name: helloworld-cluster
 contexts:
@@ -151,6 +153,9 @@ preferences: {}
 users:
 - name: test-user
   user:
+    auth-provider:
+      config: null
+      name: foo
     token: dG9rZW4K
 `,
 		},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I found a bug in the handling of cadata when specified as a secret - the cadata needs to be
base64 decoded before being serialized.

I also added a parameter to specify an authentication-plugin, which is needed in order
for kubectl to know to use GCP specific credentials.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The cluster resource now supports an "authProvider" parameter, which can be used to configure kubectl to use a specific authProvider.

```
