### PR TITLE
Fix potential bug caught by gobugs

### DIFF
--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -105,7 +105,7 @@ func GetSchedulable(g *Graph, doneTasks ...string) (map[string]struct{}, error) 
 		}
 	}
 
-	visitedNames := make([]string, len(visited))
+	var visitedNames []string
 	for v := range visited {
 		visitedNames = append(visitedNames, v)
 	}
@@ -217,7 +217,7 @@ func isSchedulable(doneTasks map[string]struct{}, prevs []*Node) bool {
 }
 
 func toMap(t ...string) map[string]struct{} {
-	m := make(map[string]struct{}, len(t))
+	m := map[string]struct{}{}
 	for _, s := range t {
 		m[s] = struct{}{}
 	}


### PR DESCRIPTION
The two-arg form of  `make` results in a slice with n empty elements, which we then `append` to, resulting in a slice with empty elements.

Instead of trying to remember to use the _correct_ form for `make` (i.e., `make([]string, 0, len(x))`), just avoid the premature optimization and declare an empty slice without capacity.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).