### PR TITLE
Fix typo in cloud event resources documentation

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -857,7 +857,7 @@ kind: PipelineResource
 metadata:
   name: event-to-sink
 spec:
-  type: cloudevent
+  type: cloudEvent
   params:
   - name: targetURI
     value: http://sink:8080


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

According to the code the cloudEvent resources type is `cloudEvent` and
not `cloudevent`. [cloud event resource tests](https://github.com/tektoncd/pipeline/blob/master/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go#L83).
This patch fix the type used in the documentation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

