### PR TITLE
Re-add support for github auth from the GITHUB_TOKEN env variable.

### DIFF
--- a/cmd/pullrequest-init/github_test.go
+++ b/cmd/pullrequest-init/github_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"go.uber.org/zap"
@@ -13,7 +14,7 @@ func TestNewGitHubHandler(t *testing.T) {
 		"https://github.tekton.dev/foo/bar/pull/1",
 	} {
 		t.Run(url, func(t *testing.T) {
-			h, err := NewGitHubHandler(zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())).Sugar(), url)
+			h, err := NewGitHubHandler(context.Background(), zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller())).Sugar(), url)
 			if err != nil {
 				t.Fatalf("error creating GitHubHandler: %v", err)
 			}

--- a/cmd/pullrequest-init/main.go
+++ b/cmd/pullrequest-init/main.go
@@ -35,7 +35,7 @@ func main() {
 	defer logger.Sync()
 	ctx := context.Background()
 
-	client, err := NewGitHubHandler(logger, *prURL)
+	client, err := NewGitHubHandler(ctx, logger, *prURL)
 	if err != nil {
 		logger.Fatalf("error creating GitHub client: %v", err)
 	}


### PR DESCRIPTION
# Changes

This was accidentally removed in #1521. We desperately need to figure out
a story for running e2e tests that require auth secrets.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
