### PR TITLE
Extract artifacts constants out of v1alpha1 package 🍳

### DIFF
--- a/pkg/apis/pipeline/constants.go
+++ b/pkg/apis/pipeline/constants.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+const (
+
+	// PipelineResourceTypeGit indicates that this source is a GitHub repo.
+	ArtifactStorageBucketType = "bucket"
+
+	// PipelineResourceTypeStorage indicates that this source is a storage blob resource.
+	ArtifactStoragePVCType = "pvc"
+)

--- a/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_bucket.go
@@ -19,48 +19,15 @@ package v1alpha1
 import (
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	// BucketConfigName is the name of the configmap containing all
-	// customizations for the storage bucket.
-	BucketConfigName = "config-artifact-bucket"
-
-	// BucketLocationKey is the name of the configmap entry that specifies
-	// loction of the bucket.
-	BucketLocationKey = "location"
-
-	// BucketServiceAccountSecretName is the name of the configmap entry that specifies
-	// the name of the secret that will provide the servie account with bucket access.
-	// This secret must  have a key called serviceaccount that will have a value with
-	// the service account with access to the bucket
-	BucketServiceAccountSecretName = "bucket.service.account.secret.name"
-
-	// BucketServiceAccountSecretKey is the name of the configmap entry that specifies
-	// the secret key that will have a value with the service account json with access
-	// to the bucket
-	BucketServiceAccountSecretKey = "bucket.service.account.secret.key"
-
-	// BucketServiceAccountFieldName is the name of the configmap entry that specifies
-	// the field name that should be used for the service account.
-	// Valid values: GOOGLE_APPLICATION_CREDENTIALS, BOTO_CONFIG. Defaults to GOOGLE_APPLICATION_CREDENTIALS.
-	BucketServiceAccountFieldName = "bucket.service.account.field.name"
-)
-
-const (
-	// PipelineResourceTypeGit indicates that this source is a GitHub repo.
-	ArtifactStorageBucketType = "bucket"
-
-	// PipelineResourceTypeStorage indicates that this source is a storage blob resource.
-	ArtifactStoragePVCType = "pvc"
 )
 
 // For some reason gosec thinks this string has enough entropy to be a potential secret.
 // The nosec comment disables it for this line.
 /* #nosec */
-var secretVolumeMountPath = "/var/bucketsecret"
+const secretVolumeMountPath = "/var/bucketsecret"
 
 // ArtifactBucket contains the Storage bucket configuration defined in the
 // Bucket config map.
@@ -75,7 +42,7 @@ type ArtifactBucket struct {
 
 // GetType returns the type of the artifact storage
 func (b *ArtifactBucket) GetType() string {
-	return ArtifactStorageBucketType
+	return pipeline.ArtifactStorageBucketType
 }
 
 // StorageBasePath returns the path to be used to store artifacts in a pipelinerun temporary storage

--- a/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
+++ b/pkg/apis/pipeline/v1alpha1/artifact_pvc.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -38,7 +39,7 @@ type ArtifactPVC struct {
 
 // GetType returns the type of the artifact storage.
 func (p *ArtifactPVC) GetType() string {
-	return ArtifactStoragePVCType
+	return pipeline.ArtifactStoragePVCType
 }
 
 // StorageBasePath returns the path to be used to store artifacts in a pipelinerun temporary storage.

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -124,12 +124,12 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "gs://fake-bucket",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "gs://fake-bucket",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		pvcNeeded: false,
@@ -138,12 +138,12 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		pvcNeeded: true,
@@ -152,11 +152,11 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		pvcNeeded: true,
@@ -165,7 +165,7 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 		},
 		pvcNeeded: true,
@@ -174,10 +174,10 @@ func TestConfigMapNeedsPVC(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey: "gs://fake-bucket",
+				BucketLocationKey: "gs://fake-bucket",
 			},
 		},
 		pvcNeeded: false,
