### PR TITLE
Move *RunControllerName out of v1alpha1 🐸

### DIFF
--- a/pkg/apis/pipeline/controller.go
+++ b/pkg/apis/pipeline/controller.go
@@ -23,10 +23,4 @@ const (
 
 	// TaskRunControllerName holds the name of the PipelineRun controller
 	TaskRunControllerName = "TaskRun"
-
-	// PipelineResourceTypeGit indicates that this source is a GitHub repo.
-	ArtifactStorageBucketType = "bucket"
-
-	// PipelineResourceTypeStorage indicates that this source is a storage blob resource.
-	ArtifactStoragePVCType = "pvc"
 )

--- a/pkg/apis/pipeline/storagetypes.go
+++ b/pkg/apis/pipeline/storagetypes.go
@@ -17,16 +17,9 @@ limitations under the License.
 package pipeline
 
 const (
-	// PipelineRunControllerName holds the name of the PipelineRun controller
-	// nolint: golint
-	PipelineRunControllerName = "PipelineRun"
-
-	// TaskRunControllerName holds the name of the PipelineRun controller
-	TaskRunControllerName = "TaskRun"
-
-	// PipelineResourceTypeGit indicates that this source is a GitHub repo.
+	// ArtifactStorageBucketType holds the name of the PipelineResource type for a bucket
 	ArtifactStorageBucketType = "bucket"
 
-	// PipelineResourceTypeStorage indicates that this source is a storage blob resource.
+	// ArtifactStoragePVCType holds the name of the PipelineResource type for a pvc
 	ArtifactStoragePVCType = "pvc"
 )

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,11 +30,10 @@ import (
 )
 
 var (
-	pipelineRunControllerName = "PipelineRun"
-	groupVersionKind          = schema.GroupVersionKind{
+	groupVersionKind = schema.GroupVersionKind{
 		Group:   SchemeGroupVersion.Group,
 		Version: SchemeGroupVersion.Version,
-		Kind:    pipelineRunControllerName,
+		Kind:    pipeline.PipelineRunControllerName,
 	}
 )
 
@@ -246,7 +245,7 @@ func (pr *PipelineRun) IsCancelled() bool {
 // GetRunKey return the pipelinerun key for timeout handler map
 func (pr *PipelineRun) GetRunKey() string {
 	// The address of the pointer is a threadsafe unique identifier for the pipelinerun
-	return fmt.Sprintf("%s/%p", pipelineRunControllerName, pr)
+	return fmt.Sprintf("%s/%p", pipeline.PipelineRunControllerName, pr)
 }
 
 // IsTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -251,7 +251,7 @@ func (tr *TaskRun) GetPipelineRunPVCName() string {
 		return ""
 	}
 	for _, ref := range tr.GetOwnerReferences() {
-		if ref.Kind == pipelineRunControllerName {
+		if ref.Kind == pipeline.PipelineRunControllerName {
 			return fmt.Sprintf("%s-pvc", ref.Name)
 		}
 	}
@@ -262,7 +262,7 @@ func (tr *TaskRun) GetPipelineRunPVCName() string {
 // owner reference of type PipelineRun
 func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 	for _, ref := range tr.GetOwnerReferences() {
-		if ref.Kind == pipelineRunControllerName {
+		if ref.Kind == pipeline.PipelineRunControllerName {
 			return true
 		}
 	}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -81,7 +81,7 @@ func NewController(images pipeline.Images) func(context.Context, configmap.Watch
 			timeoutHandler:    timeoutHandler,
 			metrics:           metrics,
 		}
-		impl := controller.NewImpl(c, c.Logger, pipelineRunControllerName)
+		impl := controller.NewImpl(c, c.Logger, pipeline.PipelineRunControllerName)
 
 		timeoutHandler.SetPipelineRunCallbackFunc(impl.Enqueue)
 		timeoutHandler.CheckTimeouts(kubeclientset, pipelineclientset)

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -74,8 +74,6 @@ const (
 	ReasonInvalidGraph = "PipelineInvalidGraph"
 	// pipelineRunAgentName defines logging agent name for PipelineRun Controller
 	pipelineRunAgentName = "pipeline-controller"
-	// pipelineRunControllerName defines name for PipelineRun Controller
-	pipelineRunControllerName = "PipelineRun"
 
 	// Event reasons
 	eventReasonFailed    = "PipelineRunFailed"

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -83,7 +83,7 @@ func NewController(images pipeline.Images) func(context.Context, configmap.Watch
 			metrics:           metrics,
 			entrypointCache:   entrypointCache,
 		}
-		impl := controller.NewImpl(c, c.Logger, taskRunControllerName)
+		impl := controller.NewImpl(c, c.Logger, pipeline.TaskRunControllerName)
 
 		timeoutHandler.SetTaskRunCallbackFunc(impl.Enqueue)
 		timeoutHandler.CheckTimeouts(kubeclientset, pipelineclientset)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -48,11 +48,6 @@ import (
 const (
 	// taskRunAgentName defines logging agent name for TaskRun Controller
 	taskRunAgentName = "taskrun-controller"
-	// taskRunControllerName defines name for TaskRun Controller
-	taskRunControllerName = "TaskRun"
-
-	// imageDigestExporterContainerName defines the name of the container that will collect the
-	// built images digest
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.


### PR DESCRIPTION
# Changes

This is not related to the API version. It also remove the constant in
the reconciler for the same information.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
