### PR TITLE
Handle injected sidecars more correctly

### DIFF
--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -168,18 +168,25 @@ func TestStopSidecars(t *testing.T) {
 		Image: "foo",
 	}
 	sidecarContainer := corev1.Container{
-		Name:    sidecarPrefix + "my-sidecar",
-		Image:   "original-image",
-		Command: []string{"my", "command"},
-		Args:    []string{"my", "args"},
-		Env:     []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+		Name:  sidecarPrefix + "my-sidecar",
+		Image: "original-image",
 	}
 	stoppedSidecarContainer := corev1.Container{
-		Name:    sidecarContainer.Name,
-		Image:   nopImage,
-		Command: []string{"my", "command"},
-		Args:    []string{"my", "args"},
-		Env:     []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+		Name:  sidecarContainer.Name,
+		Image: nopImage,
+	}
+
+	// This is a container that doesn't start with the "sidecar-" prefix,
+	// which indicates it was injected into the Pod by a Mutating Webhook
+	// Admission Controller. Injected sidecars should also be stopped if
+	// they're running.
+	injectedSidecar := corev1.Container{
+		Name:  "injected",
+		Image: "original-injected-image",
+	}
+	stoppedInjectedSidecar := corev1.Container{
+		Name:  injectedSidecar.Name,
+		Image: nopImage,
 	}
 
 	for _, c := range []struct {
@@ -187,13 +194,13 @@ func TestStopSidecars(t *testing.T) {
 		pod            corev1.Pod
 		wantContainers []corev1.Container
 	}{{
-		desc: "Running sidecar should be stopped",
+		desc: "Running sidecars (incl injected) should be stopped",
 		pod: corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-pod",
 			},
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{stepContainer, sidecarContainer},
+				Containers: []corev1.Container{stepContainer, sidecarContainer, injectedSidecar},
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
@@ -203,10 +210,14 @@ func TestStopSidecars(t *testing.T) {
 					Name: sidecarContainer.Name,
 					// Sidecar is running.
 					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())}},
+				}, {
+					Name: injectedSidecar.Name,
+					// Injected sidecar is running.
+					State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(time.Now())}},
 				}},
 			},
 		},
-		wantContainers: []corev1.Container{stepContainer, stoppedSidecarContainer},
+		wantContainers: []corev1.Container{stepContainer, stoppedSidecarContainer, stoppedInjectedSidecar},
 	}, {
 		desc: "Pending Pod should not be updated",
 		pod: corev1.Pod{
@@ -221,13 +232,13 @@ func TestStopSidecars(t *testing.T) {
 		},
 		wantContainers: []corev1.Container{stepContainer, sidecarContainer},
 	}, {
-		desc: "Non-Running sidecar should not be stopped",
+		desc: "Non-Running sidecars should not be stopped",
 		pod: corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-pod",
 			},
 			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{stepContainer, sidecarContainer},
+				Containers: []corev1.Container{stepContainer, sidecarContainer, injectedSidecar},
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
@@ -237,10 +248,14 @@ func TestStopSidecars(t *testing.T) {
 					Name: sidecarContainer.Name,
 					// Sidecar is waiting.
 					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}},
+				}, {
+					Name: injectedSidecar.Name,
+					// Injected sidecar is waiting.
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}},
 				}},
 			},
 		},
-		wantContainers: []corev1.Container{stepContainer, sidecarContainer},
+		wantContainers: []corev1.Container{stepContainer, sidecarContainer, injectedSidecar},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			kubeclient := fakek8s.NewSimpleClientset(&c.pod)

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -71,7 +71,11 @@ func SidecarsReady(podStatus corev1.PodStatus) bool {
 		return false
 	}
 	for _, s := range podStatus.ContainerStatuses {
-		if !isContainerSidecar(s.Name) {
+		// If the step indicates that it's a step, skip it.
+		// An injected sidecar might not have the "sidecar-" prefix, so
+		// we can't just look for that prefix, we need to look at any
+		// non-step container.
+		if isContainerStep(s.Name) {
 			continue
 		}
 		if s.State.Running != nil && s.Ready {


### PR DESCRIPTION
Before this change, sidecars that are injected into the Pod by external
Mutating Admission Controllers would not be guaranteed to be Ready
before starting the first step, and would not be correctly stopped when
steps finish.

This is because we only considered containers with names starting with
"sidecar-" as sidecars, and injected sidecars might have another name.

Instead, with this change, we look for any *non-step* container, which
must (currently) indicate a sidecar container, when waiting for or
stopping sidecars.

An added test covers this new behavior, which would have failed before
this change.

In general, we could use better e2e test coverage for injected sidecars (https://github.com/tektoncd/pipeline/issues/1687)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Improved support for injected sidecar containers
```
