### PR TITLE
Move creds-init to pkg/pod

### DIFF
--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/credentials"
+	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
+	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
+	"github.com/tektoncd/pipeline/pkg/names"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name of the credential initialization container.
+	credsInit = "credential-initializer"
+)
+
+func CredsInit(credsImage string, serviceAccountName, namespace string, kubeclient kubernetes.Interface, volumeMounts []corev1.VolumeMount, implicitEnvVars []corev1.EnvVar) (*corev1.Container, []corev1.Volume, error) {
+	if serviceAccountName == "" {
+		serviceAccountName = "default"
+	}
+
+	sa, err := kubeclient.CoreV1().ServiceAccounts(namespace).Get(serviceAccountName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	builders := []credentials.Builder{dockercreds.NewBuilder(), gitcreds.NewBuilder()}
+
+	var volumes []corev1.Volume
+	args := []string{}
+	for _, secretEntry := range sa.Secrets {
+		secret, err := kubeclient.CoreV1().Secrets(namespace).Get(secretEntry.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		matched := false
+		for _, b := range builders {
+			if sa := b.MatchingAnnotations(secret); len(sa) > 0 {
+				matched = true
+				args = append(args, sa...)
+			}
+		}
+
+		if matched {
+			name := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("secret-volume-%s", secret.Name))
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      name,
+				MountPath: credentials.VolumeName(secret.Name),
+			})
+			volumes = append(volumes, corev1.Volume{
+				Name: name,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: secret.Name,
+					},
+				},
+			})
+		}
+	}
+
+	if len(args) == 0 {
+		// There are no creds to initialize.
+		return nil, nil, nil
+	}
+
+	return &corev1.Container{
+		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(credsInit),
+		Image:        credsImage,
+		Command:      []string{"/ko-app/creds-init"},
+		Args:         args,
+		Env:          implicitEnvVars,
+		VolumeMounts: volumeMounts,
+	}, volumes, nil
+}

--- a/pkg/pod/creds_init_test.go
+++ b/pkg/pod/creds_init_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/test/names"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	credsImage         = "creds-image"
+	serviceAccountName = "my-service-account"
+	namespace          = "namespacey-mcnamespace"
+)
+
+func TestCredsInit(t *testing.T) {
+	volumeMounts := []corev1.VolumeMount{{
+		Name: "implicit-volume-mount",
+	}}
+	envVars := []corev1.EnvVar{{
+		Name:  "FOO",
+		Value: "bar",
+	}}
+
+	for _, c := range []struct {
+		desc string
+		want *corev1.Container
+		objs []runtime.Object
+	}{{
+		desc: "service account exists with no secrets; nothing to initialize",
+		objs: []runtime.Object{
+			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: namespace}},
+		},
+		want: nil,
+	}, {
+		desc: "service account has no annotated secrets; nothing to initialize",
+		objs: []runtime.Object{
+			&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: namespace},
+				Secrets: []corev1.ObjectReference{{
+					Name: "my-creds",
+				}},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "my-creds",
+					Namespace:   namespace,
+					Annotations: map[string]string{
+						// No matching annotations.
+					},
+				},
+			},
+		},
+		want: nil,
+	}, {
+		desc: "service account has annotated secret; initialize creds",
+		objs: []runtime.Object{
+			&corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: namespace},
+				Secrets: []corev1.ObjectReference{{
+					Name: "my-creds",
+				}},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-creds",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"tekton.dev/docker-0": "https://us.gcr.io",
+						"tekton.dev/docker-1": "https://docker.io",
+						"tekton.dev/git-0":    "github.com",
+						"tekton.dev/git-1":    "gitlab.com",
+					},
+				},
+				Type: "kubernetes.io/basic-auth",
+				Data: map[string][]byte{
+					"username": []byte("foo"),
+					"password": []byte("BestEver"),
+				},
+			},
+		},
+		want: &corev1.Container{
+			Name:    "credential-initializer-mz4c7",
+			Image:   credsImage,
+			Command: []string{"/ko-app/creds-init"},
+			Args: []string{
+				"-basic-docker=my-creds=https://docker.io",
+				"-basic-docker=my-creds=https://us.gcr.io",
+				"-basic-git=my-creds=github.com",
+				"-basic-git=my-creds=gitlab.com",
+			},
+			Env: envVars,
+			VolumeMounts: append(volumeMounts, corev1.VolumeMount{
+				Name:      "secret-volume-my-creds-9l9zj",
+				MountPath: "/var/build-secrets/my-creds",
+			}),
+		},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			names.TestingSeed()
+			kubeclient := fakek8s.NewSimpleClientset(c.objs...)
+			got, volumes, err := CredsInit(credsImage, serviceAccountName, namespace, kubeclient, volumeMounts, envVars)
+			if err != nil {
+				t.Fatalf("CredsInit: %v", err)
+			}
+			if got == nil && len(volumes) > 0 {
+				t.Errorf("Got nil creds-init container, with non-empty volumes: %v", volumes)
+			}
+			if d := cmp.Diff(c.want, got); d != "" {
+				t.Fatalf("Diff(-want, +got): %s", d)
+			}
+		})
+	}
+}

