### PR TITLE
Move workingDir initialization after script conversion

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -101,11 +101,6 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 		volumes = append(volumes, secretsVolumes...)
 	}
 
-	// Initialize any workingDirs under /workspace.
-	if workingDirInit := workingDirInit(images.ShellImage, taskSpec.Steps, implicitVolumeMounts); workingDirInit != nil {
-		initContainers = append(initContainers, *workingDirInit)
-	}
-
 	// Merge step template with steps.
 	// TODO(#1605): Move MergeSteps to pkg/pod
 	steps, err := v1alpha1.MergeStepsWithStepTemplate(taskSpec.StepTemplate, taskSpec.Steps)
@@ -119,6 +114,11 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 	if scriptsInit != nil {
 		initContainers = append(initContainers, *scriptsInit)
 		volumes = append(volumes, scriptsVolume)
+	}
+
+	// Initialize any workingDirs under /workspace.
+	if workingDirInit := workingDirInit(images.ShellImage, stepContainers, implicitVolumeMounts); workingDirInit != nil {
+		initContainers = append(initContainers, *workingDirInit)
 	}
 
 	// Resolve entrypoint for any steps that don't specify command.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -316,7 +316,7 @@ func TestMakePod(t *testing.T) {
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{{
-				Name:         "working-dir-initializer-9l9zj",
+				Name:         "working-dir-initializer-mz4c7",
 				Image:        images.ShellImage,
 				Command:      []string{"sh"},
 				Args:         []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(workspaceDir, "test"))},

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -32,14 +31,10 @@ import (
 //
 // If no such directories need to be created (i.e., no relative workingDirs
 // are specified), this method returns nil, as no init container is necessary.
-//
-// TODO(#1605): This should take []corev1.Container instead of
-// []corev1.Step, but this makes it easier to use in pod.go. When pod.go is
-// cleaned up, this can take []corev1.Container.
-func workingDirInit(shellImage string, steps []v1alpha1.Step, volumeMounts []corev1.VolumeMount) *corev1.Container {
+func workingDirInit(shellImage string, stepContainers []corev1.Container, volumeMounts []corev1.VolumeMount) *corev1.Container {
 	// Gather all unique workingDirs.
 	workingDirs := map[string]struct{}{}
-	for _, step := range steps {
+	for _, step := range stepContainers {
 		if step.WorkingDir != "" {
 			workingDirs[step.WorkingDir] = struct{}{}
 		}

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -69,18 +68,7 @@ func TestWorkingDirInit(t *testing.T) {
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			// TODO(#1605): WorkingDirInit should take
-			// Containers instead of Steps, but while we're
-			// cleaning up pod.go it's easier to have it take
-			// Steps. This test doesn't care, so let's hide this
-			// conversion in the test where it's easier to remove
-			// later.
-			var steps []v1alpha1.Step
-			for _, c := range c.stepContainers {
-				steps = append(steps, v1alpha1.Step{Container: c})
-			}
-
-			got := workingDirInit(images.ShellImage, steps, volumeMounts)
+			got := workingDirInit(images.ShellImage, c.stepContainers, volumeMounts)
 			if d := cmp.Diff(c.want, got); d != "" {
 				t.Fatalf("Diff (-want, +got): %s", d)
 			}


### PR DESCRIPTION
This allows workingDir initialization to take Containers instead of
Steps, and resolves a TODO.

#1605 


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._