### PR TITLE
Fetch {Cluster}Tasks using generated client

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -202,7 +202,7 @@ func (c *Reconciler) getTaskFunc(tr *v1alpha1.TaskRun) (resources.GetTask, v1alp
 	kind := v1alpha1.NamespacedTaskKind
 	if tr.Spec.TaskRef != nil && tr.Spec.TaskRef.Kind == v1alpha1.ClusterTaskKind {
 		gtFunc = func(name string) (v1alpha1.TaskInterface, error) {
-			t, err := c.clusterTaskLister.Get(name)
+			t, err := c.PipelineClientSet.TektonV1alpha1().ClusterTasks().Get(name, metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}
@@ -211,7 +211,7 @@ func (c *Reconciler) getTaskFunc(tr *v1alpha1.TaskRun) (resources.GetTask, v1alp
 		kind = v1alpha1.ClusterTaskKind
 	} else {
 		gtFunc = func(name string) (v1alpha1.TaskInterface, error) {
-			t, err := c.taskLister.Tasks(tr.Namespace).Get(name)
+			t, err := c.PipelineClientSet.TektonV1alpha1().Tasks(tr.Namespace).Get(name, metav1.GetOptions{})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
It seems like using the Lister to fetch ClusterTasks and Tasks results
in some flakiness when attempting to run the Task immediately after it's
created (as in clustertask.yaml). Using the Lister is likely faster, due
to caching, but if it means failed runs for just-created Tasks, that
speed isn't worth it.

Fixes https://github.com/tektoncd/pipeline/issues/1661

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._