### PR TITLE
Extract substitution code out of v1alpha1 ✂

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/param_types.go
+++ b/pkg/apis/pipeline/v1alpha1/param_types.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/substitution"
 )
 
 // ParamSpec defines arbitrary parameters needed beyond typed inputs (such as
@@ -116,11 +118,11 @@ func (arrayOrString ArrayOrString) MarshalJSON() ([]byte, error) {
 
 func (arrayOrString *ArrayOrString) ApplyReplacements(stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	if arrayOrString.Type == ParamTypeString {
-		arrayOrString.StringVal = ApplyReplacements(arrayOrString.StringVal, stringReplacements)
+		arrayOrString.StringVal = substitution.ApplyReplacements(arrayOrString.StringVal, stringReplacements)
 	} else {
 		var newArrayVal []string
 		for _, v := range arrayOrString.ArrayVal {
-			newArrayVal = append(newArrayVal, ApplyArrayReplacements(v, stringReplacements, arrayReplacements)...)
+			newArrayVal = append(newArrayVal, substitution.ApplyArrayReplacements(v, stringReplacements, arrayReplacements)...)
 		}
 		arrayOrString.ArrayVal = newArrayVal
 	}

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
+	"github.com/tektoncd/pipeline/pkg/substitution"
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -233,13 +234,13 @@ func validatePipelineVariables(tasks []PipelineTask, prefix string, paramNames m
 }
 
 func validatePipelineVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return ValidateVariable(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariable(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
 }
 
 func validatePipelineNoArrayReferenced(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return ValidateVariableProhibited(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariableProhibited(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
 }
 
 func validatePipelineArraysIsolated(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return ValidateVariableIsolated(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariableIsolated(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
 }

--- a/pkg/apis/pipeline/v1alpha1/step_replacements.go
+++ b/pkg/apis/pipeline/v1alpha1/step_replacements.go
@@ -16,53 +16,57 @@
 
 package v1alpha1
 
+import (
+	"github.com/tektoncd/pipeline/pkg/substitution"
+)
+
 func ApplyStepReplacements(step *Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
-	step.Name = ApplyReplacements(step.Name, stringReplacements)
-	step.Image = ApplyReplacements(step.Image, stringReplacements)
-	step.Script = ApplyReplacements(step.Script, stringReplacements)
+	step.Name = substitution.ApplyReplacements(step.Name, stringReplacements)
+	step.Image = substitution.ApplyReplacements(step.Image, stringReplacements)
+	step.Script = substitution.ApplyReplacements(step.Script, stringReplacements)
 
 	// Use ApplyArrayReplacements here, as additional args may be added via an array parameter.
 	var newArgs []string
 	for _, a := range step.Args {
-		newArgs = append(newArgs, ApplyArrayReplacements(a, stringReplacements, arrayReplacements)...)
+		newArgs = append(newArgs, substitution.ApplyArrayReplacements(a, stringReplacements, arrayReplacements)...)
 	}
 	step.Args = newArgs
 
 	for ie, e := range step.Env {
-		step.Env[ie].Value = ApplyReplacements(e.Value, stringReplacements)
+		step.Env[ie].Value = substitution.ApplyReplacements(e.Value, stringReplacements)
 		if step.Env[ie].ValueFrom != nil {
 			if e.ValueFrom.SecretKeyRef != nil {
-				step.Env[ie].ValueFrom.SecretKeyRef.LocalObjectReference.Name = ApplyReplacements(e.ValueFrom.SecretKeyRef.LocalObjectReference.Name, stringReplacements)
-				step.Env[ie].ValueFrom.SecretKeyRef.Key = ApplyReplacements(e.ValueFrom.SecretKeyRef.Key, stringReplacements)
+				step.Env[ie].ValueFrom.SecretKeyRef.LocalObjectReference.Name = substitution.ApplyReplacements(e.ValueFrom.SecretKeyRef.LocalObjectReference.Name, stringReplacements)
+				step.Env[ie].ValueFrom.SecretKeyRef.Key = substitution.ApplyReplacements(e.ValueFrom.SecretKeyRef.Key, stringReplacements)
 			}
 			if e.ValueFrom.ConfigMapKeyRef != nil {
-				step.Env[ie].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name = ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name, stringReplacements)
-				step.Env[ie].ValueFrom.ConfigMapKeyRef.Key = ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.Key, stringReplacements)
+				step.Env[ie].ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name = substitution.ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.LocalObjectReference.Name, stringReplacements)
+				step.Env[ie].ValueFrom.ConfigMapKeyRef.Key = substitution.ApplyReplacements(e.ValueFrom.ConfigMapKeyRef.Key, stringReplacements)
 			}
 		}
 	}
 
 	for ie, e := range step.EnvFrom {
-		step.EnvFrom[ie].Prefix = ApplyReplacements(e.Prefix, stringReplacements)
+		step.EnvFrom[ie].Prefix = substitution.ApplyReplacements(e.Prefix, stringReplacements)
 		if e.ConfigMapRef != nil {
-			step.EnvFrom[ie].ConfigMapRef.LocalObjectReference.Name = ApplyReplacements(e.ConfigMapRef.LocalObjectReference.Name, stringReplacements)
+			step.EnvFrom[ie].ConfigMapRef.LocalObjectReference.Name = substitution.ApplyReplacements(e.ConfigMapRef.LocalObjectReference.Name, stringReplacements)
 		}
 		if e.SecretRef != nil {
-			step.EnvFrom[ie].SecretRef.LocalObjectReference.Name = ApplyReplacements(e.SecretRef.LocalObjectReference.Name, stringReplacements)
+			step.EnvFrom[ie].SecretRef.LocalObjectReference.Name = substitution.ApplyReplacements(e.SecretRef.LocalObjectReference.Name, stringReplacements)
 		}
 	}
-	step.WorkingDir = ApplyReplacements(step.WorkingDir, stringReplacements)
+	step.WorkingDir = substitution.ApplyReplacements(step.WorkingDir, stringReplacements)
 
 	// Use ApplyArrayReplacements here, as additional commands may be added via an array parameter.
 	var newCommand []string
 	for _, c := range step.Command {
-		newCommand = append(newCommand, ApplyArrayReplacements(c, stringReplacements, arrayReplacements)...)
+		newCommand = append(newCommand, substitution.ApplyArrayReplacements(c, stringReplacements, arrayReplacements)...)
 	}
 	step.Command = newCommand
 
 	for iv, v := range step.VolumeMounts {
-		step.VolumeMounts[iv].Name = ApplyReplacements(v.Name, stringReplacements)
-		step.VolumeMounts[iv].MountPath = ApplyReplacements(v.MountPath, stringReplacements)
-		step.VolumeMounts[iv].SubPath = ApplyReplacements(v.SubPath, stringReplacements)
+		step.VolumeMounts[iv].Name = substitution.ApplyReplacements(v.Name, stringReplacements)
+		step.VolumeMounts[iv].MountPath = substitution.ApplyReplacements(v.MountPath, stringReplacements)
+		step.VolumeMounts[iv].SubPath = substitution.ApplyReplacements(v.SubPath, stringReplacements)
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
+	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -301,15 +302,15 @@ func validateVariables(steps []Step, prefix string, vars map[string]struct{}) *a
 }
 
 func validateTaskVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return ValidateVariable(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", vars)
+	return substitution.ValidateVariable(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", vars)
 }
 
 func validateTaskNoArrayReferenced(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
-	return ValidateVariableProhibited(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", arrayNames)
+	return substitution.ValidateVariableProhibited(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", arrayNames)
 }
 
 func validateTaskArraysIsolated(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
-	return ValidateVariableIsolated(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", arrayNames)
+	return substitution.ValidateVariableIsolated(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", arrayNames)
 }
 
 func checkForDuplicates(resources []TaskResource, path string) *apis.FieldError {

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/substitution"
 )
 
 // ApplyParameters applies the params from a TaskRun.Input.Parameters to a TaskSpec
@@ -95,15 +96,15 @@ func ApplyReplacements(spec *v1alpha1.TaskSpec, stringReplacements map[string]st
 
 	// Apply variable expansion to the build's volumes
 	for i, v := range spec.Volumes {
-		spec.Volumes[i].Name = v1alpha1.ApplyReplacements(v.Name, stringReplacements)
+		spec.Volumes[i].Name = substitution.ApplyReplacements(v.Name, stringReplacements)
 		if v.VolumeSource.ConfigMap != nil {
-			spec.Volumes[i].ConfigMap.Name = v1alpha1.ApplyReplacements(v.ConfigMap.Name, stringReplacements)
+			spec.Volumes[i].ConfigMap.Name = substitution.ApplyReplacements(v.ConfigMap.Name, stringReplacements)
 		}
 		if v.VolumeSource.Secret != nil {
-			spec.Volumes[i].Secret.SecretName = v1alpha1.ApplyReplacements(v.Secret.SecretName, stringReplacements)
+			spec.Volumes[i].Secret.SecretName = substitution.ApplyReplacements(v.Secret.SecretName, stringReplacements)
 		}
 		if v.PersistentVolumeClaim != nil {
-			spec.Volumes[i].PersistentVolumeClaim.ClaimName = v1alpha1.ApplyReplacements(v.PersistentVolumeClaim.ClaimName, stringReplacements)
+			spec.Volumes[i].PersistentVolumeClaim.ClaimName = substitution.ApplyReplacements(v.PersistentVolumeClaim.ClaimName, stringReplacements)
 		}
 	}
 

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package substitution
 
 import (
 	"fmt"

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -15,13 +15,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1_test
+package substitution_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/substitution"
 	"knative.dev/pkg/apis"
 )
 
@@ -111,7 +111,7 @@ func TestValidateVariables(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := v1alpha1.ValidateVariable("somefield", tc.args.input, tc.args.prefix, tc.args.contextPrefix, tc.args.locationName, tc.args.path, tc.args.vars)
+			got := substitution.ValidateVariable("somefield", tc.args.input, tc.args.prefix, tc.args.contextPrefix, tc.args.locationName, tc.args.path, tc.args.vars)
 
 			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("ValidateVariable() error did not match expected error %s", d)
@@ -173,7 +173,7 @@ func TestApplyReplacements(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualOutput := v1alpha1.ApplyReplacements(tt.args.input, tt.args.replacements)
+			actualOutput := substitution.ApplyReplacements(tt.args.input, tt.args.replacements)
 			if d := cmp.Diff(actualOutput, tt.expectedOutput); d != "" {
 				t.Errorf("ApplyReplacements() output did not match expected value %s", d)
 			}
@@ -225,7 +225,7 @@ func TestApplyArrayReplacements(t *testing.T) {
 		expectedOutput: []string{"1", "2"},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			actualOutput := v1alpha1.ApplyArrayReplacements(tc.args.input, tc.args.stringReplacements, tc.args.arrayReplacements)
+			actualOutput := substitution.ApplyArrayReplacements(tc.args.input, tc.args.stringReplacements, tc.args.arrayReplacements)
 			if d := cmp.Diff(actualOutput, tc.expectedOutput); d != "" {
 				t.Errorf("ApplyArrayReplacements() output did not match expected value %s", d)
 			}


### PR DESCRIPTION
# Changes

This part doesn't really have anything to do with the API so, moving
it out of the v1alpha1 api package.

This is part of the "cleaning v1alpha1 and create v1alpha2" work :wink: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
