### PR TITLE
Allow unused resource in Pipelines 🎐

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -65,9 +65,9 @@ func validateDeclaredResources(ps *PipelineSpec) error {
 	for _, resource := range ps.Resources {
 		provided = append(provided, resource.Name)
 	}
-	err := list.IsSame(required, provided)
-	if err != nil {
-		return xerrors.Errorf("Pipeline declared resources didn't match usage in Tasks: %w", err)
+	missing := list.DiffLeft(required, provided)
+	if len(missing) > 0 {
+		return xerrors.Errorf("Pipeline declared resources didn't match usage in Tasks: Didn't provide required values: %s", missing)
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -195,15 +195,6 @@ func TestPipelineSpec_Validate(t *testing.T) {
 		)),
 		failureExpected: true,
 	}, {
-		name: "unused resources declared",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineDeclaredResource("extra-resource", v1alpha1.PipelineResourceTypeImage),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("the-resource", "great-resource")),
-		)),
-		failureExpected: true,
-	}, {
 		name: "output resources missing from declaration",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),


### PR DESCRIPTION
# Changes

We need to make sure the required resources are declared, but we
shouldn't error out in case of extras. A resource could be used only
in variable substitution (e.g. an image for the tag).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @bobcatfish @piyush-garg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Do not error out in case of extra, unused resource
```
