### PR TITLE
Move Validatable/Defaultable interface checks out

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cluster_task_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_defaults.go
@@ -18,7 +18,11 @@ package v1alpha1
 
 import (
 	"context"
+
+	"knative.dev/pkg/apis"
 )
+
+var _ apis.Defaultable = (*ClusterTask)(nil)
 
 func (t *ClusterTask) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
@@ -18,13 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
-)
-
-// Check that Task may be validated and defaulted.
-var (
-	_ apis.Validatable = (*ClusterTask)(nil)
-	_ apis.Defaultable = (*ClusterTask)(nil)
 )
 
 // +genclient

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
@@ -22,6 +22,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*ClusterTask)(nil)
+
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")

--- a/pkg/apis/pipeline/v1alpha1/condition_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_defaults.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package v1alpha1
 
-import "context"
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+)
+
+var _ apis.Defaultable = (*Condition)(nil)
 
 func (c *Condition) SetDefaults(ctx context.Context) {
 	c.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/condition_types.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types.go
@@ -23,12 +23,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-// Check that Task may be validated and defaulted.
-var (
-	_ apis.Validatable = (*Condition)(nil)
-	_ apis.Defaultable = (*Condition)(nil)
-)
-
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/pipeline/v1alpha1/condition_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation.go
@@ -23,6 +23,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*Condition)(nil)
+
 func (c Condition) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(c.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")

--- a/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package v1alpha1
 
-import "context"
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+)
+
+var _ apis.Defaultable = (*Pipeline)(nil)
 
 func (p *Pipeline) SetDefaults(ctx context.Context) {
 	p.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -18,7 +18,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
 
 // PipelineSpec defines the desired state of Pipeline.
@@ -48,11 +47,6 @@ const (
 	NamespacedTaskKind TaskKind = "Task"
 	// ClusterTaskKind indicates that task type has a cluster scope.
 	ClusterTaskKind TaskKind = "ClusterTask"
-)
-
-var (
-	_ apis.Validatable = (*Pipeline)(nil)
-	_ apis.Defaultable = (*Pipeline)(nil)
 )
 
 // +genclient

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -28,6 +28,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*Pipeline)(nil)
+
 // Validate checks that the Pipeline structure is valid but does not validate
 // that any references resources exist, that is done at run time.
 func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -26,6 +26,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*PipelineResource)(nil)
+
 func (r *PipelineResource) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(r.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
@@ -22,7 +22,10 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
+
+var _ apis.Defaultable = (*PipelineRun)(nil)
 
 func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 	pr.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -36,10 +36,6 @@ var (
 		Version: SchemeGroupVersion.Version,
 		Kind:    pipelineRunControllerName,
 	}
-
-	// Check that TaskRun may be validated and defaulted.
-	_ apis.Validatable = (*PipelineRun)(nil)
-	_ apis.Defaultable = (*PipelineRun)(nil)
 )
 
 // PipelineRunSpec defines the desired state of PipelineRun

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
@@ -24,6 +24,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*PipelineRun)(nil)
+
 // Validate pipelinerun
 func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(pr.GetObjectMeta()).ViaField("metadata"); err != nil {

--- a/pkg/apis/pipeline/v1alpha1/resource_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_defaults.go
@@ -16,7 +16,13 @@ limitations under the License.
 
 package v1alpha1
 
-import "context"
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+)
+
+var _ apis.Defaultable = (*PipelineResource)(nil)
 
 func (t *PipelineResource) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/xerrors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
 
 // PipelineResourceType represents the type of endpoint the pipelineResource is, so that the
@@ -57,14 +56,8 @@ const (
 	PipelineResourceTypeCloudEvent PipelineResourceType = "cloudEvent"
 )
 
-var (
-	// AllResourceTypes can be used for validation to check if a provided Resource type is one of the known types.
-	AllResourceTypes = []PipelineResourceType{PipelineResourceTypeGit, PipelineResourceTypeStorage, PipelineResourceTypeImage, PipelineResourceTypeCluster, PipelineResourceTypePullRequest, PipelineResourceTypeCloudEvent}
-
-	// Check that PipelineResource may be validated and defaulted.
-	_ apis.Validatable = (*PipelineResource)(nil)
-	_ apis.Defaultable = (*PipelineResource)(nil)
-)
+// AllResourceTypes can be used for validation to check if a provided Resource type is one of the known types.
+var AllResourceTypes = []PipelineResourceType{PipelineResourceTypeGit, PipelineResourceTypeStorage, PipelineResourceTypeImage, PipelineResourceTypeCluster, PipelineResourceTypePullRequest, PipelineResourceTypeCloudEvent}
 
 // PipelineResourceInterface interface to be implemented by different PipelineResource types
 type PipelineResourceInterface interface {

--- a/pkg/apis/pipeline/v1alpha1/task_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/task_defaults.go
@@ -18,7 +18,11 @@ package v1alpha1
 
 import (
 	"context"
+
+	"knative.dev/pkg/apis"
 )
+
+var _ apis.Defaultable = (*Task)(nil)
 
 func (t *Task) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -19,13 +19,6 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
-)
-
-var (
-	// Check that Task may be validated and defaulted.
-	_ apis.Validatable = (*Task)(nil)
-	_ apis.Defaultable = (*Task)(nil)
 )
 
 func (t *Task) TaskSpec() TaskSpec {

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -27,6 +27,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*Task)(nil)
+
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -22,7 +22,10 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
+
+var _ apis.Defaultable = (*TaskRun)(nil)
 
 func (tr *TaskRun) SetDefaults(ctx context.Context) {
 	tr.Spec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -27,12 +27,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-var (
-	// Check that TaskRun may be validated and defaulted.
-	_ apis.Validatable = (*TaskRun)(nil)
-	_ apis.Defaultable = (*TaskRun)(nil)
-)
-
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {
 	// +optional

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -25,6 +25,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+var _ apis.Validatable = (*TaskRun)(nil)
+
 // Validate taskrun
 func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateObjectMetadata(tr.GetObjectMeta()).ViaField("metadata"); err != nil {


### PR DESCRIPTION
These type checks are a signal that the types are validatable/defaultable, which is nice, but having them in the _types.go files makes it more difficult to consume those files by themselves.

There are no functiona changes expected.

As an alternative we could move these type checks into _test.go files, where consumers who only need the message types could just not consume the _test.go files. Or we could just remove the type checks entirely -- these types are still enforced when building `cmd/controller` and `cmd/webhook`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._