### PR TITLE
Move GetPod from pod.go to taskrun.go

### DIFF
--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -36,7 +36,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/names"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/entrypoint"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -216,23 +215,6 @@ func makeWorkingDirInitializer(shellImage string, steps []v1alpha1.Step) *v1alph
 		}}
 	}
 	return nil
-}
-
-// GetPod returns the Pod for the given pod name
-type GetPod func(string, metav1.GetOptions) (*corev1.Pod, error)
-
-// TryGetPod fetches the TaskRun's pod, returning nil if it has not been created or it does not exist.
-func TryGetPod(taskRunStatus v1alpha1.TaskRunStatus, gp GetPod) (*corev1.Pod, error) {
-	if taskRunStatus.PodName == "" {
-		return nil, nil
-	}
-
-	pod, err := gp(taskRunStatus.PodName, metav1.GetOptions{})
-	if err == nil || errors.IsNotFound(err) {
-		return pod, nil
-	}
-
-	return nil, err
 }
 
 // MakePod converts TaskRun and TaskSpec objects to a Pod which implements the taskrun specified


### PR DESCRIPTION
GetPod is only called from taskrun.go, so let's just move it to that
package and unexport it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._