--- a/pkg/pod/doc.go
+++ b/pkg/pod/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pod provides methods for converting between a TaskRun and a Pod.
+package pod

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pod
 
 import (
@@ -54,6 +70,7 @@ func WorkingDirInit(shellImage string, steps []v1alpha1.Step) *corev1.Container 
 	}
 
 	if len(relativeDirs) == 0 {
+		// There are no workingDirs to initialize.
 		return nil
 	}
 

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pod
 
 import (

--- a/pkg/reconciler/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/taskrun/resources/pod_test.go
@@ -78,14 +78,6 @@ func TestMakePod(t *testing.T) {
 		},
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				Env:          implicitEnvVars,
-				VolumeMounts: implicitVolumeMounts,
-			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
 				Image:        "image",
@@ -117,7 +109,7 @@ func TestMakePod(t *testing.T) {
 			ServiceAccountName: "service-account",
 			RestartPolicy:      corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:    containerPrefix + credsInit + "-mz4c7",
+				Name:    "credential-initializer-mz4c7",
 				Image:   credsImage,
 				Command: []string{"/ko-app/creds-init"},
 				Args: []string{
@@ -143,7 +135,7 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			}},
-			Volumes: append(implicitVolumes, secretsVolumes...),
+			Volumes: append(secretsVolumes, implicitVolumes...),
 		},
 	}, {
 		desc: "with-deprecated-service-account",
@@ -160,7 +152,7 @@ func TestMakePod(t *testing.T) {
 			ServiceAccountName: "service-account",
 			RestartPolicy:      corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:    containerPrefix + credsInit + "-mz4c7",
+				Name:    "credential-initializer-mz4c7",
 				Image:   credsImage,
 				Command: []string{"/ko-app/creds-init"},
 				Args: []string{
@@ -186,7 +178,7 @@ func TestMakePod(t *testing.T) {
 					},
 				},
 			}},
-			Volumes: append(implicitVolumes, secretsVolumes...),
+			Volumes: append(secretsVolumes, implicitVolumes...),
 		},
 	}, {
 		desc: "with-pod-template",
@@ -208,14 +200,6 @@ func TestMakePod(t *testing.T) {
 		},
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				VolumeMounts: implicitVolumeMounts,
-				Env:          implicitEnvVars,
-			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",
 				Image:        "image",
@@ -251,14 +235,6 @@ func TestMakePod(t *testing.T) {
 		},
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				VolumeMounts: implicitVolumeMounts,
-				Env:          implicitEnvVars,
-			}},
 			Containers: []corev1.Container{{
 				Name:         "step-a-very-very-long-character-step-name-to-trigger-max-len",
 				Image:        "image",
@@ -288,14 +264,6 @@ func TestMakePod(t *testing.T) {
 		},
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				VolumeMounts: implicitVolumeMounts,
-				Env:          implicitEnvVars,
-			}},
 			Containers: []corev1.Container{{
 				Name:         "step-ends-with-invalid",
 				Image:        "image",
@@ -324,14 +292,7 @@ func TestMakePod(t *testing.T) {
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				VolumeMounts: implicitVolumeMounts,
-				Env:          implicitEnvVars,
-			}, {
-				Name:       "working-dir-initializer-mz4c7",
+				Name:       "working-dir-initializer-9l9zj",
 				Image:      shellImage,
 				Command:    []string{"sh"},
 				Args:       []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
@@ -367,14 +328,6 @@ func TestMakePod(t *testing.T) {
 		},
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				VolumeMounts: implicitVolumeMounts,
-				Env:          implicitEnvVars,
-			}},
 			Containers: []corev1.Container{{
 				Name:         "step-primary-name",
 				Image:        "primary-image",
@@ -424,28 +377,21 @@ print("Hello from Python")`,
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:         containerPrefix + credsInit + "-9l9zj",
-				Image:        credsImage,
-				Command:      []string{"/ko-app/creds-init"},
-				Args:         []string{},
-				VolumeMounts: implicitVolumeMounts,
-				Env:          implicitEnvVars,
-			}, {
-				Name:    "place-scripts-mz4c7",
+				Name:    "place-scripts-9l9zj",
 				Image:   images.ShellImage,
 				Command: []string{"sh"},
 				TTY:     true,
-				Args: []string{"-c", `tmpfile="/builder/scripts/script-0-mssqb"
+				Args: []string{"-c", `tmpfile="/builder/scripts/script-0-mz4c7"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-78c5n'
+cat > ${tmpfile} << 'script-heredoc-randomly-generated-mssqb'
 echo hello from step one
-script-heredoc-randomly-generated-78c5n
-tmpfile="/builder/scripts/script-1-6nl7g"
+script-heredoc-randomly-generated-mssqb
+tmpfile="/builder/scripts/script-1-78c5n"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-j2tds'
+cat > ${tmpfile} << 'script-heredoc-randomly-generated-6nl7g'
 #!/usr/bin/env python
 print("Hello from Python")
-script-heredoc-randomly-generated-j2tds
+script-heredoc-randomly-generated-6nl7g
 `},
 				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 			}},
@@ -453,7 +399,7 @@ script-heredoc-randomly-generated-j2tds
 				Name:         "step-one",
 				Image:        "image",
 				Command:      []string{"entrypointer"},
-				Args:         []string{"wait-file", "out-file", "-entrypoint", "/builder/scripts/script-0-mssqb"},
+				Args:         []string{"wait-file", "out-file", "-entrypoint", "/builder/scripts/script-0-mz4c7"},
 				Env:          implicitEnvVars,
 				VolumeMounts: append(implicitVolumeMounts, scriptsVolumeMount),
 				WorkingDir:   workspaceDir,
@@ -468,7 +414,7 @@ script-heredoc-randomly-generated-j2tds
 				Name:         "step-two",
 				Image:        "image",
 				Command:      []string{"entrypointer"},
-				Args:         []string{"wait-file", "out-file", "-entrypoint", "/builder/scripts/script-1-6nl7g"},
+				Args:         []string{"wait-file", "out-file", "-entrypoint", "/builder/scripts/script-1-78c5n"},
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{{Name: "i-have-a-volume-mount"}}, append(implicitVolumeMounts, scriptsVolumeMount)...),
 				WorkingDir:   workspaceDir,

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -206,19 +206,6 @@ var (
 		},
 	}
 
