### PR TITLE
Add Terminated, Running, and Waiting Container States to Test Builder

### DIFF
--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -400,11 +400,38 @@ func TaskRunPodSecurityContext(context *corev1.PodSecurityContext) TaskRunSpecOp
 	}
 }
 
-// StateTerminated set Terminated to the StepState.
+// StateTerminated sets Terminated to the StepState.
 func StateTerminated(exitcode int) StepStateOp {
 	return func(s *v1alpha1.StepState) {
 		s.ContainerState = corev1.ContainerState{
 			Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(exitcode)},
+		}
+	}
+}
+
+// SetStepStateTerminated sets Terminated state of a step.
+func SetStepStateTerminated(terminated corev1.ContainerStateTerminated) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Terminated: &terminated,
+		}
+	}
+}
+
+// SetStepStateRunning sets Running state of a step.
+func SetStepStateRunning(running corev1.ContainerStateRunning) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Running: &running,
+		}
+	}
+}
+
+// SetStepStateWaiting sets Waiting state of a step.
+func SetStepStateWaiting(waiting corev1.ContainerStateWaiting) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Waiting: &waiting,
 		}
 	}
 }


### PR DESCRIPTION
Closes #1549

# Changes

Adds three new funcs to test builder to allow setting the container state for testing purposes around Tekton. The three new funcs correspond to the container states for a step: Terminating, Running, and Waiting. 

As a follow up, I think removing the `StateTerminated` func from test builder would be appropriate, but there should be a formal announcement about it before any work is done towards that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

N/A
