### PR TITLE
Allow script mode to accept scripts that do not start with a shebang.

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -156,10 +156,11 @@ If this field is present, the step cannot specify `command`.
 When specified, a `script` gets invoked as if it were the contents of a file in
 the container. Any `args` are passed to the script file.
 
-Scripts should start with a
-[shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line to declare what
-tool should be used to interpret the script. That tool must then also be
-available within the step's container.
+Scripts that do not start with a shebang
+[shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line will use a default
+value of `#!/bin/sh`, although users can override this by starting their script
+with a shebang to declare what tool should be used to interpret the script.
+That tool must then also be available within the step's container.
 
 This allows you to execute a Bash script, if the image includes `bash`:
 

--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -10,6 +10,9 @@ spec:
         default: param-value
 
     steps:
+    - name: noshebang
+      image: ubuntu
+      script: echo "no shebang"
     - name: bash
       image: ubuntu
       env:

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -138,12 +138,6 @@ func validateSteps(steps []Step) *apis.FieldError {
 					Paths:   []string{"script"},
 				}
 			}
-			if !strings.HasPrefix(strings.TrimSpace(s.Script), "#!") {
-				return &apis.FieldError{
-					Message: "script must start with a shebang (#!)",
-					Paths:   []string{"script"},
-				}
-			}
 		}
 
 		if s.Name == "" {

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -632,20 +632,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Paths:   []string{"volumes.name"},
 		},
 	}, {
-		name: "step with script without shebang",
-		fields: fields{
-			Steps: []v1alpha1.Step{{
-				Container: corev1.Container{
-					Image: "my-image",
-				},
-				Script: "does not begin with shebang",
-			}},
-		},
-		expectedError: apis.FieldError{
-			Message: "script must start with a shebang (#!)",
-			Paths:   []string{"steps.script"},
-		},
-	}, {
 		name: "step with script and command",
 		fields: fields{
 			Steps: []v1alpha1.Step{{

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -435,7 +435,7 @@ func TestMakePod(t *testing.T) {
 					Name:  "one",
 					Image: "image",
 				},
-				Script: "echo hello from step one",
+				Script: "#!/bin/sh\necho hello from step one",
 			}, {
 				Container: corev1.Container{
 					Name:         "two",
@@ -462,6 +462,7 @@ print("Hello from Python")`,
 				Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-mz4c7"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'script-heredoc-randomly-generated-mssqb'
+#!/bin/sh
 echo hello from step one
 script-heredoc-randomly-generated-mssqb
 tmpfile="/tekton/scripts/script-1-78c5n"


### PR DESCRIPTION
# Changes

This prefixes scripts that do not start with a shebang with a default value of "/bin/sh".
This matches the default entrypoint/shell for docker containers, and should help
prevent an easy-to-make mistake.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Task steps that use script mode no longer need to specify a shebang line. Scripts that do not start with a shebang will use a default value of "#!/bin/sh"
```
