### PR TITLE
Remove the support for legacy image output paths.

### DIFF
--- a/cmd/imagedigestexporter/main.go
+++ b/cmd/imagedigestexporter/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"path/filepath"
 
 	"github.com/tektoncd/pipeline/pkg/termination"
 	"knative.dev/pkg/logging"
@@ -31,10 +30,6 @@ import (
 var (
 	images                 = flag.String("images", "", "List of images resources built by task in json format")
 	terminationMessagePath = flag.String("terminationMessagePath", "/dev/termination-log", "Location of file containing termination message")
-)
-
-var (
-	legacyOutputPath = "/builder/home/image-outputs"
 )
 
 /* The input of this go program will be a JSON string with all the output PipelineResources of type
@@ -58,17 +53,8 @@ func main() {
 	for _, imageResource := range imageResources {
 		ii, err := layout.ImageIndexFromPath(imageResource.OutputImageDir)
 		if err != nil {
-			// if this image doesn't have a builder that supports index.json file,
-			// then it will be skipped
-			legacyPath := filepath.Join(legacyOutputPath, imageResource.Name)
-			logger.Infof("ImageResource %s doesn't have an index.json file: %s", imageResource.Name, err)
-			logger.Infof("Checking legacy image output path: %s", legacyPath)
-			ii, err = layout.ImageIndexFromPath(legacyPath)
-			if err != nil {
-				logger.Infof("No index.json found for: %s", imageResource.Name)
-				continue
-			}
-			logger.Warnf("index.json found at legacy path: %s. Support for this location will be removed in a future release.", legacyPath)
+			logger.Infof("No index.json found for: %s", imageResource.Name)
+			continue
 		}
 		digest, err := GetDigest(ii)
 		if err != nil {


### PR DESCRIPTION
# Changes

This support was left in for one release after deprecation in #1467, which was released in 0.9.0.
It can now be safely removed.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Support for the legacy image output path (/builder/home/image-outputs) has been removed.
The new location (/workspace/output/<resource name>) should be used instead.

```
