### PR TITLE
Stop race condition on cloud event YAML test

### DIFF
--- a/examples/taskruns/cloud-event.yaml
+++ b/examples/taskruns/cloud-event.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sink
-  namespace: default
 spec:
   selector:
     app: cloudevent
@@ -17,7 +16,6 @@ metadata:
   labels:
     app: cloudevent
   name: message-sink
-  namespace: default
 spec:
   containers:
   - env:
@@ -67,6 +65,7 @@ apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
   name: send-cloud-event-task
+
 spec:
   outputs:
     resources:
@@ -75,6 +74,30 @@ spec:
       - name: notification
         type: cloudEvent
   steps:
+    - name: wait-for-sink
+      image: python:3-alpine
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/sh"]
+      args:
+      - -ce
+      - |
+        cat <<EOF | python
+        import http.client
+        import json
+        import sys
+        import time
+
+        while True:
+          conn = http.client.HTTPConnection("sink:8080")
+          try:
+            conn.request("GET", "/")
+            break
+          except:
+            # Perhaps the service is not setup yet, so service name does not
+            # resolve or it does not accept connections on 8080 yet
+            print("Not yet...")
+            time.sleep(10)
+        EOF
     - name: build-index-json
       image: busybox
       command:
@@ -83,8 +106,7 @@ spec:
       - -ce
       - |
         set -e
-        mkdir -p /builder/home/image-outputs/myimage/
-        cat <<EOF > /builder/home/image-outputs/myimage/index.json
+        cat <<EOF > $(outputs.resources.myimage.path)/index.json
         {
           "schemaVersion": 2,
           "manifests": [
@@ -117,7 +139,7 @@ spec:
       import time
 
       while True:
-        conn = http.client.HTTPConnection("sink.default:8080")
+        conn = http.client.HTTPConnection("sink:8080")
         try:
           conn.request("GET", "/")
         except:
@@ -140,6 +162,7 @@ spec:
         else:
           print("Not yet...")
           time.sleep(10)
+      EOF
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun


### PR DESCRIPTION
If the sink service is started after the cloud event fails, the
cloud event will never be delivered.
Ensure the sink is running before completing the task that sends
the cloud event.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
