### PR TITLE
Fix a gocritic lint issue: use switch instead of ifelse 🏑

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1511,11 +1511,12 @@ func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 		{
 			name: "conditionCheck exists",
 			getTaskRun: func(name string) (*v1alpha1.TaskRun, error) {
-				if name == "pipelinerun-mytask1-9l9zj-always-true-mz4c7" {
+				switch name {
+				case "pipelinerun-mytask1-9l9zj-always-true-mz4c7":
 					return cc1, nil
-				} else if name == "pipelinerun-mytask1-9l9zj" {
+				case "pipelinerun-mytask1-9l9zj":
 					return &trs[0], nil
-				} else if name == "pipelinerun-mytask1-9l9zj-always-true-mssqb" {
+				case "pipelinerun-mytask1-9l9zj-always-true-mssqb":
 					return cc2, nil
 				}
 				return nil, xerrors.Errorf("getTaskRun called with unexpected name %s", name)


### PR DESCRIPTION
# Changes

Should unblock master.

/cc @ImJasonH @chmouel @afrittoli @bobcatfish 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
