### PR TITLE
Add "/workspace" as prefix in "targetpath" case for output resource

### DIFF
--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -80,7 +80,7 @@ func AddOutputResources(
 		if output.TargetPath == "" {
 			sourcePath = filepath.Join(outputDir, boundResource.Name)
 		} else {
-			sourcePath = output.TargetPath
+			sourcePath = filepath.Join(workspaceDir, output.TargetPath)
 		}
 
 		// Add containers to mkdir each output directory. This should run before the build steps themselves.

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -765,7 +765,7 @@ func TestValidOutputResources(t *testing.T) {
 		wantSteps: []v1alpha1.Step{{Container: corev1.Container{
 			Name:    "create-dir-source-workspace-9l9zj",
 			Image:   "busybox",
-			Command: []string{"mkdir", "-p", "/workspace"},
+			Command: []string{"mkdir", "-p", "/workspace/workspace"},
 		}}},
 	}, {
 		desc: "image output resource with no steps",


### PR DESCRIPTION
Fix issue: #1642 
details please checkout attached issue, thanks

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
