### PR TITLE
Restore builder/home for publish nightly

### DIFF
--- a/tekton/publish-nightly.yaml
+++ b/tekton/publish-nightly.yaml
@@ -105,7 +105,7 @@ spec:
       DATE=$(date +"%Y%m%d")
       VERSION_TAG="$DATE-$COMMIT"
 
-      echo $VERSION_TAG > "/tekton/home/version"
+      echo $VERSION_TAG > "/builder/home/version"
 
   - name: run-ko
     # TODO(#639) we should be able to use the image built by an upstream Task here instead of hardcoding
@@ -126,7 +126,7 @@ spec:
       set -x
 
       # TODO(https://github.com/tektoncd/triggers/issues/87) if the versionTag could be generated dynamically, we could use the same Task for nightly + official releases
-      export VERSION_TAG="$(cat /tekton/home/version)"
+      export VERSION_TAG="$(cat /builder/home/version)"
 
       # Auth with CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
       gcloud auth configure-docker
@@ -170,7 +170,7 @@ spec:
       cd /workspace/bucket
 
       # TODO(https://github.com/tektoncd/triggers/issues/87) if the versionTag could be generated dynamically, we could use the same Task for nightly + official releases
-      export VERSION_TAG="$(cat /tekton/home/version)"
+      export VERSION_TAG="$(cat /builder/home/version)"
 
       mkdir -p /workspace/bucket/previous/$VERSION_TAG/
       cp /workspace/bucket/latest/release.yaml /workspace/bucket/previous/$VERSION_TAG/release.yaml
@@ -186,7 +186,7 @@ spec:
       set -x
 
       # TODO(https://github.com/tektoncd/triggers/issues/87) if the versionTag could be generated dynamically, we could use the same Task for nightly + official releases
-      export VERSION_TAG="$(cat /tekton/home/version)"
+      export VERSION_TAG="$(cat /builder/home/version)"
 
       REGIONS=(us eu asia)
       IMAGES=(


### PR DESCRIPTION
# Changes

This was changes in https://github.com/tektoncd/pipeline/pull/1628,
however since this task runs on Tekton 0.3.1, we need to stick
with /builder/home there, at least until we get rid of Tekton 0.3.1
in the Prow cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
