### PR TITLE
Remove support for the name parameter to cluster resources.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cluster_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource.go
@@ -66,8 +66,6 @@ func NewClusterResource(kubeconfigWriterImage string, r *PipelineResource) (*Clu
 	}
 	for _, param := range r.Spec.Params {
 		switch {
-		case strings.EqualFold(param.Name, "Name"):
-			clusterResource.Name = param.Value
 		case strings.EqualFold(param.Name, "URL"):
 			clusterResource.URL = param.Value
 		case strings.EqualFold(param.Name, "Revision"):

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -35,13 +35,12 @@ func TestNewClusterResource(t *testing.T) {
 		desc: "basic cluster resource",
 		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
-			tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
 			tb.PipelineResourceSpecParam("token", "my-token"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:                  "test_cluster_resource",
+			Name:                  "test-cluster-resource",
 			Type:                  v1alpha1.PipelineResourceTypeCluster,
 			URL:                   "http://10.10.10.10",
 			CAData:                []byte("my-cluster-cert"),
@@ -52,14 +51,13 @@ func TestNewClusterResource(t *testing.T) {
 		desc: "resource with password instead of token",
 		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
-			tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
 			tb.PipelineResourceSpecParam("username", "user"),
 			tb.PipelineResourceSpecParam("password", "pass"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:                  "test_cluster_resource",
+			Name:                  "test-cluster-resource",
 			Type:                  v1alpha1.PipelineResourceTypeCluster,
 			URL:                   "http://10.10.10.10",
 			CAData:                []byte("my-cluster-cert"),
@@ -71,12 +69,11 @@ func TestNewClusterResource(t *testing.T) {
 		desc: "set insecure flag to true when there is no cert",
 		resource: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
-			tb.PipelineResourceSpecParam("name", "test.cluster.resource"),
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("token", "my-token"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:                  "test.cluster.resource",
+			Name:                  "test-cluster-resource",
 			Type:                  v1alpha1.PipelineResourceTypeCluster,
 			URL:                   "http://10.10.10.10",
 			Token:                 "my-token",
@@ -87,14 +84,13 @@ func TestNewClusterResource(t *testing.T) {
 		desc: "basic cluster resource with namespace",
 		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
-			tb.PipelineResourceSpecParam("name", "test_cluster_resource"),
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
 			tb.PipelineResourceSpecParam("token", "my-token"),
 			tb.PipelineResourceSpecParam("namespace", "my-namespace"),
 		)),
 		want: &v1alpha1.ClusterResource{
-			Name:                  "test_cluster_resource",
+			Name:                  "test-cluster-resource",
 			Type:                  v1alpha1.PipelineResourceTypeCluster,
 			URL:                   "http://10.10.10.10",
 			CAData:                []byte("my-cluster-cert"),
@@ -106,7 +102,6 @@ func TestNewClusterResource(t *testing.T) {
 		desc: "basic resource with secrets",
 		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
-			tb.PipelineResourceSpecParam("name", "test-cluster-resource"),
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecSecretParam("cadata", "secret1", "cadatakey"),
 			tb.PipelineResourceSpecSecretParam("token", "secret1", "tokenkey"),

--- a/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelineresource_validation.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
-	logging "knative.dev/pkg/logging"
 )
 
 var _ apis.Validatable = (*PipelineResource)(nil)
@@ -43,7 +42,7 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 	if rs.Type == PipelineResourceTypeCluster {
-		var authFound, cadataFound, nameFound, isInsecure bool
+		var authFound, cadataFound, isInsecure bool
 		for _, param := range rs.Params {
 			switch {
 			case strings.EqualFold(param.Name, "URL"):
@@ -57,8 +56,6 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 				cadataFound = true
 			case strings.EqualFold(param.Name, "Token"):
 				authFound = true
-			case strings.EqualFold(param.Name, "name"):
-				nameFound = true
 			case strings.EqualFold(param.Name, "insecure"):
 				b, _ := strconv.ParseBool(param.Value)
 				isInsecure = b
@@ -75,10 +72,6 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 			}
 		}
 
-		if nameFound {
-			logging.FromContext(ctx).Warn(
-				"The name parameter on the cluster resource is deprecated. Support will be removed in a future release")
-		}
 		// One auth method must be supplied
 		if !(authFound) {
 			return apis.ErrMissingField("username or CAData  or token param")


### PR DESCRIPTION
# Changes

This was deprecated in #1474 which was released in 0.9.0. It can safely
be deleted in the next release.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Support for the "name" parameter to the cluster resource has been removed. Users should use the standard "name" parameter on the resource object itself instead.

```
