### PR TITLE
Make kanikotest skip on environment using scc

### DIFF
--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -41,8 +41,16 @@ const (
 	revision = "1c9d566ecd13535f93789595740f20932f655905"
 )
 
+var (
+	skipRootUserTests = "false"
+)
+
 // TestTaskRun is an integration test that will verify a TaskRun using kaniko
 func TestKanikoTaskRun(t *testing.T) {
+	if skipRootUserTests == "true" {
+		t.Skip("Skip test as skipRootUserTests set to true")
+	}
+
 	c, namespace := setup(t, withRegistry)
 	t.Parallel()
 


### PR DESCRIPTION
The TestKanikoTaskRun needs priviledged access or
needs to be run as root user on platform like
OpenShift. This will add a flag which can be
passed in go test and test can be skipped

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._