### PR TITLE
Apply param replacements in step scripts

### DIFF
--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -4,6 +4,11 @@ metadata:
   generateName: step-script-
 spec:
   taskSpec:
+    inputs:
+      params:
+      - name: PARAM
+        default: param-value
+
     steps:
     - name: bash
       image: ubuntu
@@ -58,3 +63,15 @@ spec:
       script: |
         #!/usr/bin/perl
         print "Hello from Perl!"
+
+    # Test that param values are replaced.
+    - name: params-applied
+      image: python
+      script: |
+        #!/usr/bin/env python3
+        v = '$(input.params.PARAM)'
+        if v != 'param-value':
+          print('Param values not applied')
+          print('Got: ', v)
+          quit()
+

--- a/pkg/apis/pipeline/v1alpha1/step_replacements.go
+++ b/pkg/apis/pipeline/v1alpha1/step_replacements.go
@@ -19,8 +19,9 @@ package v1alpha1
 func ApplyStepReplacements(step *Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	step.Name = ApplyReplacements(step.Name, stringReplacements)
 	step.Image = ApplyReplacements(step.Image, stringReplacements)
+	step.Script = ApplyReplacements(step.Script, stringReplacements)
 
-	//Use ApplyArrayReplacements here, as additional args may be added via an array parameter.
+	// Use ApplyArrayReplacements here, as additional args may be added via an array parameter.
 	var newArgs []string
 	for _, a := range step.Args {
 		newArgs = append(newArgs, ApplyArrayReplacements(a, stringReplacements, arrayReplacements)...)
@@ -52,7 +53,7 @@ func ApplyStepReplacements(step *Step, stringReplacements map[string]string, arr
 	}
 	step.WorkingDir = ApplyReplacements(step.WorkingDir, stringReplacements)
 
-	//Use ApplyArrayReplacements here, as additional commands may be added via an array parameter.
+	// Use ApplyArrayReplacements here, as additional commands may be added via an array parameter.
 	var newCommand []string
 	for _, c := range step.Command {
 		newCommand = append(newCommand, ApplyArrayReplacements(c, stringReplacements, arrayReplacements)...)

--- a/pkg/apis/pipeline/v1alpha1/step_replacements_test.go
+++ b/pkg/apis/pipeline/v1alpha1/step_replacements_test.go
@@ -33,91 +33,97 @@ func TestApplyStepReplacements(t *testing.T) {
 		"array.replace.me": {"val1", "val2"},
 	}
 
-	s := v1alpha1.Step{Container: corev1.Container{
-		Name:       "$(replace.me)",
-		Image:      "$(replace.me)",
-		Command:    []string{"$(array.replace.me)"},
-		Args:       []string{"$(array.replace.me)"},
-		WorkingDir: "$(replace.me)",
-		EnvFrom: []corev1.EnvFromSource{{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "$(replace.me)",
-				},
-			},
-			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "$(replace.me)",
-				},
-			},
-		}},
-		Env: []corev1.EnvVar{{
-			Name:  "not_me",
-			Value: "$(replace.me)",
-			ValueFrom: &corev1.EnvVarSource{
-				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+	s := v1alpha1.Step{
+		Script: "$(replace.me)",
+		Container: corev1.Container{
+			Name:       "$(replace.me)",
+			Image:      "$(replace.me)",
+			Command:    []string{"$(array.replace.me)"},
+			Args:       []string{"$(array.replace.me)"},
+			WorkingDir: "$(replace.me)",
+			EnvFrom: []corev1.EnvFromSource{{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "$(replace.me)",
 					},
-					Key: "$(replace.me)",
 				},
-				SecretKeyRef: &corev1.SecretKeySelector{
+				SecretRef: &corev1.SecretEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "$(replace.me)",
 					},
-					Key: "$(replace.me)",
 				},
-			},
-		}},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      "$(replace.me)",
-			MountPath: "$(replace.me)",
-			SubPath:   "$(replace.me)",
-		}},
-	}}
+			}},
+			Env: []corev1.EnvVar{{
+				Name:  "not_me",
+				Value: "$(replace.me)",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(replace.me)",
+						},
+						Key: "$(replace.me)",
+					},
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(replace.me)",
+						},
+						Key: "$(replace.me)",
+					},
+				},
+			}},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "$(replace.me)",
+				MountPath: "$(replace.me)",
+				SubPath:   "$(replace.me)",
+			}},
+		},
+	}
 
-	expected := v1alpha1.Step{Container: corev1.Container{
-		Name:       "replaced!",
-		Image:      "replaced!",
-		Command:    []string{"val1", "val2"},
-		Args:       []string{"val1", "val2"},
-		WorkingDir: "replaced!",
-		EnvFrom: []corev1.EnvFromSource{{
-			ConfigMapRef: &corev1.ConfigMapEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "replaced!",
-				},
-			},
-			SecretRef: &corev1.SecretEnvSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: "replaced!",
-				},
-			},
-		}},
-		Env: []corev1.EnvVar{{
-			Name:  "not_me",
-			Value: "replaced!",
-			ValueFrom: &corev1.EnvVarSource{
-				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+	expected := v1alpha1.Step{
+		Script: "replaced!",
+		Container: corev1.Container{
+			Name:       "replaced!",
+			Image:      "replaced!",
+			Command:    []string{"val1", "val2"},
+			Args:       []string{"val1", "val2"},
+			WorkingDir: "replaced!",
+			EnvFrom: []corev1.EnvFromSource{{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "replaced!",
 					},
-					Key: "replaced!",
 				},
-				SecretKeyRef: &corev1.SecretKeySelector{
+				SecretRef: &corev1.SecretEnvSource{
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "replaced!",
 					},
-					Key: "replaced!",
 				},
-			},
-		}},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name:      "replaced!",
-			MountPath: "replaced!",
-			SubPath:   "replaced!",
-		}},
-	}}
+			}},
+			Env: []corev1.EnvVar{{
+				Name:  "not_me",
+				Value: "replaced!",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "replaced!",
+						},
+						Key: "replaced!",
+					},
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "replaced!",
+						},
+						Key: "replaced!",
+					},
+				},
+			}},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "replaced!",
+				MountPath: "replaced!",
+				SubPath:   "replaced!",
+			}},
+		},
+	}
 	v1alpha1.ApplyStepReplacements(&s, replacements, arrayReplacements)
 	if d := cmp.Diff(s, expected); d != "" {
 		t.Errorf("Container replacements failed: %s", d)


### PR DESCRIPTION
This adds a unit test and a YAML test to demonstrate that replacements
are applied correctly.

/assign afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
