### PR TITLE
Split entrypoint_lookup implementation and interface

### DIFF
--- a/pkg/pod/entrypoint_lookup.go
+++ b/pkg/pod/entrypoint_lookup.go
@@ -1,16 +1,31 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pod
 
 import (
-	"fmt"
-
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/authn/k8schain"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
-	lru "github.com/hashicorp/golang-lru"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
 )
+
+// EntrypointCache looks up an image's entrypoint (command) in a container
+// image registry, possibly using the given service account's credentials.
+type EntrypointCache interface {
+	Get(imageName, namespace, serviceAccountName string) (cmd []string, d name.Digest, err error)
+}
 
 // ResolveEntrypoints looks up container image ENTRYPOINTs for all steps that
 // don't specify a Command.
@@ -52,75 +67,4 @@ func ResolveEntrypoints(cache EntrypointCache, namespace, serviceAccountName str
 		steps[i].Command = ep            // Specify the command explicitly.
 	}
 	return steps, nil
-}
-
-const cacheSize = 1024
-
-type EntrypointCache interface {
-	Get(imageName, namespace, serviceAccountName string) (cmd []string, d name.Digest, err error)
-}
-
-type entrypointCache struct {
-	kubeclient kubernetes.Interface
-	lru        *lru.Cache // cache of digest string -> image entrypoint []string
-}
-
-func NewEntrypointCache(kubeclient kubernetes.Interface) (EntrypointCache, error) {
-	lru, err := lru.New(cacheSize)
-	if err != nil {
-		return nil, err
-	}
-	return &entrypointCache{
-		kubeclient: kubeclient,
-		lru:        lru,
-	}, nil
-}
-
-func (e *entrypointCache) Get(imageName, namespace, serviceAccountName string) (cmd []string, d name.Digest, err error) {
-	ref, err := name.ParseReference(imageName, name.WeakValidation)
-	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error parsing reference %q: %v", imageName, err)
-	}
-
-	// If image is specified by digest, check the local cache.
-	if digest, ok := ref.(name.Digest); ok {
-		if ep, ok := e.lru.Get(digest.String()); ok {
-			return ep.([]string), digest, nil
-		}
-	}
-
-	// If the image wasn't specified by digest, or if the entrypoint
-	// wasn't found, we have to consult the remote registry, using
-	// imagePullSecrets.
-	kc, err := k8schain.New(e.kubeclient, k8schain.Options{
-		Namespace:          namespace,
-		ServiceAccountName: serviceAccountName,
-	})
-	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error creating k8schain: %v", err)
-	}
-	mkc := authn.NewMultiKeychain(kc)
-	img, err := remote.Image(ref, remote.WithAuthFromKeychain(mkc))
-	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error getting image manifest: %v", err)
-	}
-	digest, err := img.Digest()
-	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error getting image digest: %v", err)
-	}
-	cfg, err := img.ConfigFile()
-	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error getting image config: %v", err)
-	}
-	ep := cfg.Config.Entrypoint
-	if len(ep) == 0 {
-		ep = cfg.Config.Cmd
-	}
-	e.lru.Add(digest.String(), ep) // Populate the cache.
-
-	d, err = name.NewDigest(imageName+"@"+digest.String(), name.WeakValidation)
-	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error constructing resulting digest: %v", err)
-	}
-	return ep, d, nil
 }

--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	lru "github.com/hashicorp/golang-lru"
+	"k8s.io/client-go/kubernetes"
+)
+
+const cacheSize = 1024
+
+type entrypointCache struct {
+	kubeclient kubernetes.Interface
+	lru        *lru.Cache // cache of digest string -> image entrypoint []string
+}
+
+// NewEntrypointCache returns a new entrypoint cache implementation that uses
+// K8s credentials to pull image metadata from a container image registry.
+func NewEntrypointCache(kubeclient kubernetes.Interface) (EntrypointCache, error) {
+	lru, err := lru.New(cacheSize)
+	if err != nil {
+		return nil, err
+	}
+	return &entrypointCache{
+		kubeclient: kubeclient,
+		lru:        lru,
+	}, nil
+}
+
+func (e *entrypointCache) Get(imageName, namespace, serviceAccountName string) (cmd []string, d name.Digest, err error) {
+	ref, err := name.ParseReference(imageName, name.WeakValidation)
+	if err != nil {
+		return nil, name.Digest{}, fmt.Errorf("Error parsing reference %q: %v", imageName, err)
+	}
+
+	// If image is specified by digest, check the local cache.
+	if digest, ok := ref.(name.Digest); ok {
+		if ep, ok := e.lru.Get(digest.String()); ok {
+			return ep.([]string), digest, nil
+		}
+	}
+
+	// If the image wasn't specified by digest, or if the entrypoint
+	// wasn't found, we have to consult the remote registry, using
+	// imagePullSecrets.
+	kc, err := k8schain.New(e.kubeclient, k8schain.Options{
+		Namespace:          namespace,
+		ServiceAccountName: serviceAccountName,
+	})
+	if err != nil {
+		return nil, name.Digest{}, fmt.Errorf("Error creating k8schain: %v", err)
+	}
+	mkc := authn.NewMultiKeychain(kc)
+	img, err := remote.Image(ref, remote.WithAuthFromKeychain(mkc))
+	if err != nil {
+		return nil, name.Digest{}, fmt.Errorf("Error getting image manifest: %v", err)
+	}
+	digest, err := img.Digest()
+	if err != nil {
+		return nil, name.Digest{}, fmt.Errorf("Error getting image digest: %v", err)
+	}
+	cfg, err := img.ConfigFile()
+	if err != nil {
+		return nil, name.Digest{}, fmt.Errorf("Error getting image config: %v", err)
+	}
+	ep := cfg.Config.Entrypoint
+	if len(ep) == 0 {
+		ep = cfg.Config.Cmd
+	}
+	e.lru.Add(digest.String(), ep) // Populate the cache.
+
+	d, err = name.NewDigest(imageName+"@"+digest.String(), name.WeakValidation)
+	if err != nil {
+		return nil, name.Digest{}, fmt.Errorf("Error constructing resulting digest: %v", err)
+	}
+	return ep, d, nil
+}


### PR DESCRIPTION
This reorganizes code so that the interface and general code that uses
that interface is separated from the code that implements the interface
with a K8s-specific implementation.

#1605 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._
