### PR TITLE
Readd mounting volumes in workingdir

### DIFF
--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -41,7 +41,7 @@ const (
 // TODO(jasonhall): This should take []corev1.Container instead of
 // []corev1.Step, but this makes it easier to use in pod.go. When pod.go is
 // cleaned up, this can take []corev1.Container.
-func WorkingDirInit(shellImage string, steps []v1alpha1.Step) *corev1.Container {
+func WorkingDirInit(shellImage string, steps []v1alpha1.Step, volumeMounts []corev1.VolumeMount) *corev1.Container {
 	// Gather all unique workingDirs.
 	workingDirs := map[string]struct{}{}
 	for _, step := range steps {
@@ -75,10 +75,11 @@ func WorkingDirInit(shellImage string, steps []v1alpha1.Step) *corev1.Container 
 	}
 
 	return &corev1.Container{
-		Name:       names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(workingDirInit),
-		Image:      shellImage,
-		Command:    []string{"sh"},
-		Args:       []string{"-c", "mkdir -p " + strings.Join(relativeDirs, " ")},
-		WorkingDir: workspaceDir,
+		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(workingDirInit),
+		Image:        shellImage,
+		Command:      []string{"sh"},
+		Args:         []string{"-c", "mkdir -p " + strings.Join(relativeDirs, " ")},
+		WorkingDir:   workspaceDir,
+		VolumeMounts: volumeMounts,
 	}
 }

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -28,6 +28,14 @@ import (
 const shellImage = "shell-image"
 
 func TestWorkingDirInit(t *testing.T) {
+	volumeMounts := []corev1.VolumeMount{{
+		Name:      "workspace",
+		MountPath: "/workspace",
+	}, {
+		Name:      "home",
+		MountPath: "/builder/home",
+	}}
+
 	names.TestingSeed()
 	for _, c := range []struct {
 		desc           string
@@ -57,11 +65,12 @@ func TestWorkingDirInit(t *testing.T) {
 			WorkingDir: "/workspace/bbb",
 		}},
 		want: &corev1.Container{
-			Name:       "working-dir-initializer-9l9zj",
-			Image:      shellImage,
-			Command:    []string{"sh"},
-			Args:       []string{"-c", "mkdir -p /workspace/bbb aaa zzz"},
-			WorkingDir: workspaceDir,
+			Name:         "working-dir-initializer-9l9zj",
+			Image:        shellImage,
+			Command:      []string{"sh"},
+			Args:         []string{"-c", "mkdir -p /workspace/bbb aaa zzz"},
+			WorkingDir:   workspaceDir,
+			VolumeMounts: volumeMounts,
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
@@ -76,7 +85,7 @@ func TestWorkingDirInit(t *testing.T) {
 				steps = append(steps, v1alpha1.Step{Container: c})
 			}
 
-			got := WorkingDirInit(shellImage, steps)
+			got := WorkingDirInit(shellImage, steps, volumeMounts)
 			if d := cmp.Diff(c.want, got); d != "" {
 				t.Fatalf("Diff (-want, +got): %s", d)
 			}

--- a/pkg/reconciler/taskrun/resources/pod.go
+++ b/pkg/reconciler/taskrun/resources/pod.go
@@ -120,7 +120,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 		volumes = append(volumes, secretsVolumes...)
 	}
 
-	if workingDirInit := pod.WorkingDirInit(images.ShellImage, taskSpec.Steps); workingDirInit != nil {
+	if workingDirInit := pod.WorkingDirInit(images.ShellImage, taskSpec.Steps, implicitVolumeMounts); workingDirInit != nil {
 		initContainers = append(initContainers, *workingDirInit)
 	}
 

--- a/pkg/reconciler/taskrun/resources/pod_test.go
+++ b/pkg/reconciler/taskrun/resources/pod_test.go
@@ -292,11 +292,12 @@ func TestMakePod(t *testing.T) {
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:       "working-dir-initializer-9l9zj",
-				Image:      shellImage,
-				Command:    []string{"sh"},
-				Args:       []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
-				WorkingDir: workspaceDir,
+				Name:         "working-dir-initializer-9l9zj",
+				Image:        shellImage,
+				Command:      []string{"sh"},
+				Args:         []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},
+				WorkingDir:   workspaceDir,
+				VolumeMounts: implicitVolumeMounts,
 			}},
 			Containers: []corev1.Container{{
 				Name:         "step-name",


### PR DESCRIPTION
Mounting volume was dropped when we did the large refactoring in
d7f492cb8e018a8d2c65a8702b3746e710501616 which basically making
it ineffective and fails when not running as root.

Readding it in there

Closes #1608

/cc @ImJasonH 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


# Release Notes

```
Fix workingdir-init to mount the volumes when starting the initContainer.
```