### PR TITLE
Fix output/input resource issue in docs.

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -297,8 +297,8 @@ next Task is expected to be present under the path
 `/workspace/output/resource_name/`.
 
 ```yaml
-resources:
-  outputs:
+outputs:
+  resources:
     name: storage-gcs
     type: gcs
 steps:
@@ -325,11 +325,12 @@ directory. After execution of the Task steps, (new) tar file in directory
 `tar-artifact` resource definition.
 
 ```yaml
-resources:
-  inputs:
+inputs:
+  resources:
     name: tar-artifact
     targetPath: customworkspace
-  outputs:
+outputs:
+  resources:
     name: tar-artifact
 steps:
  - name: untar


### PR DESCRIPTION
# Changes

The docs had task output/resources swapped in a few places. This
corrects them, and fixes https://github.com/tektoncd/pipeline/issues/1458

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

