### PR TITLE
Fix incorrect logic in output resource handling

### DIFF
--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -807,6 +807,61 @@ func TestValidOutputResources(t *testing.T) {
 			Image:   "busybox",
 			Command: []string{"mkdir", "-p", "/workspace/output/source-workspace"},
 		}}},
+	}, {
+		desc: "multiple image output resource with no steps",
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-output-steps",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				Outputs: v1alpha1.TaskRunOutputs{
+					Resources: []v1alpha1.TaskResourceBinding{{
+						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+							Name: "source-workspace",
+							ResourceRef: &v1alpha1.PipelineResourceRef{
+								Name: "source-image",
+							},
+						},
+					}, {
+						PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+							Name: "source-workspace-1",
+							ResourceRef: &v1alpha1.PipelineResourceRef{
+								Name: "source-image",
+							},
+						},
+					}},
+				},
+			},
+		},
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{
+						ResourceDeclaration: v1alpha1.ResourceDeclaration{
+							Name: "source-workspace",
+							Type: "image",
+						}}, {
+						ResourceDeclaration: v1alpha1.ResourceDeclaration{
+							Name: "source-workspace-1",
+							Type: "image",
+						}}},
+				},
+			},
+		},
+		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
+			Name:    "create-dir-source-workspace-1-mz4c7",
+			Image:   "busybox",
+			Command: []string{"mkdir", "-p", "/workspace/output/source-workspace-1"},
+		}}, {Container: corev1.Container{
+			Name:    "create-dir-source-workspace-9l9zj",
+			Image:   "busybox",
+			Command: []string{"mkdir", "-p", "/workspace/output/source-workspace"},
+		}}},
 	}} {
 		t.Run(c.name, func(t *testing.T) {
 			names.TestingSeed()


### PR DESCRIPTION
The `storage` handle should place outof the loop which for `output resource`.
With current code, the mutiple `output resrouce` will not work, only the first `resource` could be handle.
Fix issue: #1630 
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
