### PR TITLE
Add an example that demonstrates waiting for a sidecar to become Ready

### DIFF
--- a/examples/taskruns/sidecar-ready.yaml
+++ b/examples/taskruns/sidecar-ready.yaml
@@ -1,0 +1,38 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: sidecar-ready-
+spec:
+  taskSpec:
+    sidecars:
+    - name: slow-sidecar
+      image: ubuntu
+      command: ['sleep', 'infinity']
+      # The sidecar takes 5s to report as Ready, even after it starts.  If the
+      # step runs as soon as the sidecar starts, it will fail because
+      # /shared/ready isn't available yet.
+      readinessProbe:
+        exec:
+          command:
+          - sh
+          - -c
+          - sleep 5 && touch /shared/ready
+      volumeMounts:
+      - name: shared
+        mountPath: /shared
+
+    steps:
+    - name: check-ready
+      image: ubuntu
+      # The step will only succeed if the sidecar has written this file, which
+      # it does 5s after it starts, before it reports Ready.
+      command: ['cat', '/shared/ready']
+      volumeMounts:
+      - name: shared
+        mountPath: /shared
+
+    # Sidecars don't have /workspace mounted by default, so we have to define
+    # our own shared volume.
+    volumes:
+    - name: shared
+      emptyDir: {}


### PR DESCRIPTION
This example includes a sidecar that takes some time after it starts
running to report as Ready, and a step that relies on the behavior of
the sidecar being Ready, not just started.

This tests behavior described in https://github.com/tektoncd/pipeline/issues/1569#issuecomment-558646283 which would have hopefully caught broken behavior introduced by that proposed change.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._
