### PR TITLE
Linting yamls with yamllint 🏷

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,36 @@
+ignore: |
+  /vendor
+  test/**/*-chart/**
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: enable
+  hyphens: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning
+
+  # accept both     key:
+  #                   - item
+  #
+  # and             key:
+  #                 - item
+  indentation:
+    indent-sequences: whatever

--- a/config/config-artifact-bucket.yaml
+++ b/config/config-artifact-bucket.yaml
@@ -17,14 +17,11 @@ kind: ConfigMap
 metadata:
   name: config-artifact-bucket
   namespace: tekton-pipelines
-data:
-  # location of the gcs bucket to be used for artifact storage
-  # location: "gs://bucket-name"
-
-  # name of the secret that will contain the credentials for the service account
-  # with access to the bucket
-  # bucket.service.account.secret.name:
-
-  # The key in the secret with the required service account json
-  # bucket.service.account.secret.key:
-
+#  data:
+#    # location of the gcs bucket to be used for artifact storage
+#    location: "gs://bucket-name"
+#    # name of the secret that will contain the credentials for the service account
+#    # with access to the bucket
+#    bucket.service.account.secret.name:
+#    # The key in the secret with the required service account json
+#    bucket.service.account.secret.key:

--- a/config/config-artifact-pvc.yaml
+++ b/config/config-artifact-pvc.yaml
@@ -17,9 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-artifact-pvc
   namespace: tekton-pipelines
-data:
-  # size of the PVC volume
-  # size: 5Gi
-
-  # storage class of the PVC volume
-  # storageClassName: storage-class-name
+# data:
+#   # size of the PVC volume
+#   size: 5Gi
+#
+#   # storage class of the PVC volume
+#   storageClassName: storage-class-name

--- a/examples/pipelineruns/output-pipelinerun.yaml
+++ b/examples/pipelineruns/output-pipelinerun.yaml
@@ -29,7 +29,7 @@ spec:
   - name: read-docs-old
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['-c', 'ls -la /workspace/damnworkspace/docs/README.md'] # tests that targetpath works
+    args: ['-c', 'ls -la /workspace/damnworkspace/docs/README.md']  # tests that targetpath works
   - name: write-new-stuff
     image: ubuntu
     command: ['bash']
@@ -53,9 +53,9 @@ spec:
   - name: read
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['$(inputs.params.args)'] # tests that new targetpath and previous task output is dumped
+    args: ['$(inputs.params.args)']  # tests that new targetpath and previous task output is dumped
 ---
-#The Output of the first Task (git resource) create-file is given as an `Input`
+# The Output of the first Task (git resource) create-file is given as an `Input`
 # to the next `Task` check-stuff-file-exists using`from` clause.
 
 apiVersion: tekton.dev/v1alpha1

--- a/examples/pipelineruns/pipelinerun.yaml
+++ b/examples/pipelineruns/pipelinerun.yaml
@@ -104,7 +104,7 @@ spec:
     - --destination=$(outputs.resources.builtImage.url)
     - --context=$(inputs.params.pathToContext)
 ---
-#This task deploys with kubectl apply -f <filename>
+# This task deploys with kubectl apply -f <filename>
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:

--- a/examples/taskruns/build-push-kaniko.yaml
+++ b/examples/taskruns/build-push-kaniko.yaml
@@ -20,7 +20,7 @@ spec:
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---
-#Builds an image via kaniko and pushes it to registry.
+# Builds an image via kaniko and pushes it to registry.
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:

--- a/examples/taskruns/git-volume.yaml
+++ b/examples/taskruns/git-volume.yaml
@@ -15,7 +15,7 @@ spec:
 
     volumes:
     - name: source
-      gitRepo: # https://kubernetes.io/docs/concepts/storage/volumes/#gitrepo
+      gitRepo:  # https://kubernetes.io/docs/concepts/storage/volumes/#gitrepo
         # gitRepo is deprecated.
         repository: "https://github.com/bazelbuild/rules_docker.git"
         revision: "3caddbe7f75fde6afb2e2c63654b5bbeeeedf2ac"

--- a/examples/taskruns/pull-private-image.yaml
+++ b/examples/taskruns/pull-private-image.yaml
@@ -34,7 +34,7 @@ secrets:
 imagePullSecrets:
 - name: test-readonly-credentials
 ---
-#This example contains embedded taskSpec. This taskrun requires the secrets and service accounts to be able to pull the
+# This example contains embedded taskSpec. This taskrun requires the secrets and service accounts to be able to pull the
 # private image. Required secret and service account for this run is configured in test-build-robot SA and test-readonly-credentials secret.
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun

--- a/examples/taskruns/task-multiple-output-image.yaml
+++ b/examples/taskruns/task-multiple-output-image.yaml
@@ -6,7 +6,7 @@ spec:
   type: image
   params:
   - name: url
-    value: gcr.io/dlorenc-vmtest2/leeroy-web # Replace this URL with $KO_DOCKER_REPO
+    value: gcr.io/dlorenc-vmtest2/leeroy-web  # Replace this URL with $KO_DOCKER_REPO
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -16,7 +16,7 @@ spec:
   type: image
   params:
   - name: url
-    value: gcr.io/christiewilson-catfactory/leeroy-web # Replace this URL with $KO_DOCKER_REPO
+    value: gcr.io/christiewilson-catfactory/leeroy-web  # Replace this URL with $KO_DOCKER_REPO
 ---
 # This demo modifies the cluster (deploys to it) you must use a service
 # account with permission to admin the cluster (or make your default user an admin

--- a/examples/taskruns/task-output-image.yaml
+++ b/examples/taskruns/task-output-image.yaml
@@ -6,7 +6,7 @@ spec:
   type: image
   params:
   - name: url
-    value: gcr.io/christiewilson-catfactory/leeroy-web # Replace this URL with $KO_DOCKER_REPO
+    value: gcr.io/christiewilson-catfactory/leeroy-web  # Replace this URL with $KO_DOCKER_REPO
 ---
 # This demo modifies the cluster (deploys to it) you must use a service
 # account with permission to admin the cluster (or make your default user an admin

--- a/tekton/ci-images.yaml
+++ b/tekton/ci-images.yaml
@@ -1,4 +1,4 @@
-
+---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:
@@ -38,7 +38,6 @@ spec:
       secret:
         secretName: release-secret
 ---
-
 apiVersion: tekton.dev/v1alpha1
 kind: Task
 metadata:

--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -143,7 +143,7 @@ spec:
   - name: builtGcsFetcherImage
     type: image
   - name: notification
-    type: cloudEvent    
+    type: cloudEvent
   tasks:
     - name: lint
       taskRef:

--- a/tekton/resources.yaml
+++ b/tekton/resources.yaml
@@ -8,7 +8,7 @@ spec:
   - name: url
     value: https://github.com/tektoncd/pipeline
   - name: revision
-    value:  vX.Y.Z-invalid-tags-boouuhhh # REPLACE with the commit you want to release
+    value: vX.Y.Z-invalid-tags-boouuhhh  # REPLACE with the commit you want to release
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -17,12 +17,12 @@ metadata:
 spec:
   type: storage
   params:
-   - name: type
-     value: gcs
-   - name: location
-     value: gs://tekton-releases/pipeline
-   - name: dir
-     value: "y"
+  - name: type
+    value: gcs
+  - name: location
+    value: gs://tekton-releases/pipeline
+  - name: dir
+    value: "y"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -31,12 +31,12 @@ metadata:
 spec:
   type: storage
   params:
-   - name: type
-     value: gcs
-   - name: location
-     value: gs://tekton-releases-nightly
-   - name: dir
-     value: "y"
+  - name: type
+    value: gcs
+  - name: location
+    value: gs://tekton-releases-nightly
+  - name: dir
+    value: "y"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -45,8 +45,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: ko-ci # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: ko-ci  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -55,8 +55,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: build-base # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: build-base  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -65,8 +65,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/entrypoint # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/entrypoint  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -75,8 +75,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/kubeconfigwriter # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/kubeconfigwriter  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -85,8 +85,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/creds-init # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/creds-init  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -95,8 +95,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/git-init # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/git-init  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -105,8 +105,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/controller # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/controller  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -115,8 +115,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/webhook # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/webhook  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -125,8 +125,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/imagedigestexporter # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/imagedigestexporter  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -135,8 +135,8 @@ metadata:
 spec:
   type: image
   params:
-   - name: url
-     value: cmd/pullrequest-init # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: cmd/pullrequest-init  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -145,8 +145,8 @@ metadata:
 spec:
   type: image
   params:
-    - name: url
-      value: vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher # Registry is provided via parameter, this is a hack see #569
+  - name: url
+    value: vendor/github.com/googlecloudplatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher  # Registry is provided via parameter, this is a hack see #569
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -155,5 +155,5 @@ metadata:
 spec:
   type: cloudEvent
   params:
-    - name: targetURI
-      value: http://post-release-trigger-sink # This has to be changed to a valid URL
+  - name: targetURI
+    value: http://post-release-trigger-sink  # This has to be changed to a valid URL


### PR DESCRIPTION
# Changes

Next update of plumbing will enable `yamllint` check, so this make
sure we have linted yaml before 👼

Related to tektoncd/catalog#101 (not closing it yet as the CI is not hooked up, needs tektoncd/plumbing#111 and a prow config update :stuck_out_tongue: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