@@ -241,12 +241,12 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "gs://fake-bucket",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "gs://fake-bucket",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
@@ -265,12 +265,12 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
@@ -284,11 +284,11 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
@@ -302,7 +302,7 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
@@ -316,10 +316,10 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey: "gs://fake-bucket",
+				BucketLocationKey: "gs://fake-bucket",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
@@ -333,13 +333,13 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "s3://fake-bucket",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
-				v1alpha1.BucketServiceAccountFieldName:  "BOTO_CONFIG",
+				BucketLocationKey:              "s3://fake-bucket",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
+				BucketServiceAccountFieldName:  "BOTO_CONFIG",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
@@ -461,12 +461,12 @@ func TestInitializeArtifactStorageNoStorageNeeded(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "gs://fake-bucket",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "gs://fake-bucket",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 	}, {
@@ -474,12 +474,12 @@ func TestInitializeArtifactStorageNoStorageNeeded(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 	}} {
@@ -512,12 +512,12 @@ func TestCleanupArtifactStorage(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 	}, {
@@ -525,11 +525,11 @@ func TestCleanupArtifactStorage(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 	}, {
@@ -537,7 +537,7 @@ func TestCleanupArtifactStorage(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 		},
 	}} {
@@ -603,12 +603,12 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "gs://fake-bucket",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "gs://fake-bucket",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactBucket{
@@ -626,12 +626,12 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketLocationKey:              "",
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketLocationKey:              "",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
@@ -643,11 +643,11 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 			Data: map[string]string{
-				v1alpha1.BucketServiceAccountSecretName: "secret1",
-				v1alpha1.BucketServiceAccountSecretKey:  "sakey",
+				BucketServiceAccountSecretName: "secret1",
+				BucketServiceAccountSecretKey:  "sakey",
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{
@@ -659,7 +659,7 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 		configMap: &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: system.GetNamespace(),
-				Name:      v1alpha1.BucketConfigName,
+				Name:      BucketConfigName,
 			},
 		},
 		expectedArtifactStorage: &v1alpha1.ArtifactPVC{

--- a/pkg/reconciler/pipelinerun/config/store.go
+++ b/pkg/reconciler/pipelinerun/config/store.go
@@ -53,7 +53,7 @@ func NewStore(images pipeline.Images, logger configmap.Logger) *Store {
 			"pipelinerun",
 			logger,
 			configmap.Constructors{
-				v1alpha1.BucketConfigName: artifacts.NewArtifactBucketConfigFromConfigMap(images),
+				artifacts.BucketConfigName: artifacts.NewArtifactBucketConfigFromConfigMap(images),
 			},
 		),
 		images: images,
@@ -65,7 +65,7 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 }
 
 func (s *Store) Load() *Config {
-	ep := s.UntypedLoad(v1alpha1.BucketConfigName)
+	ep := s.UntypedLoad(artifacts.BucketConfigName)
 	if ep == nil {
 		return &Config{
 			ArtifactBucket: &v1alpha1.ArtifactBucket{

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/artifacts"
 	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/test/names"
 	"go.uber.org/zap"
@@ -1172,12 +1173,12 @@ func TestAddStepsToTaskWithBucketFromConfigMap(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "tekton-pipelines",
-						Name:      v1alpha1.BucketConfigName,
+						Name:      artifacts.BucketConfigName,
 					},
 					Data: map[string]string{
-						v1alpha1.BucketLocationKey:              "gs://fake-bucket",
-						v1alpha1.BucketServiceAccountSecretName: "gcs-config",
-						v1alpha1.BucketServiceAccountSecretKey:  "my-key",
+						artifacts.BucketLocationKey:              "gs://fake-bucket",
+						artifacts.BucketServiceAccountSecretName: "gcs-config",
+						artifacts.BucketServiceAccountSecretKey:  "my-key",
 					},
 				},
 			)

--- a/pkg/reconciler/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/taskrun/resources/input_resources.go
@@ -89,7 +89,7 @@ func AddInputResource(
 		if v1alpha1.AllowedOutputResources[resource.GetType()] && taskRun.HasPipelineRunOwnerReference() {
 			for _, path := range boundResource.Paths {
 				cpSteps := as.GetCopyFromStorageToSteps(boundResource.Name, path, dPath)
-				if as.GetType() == v1alpha1.ArtifactStoragePVCType {
+				if as.GetType() == pipeline.ArtifactStoragePVCType {
 					mountPVC = true
 					for _, s := range cpSteps {
 						s.VolumeMounts = []corev1.VolumeMount{v1alpha1.GetPvcMount(pvcName)}

--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -108,7 +108,7 @@ func AddOutputResources(
 		}
 
 		// Attach the PVC that will be used for `from` copying.
-		if as.GetType() == v1alpha1.ArtifactStoragePVCType {
+		if as.GetType() == pipeline.ArtifactStoragePVCType {
 			if pvcName == "" {
 				return taskSpec, nil
 			}

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/artifacts"
 	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
@@ -1003,10 +1004,10 @@ func TestValidOutputResourcesWithBucketStorage(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "tekton-pipelines",
-						Name:      v1alpha1.BucketConfigName,
+						Name:      artifacts.BucketConfigName,
 					},
 					Data: map[string]string{
-						v1alpha1.BucketLocationKey: "gs://fake-bucket",
+						artifacts.BucketLocationKey: "gs://fake-bucket",
 					},
 				},
 			)

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/artifacts"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,22 +100,22 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 
 	defer runTaskToDeleteBucket(c, t, namespace, bucketName, bucketSecretName, bucketSecretKey)
 
-	originalConfigMap, err := c.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get(v1alpha1.BucketConfigName, metav1.GetOptions{})
+	originalConfigMap, err := c.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get(artifacts.BucketConfigName, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get ConfigMap `%s`: %s", v1alpha1.BucketConfigName, err)
+		t.Fatalf("Failed to get ConfigMap `%s`: %s", artifacts.BucketConfigName, err)
 	}
 	originalConfigMapData := originalConfigMap.Data
 
-	t.Logf("Creating ConfigMap %s", v1alpha1.BucketConfigName)
+	t.Logf("Creating ConfigMap %s", artifacts.BucketConfigName)
 	configMapData := map[string]string{
-		v1alpha1.BucketLocationKey:              fmt.Sprintf("gs://%s", bucketName),
-		v1alpha1.BucketServiceAccountSecretName: bucketSecretName,
-		v1alpha1.BucketServiceAccountSecretKey:  bucketSecretKey,
+		artifacts.BucketLocationKey:              fmt.Sprintf("gs://%s", bucketName),
+		artifacts.BucketServiceAccountSecretName: bucketSecretName,
+		artifacts.BucketServiceAccountSecretKey:  bucketSecretKey,
 	}
-	if err := updateConfigMap(c.KubeClient, systemNamespace, v1alpha1.BucketConfigName, configMapData); err != nil {
+	if err := updateConfigMap(c.KubeClient, systemNamespace, artifacts.BucketConfigName, configMapData); err != nil {
 		t.Fatal(err)
 	}
-	defer resetConfigMap(t, c, systemNamespace, v1alpha1.BucketConfigName, originalConfigMapData)
+	defer resetConfigMap(t, c, systemNamespace, artifacts.BucketConfigName, originalConfigMapData)
 
 	t.Logf("Creating Git PipelineResource %s", helloworldResourceName)
 	helloworldResource := tb.PipelineResource(helloworldResourceName, namespace, tb.PipelineResourceSpec(


### PR DESCRIPTION
# Changes

Those constants do not need to be in the v1alpha1 package, as they
don't depend on the version of the API (or rather, should not)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
