### PR TITLE
Allow Resources to be Optional in Task, ClusterTask, and Condition

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -16,6 +16,12 @@ For example:
 --------------------------------------------------------------------------------
 
 -   [Syntax](#syntax)
+-   [Using Resources](#using-resources)
+    - [Variable substitution](#variable-substitution)
+    - [Controlling where resources are mounted](#controlling-where-resources-are-mounted)
+    - [Overriding where resources are copied from](#overriding-where-resources-are-copied-from)
+    - [Resource Status](#resource-status)
+    - [Optional Resources](#optional-resources)
 -   [Resource types](#resource-types)
     -   [Git Resource](#git-resource)
     -   [Pull Request Resource](#pull-request-resource)
@@ -25,7 +31,6 @@ For example:
         -   [GCS Storage Resource](#gcs-storage-resource)
         -   [BuildGCS Storage Resource](#buildgcs-storage-resource)
     -   [Cloud Event Resource](#cloud-event-resource)
--   [Using Resources](#using-resources)
 
 ## Syntax
 
@@ -46,6 +51,8 @@ following fields:
 -   Optional:
     -   [`params`](#resource-types) - Parameters which are specific to each type
         of `PipelineResource`
+    -   [`optional`](#optional-resources) - Boolean flag to mark a resource optional
+        (by default, `optional` is set to `false` making resources mandatory).
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -217,6 +224,30 @@ resourcesResult:
   resourceRef:
     name: skaffold-image-leeroy-web
 ```
+
+### Optional Resources
+
+By default, a resource is declared as mandatory unless `optional` is set `true` for that resource.
+Resources declared as `optional` in a `Task` does not have be specified in `TaskRun`.
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-check-optional-resources
+spec:
+  inputs:
+    resources:
+      - name: git-repo
+        type: git
+        optional: true
+```
+
+You can refer to different examples demonstrating usage of optional resources in `Task` and `Condition`:
+
+- [Task](../examples/taskruns/optional-resources.yaml)
+- [Cluster Task](../examples/taskruns/optional-resources-with-clustertask.yaml)
+- [Condition](../examples/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml)
 
 ## Resource Types
 

--- a/examples/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml
+++ b/examples/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml
@@ -1,0 +1,88 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: verify-no-file-exists-without-resource
+spec:
+  params:
+    - name: "path"
+  resources:
+    - name: optional-workspace
+      type: git
+      optional: true
+  check:
+    image: alpine
+    command: ["/bin/sh"]
+    args: ['-c', 'test ! -f $(resources.optional-workspace.path)/$(params.path)']
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: pipeline-git-repo
+spec:
+  type: git
+  params:
+    - name: revision
+      value: master
+    - name: url
+      value: https://github.com/tektoncd/pipeline
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: list-pipeline-repo-files
+spec:
+  inputs:
+    resources:
+      - name: optional-workspace
+        type: git
+        optional: true
+  steps:
+    - name: run-ls
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        ls -al $(inputs.resources.optional-workspace.path)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: pipeline-list-pipeline-repo-files
+spec:
+  resources:
+    - name: pipeline-source-repo
+      type: git
+  params:
+    - name: "path"
+      default: "README.md"
+  tasks:
+    - name: list-pipeline-repo-files-1
+      taskRef:
+        name: list-pipeline-repo-files
+      conditions:
+        - conditionRef: "verify-no-file-exists-without-resource"
+          params:
+            - name: "path"
+              value: "$(params.path)"
+# NOTE: Resource "optional-workspace" is declared as optional in Condition
+# No resource specified for the condition here since its optional
+# "DO NOT UNCOMMENT THE FOLLOWING RESOURCE"
+#          resources:
+#            - name: optional-workspace
+#              resource: pipeline-source-repo
+      resources:
+        inputs:
+          - name: optional-workspace
+            resource: pipeline-source-repo
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: demo-condtional-pr-without-condition-resource
+spec:
+  pipelineRef:
+    name: pipeline-list-pipeline-repo-files
+  serviceAccountName: 'default'
+  resources:
+    - name: pipeline-source-repo
+      resourceRef:
+        name: pipeline-git-repo

--- a/examples/taskruns/optional-resources-with-clustertask.yaml
+++ b/examples/taskruns/optional-resources-with-clustertask.yaml
@@ -1,0 +1,35 @@
+apiVersion: tekton.dev/v1alpha1
+kind: ClusterTask
+metadata:
+  name: clustertask-with-optional-resources
+spec:
+  inputs:
+    resources:
+      - name: git-repo
+        type: git
+        optional: true
+    params:
+      - name: filename
+        type: string
+        default: "README.md"
+  outputs:
+    resources:
+      - name: optionalimage
+        type: image
+        optional: true
+  steps:
+    - name: task-echo-success
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        echo "success"
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: clustertask-without-resources
+spec:
+  taskRef:
+    name: clustertask-with-optional-resources
+    kind: ClusterTask

--- a/examples/taskruns/optional-resources.yaml
+++ b/examples/taskruns/optional-resources.yaml
@@ -1,0 +1,131 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: task-check-optional-resources
+spec:
+  inputs:
+    resources:
+      - name: git-repo
+        type: git
+        optional: true
+    params:
+      - name: filename
+        type: string
+        default: "README.md"
+  outputs:
+    resources:
+      - name: optionalimage
+        type: image
+        optional: true
+  steps:
+    - name: check-git-repo
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        if [ -d $(inputs.resources.git-repo.path) ]; then
+          echo "Git repo was cloned at $(inputs.resources.git-repo.path)"
+          if [ -f $(inputs.resources.git-repo.path)/$(inputs.params.filename) ]; then
+            echo "$(inputs.params.filename) does exist at $(inputs.resources.git-repo.path)"
+          else
+            echo "$(inputs.params.filename) does not exist at $(inputs.resources.git-repo.path)"
+          fi
+        else
+          echo "Git repo was not cloned at $(inputs.resources.git-repo.path)"
+        fi
+        if [ "$(outputs.resources.optionalimage.url)" == "" ]; then
+          echo "Image URL: $(outputs.resources.optionalimage.url)"
+        else
+          echo "No image URL specified."
+        fi
+        echo "Yay, Input and Output Resources can be Optional!"
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: demo-optional-inputs-resources-with-resources
+spec:
+  inputs:
+    resources:
+      - name: git-repo
+        resourceSpec:
+          type: git
+          params:
+            - name: url
+              value: https://github.com/tektoncd/pipeline.git
+    params:
+      - name: filename
+        value: "README.md"
+  outputs:
+    resources:
+      - name: optionalimage
+        resourceSpec:
+          type: image
+          params:
+            - name: url
+              value: gcr.io/foo/bar
+  taskRef:
+    name: task-check-optional-resources
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: demo-optional-inputs-resources-invalid-filename
+spec:
+  inputs:
+    resources:
+      - name: git-repo
+        resourceSpec:
+          type: git
+          params:
+            - name: url
+              value: https://github.com/tektoncd/pipeline.git
+    params:
+      - name: filename
+        value: "invalid.md"
+  taskRef:
+    name: task-check-optional-resources
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: demo-optional-inputs-resources-without-resources
+spec:
+  inputs:
+    params:
+      - name: filename
+        value: "README.md"
+  taskRef:
+    name: task-check-optional-resources
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: demo-optional-inputs-resources-without-resources-and-params
+spec:
+  taskRef:
+    name: task-check-optional-resources
+---
+
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: demo-optional-outputs-resources-with-input-resources
+spec:
+  inputs:
+    resources:
+      - name: git-repo
+        resourceSpec:
+          type: git
+          params:
+            - name: url
+              value: https://github.com/tektoncd/pipeline.git
+    params:
+      - name: filename
+        value: "README.md"
+  taskRef:
+    name: task-check-optional-resources
+---

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -209,7 +209,7 @@ type PipelineResourceList struct {
 type ResourceDeclaration = v1alpha2.ResourceDeclaration
 
 // ResourceFromType returns an instance of the correct PipelineResource object type which can be
-// used to add input and ouput containers as well as volumes to a TaskRun's pod in order to realize
+// used to add input and output containers as well as volumes to a TaskRun's pod in order to realize
 // a PipelineResource in a pod.
 func ResourceFromType(r *PipelineResource, images pipeline.Images) (PipelineResourceInterface, error) {
 	switch r.Spec.Type {

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -49,6 +49,22 @@ var invalidResource = v1alpha1.TaskResource{
 	},
 }
 
+var optionalResource = v1alpha1.TaskResource{
+	ResourceDeclaration: v1alpha1.ResourceDeclaration{
+		Name:     "source",
+		Type:     "git",
+		Optional: true,
+	},
+}
+
+var requiredResource = v1alpha1.TaskResource{
+	ResourceDeclaration: v1alpha1.ResourceDeclaration{
+		Name:     "source",
+		Type:     "git",
+		Optional: false,
+	},
+}
+
 var validSteps = []v1alpha1.Step{{Container: corev1.Container{
 	Name:  "mystep",
 	Image: "myimage",
@@ -106,6 +122,22 @@ func TestTaskSpecValidate(t *testing.T) {
 			Steps: validSteps,
 		},
 	}, {
+		name: "valid inputs (required)",
+		fields: fields{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{requiredResource},
+			},
+			Steps: validSteps,
+		},
+	}, {
+		name: "valid inputs (optional)",
+		fields: fields{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{optionalResource},
+			},
+			Steps: validSteps,
+		},
+	}, {
 		name: "valid outputs",
 		fields: fields{
 			Outputs: &v1alpha1.Outputs{
@@ -132,6 +164,22 @@ func TestTaskSpecValidate(t *testing.T) {
 			},
 			Outputs: &v1alpha1.Outputs{
 				Resources: []v1alpha1.TaskResource{validImageResource},
+			},
+			Steps: validSteps,
+		},
+	}, {
+		name: "valid outputs (required)",
+		fields: fields{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{requiredResource},
+			},
+			Steps: validSteps,
+		},
+	}, {
+		name: "valid outputs (optional)",
+		fields: fields{
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{optionalResource},
 			},
 			Steps: validSteps,
 		},

--- a/pkg/apis/pipeline/v1alpha2/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha2/resource_types.go
@@ -94,6 +94,11 @@ type ResourceDeclaration struct {
 	// will be copied.
 	// +optional
 	TargetPath string `json:"targetPath,omitempty"`
+	// Optional declares the resource as optional.
+	// By default optional is set to false which makes a resource required.
+	// optional: true - the resource is considered optional
+	// optional: false - the resource is considered required (equivalent of not specifying it)
+	Optional bool `json:"optional,omitempty"`
 }
 
 // TaskModifier is an interface to be implemented by different PipelineResources

--- a/pkg/reconciler/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/taskrun/resources/input_resources.go
@@ -75,7 +75,12 @@ func AddInputResource(
 	for i := len(taskSpec.Inputs.Resources) - 1; i >= 0; i-- {
 		input := taskSpec.Inputs.Resources[i]
 		boundResource, err := getBoundResource(input.Name, taskRun.Spec.Inputs.Resources)
-		if err != nil {
+		// Continue if the declared resource is optional and not specified in TaskRun
+		// boundResource is nil if the declared resource in Task does not have any resource specified in the TaskRun
+		if input.Optional && boundResource == nil {
+			continue
+		} else if err != nil {
+			// throw an error for required resources, if not specified in the TaskRun
 			return nil, fmt.Errorf("failed to get bound resource: %w", err)
 		}
 		resource, ok := inputResources[boundResource.Name]

--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -67,10 +67,14 @@ func AddOutputResources(
 	needsPvc := false
 	for _, output := range taskSpec.Outputs.Resources {
 		boundResource, err := getBoundResource(output.Name, taskRun.Spec.Outputs.Resources)
-		if err != nil {
+		// Continue if the declared resource is optional and not specified in TaskRun
+		// boundResource is nil if the declared resource in Task does not have any resource specified in the TaskRun
+		if output.Optional && boundResource == nil {
+			continue
+		} else if err != nil {
+			// throw an error for required resources, if not specified in the TaskRun
 			return nil, fmt.Errorf("failed to get bound resource: %w", err)
 		}
-
 		resource, ok := outputResources[boundResource.Name]
 		if !ok || resource == nil {
 			return nil, fmt.Errorf("failed to get output pipeline Resource for task %q resource %v", taskName, boundResource)

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -1147,7 +1147,7 @@ func TestInvalidOutputResources(t *testing.T) {
 		},
 		wantErr: false,
 	}, {
-		desc: "no outputs defined in tasktun but defined in task",
+		desc: "no outputs defined in taskrun but defined in task",
 		task: &v1alpha1.Task{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "task1",
@@ -1207,6 +1207,62 @@ func TestInvalidOutputResources(t *testing.T) {
 							Type: "storage",
 						}}},
 				},
+			},
+		},
+		wantErr: true,
+	}, {
+		desc: "optional outputs declared",
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{ResourceDeclaration: v1alpha1.ResourceDeclaration{
+						Name:     "source-workspace",
+						Type:     "git",
+						Optional: true,
+					}}},
+				},
+			},
+		},
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-optional-output",
+				Namespace: "marshmallow",
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind: "PipelineRun",
+					Name: "pipelinerun",
+				}},
+			},
+		},
+		wantErr: false,
+	}, {
+		desc: "required outputs declared",
+		task: &v1alpha1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "task1",
+				Namespace: "marshmallow",
+			},
+			Spec: v1alpha1.TaskSpec{
+				Outputs: &v1alpha1.Outputs{
+					Resources: []v1alpha1.TaskResource{{ResourceDeclaration: v1alpha1.ResourceDeclaration{
+						Name:     "source-workspace",
+						Type:     "git",
+						Optional: false,
+					}}},
+				},
+			},
+		},
+		taskRun: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-taskrun-run-required-output",
+				Namespace: "marshmallow",
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind: "PipelineRun",
+					Name: "pipelinerun",
+				}},
 			},
 		},
 		wantErr: true,

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -29,14 +29,27 @@ func TestValidateResolvedTaskResources_ValidResources(t *testing.T) {
 	rtr := tb.ResolvedTaskResources(
 		tb.ResolvedTaskResourcesTaskSpec(
 			tb.Step("mystep", "myimage", tb.StepCommand("mycmd")),
-			tb.TaskInputs(tb.InputsResource("resource-to-build", v1alpha1.PipelineResourceTypeGit)),
-			tb.TaskOutputs(tb.OutputsResource("resource-to-provide", v1alpha1.PipelineResourceTypeImage)),
+			tb.TaskInputs(
+				tb.InputsResource("resource-to-build", v1alpha1.PipelineResourceTypeGit),
+				tb.InputsResource("optional-resource-to-build", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true)),
+			),
+			tb.TaskOutputs(
+				tb.OutputsResource("resource-to-provide", v1alpha1.PipelineResourceTypeImage),
+				tb.OutputsResource("optional-resource-to-provide", v1alpha1.PipelineResourceTypeImage, tb.ResourceOptional(true)),
+			),
 		),
 		tb.ResolvedTaskResourcesInputs("resource-to-build", tb.PipelineResource("example-resource", "foo",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("foo", "bar"),
 			))),
+		tb.ResolvedTaskResourcesInputs("optional-resource-to-build", tb.PipelineResource("example-resource", "foo",
+			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
+				tb.PipelineResourceSpecParam("foo", "bar"),
+			))),
 		tb.ResolvedTaskResourcesOutputs("resource-to-provide", tb.PipelineResource("example-image", "bar",
+			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage)),
+		),
+		tb.ResolvedTaskResourcesOutputs("optional-resource-to-provide", tb.PipelineResource("example-image", "bar",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage)),
 		))
 	if err := taskrun.ValidateResolvedTaskResources([]v1alpha1.Param{}, rtr); err != nil {
@@ -164,6 +177,26 @@ func TestValidateResolvedTaskResources_InvalidResources(t *testing.T) {
 			tb.TaskInputs(tb.InputsResource("testinput", v1alpha1.PipelineResourceTypeGit))),
 			tb.ResolvedTaskResourcesInputs("testinput", r),
 			tb.ResolvedTaskResourcesOutputs("someextraoutput", r),
+		),
+	}, {
+		name: "required-input-resource-missing",
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskInputs(tb.InputsResource("requiredgitinput", v1alpha1.PipelineResourceTypeGit,
+				tb.ResourceOptional(false)))),
+		),
+	}, {
+		name: "required-output-resource-missing",
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskOutputs(tb.OutputsResource("requiredgitoutput", v1alpha1.PipelineResourceTypeGit,
+				tb.ResourceOptional(false)))),
+		),
+	}, {
+		name: "required-input-and-output-resource-missing",
+		rtr: tb.ResolvedTaskResources(tb.ResolvedTaskResourcesTaskSpec(
+			tb.TaskInputs(tb.InputsResource("requiredimageinput", v1alpha1.PipelineResourceTypeImage,
+				tb.ResourceOptional(false))),
+			tb.TaskOutputs(tb.OutputsResource("requiredimageoutput", v1alpha1.PipelineResourceTypeImage,
+				tb.ResourceOptional(false)))),
 		),
 	}}
 

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -239,6 +239,12 @@ func InputsResource(name string, resourceType v1alpha1.PipelineResourceType, ops
 	}
 }
 
