### PR TITLE
Don't fail if there are no comments, labels or statuses.

### DIFF
--- a/cmd/pullrequest-init/disk.go
+++ b/cmd/pullrequest-init/disk.go
@@ -231,6 +231,9 @@ func manifestFromDisk(path string) (Manifest, error) {
 
 func commentsFromDisk(path string) ([]*scm.Comment, Manifest, error) {
 	fis, err := ioutil.ReadDir(path)
+	if isNotExistError(err) {
+		return nil, nil, nil
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -261,6 +264,9 @@ func commentsFromDisk(path string) ([]*scm.Comment, Manifest, error) {
 
 func labelsFromDisk(path string) ([]*scm.Label, Manifest, error) {
 	fis, err := ioutil.ReadDir(path)
+	if isNotExistError(err) {
+		return nil, nil, nil
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -286,6 +292,9 @@ func labelsFromDisk(path string) ([]*scm.Label, Manifest, error) {
 
 func statusesFromDisk(path string) (*scm.CombinedStatus, error) {
 	fis, err := ioutil.ReadDir(path)
+	if isNotExistError(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -317,4 +326,8 @@ func refFromDisk(path, name string) (scm.PullRequestBranch, error) {
 		return scm.PullRequestBranch{}, err
 	}
 	return ref, nil
+}
+
+func isNotExistError(err error) bool {
+	return err != nil && os.IsNotExist(err)
 }

--- a/cmd/pullrequest-init/disk_test.go
+++ b/cmd/pullrequest-init/disk_test.go
@@ -194,6 +194,52 @@ func TestToDisk(t *testing.T) {
 	}
 }
 
+func TestFromDiskWithoutComments(t *testing.T) {
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+
+	// Write some refs
+	base := scm.PullRequestBranch{
+		Repo: scm.Repository{Name: "repo1"},
+		Ref:  "refs/heads/branch1",
+		Sha:  "sha1",
+	}
+	head := scm.PullRequestBranch{
+		Repo: scm.Repository{Name: "repo2"},
+		Ref:  "refs/heads/branch2",
+		Sha:  "sha2",
+	}
+
+	writeFile := func(p string, v interface{}) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile(p, b, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(filepath.Join(d, "base.json"), &base)
+	writeFile(filepath.Join(d, "head.json"), &head)
+
+	rsrc, err := FromDisk(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the refs
+	if diff := cmp.Diff(rsrc.PR.Base, base); diff != "" {
+		t.Errorf("Get Base: -want +got: %s", diff)
+	}
+	if diff := cmp.Diff(rsrc.PR.Head, head); diff != "" {
+		t.Errorf("Get Head: -want +got: %s", diff)
+	}
+
+}
+
 func TestFromDisk(t *testing.T) {
 	d, err := ioutil.TempDir("", "")
 	if err != nil {


### PR DESCRIPTION
# Changes

This fixes #1665 by testing the error response from `ioutil.ReadDir` and not considering it to be an error if the directory does not exist.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
 - Can now update a pullrequest output, and add a status even if the PR has no comments.
```
