### PR TITLE
Move working dir initialization out to pkg/pod/

### DIFF
--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -1,0 +1,67 @@
+package pod
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/names"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	workspaceDir   = "/workspace"
+	workingDirInit = "working-dir-initializer"
+)
+
+// WorkingDirInit returns a Container that should be run as an init
+// container to ensure that all steps' workingDirs relative to the workspace
+// exist.
+//
+// If no such directories need to be created (i.e., no relative workingDirs
+// are specified), this method returns nil, as no init container is necessary.
+//
+// TODO(jasonhall): This should take []corev1.Container instead of
+// []corev1.Step, but this makes it easier to use in pod.go. When pod.go is
+// cleaned up, this can take []corev1.Container.
+func WorkingDirInit(shellImage string, steps []v1alpha1.Step) *corev1.Container {
+	// Gather all unique workingDirs.
+	workingDirs := map[string]struct{}{}
+	for _, step := range steps {
+		if step.WorkingDir != "" {
+			workingDirs[step.WorkingDir] = struct{}{}
+		}
+	}
+	if len(workingDirs) == 0 {
+		return nil
+	}
+
+	// Sort unique workingDirs.
+	var orderedDirs []string
+	for wd := range workingDirs {
+		orderedDirs = append(orderedDirs, wd)
+	}
+	sort.Strings(orderedDirs)
+
+	// Clean and append each relative workingDir.
+	var relativeDirs []string
+	for _, wd := range orderedDirs {
+		p := filepath.Clean(wd)
+		if !filepath.IsAbs(p) || strings.HasPrefix(p, "/workspace/") {
+			relativeDirs = append(relativeDirs, p)
+		}
+	}
+
+	if len(relativeDirs) == 0 {
+		return nil
+	}
+
+	return &corev1.Container{
+		Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(workingDirInit),
+		Image:      shellImage,
+		Command:    []string{"sh"},
+		Args:       []string{"-c", "mkdir -p " + strings.Join(relativeDirs, " ")},
+		WorkingDir: workspaceDir,
+	}
+}

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -1,0 +1,69 @@
+package pod
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const shellImage = "shell-image"
+
+func TestWorkingDirInit(t *testing.T) {
+	names.TestingSeed()
+	for _, c := range []struct {
+		desc           string
+		stepContainers []corev1.Container
+		want           *corev1.Container
+	}{{
+		desc: "no workingDirs",
+		stepContainers: []corev1.Container{{
+			Name: "no-working-dir",
+		}},
+		want: nil,
+	}, {
+		desc: "workingDirs are unique and sorted, absolute dirs are ignored",
+		stepContainers: []corev1.Container{{
+			WorkingDir: "zzz",
+		}, {
+			WorkingDir: "aaa",
+		}, {
+			WorkingDir: "/ignored",
+		}, {
+			WorkingDir: "/workspace", // ignored
+		}, {
+			WorkingDir: "zzz",
+		}, {
+			// Even though it's specified absolute, it's relative
+			// to /workspace, so we need to create it.
+			WorkingDir: "/workspace/bbb",
+		}},
+		want: &corev1.Container{
+			Name:       "working-dir-initializer-9l9zj",
+			Image:      shellImage,
+			Command:    []string{"sh"},
+			Args:       []string{"-c", "mkdir -p /workspace/bbb aaa zzz"},
+			WorkingDir: workspaceDir,
+		},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			// TODO(jasonhall): WorkingDirInit should take
+			// Containers instead of Steps, but while we're
+			// cleaning up pod.go it's easier to have it take
+			// Steps. This test doesn't care, so let's hide this
+			// conversion in the test where it's easier to remove
+			// later.
+			var steps []v1alpha1.Step
+			for _, c := range c.stepContainers {
+				steps = append(steps, v1alpha1.Step{Container: c})
+			}
+
+			got := WorkingDirInit(shellImage, steps)
+			if d := cmp.Diff(c.want, got); d != "" {
+				t.Fatalf("Diff (-want, +got): %s", d)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -34,6 +33,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
 	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
 	"github.com/tektoncd/pipeline/pkg/names"
+	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/entrypoint"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -107,34 +107,36 @@ const (
 	containerPrefix            = "step-"
 	unnamedInitContainerPrefix = "step-unnamed-"
 	// Name of the credential initialization container.
-	credsInit = "credential-initializer"
-	// Name of the working dir initialization container.
-	workingDirInit       = "working-dir-initializer"
+	credsInit            = "credential-initializer"
 	ReadyAnnotation      = "tekton.dev/ready"
 	readyAnnotationValue = "READY"
 	sidecarPrefix        = "sidecar-"
 )
 
-func makeCredentialInitializer(credsImage, serviceAccountName, namespace string, kubeclient kubernetes.Interface) (*v1alpha1.Step, []corev1.Volume, error) {
+// TODO(jasonhall): If there are no creds to initialize, return a nil Container
+// and don't add it to initContainers, instead of appending an init container
+// that runs and does nothing.
+func makeCredentialInitializer(credsImage, serviceAccountName, namespace string, kubeclient kubernetes.Interface) (corev1.Container, []corev1.Volume, error) {
 	if serviceAccountName == "" {
 		serviceAccountName = "default"
 	}
 
 	sa, err := kubeclient.CoreV1().ServiceAccounts(namespace).Get(serviceAccountName, metav1.GetOptions{})
 	if err != nil {
-		return nil, nil, err
+		return corev1.Container{}, nil, err
 	}
 
 	builders := []credentials.Builder{dockercreds.NewBuilder(), gitcreds.NewBuilder()}
 
-	// Collect the volume declarations, there mounts into the cred-init container, and the arguments to it.
-	volumes := []corev1.Volume{}
+	// Collect the volume declarations, there mounts into the cred-init
+	// container, and the arguments to it.
+	var volumes []corev1.Volume
 	volumeMounts := implicitVolumeMounts
 	args := []string{}
 	for _, secretEntry := range sa.Secrets {
 		secret, err := kubeclient.CoreV1().Secrets(namespace).Get(secretEntry.Name, metav1.GetOptions{})
 		if err != nil {
-			return nil, nil, err
+			return corev1.Container{}, nil, err
 		}
 
 		matched := false
@@ -162,60 +164,14 @@ func makeCredentialInitializer(credsImage, serviceAccountName, namespace string,
 		}
 	}
 
-	return &v1alpha1.Step{Container: corev1.Container{
+	return corev1.Container{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(containerPrefix + credsInit),
 		Image:        credsImage,
 		Command:      []string{"/ko-app/creds-init"},
 		Args:         args,
-		VolumeMounts: volumeMounts,
 		Env:          implicitEnvVars,
-		WorkingDir:   workspaceDir,
-	}}, volumes, nil
-}
-
-func makeWorkingDirScript(workingDirs map[string]bool) string {
-	script := ""
-	var orderedDirs []string
-
-	for wd := range workingDirs {
-		if wd != "" {
-			orderedDirs = append(orderedDirs, wd)
-		}
-	}
-	sort.Strings(orderedDirs)
-
-	for _, wd := range orderedDirs {
-		p := filepath.Clean(wd)
-		if rel, err := filepath.Rel(workspaceDir, p); err == nil && !strings.HasPrefix(rel, ".") {
-			if script == "" {
-				script = fmt.Sprintf("mkdir -p %s", p)
-			} else {
-				script = fmt.Sprintf("%s %s", script, p)
-			}
-		}
-	}
-
-	return script
-}
-
-func makeWorkingDirInitializer(shellImage string, steps []v1alpha1.Step) *v1alpha1.Step {
-	workingDirs := make(map[string]bool)
-	for _, step := range steps {
-		workingDirs[step.WorkingDir] = true
-	}
-
-	if script := makeWorkingDirScript(workingDirs); script != "" {
-		return &v1alpha1.Step{Container: corev1.Container{
-			Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(containerPrefix + workingDirInit),
-			Image:        shellImage,
-			Command:      []string{"sh"},
-			Args:         []string{"-c", script},
-			VolumeMounts: implicitVolumeMounts,
-			Env:          implicitEnvVars,
-			WorkingDir:   workspaceDir,
-		}}
-	}
-	return nil
+		VolumeMounts: volumeMounts,
+	}, volumes, nil
 }
 
 // GetPod returns the Pod for the given pod name
@@ -238,28 +194,29 @@ func TryGetPod(taskRunStatus v1alpha1.TaskRunStatus, gp GetPod) (*corev1.Pod, er
 // MakePod converts TaskRun and TaskSpec objects to a Pod which implements the taskrun specified
 // by the supplied CRD.
 func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec, kubeclient kubernetes.Interface) (*corev1.Pod, error) {
-	cred, secrets, err := makeCredentialInitializer(images.CredsImage, taskRun.GetServiceAccountName(), taskRun.Namespace, kubeclient)
+	credsInitContainer, secrets, err := makeCredentialInitializer(images.CredsImage, taskRun.GetServiceAccountName(), taskRun.Namespace, kubeclient)
 	if err != nil {
 		return nil, err
 	}
-	initSteps := []v1alpha1.Step{*cred}
-	var podSteps []v1alpha1.Step
+	initContainers := []corev1.Container{credsInitContainer}
 
-	if workingDir := makeWorkingDirInitializer(images.ShellImage, taskSpec.Steps); workingDir != nil {
-		initSteps = append(initSteps, *workingDir)
+	if workingDirInit := pod.WorkingDirInit(images.ShellImage, taskSpec.Steps); workingDirInit != nil {
+		initContainers = append(initContainers, *workingDirInit)
 	}
+
+	var podSteps []v1alpha1.Step
 
 	maxIndicesByResource := findMaxResourceRequest(taskSpec.Steps, corev1.ResourceCPU, corev1.ResourceMemory, corev1.ResourceEphemeralStorage)
 
 	placeScripts := false
-	placeScriptsStep := v1alpha1.Step{Container: corev1.Container{
+	placeScriptsInitContainer := corev1.Container{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("place-scripts"),
 		Image:        images.ShellImage,
 		TTY:          true,
 		Command:      []string{"sh"},
 		Args:         []string{"-c", ""},
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
-	}}
+	}
 
 	for i, s := range taskSpec.Steps {
 		s.Env = append(implicitEnvVars, s.Env...)
@@ -297,7 +254,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 			// interpreted as env vars and likely end up replaced
 			// with empty strings. See
 			// https://stackoverflow.com/a/27921346
-			placeScriptsStep.Args[1] += fmt.Sprintf(`tmpfile="%s"
+			placeScriptsInitContainer.Args[1] += fmt.Sprintf(`tmpfile="%s"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << '%s'
 %s
@@ -333,8 +290,11 @@ cat > ${tmpfile} << '%s'
 		}
 		// use the container name to add the entrypoint binary as an
 		// init container.
+		// TODO(jasonhall): Entrypoint init container should be
+		// explicitly added as an init container, not added to steps
+		// then pulled out when translating to Pod containers.
 		if s.Name == names.SimpleNameGenerator.RestrictLength(fmt.Sprintf("%v%v", containerPrefix, entrypoint.InitContainerName)) {
-			initSteps = append(initSteps, s)
+			initContainers = append(initContainers, s.Container)
 		} else {
 			zeroNonMaxResourceRequests(&s, i, maxIndicesByResource)
 			podSteps = append(podSteps, s)
@@ -352,7 +312,7 @@ cat > ${tmpfile} << '%s'
 	// a script.
 	if placeScripts {
 		volumes = append(volumes, scriptsVolume)
-		initSteps = append(initSteps, placeScriptsStep)
+		initContainers = append(initContainers, placeScriptsInitContainer)
 	}
 
 	if err := v1alpha1.ValidateVolumes(volumes); err != nil {
@@ -366,14 +326,6 @@ cat > ${tmpfile} << '%s'
 	}
 	gibberish := hex.EncodeToString(b)
 
-	mergedInitSteps, err := v1alpha1.MergeStepsWithStepTemplate(taskSpec.StepTemplate, initSteps)
-	if err != nil {
-		return nil, err
-	}
-	var mergedInitContainers []corev1.Container
-	for _, s := range mergedInitSteps {
-		mergedInitContainers = append(mergedInitContainers, s.Container)
-	}
 	mergedPodSteps, err := v1alpha1.MergeStepsWithStepTemplate(taskSpec.StepTemplate, podSteps)
 	if err != nil {
 		return nil, err
@@ -406,7 +358,7 @@ cat > ${tmpfile} << '%s'
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:      corev1.RestartPolicyNever,
-			InitContainers:     mergedInitContainers,
+			InitContainers:     initContainers,
 			Containers:         mergedPodContainers,
 			ServiceAccountName: taskRun.GetServiceAccountName(),
 			Volumes:            volumes,

--- a/pkg/reconciler/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/taskrun/resources/pod_test.go
@@ -108,14 +108,14 @@ func TestTryGetPod(t *testing.T) {
 func TestMakePod(t *testing.T) {
 	names.TestingSeed()
 
-	implicitVolumeMountsWithSecrets := append(implicitVolumeMounts, corev1.VolumeMount{
+	secretsVolumeMounts := []corev1.VolumeMount{{
 		Name:      "secret-volume-multi-creds-9l9zj",
 		MountPath: "/var/build-secrets/multi-creds",
-	})
-	implicitVolumesWithSecrets := append(implicitVolumes, corev1.Volume{
+	}}
+	secretsVolumes := []corev1.Volume{{
 		Name:         "secret-volume-multi-creds-9l9zj",
 		VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "multi-creds"}},
-	})
+	}}
 
 	runtimeClassName := "gvisor"
 
@@ -149,7 +149,6 @@ func TestMakePod(t *testing.T) {
 				Args:         []string{},
 				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
@@ -191,9 +190,8 @@ func TestMakePod(t *testing.T) {
 					"-basic-git=multi-creds=github.com",
 					"-basic-git=multi-creds=gitlab.com",
 				},
+				VolumeMounts: append(implicitVolumeMounts, secretsVolumeMounts...),
 				Env:          implicitEnvVars,
-				VolumeMounts: implicitVolumeMountsWithSecrets,
-				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
@@ -209,7 +207,7 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			}},
-			Volumes: implicitVolumesWithSecrets,
+			Volumes: append(implicitVolumes, secretsVolumes...),
 		},
 	}, {
 		desc: "with-deprecated-service-account",
@@ -235,9 +233,8 @@ func TestMakePod(t *testing.T) {
 					"-basic-git=multi-creds=github.com",
 					"-basic-git=multi-creds=gitlab.com",
 				},
+				VolumeMounts: append(implicitVolumeMounts, secretsVolumeMounts...),
 				Env:          implicitEnvVars,
-				VolumeMounts: implicitVolumeMountsWithSecrets,
-				WorkingDir:   workspaceDir,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
@@ -253,7 +250,7 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			}},
-			Volumes: implicitVolumesWithSecrets,
+			Volumes: append(implicitVolumes, secretsVolumes...),
 		},
 	}, {
 		desc: "with-pod-template",
@@ -280,9 +277,8 @@ func TestMakePod(t *testing.T) {
 				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
-				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Env:          implicitEnvVars,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
@@ -324,9 +320,8 @@ func TestMakePod(t *testing.T) {
 				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
-				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Env:          implicitEnvVars,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-a-very-very-long-character-step-name-to-trigger-max-len",
@@ -362,9 +357,8 @@ func TestMakePod(t *testing.T) {
 				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
-				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Env:          implicitEnvVars,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-ends-with-invalid",
@@ -398,17 +392,14 @@ func TestMakePod(t *testing.T) {
 				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
-				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Env:          implicitEnvVars,
 			}, {
-				Name:         containerPrefix + workingDirInit + "-mz4c7",
-				Image:        shellImage,
-				Command:      []string{"sh"},
-				Args:         []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
-				Env:          implicitEnvVars,
-				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Name:       "working-dir-initializer-mz4c7",
+				Image:      shellImage,
+				Command:    []string{"sh"},
+				Args:       []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
+				WorkingDir: workspaceDir,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
@@ -445,9 +436,8 @@ func TestMakePod(t *testing.T) {
 				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
-				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Env:          implicitEnvVars,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-primary-name",
@@ -502,9 +492,8 @@ print("Hello from Python")`,
 				Image:        credsImage,
 				Command:      []string{"/ko-app/creds-init"},
 				Args:         []string{},
-				Env:          implicitEnvVars,
 				VolumeMounts: implicitVolumeMounts,
-				WorkingDir:   workspaceDir,
+				Env:          implicitEnvVars,
 			}, {
 				Name:    "place-scripts-mz4c7",
 				Image:   images.ShellImage,
@@ -600,8 +589,8 @@ script-heredoc-randomly-generated-j2tds
 				t.Errorf("Pod name got %q, want %q", got.Name, wantName)
 			}
 
-			if d := cmp.Diff(&got.Spec, c.want, resourceQuantityCmp); d != "" {
-				t.Errorf("Diff spec:\n%s", d)
+			if d := cmp.Diff(c.want, &got.Spec, resourceQuantityCmp); d != "" {
+				t.Errorf("Diff(-want, +got):\n%s", d)
 			}
 
 			wantAnnotations := map[string]string{ReadyAnnotation: ""}
@@ -719,32 +708,6 @@ func TestMakeAnnotations(t *testing.T) {
 				if receivedValue != v {
 					t.Errorf("expected annotation %q=%q, received %q=%q", k, v, k, receivedValue)
 				}
-			}
-		})
-	}
-}
-
-func TestMakeWorkingDirScript(t *testing.T) {
-	for _, c := range []struct {
-		desc        string
-		workingDirs map[string]bool
-		want        string
-	}{{
-		desc:        "default",
-		workingDirs: map[string]bool{"/workspace": true},
-		want:        "",
-	}, {
-		desc:        "simple",
-		workingDirs: map[string]bool{"/workspace/foo": true, "/workspace/bar": true, "/baz": true},
-		want:        "mkdir -p /workspace/bar /workspace/foo",
-	}, {
-		desc:        "empty",
-		workingDirs: map[string]bool{"/workspace": true, "": true, "/baz": true, "/workspacedir": true},
-		want:        "",
-	}} {
-		t.Run(c.desc, func(t *testing.T) {
-			if script := makeWorkingDirScript(c.workingDirs); script != c.want {
-				t.Errorf("Expected `%v`, got `%v`", c.want, script)
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -207,7 +207,6 @@ var (
 	getCredentialsInitContainer = func(suffix string, ops ...tb.ContainerOp) tb.PodSpecOp {
 		actualOps := []tb.ContainerOp{
 			tb.Command("/ko-app/creds-init"),
-			tb.WorkingDir(workspaceDir),
 			tb.EnvVar("HOME", "/builder/home"),
 			tb.VolumeMount("workspace", workspaceDir),
 			tb.VolumeMount("home", "/builder/home"),
@@ -1118,8 +1117,8 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj", tb.EnvVar("FRUIT", "APPLE")),
-				getPlaceToolsInitContainer(tb.EnvVar("FRUIT", "APPLE")),
+				getCredentialsInitContainer("9l9zj"),
+				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-env-step", "foo", tb.Command(entrypointLocation),
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/builder/downward/ready", "-post_file", "/builder/tools/0", "-wait_file_content", "-entrypoint", "/mycmd", "--"),


### PR DESCRIPTION
This simplifies pod.go and makes this logic more easily
testable/understandable in isolation, as part of an overall plan to simplify pod.go.

This also removes stepTemplate merging from init containers, where users
shouldn't know/care about the details of those containers anyway.

This makes some simplifying changes to creds-init as well, and adds
TODOs to further simplify.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

cc @dicarlo2 