### PR TITLE
Small e2e tests refactoring

### DIFF
--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -35,6 +35,32 @@ const (
 	taskOutput = "do you want to build a snowman"
 )
 
+// TestTaskRun_EmbeddedResource is an integration test that will verify a very simple "hello world" TaskRun can be
+// executed with an embedded resource spec.
+func TestTaskRun_EmbeddedResource(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	if _, err := c.TaskClient.Create(getEmbeddedTask(namespace, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)})); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", embedTaskName, err)
+	}
+	if _, err := c.TaskRunClient.Create(getEmbeddedTaskRun(namespace)); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", embedTaskRunName, err)
+	}
+
+	t.Logf("Waiting for TaskRun %s in namespace %s to complete", embedTaskRunName, namespace)
+	if err := WaitForTaskRunState(c, embedTaskRunName, TaskRunSucceed(embedTaskRunName), "TaskRunSuccess"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", embedTaskRunName, err)
+	}
+
+	// TODO(#127) Currently we have no reliable access to logs from the TaskRun so we'll assume successful
+	// completion of the TaskRun means the TaskRun did what it was intended.
+}
+
 func getEmbeddedTask(namespace string, args []string) *v1alpha1.Task {
 	return tb.Task(embedTaskName, namespace,
 		tb.TaskSpec(
@@ -61,30 +87,4 @@ func getEmbeddedTaskRun(namespace string) *v1alpha1.TaskRun {
 				tb.TaskRunInputsResource("docs", tb.TaskResourceBindingResourceSpec(testSpec)),
 			),
 			tb.TaskRunTaskRef(embedTaskName)))
-}
-
-// TestTaskRun_EmbeddedResource is an integration test that will verify a very simple "hello world" TaskRun can be
-// executed with an embedded resource spec.
-func TestTaskRun_EmbeddedResource(t *testing.T) {
-	c, namespace := setup(t)
-	t.Parallel()
-
-	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
-	defer tearDown(t, c, namespace)
-
-	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(getEmbeddedTask(namespace, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)})); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", embedTaskName, err)
-	}
-	if _, err := c.TaskRunClient.Create(getEmbeddedTaskRun(namespace)); err != nil {
-		t.Fatalf("Failed to create TaskRun `%s`: %s", embedTaskRunName, err)
-	}
-
-	t.Logf("Waiting for TaskRun %s in namespace %s to complete", embedTaskRunName, namespace)
-	if err := WaitForTaskRunState(c, embedTaskRunName, TaskRunSucceed(embedTaskRunName), "TaskRunSuccess"); err != nil {
-		t.Errorf("Error waiting for TaskRun %s to finish: %s", embedTaskRunName, err)
-	}
-
-	// TODO(#127) Currently we have no reliable access to logs from the TaskRun so we'll assume successful
-	// completion of the TaskRun means the TaskRun did what it was intended.
 }

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -45,34 +45,36 @@ func TestGitPipelineRun(t *testing.T) {
 
 	for _, revision := range revisions {
 
-		c, namespace := setup(t)
-		knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
-		defer tearDown(t, c, namespace)
+		t.Run(revision, func(t *testing.T) {
+			c, namespace := setup(t)
+			knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+			defer tearDown(t, c, namespace)
 
-		t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-		if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, revision)); err != nil {
-			t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
-		}
+			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
+			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, revision)); err != nil {
+				t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
+			}
 
-		t.Logf("Creating Task %s", gitTestTaskName)
-		if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
-			t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
-		}
+			t.Logf("Creating Task %s", gitTestTaskName)
+			if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
+				t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
+			}
 
-		t.Logf("Creating Pipeline %s", gitTestPipelineName)
-		if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
-			t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
-		}
+			t.Logf("Creating Pipeline %s", gitTestPipelineName)
+			if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
+				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
+			}
 
-		t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-		if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
-			t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
-		}
+			t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
+			if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
+				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
+			}
 
-		if err := WaitForPipelineRunState(c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted"); err != nil {
-			t.Errorf("Error waiting for PipelineRun %s to finish: %s", gitTestPipelineRunName, err)
-			t.Fatalf("PipelineRun execution failed")
-		}
+			if err := WaitForPipelineRunState(c, gitTestPipelineRunName, timeout, PipelineRunSucceed(gitTestPipelineRunName), "PipelineRunCompleted"); err != nil {
+				t.Errorf("Error waiting for PipelineRun %s to finish: %s", gitTestPipelineRunName, err)
+				t.Fatalf("PipelineRun execution failed")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# Changes

- Update TestGitPipelineRun to use subtests
- Put the tests on top of the file (above helper function), for readability (aka I want to see the test first)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
