### PR TITLE
Use script mode in the cloud-event example

### DIFF
--- a/examples/taskruns/cloud-event.yaml
+++ b/examples/taskruns/cloud-event.yaml
@@ -65,7 +65,6 @@ apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
   name: send-cloud-event-task
-
 spec:
   outputs:
     resources:
@@ -76,7 +75,6 @@ spec:
   steps:
     - name: wait-for-sink
       image: python:3-alpine
-      imagePullPolicy: IfNotPresent
       script: |
         #!/usr/bin/env python3
         import http.client
@@ -97,7 +95,8 @@ spec:
     - name: build-index-json
       image: busybox
       script: |
-        set -e
+        #!/bin/sh
+        set -ex
         cat <<EOF > $(outputs.resources.myimage.path)/index.json
         {
           "schemaVersion": 2,
@@ -118,7 +117,6 @@ spec:
   steps:
   - name: polling
     image: python:3-alpine
-    imagePullPolicy: IfNotPresent
     script: |
       #!/usr/bin/env python3
       import http.client
@@ -169,7 +167,7 @@ spec:
         type: cloudEvent
         params:
         - name: targetURI
-          value: http://sink.default:8080
+          value: http://sink:8080
   taskRef:
     name: send-cloud-event-task
 ---


### PR DESCRIPTION
@ImJasonH 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
