### PR TITLE
Kaniko test follow up

### DIFF
--- a/test/builder/step.go
+++ b/test/builder/step.go
@@ -29,6 +29,13 @@ func StepCommand(args ...string) StepOp {
 	}
 }
 
+// StepSecurityContext sets the SecurityContext to the Step.
+func StepSecurityContext(context *corev1.SecurityContext) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.SecurityContext = context
+	}
+}
+
 // StepArgs sets the command arguments to the Container (step in this case).
 func StepArgs(args ...string) StepOp {
 	return func(step *v1alpha1.Step) {

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -372,21 +372,21 @@ func TaskRunNilTimeout(spec *v1alpha1.TaskRunSpec) {
 	spec.Timeout = nil
 }
 
-// TaskRunNodeSelector sets the NodeSelector to the PipelineSpec.
+// TaskRunNodeSelector sets the NodeSelector to the TaskRunSpec.
 func TaskRunNodeSelector(values map[string]string) TaskRunSpecOp {
 	return func(spec *v1alpha1.TaskRunSpec) {
 		spec.PodTemplate.NodeSelector = values
 	}
 }
 
-// TaskRunTolerations sets the Tolerations to the PipelineSpec.
+// TaskRunTolerations sets the Tolerations to the TaskRunSpec.
 func TaskRunTolerations(values []corev1.Toleration) TaskRunSpecOp {
 	return func(spec *v1alpha1.TaskRunSpec) {
 		spec.PodTemplate.Tolerations = values
 	}
 }
 
-// TaskRunAffinity sets the Affinity to the PipelineSpec.
+// TaskRunAffinity sets the Affinity to the TaskRunSpec.
 func TaskRunAffinity(affinity *corev1.Affinity) TaskRunSpecOp {
 	return func(spec *v1alpha1.TaskRunSpec) {
 		spec.PodTemplate.Affinity = affinity

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -393,6 +393,13 @@ func TaskRunAffinity(affinity *corev1.Affinity) TaskRunSpecOp {
 	}
 }
 
+// TaskRunPodSecurityContext sets the SecurityContext to the TaskRunSpec (through PodTemplate).
+func TaskRunPodSecurityContext(context *corev1.PodSecurityContext) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.PodTemplate.SecurityContext = context
+	}
+}
+
 // StateTerminated set Terminated to the StepState.
 func StateTerminated(exitcode int) StepStateOp {
 	return func(s *v1alpha1.StepState) {

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -130,6 +130,7 @@ func getImageResource(namespace, repo string) *v1alpha1.PipelineResource {
 }
 
 func getTask(repo, namespace string) *v1alpha1.Task {
+	root := int64(0)
 	taskSpecOps := []tb.TaskSpecOp{
 		tb.TaskInputs(tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit)),
 		tb.TaskOutputs(tb.OutputsResource("builtImage", v1alpha1.PipelineResourceTypeImage)),
@@ -144,6 +145,7 @@ func getTask(repo, namespace string) *v1alpha1.Task {
 			"--insecure-pull",
 			"--insecure-registry=registry."+namespace+":5000/",
 		),
+		tb.StepSecurityContext(&corev1.SecurityContext{RunAsUser: &root}),
 	}
 	step := tb.Step("kaniko", "gcr.io/kaniko-project/executor:v0.13.0", stepOps...)
 	taskSpecOps = append(taskSpecOps, step)

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -164,6 +164,11 @@ func getTaskRun(namespace string) *v1alpha1.TaskRun {
 	))
 }
 
+// getRemoteDigest starts a pod to query the registry from the namespace itself, using skopeo (and jq).
+// The reason we have to do that is because the image is pushed on a local registry that is not exposed
+// to the "outside" of the test, this means it can be query by the test itself. It can only be query from
+// a pod in the namespace. skopeo is able to do that query and we use jq to extract the digest from its
+// output. The image used for this pod is build in the tektoncd/plumbing repository.
 func getRemoteDigest(t *testing.T, c *clients, namespace, image string) (string, error) {
 	t.Helper()
 	podName := "skopeo-jq"


### PR DESCRIPTION
# Changes

Few updates on the `TeskKanikoTaskRun`.
- Explicitely run as root (using `runAsUser`) as kaniko *needs* to be run as root. This is particularly useful on platform that default to run as random uid (like OpenShift).
- Remove the `time.Sleep(5)` and watch the deployment replicas (expected vs read) instead
- Fix and add some docstring

This is a follow-up on #1516

/cc @chmouel @bobcatfish

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
