### PR TITLE
Allow steps to run regardless of previous step errors

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -33,6 +33,7 @@ var (
 	waitFiles       = flag.String("wait_file", "", "Comma-separated list of paths to wait for")
 	waitFileContent = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
 	postFile        = flag.String("post_file", "", "If specified, file to write upon completion")
+	errorStrategy   = flag.String("error_strategy", "", "The strategy to use if a prior step has errored")
 
 	waitPollingInterval = time.Second
 )
@@ -45,6 +46,7 @@ func main() {
 		WaitFiles:       strings.Split(*waitFiles, ","),
 		WaitFileContent: *waitFileContent,
 		PostFile:        *postFile,
+		ErrorStrategy:   entrypoint.ErrorStrategy(*errorStrategy),
 		Args:            flag.Args(),
 		Waiter:          &realWaiter{},
 		Runner:          &realRunner{},
@@ -52,7 +54,7 @@ func main() {
 	}
 	if err := e.Go(); err != nil {
 		switch t := err.(type) {
-		case skipError:
+		case entrypoint.SkipError:
 			log.Print("Skipping step because a previous step failed")
 			os.Exit(1)
 		case *exec.ExitError:

--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -21,7 +21,7 @@ var _ entrypoint.Waiter = (*realWaiter)(nil)
 // immediately.
 //
 // If a file of the same name with a ".err" extension exists then this Wait
-// will end with a skipError.
+// will end with an entrypoint.SkipError.
 func (*realWaiter) Wait(file string, expectContent bool) error {
 	if file == "" {
 		return nil
@@ -35,13 +35,7 @@ func (*realWaiter) Wait(file string, expectContent bool) error {
 			return xerrors.Errorf("Waiting for %q: %w", file, err)
 		}
 		if _, err := os.Stat(file + ".err"); err == nil {
-			return skipError("error file present, bail and skip the step")
+			return entrypoint.SkipError("error file present, bail and skip the step")
 		}
 	}
-}
-
-type skipError string
-
-func (e skipError) Error() string {
-	return string(e)
 }

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/tektoncd/pipeline/pkg/entrypoint"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -59,6 +60,10 @@ type TaskSpec struct {
 	// Sidecars are run alongside the Task's step containers. They begin before
 	// the steps start and end after the steps complete.
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
+
+	// DefaultErrorStrategy sets the error strategy for any step that doesn't
+	// include one of its own.
+	DefaultErrorStrategy entrypoint.ErrorStrategy `json:"defaultErrorStrategy,omitempty"`
 }
 
 // Step embeds the Container type, which allows it to include fields not
@@ -70,6 +75,14 @@ type Step struct {
 	//
 	// If Script is not empty, the Step cannot have an Command or Args.
 	Script string `json:"script,omitempty"`
+
+	// ErrorStrategy dictates how this step will behave when errors
+	// occurred in prior steps.
+	//
+	// Possible values are SkipOnPriorStepErrors or IgnorePriorStepErrors.
+	//
+	// Defaults to SkipOnPriorStepErrors.
+	ErrorStrategy entrypoint.ErrorStrategy `json:"errorStrategy,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -204,6 +204,16 @@ func TestTaskSpecValidate(t *testing.T) {
 				hello world`,
 			}},
 		},
+	}, {
+		name: "valid error strategy in step",
+		fields: fields{
+			Steps: []v1alpha1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+				},
+				ErrorStrategy: "IgnorePriorStepErrors",
+			}},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -661,6 +671,20 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: "script cannot be used with args or command",
 			Paths:   []string{"steps.script"},
+		},
+	}, {
+		name: "step with invalid error strategy",
+		fields: fields{
+			Steps: []v1alpha1.Step{{
+				Container: corev1.Container{
+					Image: "myimage",
+				},
+				ErrorStrategy: "FooBarStrategyBaz",
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: "errorStrategy must be one of SkipOnPriorStepErrors, IgnorePriorStepErrors",
+			Paths:   []string{"steps.errorStrategy"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/entrypoint/error_strategies.go
+++ b/pkg/entrypoint/error_strategies.go
@@ -1,0 +1,27 @@
+package entrypoint
+
+type ErrorStrategy string
+
+const (
+	SkipOnPriorStepErrors ErrorStrategy = "SkipOnPriorStepErrors"
+	IgnorePriorStepErrors ErrorStrategy = "IgnorePriorStepErrors"
+)
+
+var allErrorStrategies = []ErrorStrategy{SkipOnPriorStepErrors, IgnorePriorStepErrors}
+
+func IsValidErrorStrategy(e ErrorStrategy) bool {
+	for _, strat := range allErrorStrategies {
+		if e == strat {
+			return true
+		}
+	}
+	return false
+}
+
+func GetErrorStrategyNames() []string {
+	ret := []string{}
+	for _, s := range allErrorStrategies {
+		ret = append(ret, string(s))
+	}
+	return ret
+}

--- a/pkg/entrypoint/skip_error.go
+++ b/pkg/entrypoint/skip_error.go
@@ -1,0 +1,10 @@
+package entrypoint
+
+// SkipError is returned when an entrypoint Waiter detects that a prior
+// step failed and therefore this step should also be skipped.
+type SkipError string
+
+// Error returns the string message of the SkipError.
+func (e SkipError) Error() string {
+	return string(e)
+}

--- a/test/builder/step.go
+++ b/test/builder/step.go
@@ -15,6 +15,7 @@ package builder
 
 import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/entrypoint"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -139,5 +140,12 @@ func StepTerminationMessagePath(terminationMessagePath string) StepOp {
 func StepTerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) StepOp {
 	return func(step *v1alpha1.Step) {
 		step.TerminationMessagePolicy = terminationMessagePolicy
+	}
+}
+
+// StepErrorStrategy sets the error strategy of the step.
+func StepErrorStrategy(strat entrypoint.ErrorStrategy) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.ErrorStrategy = strat
 	}
 }

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/entrypoint"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -187,6 +188,14 @@ func TaskVolume(name string, ops ...VolumeOp) TaskSpecOp {
 			op(v)
 		}
 		spec.Volumes = append(spec.Volumes, *v)
+	}
+}
+
+// TaskDefaultErrorStrategy sets the default error strategy on
+// the provided TaskSpec.
+func TaskDefaultErrorStrategy(strat entrypoint.ErrorStrategy) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		spec.DefaultErrorStrategy = strat
 	}
 }
 


### PR DESCRIPTION
Fixes #1559 

# Changes

Outstanding TODOs:
- [x] Implement `defaultErrorStrategy` behaviour: its value should be copied into any steps that dont include their own `errorStrategy` field.
- [x] Confirm how this interacts with existing output pipeline resources.

This commit introduces an `errorStrategy` field to Steps and a `defaultErrorStrategy` field to Tasks. These fields can currently accept one of two possible strategies. The first is `SkipOnPriorStepErrors` and tells the Step to skip its work if a prior step has failed. This is how Tekton works today and is therefore the default value if the field is omitted or left blank. The second strategy is `IgnorePriorStepErrors` and tells a step to run regardless of whether a previous step has already errored out.

This feature is intended to serve two similar use-cases:

1. Unit test failures in a step can be written to the task workspace and then uploaded to persistent storage in a subsequent step, even though the unit test failure resulted in a non-zero exit code.
2. Pipeline resources that need to report on the failed status of a step can do so. For example the pull request resource could be updated to add a final step to a Task that updates a PR with the status of a build step. Currently if a build step fails then any later steps will be skipped.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The steps of a task can now be run regardless of previous steps' errors. A step can now upload test results even if the test runner step before it failed.
```