### PR TITLE
Make sure v1alpha1.Condition satisfy webhook.GenericCRD ⚙

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/types_test.go
@@ -30,4 +30,5 @@ func TestTypes(t *testing.T) {
 	var _ webhook.GenericCRD = (*v1alpha1.PipelineResource)(nil)
 	var _ webhook.GenericCRD = (*v1alpha1.Task)(nil)
 	var _ webhook.GenericCRD = (*v1alpha1.TaskRun)(nil)
+	var _ webhook.GenericCRD = (*v1alpha1.Condition)(nil)
 }


### PR DESCRIPTION
# Changes

This makes Condition consistent with the rest of the CRDs defined by
tektoncd/pipeline.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @dibyom 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
