### PR TITLE
Split out step resource request management

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -39,9 +39,6 @@ var (
 		CredsImage:      "override-with-creds:latest",
 		ShellImage:      "busybox",
 	}
-	resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
-		return x.Cmp(y) == 0
-	})
 )
 
 func TestMakePod(t *testing.T) {
@@ -103,13 +100,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
 		},
@@ -160,13 +151,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, secretsVolume, toolsVolume, downwardVolume),
 		},
@@ -209,13 +194,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
 			SecurityContext: &corev1.PodSecurityContext{
@@ -254,13 +233,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
 		},
@@ -293,13 +266,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
 		},
@@ -342,13 +309,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   filepath.Join(workspaceDir, "test"),
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
 		},
@@ -386,13 +347,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}, {
 				Name:  "sidecar-sc-name",
 				Image: "sidecar-image",
@@ -445,13 +400,7 @@ func TestMakePod(t *testing.T) {
 				Env:          implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("8"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}, {
 				Name:    "step-unnamed-1",
 				Image:   "image",
@@ -470,7 +419,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   workspaceDir,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceCPU:              resource.MustParse("8"),
 						corev1.ResourceMemory:           resource.MustParse("100Gi"),
 						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
 					},
@@ -550,13 +499,7 @@ script-heredoc-randomly-generated-6nl7g
 				Env:          append(implicitEnvVars, corev1.EnvVar{Name: "FOO", Value: "bar"}),
 				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, toolsMount, downwardMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}, {
 				Name:    "step-two",
 				Image:   "image",
@@ -573,13 +516,7 @@ script-heredoc-randomly-generated-6nl7g
 				Env:          append(implicitEnvVars, corev1.EnvVar{Name: "FOO", Value: "bar"}),
 				VolumeMounts: append([]corev1.VolumeMount{{Name: "i-have-a-volume-mount"}, scriptsVolumeMount, toolsMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}, {
 				Name:    "step-regular-step",
 				Image:   "image",
@@ -599,13 +536,7 @@ script-heredoc-randomly-generated-6nl7g
 				Env:          append(implicitEnvVars, corev1.EnvVar{Name: "FOO", Value: "bar"}),
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount}, implicitVolumeMounts...),
 				WorkingDir:   workspaceDir,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("0"),
-						corev1.ResourceMemory:           resource.MustParse("0"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-					},
-				},
+				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
 			}},
 			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume),
 		},

--- a/pkg/pod/resource_request.go
+++ b/pkg/pod/resource_request.go
@@ -1,0 +1,36 @@
+package pod
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var zeroQty = resource.MustParse("0")
+
+func allZeroQty() corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceCPU:              zeroQty,
+		corev1.ResourceMemory:           zeroQty,
+		corev1.ResourceEphemeralStorage: zeroQty,
+	}
+}
+
+func resolveResourceRequests(containers []corev1.Container) []corev1.Container {
+	max := allZeroQty()
+	for _, c := range containers {
+		for k, v := range c.Resources.Requests {
+			if v.Cmp(max[k]) > 0 {
+				max[k] = v
+			}
+		}
+	}
+
+	// Set resource requests for all steps but the theh last container to
+	// zero.
+	for i := range containers[:len(containers)-1] {
+		containers[i].Resources.Requests = allZeroQty()
+	}
+	// Set the last container's request to the max of all resources.
+	containers[len(containers)-1].Resources.Requests = max
+	return containers
+}

--- a/pkg/pod/resource_request_test.go
+++ b/pkg/pod/resource_request_test.go
@@ -1,0 +1,88 @@
+package pod
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
+	return x.Cmp(y) == 0
+})
+
+func TestResolveResourceRequests(t *testing.T) {
+	for _, c := range []struct {
+		desc     string
+		in, want []corev1.Container
+	}{{
+		desc: "three steps, no requests",
+		in:   []corev1.Container{{}, {}, {}},
+		want: []corev1.Container{{
+			Resources: corev1.ResourceRequirements{Requests: allZeroQty()},
+		}, {
+			Resources: corev1.ResourceRequirements{Requests: allZeroQty()},
+		}, {
+			Resources: corev1.ResourceRequirements{Requests: allZeroQty()},
+		}},
+	}, {
+		desc: "requests are moved, limits aren't changed",
+		in: []corev1.Container{{
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("10"),
+				},
+			},
+		}, {
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("10Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("11Gi"),
+				},
+			},
+		}, {
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
+				},
+			},
+		}},
+		want: []corev1.Container{{
+			// All zeroed out.
+			Resources: corev1.ResourceRequirements{Requests: allZeroQty()},
+		}, {
+			// Requests zeroed out, limits remain.
+			Resources: corev1.ResourceRequirements{
+				Requests: allZeroQty(),
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("11Gi"),
+				},
+			},
+		}, {
+			// Requests to the max, limits remain.
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("10"),
+					corev1.ResourceMemory:           resource.MustParse("10Gi"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
+				},
+			},
+		}},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := resolveResourceRequests(c.in)
+			if d := cmp.Diff(c.want, got, resourceQuantityCmp); d != "" {
+				t.Errorf("Diff(-want, +got): %s", d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Before this change, all steps' resource requests (*not* limits) were
zeroed out unless that value for that metric represented the maximum
across all steps. If step 2 requested the maximum memory of all steps,
but not the max CPU, its memory request would persist but its CPU
request would be zeroed out.

After this change, the max request for each resource type (CPU, memory,
ephermeral storage) is calculated, then applied to the *last* step's
container. The effect is the same, unless Pods' resource requests are
updated to account for exited containers (afaik they're not), and this
is simpler to express and explain. And since all the code for this is in
its own method and file, it's easier to test in isolation.

Fixes #1605

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._