+func ResourceOptional(optional bool) TaskResourceOp {
+	return func(r *v1alpha1.TaskResource) {
+		r.Optional = optional
+	}
+}
+
 func ResourceTargetPath(path string) TaskResourceOp {
 	return func(r *v1alpha1.TaskResource) {
 		r.TargetPath = path
@@ -246,13 +252,17 @@ func ResourceTargetPath(path string) TaskResourceOp {
 }
 
 // OutputsResource adds a resource, with specified name and type, to the Outputs.
-func OutputsResource(name string, resourceType v1alpha1.PipelineResourceType) OutputsOp {
+func OutputsResource(name string, resourceType v1alpha1.PipelineResourceType, ops ...TaskResourceOp) OutputsOp {
 	return func(o *v1alpha1.Outputs) {
-		o.Resources = append(o.Resources, v1alpha1.TaskResource{
+		r := &v1alpha1.TaskResource{
 			ResourceDeclaration: v1alpha1.ResourceDeclaration{
 				Name: name,
 				Type: resourceType,
-			}})
+			}}
+		for _, op := range ops {
+			op(r)
+		}
+		o.Resources = append(o.Resources, *r)
 	}
 }
 

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -44,10 +44,14 @@ func TestTask(t *testing.T) {
 	task := tb.Task("test-task", "foo", tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceTargetPath("/foo/bar")),
+			tb.InputsResource("optional_workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true)),
 			tb.InputsParamSpec("param", v1alpha1.ParamTypeString, tb.ParamSpecDescription("mydesc"), tb.ParamSpecDefault("default")),
 			tb.InputsParamSpec("array-param", v1alpha1.ParamTypeString, tb.ParamSpecDescription("desc"), tb.ParamSpecDefault("array", "values")),
 		),
-		tb.TaskOutputs(tb.OutputsResource("myotherimage", v1alpha1.PipelineResourceTypeImage)),
+		tb.TaskOutputs(
+			tb.OutputsResource("myotherimage", v1alpha1.PipelineResourceTypeImage),
+			tb.OutputsResource("myoptionalimage", v1alpha1.PipelineResourceTypeImage, tb.ResourceOptional(true)),
+		),
 		tb.Step("mycontainer", "myimage", tb.StepCommand("/mycmd"), tb.StepArgs(
 			"--my-other-arg=$(inputs.resources.workspace.url)",
 		)),
@@ -73,6 +77,12 @@ func TestTask(t *testing.T) {
 						Name:       "workspace",
 						Type:       v1alpha1.PipelineResourceTypeGit,
 						TargetPath: "/foo/bar",
+					}}, {
+					ResourceDeclaration: v1alpha1.ResourceDeclaration{
+						Name:       "optional_workspace",
+						Type:       v1alpha1.PipelineResourceTypeGit,
+						TargetPath: "",
+						Optional:   true,
 					}}},
 				Params: []v1alpha1.ParamSpec{{
 					Name:        "param",
@@ -90,6 +100,12 @@ func TestTask(t *testing.T) {
 					ResourceDeclaration: v1alpha1.ResourceDeclaration{
 						Name: "myotherimage",
 						Type: v1alpha1.PipelineResourceTypeImage,
+					}}, {
+					ResourceDeclaration: v1alpha1.ResourceDeclaration{
+						Name:       "myoptionalimage",
+						Type:       v1alpha1.PipelineResourceTypeImage,
+						TargetPath: "",
+						Optional:   true,
 					}}},
 			},
 			Volumes: []corev1.Volume{{
@@ -248,6 +264,7 @@ func TestTaskRunWithTaskSpec(t *testing.T) {
 	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
 		tb.TaskRunTaskSpec(
 			tb.Step("step", "image", tb.StepCommand("/mycmd")),
+			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true))),
 		),
 		tb.TaskRunServiceAccountName("sa"),
 		tb.TaskRunTimeout(2*time.Minute),
@@ -265,6 +282,15 @@ func TestTaskRunWithTaskSpec(t *testing.T) {
 					Image:   "image",
 					Command: []string{"/mycmd"},
 				}}},
