### PR TITLE
Disable colour in tkn logs

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -42,10 +42,10 @@ function output_pods_logs() {
 	echo ">>>> $1 ${run}"
 	case "$1" in
 	    "taskrun")
-		tkn taskrun logs ${run}
+		tkn taskrun logs --nocolour ${run}
 		;;
 	    "pipelinerun")
-		tkn pipelinerun logs ${run}
+		tkn pipelinerun logs --nocolour ${run}
 		;;
 	esac
     done


### PR DESCRIPTION
We use tkn to capture task and pipeline logs from CI runs. By default
the output includes colour, but in a log file the colour codes
make the log less readable, e.g.

I1104 14:45:18.925] [92m[92;1m[client] [0m7ddbc47eeb70: Pulling fs layer

Add the --nocolour flag to avoid that.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
