### PR TITLE
Support stepTemplate alongside script mode

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/merge.go
+++ b/pkg/apis/pipeline/v1alpha1/merge.go
@@ -84,7 +84,8 @@ func MergeStepsWithStepTemplate(template *v1.Container, steps []Step) ([]Step, e
 			merged.Args = []string{}
 		}
 
-		steps[i] = Step{Container: *merged}
+		// Pass through original step Script, for later conversion.
+		steps[i] = Step{Container: *merged, Script: s.Script}
 	}
 	return steps, nil
 }

--- a/pkg/pod/entrypoint_lookup_test.go
+++ b/pkg/pod/entrypoint_lookup_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package pod
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -92,7 +91,7 @@ func (f fakeCache) Get(imageName, _, _ string) ([]string, name.Digest, error) {
 
 	d, found := f[imageName]
 	if !found {
-		return nil, name.Digest{}, errors.New("not found")
+		return nil, name.Digest{}, fmt.Errorf("Image %q not found", imageName)
 	}
 	if d.seen {
 		return nil, name.Digest{}, fmt.Errorf("Image %q was already looked up!", imageName)

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -90,8 +90,13 @@ cat > ${tmpfile} << '%s'
 %s
 `, tmpFile, heredoc, s.Script, heredoc)
 
-		// Set the command to execute the correct script in the mounted volume.
+		// Set the command to execute the correct script in the mounted
+		// volume.
+		// A previous merge with stepTemplate may have populated
+		// Command and Args, even though this is not normally valid, so
+		// we'll clear out the Args and overwrite Command.
 		steps[i].Command = []string{tmpFile}
+		steps[i].Args = nil // TODO(#1652): Don't overwrite this.
 		steps[i].VolumeMounts = append(steps[i].VolumeMounts, scriptsVolumeMount)
 		containers = append(containers, steps[i].Container)
 	}


### PR DESCRIPTION
`MergeStepsWithStepTemplate` now takes into account a step Script, instead
of zeroing it out.

There's still room for improvement here; Merge can happen after script
conversion, if script mode is able to accept template-provided args (#1652)

Fixes #1647 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._