+				Inputs: &v1alpha1.Inputs{
+					Resources: []v1alpha1.TaskResource{{
+						ResourceDeclaration: v1alpha1.ResourceDeclaration{
+							Name:     "workspace",
+							Type:     v1alpha1.PipelineResourceTypeGit,
+							Optional: true,
+						}}},
+					Params: nil,
+				},
 			},
 			ServiceAccountName: "sa",
 			Status:             v1alpha1.TaskRunSpecStatusCancelled,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Task inputs and outputs are considered required, there is no way
today to mark them optional. This change introduced a new field called
`optional` as part of the `PipelineResourceDeclaration` by default a resource
is required. To mark any resource optional, set `optional` to `true`:

```
apiVersion: tekton.dev/v1alpha1
kind: Task
metadata:
 name: task-check-workspace
spec:
 inputs:
   resources:
     - name: workspace
       type: git
       optional: true
 steps:
   - name: check-workspace
```

These changes apply to `Task`, `ClusterTask` and `Condition` resources.

Closes #812 

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

Introducing a new key called `optional` as part of the `PipelineResourceDeclaration` by default a resource is required (as is - no change in behavior). To mark any resource optional, set `optional` to `true`:

```
apiVersion: tekton.dev/v1alpha1
kind: Task
metadata:
 name: task-check-workspace
spec:
 inputs:
   resources:
     - name: workspace
       type: git
       optional: true
 steps:
   - name: check-workspace
```