-	getCredentialsInitContainer = func(suffix string, ops ...tb.ContainerOp) tb.PodSpecOp {
-		actualOps := []tb.ContainerOp{
-			tb.Command("/ko-app/creds-init"),
-			tb.EnvVar("HOME", "/builder/home"),
-			tb.VolumeMount("workspace", workspaceDir),
-			tb.VolumeMount("home", "/builder/home"),
-		}
-
-		actualOps = append(actualOps, ops...)
-
-		return tb.PodInitContainer("step-credential-initializer-"+suffix, "override-with-creds:latest", actualOps...)
-	}
-
 	getMkdirResourceContainer = func(name, dir, suffix string, ops ...tb.ContainerOp) tb.PodSpecOp {
 		actualOps := []tb.ContainerOp{
 			tb.Command("/builder/tools/entrypoint"),
@@ -320,7 +307,6 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 				tb.PodServiceAccountName(defaultSAName),
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
@@ -353,7 +339,6 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 				tb.PodServiceAccountName("test-sa"),
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-sa-step", "foo",
 					tb.Command(entrypointLocation),
@@ -609,7 +594,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
@@ -642,7 +626,6 @@ func TestReconcile(t *testing.T) {
 				tb.PodServiceAccountName("test-sa"),
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-sa-step", "foo",
 					tb.Command(entrypointLocation),
@@ -675,7 +658,6 @@ func TestReconcile(t *testing.T) {
 				tb.PodServiceAccountName("test-deprecated-sa"),
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-sa-step", "foo",
 					tb.Command(entrypointLocation),
@@ -716,7 +698,6 @@ func TestReconcile(t *testing.T) {
 					},
 				}, toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("78c5n"),
 				getPlaceToolsInitContainer(),
 				getMkdirResourceContainer("myimage", "/workspace/output/myimage", "mssqb"),
 				tb.PodContainer("step-git-source-git-resource-mz4c7", "override-with-git:latest",
@@ -805,7 +786,6 @@ func TestReconcile(t *testing.T) {
 					},
 				}, toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("l22wn"),
 				getPlaceToolsInitContainer(),
 				getMkdirResourceContainer("git-resource", "/workspace/output/git-resource", "6nl7g"),
 				tb.PodContainer("step-create-dir-git-resource-78c5n", "busybox",
@@ -924,7 +904,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("mz4c7"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-git-source-git-resource-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
@@ -973,7 +952,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
@@ -1004,7 +982,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("mz4c7"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-git-source-workspace-9l9zj", "override-with-git:latest",
 					tb.Command(entrypointLocation),
@@ -1054,7 +1031,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
@@ -1087,7 +1063,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),
@@ -1119,7 +1094,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-env-step", "foo", tb.Command(entrypointLocation),
 					tb.Command(entrypointLocation),
@@ -1152,7 +1126,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-step1", "foo",
 					tb.Command(entrypointLocation),
@@ -1221,7 +1194,6 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodVolumes(toolsVolume, downward, workspaceVolume, homeVolume),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
-				getCredentialsInitContainer("9l9zj"),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
 					tb.Command(entrypointLocation),


### PR DESCRIPTION
This simplifies pod.go and makes this logic more easily
testable/understandable in isolation, as part of an overall plan to simplify pod.go.

This change also avoids running creds-init when there are no credentials
to initialize. Previously, we would unconditionally run the creds-init
image, and just pass it zero args if there were no creds, in which case
it would exit immediately.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
