### PR TITLE
Set scm.PR.Sha to scm.PR.Head.Sha when loading from disk.

### DIFF
--- a/pkg/pullrequest/disk.go
+++ b/pkg/pullrequest/disk.go
@@ -197,6 +197,8 @@ func FromDisk(path string) (*Resource, error) {
 		return nil, err
 	}
 
+	r.PR.Sha = r.PR.Head.Sha
+
 	return r, nil
 }
 

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -342,6 +342,9 @@ func TestFromDisk(t *testing.T) {
 	if diff := cmp.Diff(rsrc.PR.Head, head); diff != "" {
 		t.Errorf("Get Head: -want +got: %s", diff)
 	}
+	if diff := cmp.Diff(rsrc.PR.Sha, head.Sha); diff != "" {
+		t.Errorf("Get Sha: -want +got: %s", diff)
+	}
 
 	// Check the comments
 	commentMap := map[int]scm.Comment{}


### PR DESCRIPTION
# Changes

This guarantee is made when retrieving a PR from a provider, but we do not persist
that guarantee when roundtripping from disk.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
