### PR TITLE
Start using embedded resources in task examples

### DIFF
--- a/examples/taskruns/cloud-event.yaml
+++ b/examples/taskruns/cloud-event.yaml
@@ -64,26 +64,6 @@ spec:
       protocol: TCP
 ---
 apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: to-message-sink
-spec:
-  type: cloudEvent
-  params:
-  - name: targetURI
-    value: http://sink.default:8080
----
-apiVersion: tekton.dev/v1alpha1
-kind: PipelineResource
-metadata:
-  name: fake-image
-spec:
-  type: image
-  params:
-  - name: url
-    value: fake-registry/test/fake-image
----
-apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
   name: send-cloud-event-task
@@ -153,7 +133,7 @@ spec:
           digest = taskrun['taskRun']['status']['resourcesResult'][0]['digest']
           image_name = taskrun['taskRun']['status']['resourcesResult'][0]['name']
           print("Got digest %s for image %s" % (digest, image_name))
-          if image_name == "fake-image" and digest:
+          if image_name == "myimage" and digest:
             break
           else:
             sys.exit(1)
@@ -169,11 +149,17 @@ spec:
   outputs:
     resources:
     - name: myimage
-      resourceRef:
-        name: fake-image
+      resourceSpec:
+        type: image
+        params:
+        - name: url
+          value: fake-registry/test/fake-image
     - name: notification
-      resourceRef:
-        name: to-message-sink
+      resourceSpec:
+        type: cloudEvent
+        params:
+        - name: targetURI
+          value: http://sink.default:8080
   taskRef:
     name: send-cloud-event-task
 ---


### PR DESCRIPTION
Change the cloud event example to use embedded resource specs.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
