### PR TITLE
Exit with a non-zero exit code when we skip a command in the entrypoi…

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -53,7 +53,8 @@ func main() {
 	if err := e.Go(); err != nil {
 		switch t := err.(type) {
 		case skipError:
-			os.Exit(0)
+			log.Print("Skipping step because a previous step failed")
+			os.Exit(1)
 		case *exec.ExitError:
 			// Copied from https://stackoverflow.com/questions/10385551/get-exit-code-go
 			// This works on both Unix and Windows. Although

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -93,8 +93,8 @@ func TestTaskRunFailure(t *testing.T) {
 	}, {
 		ContainerState: corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{
-				ExitCode: 0,
-				Reason:   "Completed",
+				ExitCode: 1,
+				Reason:   "Error",
 			},
 		},
 		Name:          "world",


### PR DESCRIPTION
…nter.

# Changes

When an early step fails, our entrypointer correctly skips all subsequent steps.
Unfortunately, the containers currently exit with 0 which may be interpreted as
these steps having successfully completed.

Fixes #1439 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Steps now exit with an exit code of 1 if they are skipped because a previous step failed.
```
