### PR TITLE
Extract validateObjectMetadata to a validate package ✂

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
@@ -19,13 +19,14 @@ package v1alpha1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"knative.dev/pkg/apis"
 )
 
 var _ apis.Validatable = (*ClusterTask)(nil)
 
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(t.GetObjectMeta()); err != nil {
+	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return t.Spec.Validate(ctx)

--- a/pkg/apis/pipeline/v1alpha1/condition_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -26,7 +27,7 @@ import (
 var _ apis.Validatable = (*Condition)(nil)
 
 func (c Condition) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(c.GetObjectMeta()); err != nil {
+	if err := validate.ObjectMetadata(c.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return c.Spec.Validate(ctx).ViaField("Spec")

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"golang.org/x/xerrors"
@@ -34,7 +35,7 @@ var _ apis.Validatable = (*Pipeline)(nil)
 // Validate checks that the Pipeline structure is valid but does not validate
 // that any references resources exist, that is done at run time.
 func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(p.GetObjectMeta()); err != nil {
+	if err := validate.ObjectMetadata(p.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return p.Spec.Validate(ctx)

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -29,7 +30,7 @@ import (
 var _ apis.Validatable = (*PipelineResource)(nil)
 
 func (r *PipelineResource) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(r.GetObjectMeta()); err != nil {
+	if err := validate.ObjectMetadata(r.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -28,7 +29,7 @@ var _ apis.Validatable = (*PipelineRun)(nil)
 
 // Validate pipelinerun
 func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(pr.GetObjectMeta()).ViaField("metadata"); err != nil {
+	if err := validate.ObjectMetadata(pr.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
 	}
 	return pr.Spec.Validate(ctx)

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -30,7 +31,7 @@ import (
 var _ apis.Validatable = (*Task)(nil)
 
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(t.GetObjectMeta()); err != nil {
+	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
 	return t.Spec.Validate(ctx)

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -29,7 +30,7 @@ var _ apis.Validatable = (*TaskRun)(nil)
 
 // Validate taskrun
 func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
-	if err := validateObjectMetadata(tr.GetObjectMeta()).ViaField("metadata"); err != nil {
+	if err := validate.ObjectMetadata(tr.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
 	}
 	return tr.Spec.Validate(ctx)

--- a/pkg/apis/validate/metadata.go
+++ b/pkg/apis/validate/metadata.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package validate
 
 import (
 	"strings"
@@ -23,9 +23,9 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-const maxLength = 63
+const MaxLength = 63
 
-func validateObjectMetadata(meta metav1.Object) *apis.FieldError {
+func ObjectMetadata(meta metav1.Object) *apis.FieldError {
 	name := meta.GetName()
 
 	if strings.Contains(name, ".") {
@@ -35,7 +35,7 @@ func validateObjectMetadata(meta metav1.Object) *apis.FieldError {
 		}
 	}
 
-	if len(name) > maxLength {
+	if len(name) > MaxLength {
 		return &apis.FieldError{
 			Message: "Invalid resource name: length must be no more than 63 characters",
 			Paths:   []string{"name"},

--- a/pkg/apis/validate/metadata_test.go
+++ b/pkg/apis/validate/metadata_test.go
@@ -14,23 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package validate_test
 
 import (
 	"strings"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMetadataInvalidLongName(t *testing.T) {
 
 	invalidMetas := []*metav1.ObjectMeta{
-		{Name: strings.Repeat("s", maxLength+1)},
+		{Name: strings.Repeat("s", validate.MaxLength+1)},
 		{Name: "bad.name"},
 	}
 	for _, invalidMeta := range invalidMetas {
-		if err := validateObjectMetadata(invalidMeta); err == nil {
+		if err := validate.ObjectMetadata(invalidMeta); err == nil {
 			t.Errorf("Failed to validate object meta data: %s", err)
 		}
 	}


### PR DESCRIPTION
# Changes

It doesn't depend on the API resources and can be reused and share
across multiple api version.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
