### PR TITLE
Store tektoncd/pipeline release version to a variable during build

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,20 @@
+// Copyright © 2019 The Tekton Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// NOTE: use go build -ldflags "-X github.com/tektoncd/pipeline/pkg/cmd/version.PipelineVersion=$(git describe)"
+const devVersion = "dev"
+
+var PipelineVersion = devVersion

--- a/tekton/publish-nightly.yaml
+++ b/tekton/publish-nightly.yaml
@@ -58,27 +58,6 @@ spec:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /secret/release.json
 
-  - name: create-ko-yaml
-    image: busybox
-    command:
-    - /bin/sh
-    args:
-    - -ce
-    - |
-      set -e
-      set -x
-
-      cat <<EOF > /workspace/go/src/github.com/tektoncd/pipeline/.ko.yaml
-      # By default ko will build images on top of distroless
-      baseImageOverrides:
-        # Use the images we just built as base images
-        ${inputs.params.pathToProject}/${outputs.resources.builtCredsInitImage.url}: ${inputs.params.imageRegistry}/${inputs.params.pathToProject}/build-base:latest
-        ${inputs.params.pathToProject}/${outputs.resources.builtGitInitImage.url}: ${inputs.params.imageRegistry}/${inputs.params.pathToProject}/build-base:latest
-        ${inputs.params.pathToProject}/${outputs.resources.builtEntrypointImage.url}: busybox # image should have shell in $PATH
-      EOF
-
-      cat /workspace/go/src/github.com/tektoncd/pipeline/.ko.yaml
-
   - name: ensure-release-dirs-exist
     image: busybox
     command: ["mkdir"]
@@ -106,6 +85,35 @@ spec:
       VERSION_TAG="$DATE-$COMMIT"
 
       echo $VERSION_TAG > "/builder/home/version"
+
+  - name: create-ko-yaml
+    image: busybox
+    command:
+      - /bin/sh
+    args:
+      - -ce
+      - |
+        set -e
+        set -x
+
+        cat <<EOF > /workspace/go/src/github.com/tektoncd/pipeline/.ko.yaml
+        # By default ko will build images on top of distroless
+        baseImageOverrides:
+          # Use the images we just built as base images
+          ${inputs.params.pathToProject}/${outputs.resources.builtCredsInitImage.url}: ${inputs.params.imageRegistry}/${inputs.params.pathToProject}/build-base:latest
+          ${inputs.params.pathToProject}/${outputs.resources.builtGitInitImage.url}: ${inputs.params.imageRegistry}/${inputs.params.pathToProject}/build-base:latest
+          ${inputs.params.pathToProject}/${outputs.resources.builtEntrypointImage.url}: busybox # image should have shell in $PATH
+        baseBuildOverrides:
+          $(input.params.pathToProject)/$(outputs.resources.builtControllerImage.url):
+            env:
+              - name: CGO_ENABLED
+                value: 1
+            flags:
+              - name: ldflags
+                value: "-X $(inputs.params.pathToProject)/pkg/version.PipelineVersion=$(cat /builder/home/version)"
+        EOF
+
+        cat /workspace/go/src/github.com/tektoncd/pipeline/.ko.yaml
 
   - name: run-ko
     # TODO(#639) we should be able to use the image built by an upstream Task here instead of hardcoding

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -77,6 +77,14 @@ spec:
         $(inputs.params.pathToProject)/$(outputs.resources.builtCredsInitImage.url): $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/build-base:latest
         $(inputs.params.pathToProject)/$(outputs.resources.builtGitInitImage.url): $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/build-base:latest
         $(inputs.params.pathToProject)/$(outputs.resources.builtEntrypointImage.url): busybox # image should have shell in $PATH
+      baseBuildOverrides:
+        $(input.params.pathToProject)/$(outputs.resources.builtControllerImage.url):
+          env:
+            - name: CGO_ENABLED
+              value: 1
+          flags:
+            - name: ldflags
+              value: "-X $(inputs.params.pathToProject)/pkg/version.PipelineVersion=$(inputs.params.versionTag)"
       EOF
 
       cat /workspace/go/src/github.com/tektoncd/pipeline/.ko.yaml

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -85,6 +85,8 @@ spec:
       params:
         - name: package
           value: $(params.package)
+        - name: flags
+          value: -ldflags "-X github.com/tektoncd/pipeline/pkg/version.PipelineVersion=$(params.versionTag)"
       resources:
         inputs:
           - name: source


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Fixes https://github.com/tektoncd/pipeline/issues/1543
- Sets the PipelineVersion variable value through golang-build task used during release.
- Solution to https://github.com/tektoncd/cli/issues/463 would augment this, by using the cli to show forth the value for PipelineVersion which would be the release version for tektoncd/pipeline

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
