### PR TITLE
Align pull request resource and pullrequest-init

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	prSource       = "pr-source"
-	githubTokenEnv = "githubToken"
+	prSource         = "pr-source"
+	githubTokenField = "githubToken"
+	// nolint: gosec
+	githubTokenEnv = "GITHUB_TOKEN"
 )
 
 // PullRequestResource is an endpoint from which to get data which is required
@@ -107,9 +109,9 @@ func (s *PullRequestResource) getSteps(mode string, sourcePath string) []Step {
 
 	evs := []corev1.EnvVar{}
 	for _, sec := range s.Secrets {
-		if strings.EqualFold(sec.FieldName, githubTokenEnv) {
+		if strings.EqualFold(sec.FieldName, githubTokenField) {
 			ev := corev1.EnvVar{
-				Name: strings.ToUpper(sec.FieldName),
+				Name: githubTokenEnv,
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -98,7 +98,7 @@ func containerTestCases(mode string) []testcase {
 			Command:    []string{"/ko-app/pullrequest-init"},
 			Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode},
 			Env: []corev1.EnvVar{{
-				Name: "GITHUBTOKEN",
+				Name: "GITHUB_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
The pullrequest-init module reads the token from GITHUB_TOKEN.
The pull request resources sets strings.ToUpper('githubToken'),
so credentials are not picked up.

The environment variable name and the pull request field name
do not need to be bound to each other, so keep the pull request
field name to 'githubToken' (do not break anyone) - keep the
pullrequest-init interface with GITHUB_TOKEN, in case someone
uses it outside of the resource, and pass the right env
variable to match what pullrequest-init expects.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
