### PR TITLE
Added condition Resource E2E Test and also updated Clients structure to make it exportable

### DIFF
--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -219,19 +219,19 @@ func getBucketSecret(t *testing.T, configFilePath, namespace string) *corev1.Sec
 	}
 }
 
-func deleteBucketSecret(c *clients, t *testing.T, namespace string) {
+func deleteBucketSecret(c *Client, t *testing.T, namespace string) {
 	if err := c.KubeClient.Kube.CoreV1().Secrets(namespace).Delete(bucketSecretName, &metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete Secret `%s`: %s", bucketSecretName, err)
 	}
 }
 
-func resetConfigMap(t *testing.T, c *clients, namespace, configName string, values map[string]string) {
+func resetConfigMap(t *testing.T, c *Client, namespace, configName string, values map[string]string) {
 	if err := updateConfigMap(c.KubeClient, namespace, configName, values); err != nil {
 		t.Log(err)
 	}
 }
 
-func runTaskToDeleteBucket(c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
+func runTaskToDeleteBucket(c *Client, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
 	deletelbuckettask := tb.Task("deletelbuckettask", namespace, tb.TaskSpec(
 		tb.TaskVolume("bucket-secret-volume", tb.VolumeSource(corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{

--- a/test/build_logs.go
+++ b/test/build_logs.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CollectPodLogs will get the logs for all containers in a Pod
-func CollectPodLogs(c *clients, podName, namespace string, logf logging.FormatLogger) {
+func CollectPodLogs(c *Client, podName, namespace string, logf logging.FormatLogger) {
 	logs, err := getContainersLogsFromPod(c.KubeClient.Kube, podName, namespace)
 	if err != nil {
 		logf("Could not get logs for pod %s: %s", podName, err)

--- a/test/clients.go
+++ b/test/clients.go
@@ -46,8 +46,8 @@ import (
 	knativetest "knative.dev/pkg/test"
 )
 
-// clients holds instances of interfaces for making requests to the Pipeline controllers.
-type clients struct {
+// Client holds instances of interfaces for making requests to the Pipeline controllers.
+type Client struct {
 	KubeClient *knativetest.KubeClient
 
 	PipelineClient         v1alpha1.PipelineInterface
@@ -61,10 +61,10 @@ type clients struct {
 // newClients instantiates and returns several clientsets required for making requests to the
 // Pipeline cluster specified by the combination of clusterName and configPath. Clients can
 // make requests within namespace.
-func newClients(t *testing.T, configPath, clusterName, namespace string) *clients {
+func newClients(t *testing.T, configPath, clusterName, namespace string) *Client {
 	t.Helper()
 	var err error
-	c := &clients{}
+	c := &Client{}
 
 	c.KubeClient, err = knativetest.NewKubeClient(configPath, clusterName)
 	if err != nil {

--- a/test/conditional_check_test.go
+++ b/test/conditional_check_test.go
@@ -1,0 +1,92 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	knativetest "knative.dev/pkg/test"
+)
+
+func TestPipelineRunConditionalResource(t *testing.T) {
+	c, namespace := setup(t)
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	condResource := tb.Condition("file-exists", namespace,
+		tb.ConditionSpec(
+			tb.ConditionParamSpec("path", v1alpha1.ParamTypeString),
+			tb.ConditionResource("workspace", v1alpha1.PipelineResourceTypeGit),
+			tb.ConditionSpecCheck("", "alpine", tb.Command("/bin/sh"), tb.Args("-c", "cat $(resources.workspace.path)/$(params.path)| grep \"Cloud Native\"")),
+		),
+	)
+
+	if _, err := c.ConditionClient.Create(condResource); err != nil {
+		t.Fatalf("Failed to create simple repo PipelineResource: %s", err)
+	}
+
+	repoResource := tb.PipelineResource("pipeline-git", namespace, tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit,
+		tb.PipelineResourceSpecParam("Url", "https://github.com/tektoncd/pipeline"),
+		tb.PipelineResourceSpecParam("Revision", "master"),
+	))
+	if _, err := c.PipelineResourceClient.Create(repoResource); err != nil {
+		t.Fatalf("Failed to create simple repo PipelineResource: %s", err)
+	}
+
+	conditionalTask := tb.Task("list-files", namespace, tb.TaskSpec(
+		tb.TaskInputs(
+			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
+		),
+		tb.Step("run-ls", "ubuntu", tb.StepCommand("/bin/bash"), tb.StepArgs("-c", "ls -al $(inputs.resources.workspace.path)")),
+	))
+
+	if _, err := c.TaskClient.Create(conditionalTask); err != nil {
+		t.Fatalf("Failed to create echo Task: %s", err)
+	}
+
+	pipeline := tb.Pipeline("list-files-pipeline", namespace, tb.PipelineSpec(
+		tb.PipelineDeclaredResource("source-repo", "git"),
+		tb.PipelineParamSpec("path", v1alpha1.ParamTypeString, tb.ParamSpecDefault("README.md")),
+		tb.PipelineTask("list-files-1", "list-files",
+			tb.PipelineTaskCondition("file-exists",
+				tb.PipelineTaskConditionParam("path", "$(params.path)"),
+				tb.PipelineTaskConditionResource("workspace", "source-repo")),
+			tb.PipelineTaskInputResource("workspace", "source-repo"),
+		),
+	))
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create list-files-pipelin: %s", err)
+	}
+	pipelineRun := tb.PipelineRun("demo-condtional-pr", namespace, tb.PipelineRunSpec("list-files-pipeline",
+		tb.PipelineRunServiceAccountName("default"),
+		tb.PipelineRunResourceBinding("source-repo", tb.PipelineResourceBindingRef("pipeline-git")),
+	))
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create demo-condtional-pr PipelineRun: %s", err)
+	}
+	t.Logf("Waiting for Conditional pipeline to complete")
+	if err := WaitForPipelineRunState(c, "demo-condtional-pr", pipelineRunTimeout, PipelineRunSucceed("demo-condtional-pr"), "PipelineRunSuccess"); err != nil {
+		t.Fatalf("Error waiting for PipelineRun to finish: %s", err)
+	}
+
+}

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -212,7 +212,7 @@ func getHelmDeployPipelineRun(namespace string) *v1alpha1.PipelineRun {
 	))
 }
 
-func setupClusterBindingForHelm(c *clients, t *testing.T, namespace string) {
+func setupClusterBindingForHelm(c *Client, t *testing.T, namespace string) {
 	tillerServiceAccount = &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "tiller",
@@ -283,7 +283,7 @@ func setupClusterBindingForHelm(c *clients, t *testing.T, namespace string) {
 	}
 }
 
-func helmCleanup(c *clients, t *testing.T, namespace string) {
+func helmCleanup(c *Client, t *testing.T, namespace string) {
 	t.Logf("Cleaning up helm from cluster...")
 
 	removeAllHelmReleases(c, t, namespace)
@@ -302,7 +302,7 @@ func helmCleanup(c *clients, t *testing.T, namespace string) {
 	}
 }
 
-func removeAllHelmReleases(c *clients, t *testing.T, namespace string) {
+func removeAllHelmReleases(c *Client, t *testing.T, namespace string) {
 	helmRemoveAllTaskName := "helm-remove-all-task"
 	helmRemoveAllTask := tb.Task(helmRemoveAllTaskName, namespace, tb.TaskSpec(
 		tb.Step("helm-remove-all", "alpine/helm:2.14.0", tb.StepCommand("/bin/sh"),
@@ -331,7 +331,7 @@ func removeAllHelmReleases(c *clients, t *testing.T, namespace string) {
 	}
 }
 
-func removeHelmFromCluster(c *clients, t *testing.T, namespace string) {
+func removeHelmFromCluster(c *Client, t *testing.T, namespace string) {
 	helmResetTaskName := "helm-reset-task"
 	helmResetTask := tb.Task(helmResetTaskName, namespace, tb.TaskSpec(
 		tb.Step("helm-reset", "alpine/helm:2.14.0", tb.StepArgs("reset", "--force")),

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -45,7 +45,7 @@ import (
 
 var initMetrics sync.Once
 
-func setup(t *testing.T, fn ...func(*testing.T, *clients, string)) (*clients, string) {
+func setup(t *testing.T, fn ...func(*testing.T, *Client, string)) (*Client, string) {
 	t.Helper()
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
 
@@ -72,7 +72,7 @@ func header(logf logging.FormatLogger, text string) {
 	logf(bar)
 }
 
-func tearDown(t *testing.T, cs *clients, namespace string) {
+func tearDown(t *testing.T, cs *Client, namespace string) {
 	t.Helper()
 	if cs.KubeClient == nil {
 		return
@@ -149,7 +149,7 @@ func TestMain(m *testing.M) {
 	os.Exit(c)
 }
 
-func getCRDYaml(cs *clients, ns string) ([]byte, error) {
+func getCRDYaml(cs *Client, ns string) ([]byte, error) {
 	var output []byte
 	printOrAdd := func(i interface{}) {
 		bs, err := yaml.Marshal(i)

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -177,7 +177,7 @@ func getTaskRun(namespace string) *v1alpha1.TaskRun {
 // to the "outside" of the test, this means it can be query by the test itself. It can only be query from
 // a pod in the namespace. skopeo is able to do that query and we use jq to extract the digest from its
 // output. The image used for this pod is build in the tektoncd/plumbing repository.
-func getRemoteDigest(t *testing.T, c *clients, namespace, image string) (string, error) {
+func getRemoteDigest(t *testing.T, c *Client, namespace, image string) (string, error) {
 	t.Helper()
 	podName := "skopeo-jq"
 	if _, err := c.KubeClient.Kube.CoreV1().Pods(namespace).Create(&corev1.Pod{

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -52,7 +52,7 @@ func TestPipelineRun(t *testing.T) {
 	t.Parallel()
 	type tests struct {
 		name                   string
-		testSetup              func(t *testing.T, c *clients, namespace string, index int)
+		testSetup              func(t *testing.T, c *Client, namespace string, index int)
 		expectedTaskRuns       []string
 		expectedNumberOfEvents int
 		pipelineRunFunc        func(int, string) *v1alpha1.PipelineRun
@@ -60,7 +60,7 @@ func TestPipelineRun(t *testing.T) {
 
 	tds := []tests{{
 		name: "fan-in and fan-out",
-		testSetup: func(t *testing.T, c *clients, namespace string, index int) {
+		testSetup: func(t *testing.T, c *Client, namespace string, index int) {
 			t.Helper()
 			for _, task := range getFanInFanOutTasks(namespace) {
 				if _, err := c.TaskClient.Create(task); err != nil {
@@ -84,7 +84,7 @@ func TestPipelineRun(t *testing.T) {
 		expectedNumberOfEvents: 5,
 	}, {
 		name: "service account propagation and pipeline param",
-		testSetup: func(t *testing.T, c *clients, namespace string, index int) {
+		testSetup: func(t *testing.T, c *Client, namespace string, index int) {
 			t.Helper()
 			if _, err := c.KubeClient.Kube.CoreV1().Secrets(namespace).Create(getPipelineRunSecret(index, namespace)); err != nil {
 				t.Fatalf("Failed to create secret `%s`: %s", getName(secretName, index), err)
@@ -117,7 +117,7 @@ func TestPipelineRun(t *testing.T) {
 		pipelineRunFunc:        getHelloWorldPipelineRun,
 	}, {
 		name: "pipeline succeeds when task skipped due to failed condition",
-		testSetup: func(t *testing.T, c *clients, namespace string, index int) {
+		testSetup: func(t *testing.T, c *Client, namespace string, index int) {
 			t.Helper()
 			cond := getFailingCondition(namespace)
 			if _, err := c.ConditionClient.Create(cond); err != nil {
@@ -418,7 +418,7 @@ func collectMatchingEvents(kubeClient *knativetest.KubeClient, namespace string,
 
 // checkLabelPropagation checks that labels are correctly propagating from
 // Pipelines, PipelineRuns, and Tasks to TaskRuns and Pods.
-func checkLabelPropagation(t *testing.T, c *clients, namespace string, pipelineRunName string, tr *v1alpha1.TaskRun) {
+func checkLabelPropagation(t *testing.T, c *Client, namespace string, pipelineRunName string, tr *v1alpha1.TaskRun) {
 	// Our controllers add 4 labels automatically. If custom labels are set on
 	// the Pipeline, PipelineRun, or Task then the map will have to be resized.
 	labels := make(map[string]string, 4)
@@ -471,7 +471,7 @@ func checkLabelPropagation(t *testing.T, c *clients, namespace string, pipelineR
 
 // checkAnnotationPropagation checks that annotations are correctly propagating from
 // Pipelines, PipelineRuns, and Tasks to TaskRuns and Pods.
-func checkAnnotationPropagation(t *testing.T, c *clients, namespace string, pipelineRunName string, tr *v1alpha1.TaskRun) {
+func checkAnnotationPropagation(t *testing.T, c *Client, namespace string, pipelineRunName string, tr *v1alpha1.TaskRun) {
 	annotations := make(map[string]string)
 
 	// Check annotation propagation to PipelineRuns.

--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func withRegistry(t *testing.T, c *clients, namespace string) {
+func withRegistry(t *testing.T, c *Client, namespace string) {
 	deployment := getRegistryDeployment(namespace)
 	if _, err := c.KubeClient.Kube.AppsV1().Deployments(namespace).Create(deployment); err != nil {
 		t.Fatalf("Failed to create the local registry deployment: %v", err)

--- a/test/wait.go
+++ b/test/wait.go
@@ -72,7 +72,7 @@ type PipelineRunStateFn func(pr *v1alpha1.PipelineRun) (bool, error)
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForTaskRunState(c *clients, name string, inState TaskRunStateFn, desc string) error {
+func WaitForTaskRunState(c *Client, name string, inState TaskRunStateFn, desc string) error {
 	metricName := fmt.Sprintf("WaitForTaskRunState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
@@ -90,7 +90,7 @@ func WaitForTaskRunState(c *clients, name string, inState TaskRunStateFn, desc s
 // from client every interval until inState returns `true` indicating it is done,
 // returns an  error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForDeploymentState(c *clients, name string, namespace string, inState func(d *appsv1.Deployment) (bool, error), desc string) error {
+func WaitForDeploymentState(c *Client, name string, namespace string, inState func(d *appsv1.Deployment) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForDeploymentState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
@@ -108,7 +108,7 @@ func WaitForDeploymentState(c *clients, name string, namespace string, inState f
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForPodState(c *clients, name string, namespace string, inState func(r *corev1.Pod) (bool, error), desc string) error {
+func WaitForPodState(c *Client, name string, namespace string, inState func(r *corev1.Pod) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForPodState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
@@ -126,7 +126,7 @@ func WaitForPodState(c *clients, name string, namespace string, inState func(r *
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForPipelineRunState(c *clients, name string, polltimeout time.Duration, inState PipelineRunStateFn, desc string) error {
+func WaitForPipelineRunState(c *Client, name string, polltimeout time.Duration, inState PipelineRunStateFn, desc string) error {
 	metricName := fmt.Sprintf("WaitForPipelineRunState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()
@@ -144,7 +144,7 @@ func WaitForPipelineRunState(c *clients, name string, polltimeout time.Duration,
 // interval until an external ip is assigned indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to
 // track how long it took for name to get into the state checked by inState.
-func WaitForServiceExternalIPState(c *clients, namespace, name string, inState func(s *corev1.Service) (bool, error), desc string) error {
+func WaitForServiceExternalIPState(c *Client, namespace, name string, inState func(s *corev1.Service) (bool, error), desc string) error {
 	metricName := fmt.Sprintf("WaitForServiceExternalIPState/%s/%s", name, desc)
 	_, span := trace.StartSpan(context.Background(), metricName)
 	defer span.End()

--- a/test/wait_example_test.go
+++ b/test/wait_example_test.go
@@ -30,7 +30,7 @@ var (
 	// it so that examples still compiles (`go test` tries to compile those) and look
 	// nice in the go documentation.
 	t testingT
-	c *clients
+	c *Client
 )
 
 type testingT interface {

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -100,12 +100,12 @@ func TestWaitForPipelineRunStateFailed(t *testing.T) {
 	}
 }
 
-func fakeClients(t *testing.T, d Data) (*clients, func()) {
+func fakeClients(t *testing.T, d Data) (*Client, func()) {
 	ctx, _ := rtesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	fakeClients, _ := SeedTestData(t, ctx, d)
 	// 	c.KubeClient = fakeClients.Kube
-	return &clients{
+	return &Client{
 		PipelineClient:         fakeClients.Pipeline.TektonV1alpha1().Pipelines(waitNamespace),
 		PipelineResourceClient: fakeClients.Pipeline.TektonV1alpha1().PipelineResources(waitNamespace),
 		PipelineRunClient:      fakeClients.Pipeline.TektonV1alpha1().PipelineRuns(waitNamespace),


### PR DESCRIPTION
Added condition Resource E2E tests and also updated "clients" structure to "Client" make it exportable 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
