### PR TITLE
 test/builder: prepare multiple API version 👷

### DIFF
--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -17,79 +17,32 @@ limitations under the License.
 package builder
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
 )
 
 // ConditionOp is an operation which modifies a Condition struct.
-type ConditionOp func(*v1alpha1.Condition)
+type ConditionOp = builder.ConditionOp
 
 // ConditionSpecOp is an operation which modifies a ConditionSpec struct.
-type ConditionSpecOp func(spec *v1alpha1.ConditionSpec)
+type ConditionSpecOp = builder.ConditionSpecOp
 
-// Condition creates a Condition with default values.
-// Any number of Condition modifiers can be passed to transform it.
-func Condition(name, namespace string, ops ...ConditionOp) *v1alpha1.Condition {
-	condition := &v1alpha1.Condition{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
-	for _, op := range ops {
-		op(condition)
-	}
-	return condition
-}
+var (
+	// Condition creates a Condition with default values.
+	// Any number of Condition modifiers can be passed to transform it.
+	Condition = builder.Condition
 
-// ConditionSpec creates a ConditionSpec with default values.
-// Any number of ConditionSpec modifiers can be passed to transform it.
-func ConditionSpec(ops ...ConditionSpecOp) ConditionOp {
-	return func(Condition *v1alpha1.Condition) {
-		ConditionSpec := &Condition.Spec
-		for _, op := range ops {
-			op(ConditionSpec)
-		}
-		Condition.Spec = *ConditionSpec
-	}
-}
+	// ConditionSpec creates a ConditionSpec with default values.
+	// Any number of ConditionSpec modifiers can be passed to transform it.
+	ConditionSpec = builder.ConditionSpec
 
-// ConditionSpecCheck adds a Container, with the specified name and image, to the Condition Spec Check.
-// Any number of Container modifiers can be passed to transform it.
-func ConditionSpecCheck(name, image string, ops ...ContainerOp) ConditionSpecOp {
-	return func(spec *v1alpha1.ConditionSpec) {
-		c := &corev1.Container{
-			Name:  name,
-			Image: image,
-		}
-		for _, op := range ops {
-			op(c)
-		}
-		spec.Check = *c
-	}
-}
+	// ConditionSpecCheck adds a Container, with the specified name and image, to the Condition Spec Check.
+	// Any number of Container modifiers can be passed to transform it.
+	ConditionSpecCheck = builder.ConditionSpecCheck
 
-// ConditionParamSpec adds a param, with specified name, to the Spec.
-// Any number of ParamSpec modifiers can be passed to transform it.
-func ConditionParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) ConditionSpecOp {
-	return func(ps *v1alpha1.ConditionSpec) {
-		pp := &v1alpha1.ParamSpec{Name: name, Type: pt}
-		for _, op := range ops {
-			op(pp)
-		}
-		ps.Params = append(ps.Params, *pp)
-	}
-}
+	// ConditionParamSpec adds a param, with specified name, to the Spec.
+	// Any number of ParamSpec modifiers can be passed to transform it.
+	ConditionParamSpec = builder.ConditionParamSpec
 
-// ConditionResource adds a resource with specified name, and type to the ConditionSpec.
-func ConditionResource(name string, resourceType v1alpha1.PipelineResourceType) ConditionSpecOp {
-	return func(spec *v1alpha1.ConditionSpec) {
-		r := v1alpha1.ResourceDeclaration{
-			Name: name,
-			Type: resourceType,
-		}
-		spec.Resources = append(spec.Resources, r)
-	}
-}
+	// ConditionResource adds a resource with specified name, and type to the ConditionSpec.
+	ConditionResource = builder.ConditionResource
+)

--- a/test/builder/container.go
+++ b/test/builder/container.go
@@ -17,124 +17,56 @@ limitations under the License.
 package builder
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
 )
 
 // ContainerOp is an operation which modifies a Container struct.
-type ContainerOp func(*corev1.Container)
+type ContainerOp = builder.ContainerOp
 
 // VolumeMountOp is an operation which modifies a VolumeMount struct.
-type VolumeMountOp func(*corev1.VolumeMount)
+type VolumeMountOp = builder.VolumeMountOp
 
 // ResourceRequirementsOp is an operation which modifies a ResourceRequirements struct.
-type ResourceRequirementsOp func(*corev1.ResourceRequirements)
+type ResourceRequirementsOp = builder.ResourceRequirementsOp
 
 // ResourceListOp is an operation which modifies a ResourceList struct.
-type ResourceListOp func(corev1.ResourceList)
+type ResourceListOp = builder.ResourceListOp
 
-// Command sets the command to the Container (step in this case).
-func Command(args ...string) ContainerOp {
-	return func(container *corev1.Container) {
-		container.Command = args
-	}
-}
+var (
 
-// Args sets the command arguments to the Container (step in this case).
-func Args(args ...string) ContainerOp {
-	return func(container *corev1.Container) {
-		container.Args = args
-	}
-}
+	// Command sets the command to the Container (step in this case).
+	Command = builder.Command
 
-// EnvVar add an environment variable, with specified name and value, to the Container (step).
-func EnvVar(name, value string) ContainerOp {
-	return func(c *corev1.Container) {
-		c.Env = append(c.Env, corev1.EnvVar{
-			Name:  name,
-			Value: value,
-		})
-	}
-}
+	// Args sets the command arguments to the Container (step in this case).
+	Args = builder.Args
 
-// WorkingDir sets the WorkingDir on the Container.
-func WorkingDir(workingDir string) ContainerOp {
-	return func(c *corev1.Container) {
-		c.WorkingDir = workingDir
-	}
-}
+	// EnvVar add an environment variable, with specified name and value, to the Container (step).
+	EnvVar = builder.EnvVar
 
-// VolumeMount add a VolumeMount to the Container (step).
-func VolumeMount(name, mountPath string, ops ...VolumeMountOp) ContainerOp {
-	return func(c *corev1.Container) {
-		mount := &corev1.VolumeMount{
-			Name:      name,
-			MountPath: mountPath,
-		}
-		for _, op := range ops {
-			op(mount)
-		}
-		c.VolumeMounts = append(c.VolumeMounts, *mount)
-	}
-}
+	// WorkingDir sets the WorkingDir on the Container.
+	WorkingDir = builder.WorkingDir
 
-// Resources adds ResourceRequirements to the Container (step).
-func Resources(ops ...ResourceRequirementsOp) ContainerOp {
-	return func(c *corev1.Container) {
-		rr := &corev1.ResourceRequirements{}
-		for _, op := range ops {
-			op(rr)
-		}
-		c.Resources = *rr
-	}
-}
+	// VolumeMount add a VolumeMount to the Container (step).
+	VolumeMount = builder.VolumeMount
 
-// Limits adds Limits to the ResourceRequirements.
-func Limits(ops ...ResourceListOp) ResourceRequirementsOp {
-	return func(rr *corev1.ResourceRequirements) {
-		limits := corev1.ResourceList{}
-		for _, op := range ops {
-			op(limits)
-		}
-		rr.Limits = limits
-	}
-}
+	// Resources adds ResourceRequirements to the Container (step).
+	Resources = builder.Resources
 
-// Requests adds Requests to the ResourceRequirements.
-func Requests(ops ...ResourceListOp) ResourceRequirementsOp {
-	return func(rr *corev1.ResourceRequirements) {
-		requests := corev1.ResourceList{}
-		for _, op := range ops {
-			op(requests)
-		}
-		rr.Requests = requests
-	}
-}
+	// Limits adds Limits to the ResourceRequirements.
+	Limits = builder.Limits
 
-// CPU sets the CPU resource on the ResourceList.
-func CPU(val string) ResourceListOp {
-	return func(r corev1.ResourceList) {
-		r[corev1.ResourceCPU] = resource.MustParse(val)
-	}
-}
+	// Requests adds Requests to the ResourceRequirements.
+	Requests = builder.Requests
 
-// Memory sets the memory resource on the ResourceList.
-func Memory(val string) ResourceListOp {
-	return func(r corev1.ResourceList) {
-		r[corev1.ResourceMemory] = resource.MustParse(val)
-	}
-}
+	// CPU sets the CPU resource on the ResourceList.
+	CPU = builder.CPU
 
-// EphemeralStorage sets the ephemeral storage resource on the ResourceList.
-func EphemeralStorage(val string) ResourceListOp {
-	return func(r corev1.ResourceList) {
-		r[corev1.ResourceEphemeralStorage] = resource.MustParse(val)
-	}
-}
+	// Memory sets the memory resource on the ResourceList.
+	Memory = builder.Memory
 
-// TerminationMessagePolicy sets the policy of the termination message.
-func TerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) ContainerOp {
-	return func(c *corev1.Container) {
-		c.TerminationMessagePolicy = terminationMessagePolicy
-	}
-}
+	// EphemeralStorage sets the ephemeral storage resource on the ResourceList.
+	EphemeralStorage = builder.EphemeralStorage
+
+	// TerminationMessagePolicy sets the policy of the termination message.
+	TerminationMessagePolicy = builder.TerminationMessagePolicy
+)

--- a/test/builder/param.go
+++ b/test/builder/param.go
@@ -13,38 +13,21 @@ limitations under the License.
 
 package builder
 
-import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+import (
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+)
 
 // ParamSpecOp is an operation which modify a ParamSpec struct.
-type ParamSpecOp func(*v1alpha1.ParamSpec)
+type ParamSpecOp = builder.ParamSpecOp
 
-// ArrayOrString creates an ArrayOrString of type ParamTypeString or ParamTypeArray, based on
-// how many inputs are given (>1 input will create an array, not string).
-func ArrayOrString(value string, additionalValues ...string) *v1alpha1.ArrayOrString {
-	if len(additionalValues) > 0 {
-		additionalValues = append([]string{value}, additionalValues...)
-		return &v1alpha1.ArrayOrString{
-			Type:     v1alpha1.ParamTypeArray,
-			ArrayVal: additionalValues,
-		}
-	}
-	return &v1alpha1.ArrayOrString{
-		Type:      v1alpha1.ParamTypeString,
-		StringVal: value,
-	}
-}
+var (
+	// ArrayOrString creates an ArrayOrString of type ParamTypeString or ParamTypeArray, based on
+	// how many inputs are given (>1 input will create an array, not string).
+	ArrayOrString = builder.ArrayOrString
 
-// ParamSpecDescription sets the description of a ParamSpec.
-func ParamSpecDescription(desc string) ParamSpecOp {
-	return func(ps *v1alpha1.ParamSpec) {
-		ps.Description = desc
-	}
-}
+	// ParamSpecDescription sets the description of a ParamSpec.
+	ParamSpecDescription = builder.ParamSpecDescription
 
-// ParamSpecDefault sets the default value of a ParamSpec.
-func ParamSpecDefault(value string, additionalValues ...string) ParamSpecOp {
-	arrayOrString := ArrayOrString(value, additionalValues...)
-	return func(ps *v1alpha1.ParamSpec) {
-		ps.Default = arrayOrString
-	}
-}
+	// ParamSpecDefault sets the default value of a ParamSpec.
+	ParamSpecDefault = builder.ParamSpecDefault
+)

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -17,483 +17,180 @@ limitations under the License.
 package builder
 
 import (
-	"time"
-
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
 )
 
 // PipelineOp is an operation which modify a Pipeline struct.
-type PipelineOp func(*v1alpha1.Pipeline)
+type PipelineOp = builder.PipelineOp
 
 // PipelineSpecOp is an operation which modify a PipelineSpec struct.
-type PipelineSpecOp func(*v1alpha1.PipelineSpec)
+type PipelineSpecOp = builder.PipelineSpecOp
 
 // PipelineTaskOp is an operation which modify a PipelineTask struct.
-type PipelineTaskOp func(*v1alpha1.PipelineTask)
+type PipelineTaskOp = builder.PipelineTaskOp
 
 // PipelineRunOp is an operation which modify a PipelineRun struct.
-type PipelineRunOp func(*v1alpha1.PipelineRun)
+type PipelineRunOp = builder.PipelineRunOp
 
 // PipelineRunSpecOp is an operation which modify a PipelineRunSpec struct.
-type PipelineRunSpecOp func(*v1alpha1.PipelineRunSpec)
+type PipelineRunSpecOp = builder.PipelineRunSpecOp
 
 // PipelineResourceOp is an operation which modify a PipelineResource struct.
-type PipelineResourceOp func(*v1alpha1.PipelineResource)
+type PipelineResourceOp = builder.PipelineResourceOp
 
 // PipelineResourceBindingOp is an operation which modify a PipelineResourceBinding struct.
-type PipelineResourceBindingOp func(*v1alpha1.PipelineResourceBinding)
+type PipelineResourceBindingOp = builder.PipelineResourceBindingOp
 
 // PipelineResourceSpecOp is an operation which modify a PipelineResourceSpec struct.
-type PipelineResourceSpecOp func(*v1alpha1.PipelineResourceSpec)
+type PipelineResourceSpecOp = builder.PipelineResourceSpecOp
 
 // PipelineTaskInputResourceOp is an operation which modifies a PipelineTaskInputResource.
-type PipelineTaskInputResourceOp func(*v1alpha1.PipelineTaskInputResource)
+type PipelineTaskInputResourceOp = builder.PipelineTaskInputResourceOp
 
 // PipelineRunStatusOp is an operation which modifies a PipelineRunStatus
-type PipelineRunStatusOp func(*v1alpha1.PipelineRunStatus)
+type PipelineRunStatusOp = builder.PipelineRunStatusOp
 
 // PipelineTaskConditionOp is an operation which modifies a PipelineTaskCondition
-type PipelineTaskConditionOp func(condition *v1alpha1.PipelineTaskCondition)
+type PipelineTaskConditionOp = builder.PipelineTaskConditionOp
 
-// Pipeline creates a Pipeline with default values.
-// Any number of Pipeline modifier can be passed to transform it.
-func Pipeline(name, namespace string, ops ...PipelineOp) *v1alpha1.Pipeline {
-	p := &v1alpha1.Pipeline{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
+var (
 
-	for _, op := range ops {
-		op(p)
-	}
+	// Pipeline creates a Pipeline with default values.
+	// Any number of Pipeline modifier can be passed to transform it.
+	Pipeline = builder.Pipeline
 
-	return p
-}
+	// PipelineSpec sets the PipelineSpec to the Pipeline.
+	// Any number of PipelineSpec modifier can be passed to transform it.
+	PipelineSpec = builder.PipelineSpec
 
-// PipelineSpec sets the PipelineSpec to the Pipeline.
-// Any number of PipelineSpec modifier can be passed to transform it.
-func PipelineSpec(ops ...PipelineSpecOp) PipelineOp {
-	return func(p *v1alpha1.Pipeline) {
-		ps := &p.Spec
+	// PipelineCreationTimestamp sets the creation time of the pipeline
+	PipelineCreationTimestamp = builder.PipelineCreationTimestamp
 
-		for _, op := range ops {
-			op(ps)
-		}
+	// PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
+	PipelineRunCancelled = builder.PipelineRunCancelled
 
-		p.Spec = *ps
-	}
-}
+	// PipelineDeclaredResource adds a resource declaration to the Pipeline Spec,
+	// with the specified name and type.
+	PipelineDeclaredResource = builder.PipelineDeclaredResource
 
-// PipelineCreationTimestamp sets the creation time of the pipeline
-func PipelineCreationTimestamp(t time.Time) PipelineOp {
-	return func(p *v1alpha1.Pipeline) {
-		p.CreationTimestamp = metav1.Time{Time: t}
-	}
-}
+	// PipelineParamSpec adds a param, with specified name and type, to the PipelineSpec.
+	// Any number of PipelineParamSpec modifiers can be passed to transform it.
+	PipelineParamSpec = builder.PipelineParamSpec
 
-// PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
-func PipelineRunCancelled(spec *v1alpha1.PipelineRunSpec) {
-	spec.Status = v1alpha1.PipelineRunSpecStatusCancelled
-}
+	// PipelineTask adds a PipelineTask, with specified name and task name, to the PipelineSpec.
+	// Any number of PipelineTask modifier can be passed to transform it.
+	PipelineTask = builder.PipelineTask
 
-// PipelineDeclaredResource adds a resource declaration to the Pipeline Spec,
-// with the specified name and type.
-func PipelineDeclaredResource(name string, t v1alpha1.PipelineResourceType) PipelineSpecOp {
-	return func(ps *v1alpha1.PipelineSpec) {
-		r := v1alpha1.PipelineDeclaredResource{
-			Name: name,
-			Type: t,
-		}
-		ps.Resources = append(ps.Resources, r)
-	}
-}
+	Retries = builder.Retries
 
-// PipelineParamSpec adds a param, with specified name and type, to the PipelineSpec.
-// Any number of PipelineParamSpec modifiers can be passed to transform it.
-func PipelineParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) PipelineSpecOp {
-	return func(ps *v1alpha1.PipelineSpec) {
-		pp := &v1alpha1.ParamSpec{Name: name, Type: pt}
-		for _, op := range ops {
-			op(pp)
-		}
-		ps.Params = append(ps.Params, *pp)
-	}
-}
+	// RunAfter will update the provided Pipeline Task to indicate that it
+	// should be run after the provided list of Pipeline Task names.
+	RunAfter = builder.RunAfter
 
-// PipelineTask adds a PipelineTask, with specified name and task name, to the PipelineSpec.
-// Any number of PipelineTask modifier can be passed to transform it.
-func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
-	return func(ps *v1alpha1.PipelineSpec) {
-		pTask := &v1alpha1.PipelineTask{
-			Name: name,
-			TaskRef: v1alpha1.TaskRef{
-				Name: taskName,
-			},
-		}
-		for _, op := range ops {
-			op(pTask)
-		}
-		ps.Tasks = append(ps.Tasks, *pTask)
-	}
-}
+	// PipelineTaskRefKind sets the TaskKind to the PipelineTaskRef.
+	PipelineTaskRefKind = builder.PipelineTaskRefKind
 
-func Retries(retries int) PipelineTaskOp {
-	return func(pt *v1alpha1.PipelineTask) {
-		pt.Retries = retries
-	}
-}
+	// PipelineTaskParam adds a ResourceParam, with specified name and value, to the PipelineTask.
+	PipelineTaskParam = builder.PipelineTaskParam
 
-// RunAfter will update the provided Pipeline Task to indicate that it
-// should be run after the provided list of Pipeline Task names.
-func RunAfter(tasks ...string) PipelineTaskOp {
-	return func(pt *v1alpha1.PipelineTask) {
-		pt.RunAfter = tasks
-	}
-}
+	// From will update the provided PipelineTaskInputResource to indicate that it
+	// should come from tasks.
+	From = builder.From
 
-// PipelineTaskRefKind sets the TaskKind to the PipelineTaskRef.
-func PipelineTaskRefKind(kind v1alpha1.TaskKind) PipelineTaskOp {
-	return func(pt *v1alpha1.PipelineTask) {
-		pt.TaskRef.Kind = kind
-	}
-}
+	// PipelineTaskInputResource adds an input resource to the PipelineTask with the specified
+	// name, pointing at the declared resource.
+	// Any number of PipelineTaskInputResource modifies can be passed to transform it.
+	PipelineTaskInputResource = builder.PipelineTaskInputResource
 
-// PipelineTaskParam adds a ResourceParam, with specified name and value, to the PipelineTask.
-func PipelineTaskParam(name string, value string, additionalValues ...string) PipelineTaskOp {
-	arrayOrString := ArrayOrString(value, additionalValues...)
-	return func(pt *v1alpha1.PipelineTask) {
-		pt.Params = append(pt.Params, v1alpha1.Param{
-			Name:  name,
-			Value: *arrayOrString,
-		})
-	}
-}
+	// PipelineTaskOutputResource adds an output resource to the PipelineTask with the specified
+	// name, pointing at the declared resource.
+	PipelineTaskOutputResource = builder.PipelineTaskOutputResource
 
-// From will update the provided PipelineTaskInputResource to indicate that it
-// should come from tasks.
-func From(tasks ...string) PipelineTaskInputResourceOp {
-	return func(r *v1alpha1.PipelineTaskInputResource) {
-		r.From = tasks
-	}
-}
+	// PipelineTaskCondition adds a condition to the PipelineTask with the
+	// specified conditionRef. Any number of PipelineTaskCondition modifiers can be passed
+	// to transform it
+	PipelineTaskCondition = builder.PipelineTaskCondition
 
-// PipelineTaskInputResource adds an input resource to the PipelineTask with the specified
-// name, pointing at the declared resource.
-// Any number of PipelineTaskInputResource modifies can be passed to transform it.
-func PipelineTaskInputResource(name, resource string, ops ...PipelineTaskInputResourceOp) PipelineTaskOp {
-	return func(pt *v1alpha1.PipelineTask) {
-		r := v1alpha1.PipelineTaskInputResource{
-			Name:     name,
-			Resource: resource,
-		}
-		for _, op := range ops {
-			op(&r)
-		}
-		if pt.Resources == nil {
-			pt.Resources = &v1alpha1.PipelineTaskResources{}
-		}
-		pt.Resources.Inputs = append(pt.Resources.Inputs, r)
-	}
-}
+	// PipelineTaskConditionParam adds a parameter to a PipelineTaskCondition
+	PipelineTaskConditionParam = builder.PipelineTaskConditionParam
 
-// PipelineTaskOutputResource adds an output resource to the PipelineTask with the specified
-// name, pointing at the declared resource.
-func PipelineTaskOutputResource(name, resource string) PipelineTaskOp {
-	return func(pt *v1alpha1.PipelineTask) {
-		r := v1alpha1.PipelineTaskOutputResource{
-			Name:     name,
-			Resource: resource,
-		}
-		if pt.Resources == nil {
-			pt.Resources = &v1alpha1.PipelineTaskResources{}
-		}
-		pt.Resources.Outputs = append(pt.Resources.Outputs, r)
-	}
-}
+	// PipelineTaskConditionResource adds a resource to a PipelineTaskCondition
+	PipelineTaskConditionResource = builder.PipelineTaskConditionResource
 
-// PipelineTaskCondition adds a condition to the PipelineTask with the
-// specified conditionRef. Any number of PipelineTaskCondition modifiers can be passed
-// to transform it
-func PipelineTaskCondition(conditionRef string, ops ...PipelineTaskConditionOp) PipelineTaskOp {
-	return func(pt *v1alpha1.PipelineTask) {
-		c := &v1alpha1.PipelineTaskCondition{
-			ConditionRef: conditionRef,
-		}
-		for _, op := range ops {
-			op(c)
-		}
-		pt.Conditions = append(pt.Conditions, *c)
-	}
-}
+	// PipelineRun creates a PipelineRun with default values.
+	// Any number of PipelineRun modifier can be passed to transform it.
+	PipelineRun = builder.PipelineRun
 
-// PipelineTaskConditionParam adds a parameter to a PipelineTaskCondition
-func PipelineTaskConditionParam(name, val string) PipelineTaskConditionOp {
-	return func(condition *v1alpha1.PipelineTaskCondition) {
-		if condition.Params == nil {
-			condition.Params = []v1alpha1.Param{}
-		}
-		condition.Params = append(condition.Params, v1alpha1.Param{
-			Name:  name,
-			Value: *ArrayOrString(val),
-		})
-	}
-}
+	// PipelineRunSpec sets the PipelineRunSpec, references Pipeline with specified name, to the PipelineRun.
+	// Any number of PipelineRunSpec modifier can be passed to transform it.
+	PipelineRunSpec = builder.PipelineRunSpec
 
-// PipelineTaskConditionResource adds a resource to a PipelineTaskCondition
-func PipelineTaskConditionResource(name, resource string) PipelineTaskConditionOp {
-	return func(condition *v1alpha1.PipelineTaskCondition) {
-		if condition.Resources == nil {
-			condition.Resources = []v1alpha1.PipelineConditionResource{}
-		}
-		condition.Resources = append(condition.Resources, v1alpha1.PipelineConditionResource{
-			Name:     name,
-			Resource: resource,
-		})
-	}
-}
+	// PipelineRunLabels adds a label to the PipelineRun.
+	PipelineRunLabel = builder.PipelineRunLabel
 
-// PipelineRun creates a PipelineRun with default values.
-// Any number of PipelineRun modifier can be passed to transform it.
-func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
-	pr := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-		Spec: v1alpha1.PipelineRunSpec{},
-	}
+	// PipelineRunAnnotations adds a annotation to the PipelineRun.
+	PipelineRunAnnotation = builder.PipelineRunAnnotation
 
-	for _, op := range ops {
-		op(pr)
-	}
+	// PipelineRunResourceBinding adds bindings from actual instances to a Pipeline's declared resources.
+	PipelineRunResourceBinding = builder.PipelineRunResourceBinding
 
-	return pr
-}
+	// PipelineResourceBindingRef set the ResourceRef name to the Resource called Name.
+	PipelineResourceBindingRef = builder.PipelineResourceBindingRef
 
-// PipelineRunSpec sets the PipelineRunSpec, references Pipeline with specified name, to the PipelineRun.
-// Any number of PipelineRunSpec modifier can be passed to transform it.
-func PipelineRunSpec(name string, ops ...PipelineRunSpecOp) PipelineRunOp {
-	return func(pr *v1alpha1.PipelineRun) {
-		prs := &pr.Spec
+	// PipelineResourceBindingResourceSpec set the PipelineResourceResourceSpec to the PipelineResourceBinding.
+	PipelineResourceBindingResourceSpec = builder.PipelineResourceBindingResourceSpec
 
-		prs.PipelineRef = &v1alpha1.PipelineRef{
-			Name: name,
-		}
-		// Set a default timeout
-		prs.Timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
+	// PipelineRunServiceAccount sets the service account to the PipelineRunSpec.
+	PipelineRunServiceAccountName = builder.PipelineRunServiceAccountName
 
-		for _, op := range ops {
-			op(prs)
-		}
+	// PipelineRunServiceAccountTask configures the service account for given Task in PipelineRun.
+	PipelineRunServiceAccountNameTask = builder.PipelineRunServiceAccountNameTask
 
-		pr.Spec = *prs
-	}
-}
+	// PipelineRunParam add a param, with specified name and value, to the PipelineRunSpec.
+	PipelineRunParam = builder.PipelineRunParam
 
-// PipelineRunLabels adds a label to the PipelineRun.
-func PipelineRunLabel(key, value string) PipelineRunOp {
-	return func(pr *v1alpha1.PipelineRun) {
-		if pr.ObjectMeta.Labels == nil {
-			pr.ObjectMeta.Labels = map[string]string{}
-		}
-		pr.ObjectMeta.Labels[key] = value
-	}
-}
+	// PipelineRunTimeout sets the timeout to the PipelineRunSpec.
+	PipelineRunTimeout = builder.PipelineRunTimeout
 
-// PipelineRunAnnotations adds a annotation to the PipelineRun.
-func PipelineRunAnnotation(key, value string) PipelineRunOp {
-	return func(pr *v1alpha1.PipelineRun) {
-		if pr.ObjectMeta.Annotations == nil {
-			pr.ObjectMeta.Annotations = map[string]string{}
-		}
-		pr.ObjectMeta.Annotations[key] = value
-	}
-}
+	// PipelineRunNilTimeout sets the timeout to nil on the PipelineRunSpec
+	PipelineRunNilTimeout = builder.PipelineRunNilTimeout
 
-// PipelineRunResourceBinding adds bindings from actual instances to a Pipeline's declared resources.
-func PipelineRunResourceBinding(name string, ops ...PipelineResourceBindingOp) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		r := &v1alpha1.PipelineResourceBinding{
-			Name: name,
-		}
-		for _, op := range ops {
-			op(r)
-		}
-		prs.Resources = append(prs.Resources, *r)
-	}
-}
+	// PipelineRunNodeSelector sets the Node selector to the PipelineSpec.
+	PipelineRunNodeSelector = builder.PipelineRunNodeSelector
 
-// PipelineResourceBindingRef set the ResourceRef name to the Resource called Name.
-func PipelineResourceBindingRef(name string) PipelineResourceBindingOp {
-	return func(b *v1alpha1.PipelineResourceBinding) {
-		b.ResourceRef = &v1alpha1.PipelineResourceRef{
-			Name: name,
-		}
-	}
-}
+	// PipelineRunTolerations sets the Node selector to the PipelineSpec.
+	PipelineRunTolerations = builder.PipelineRunTolerations
 
-// PipelineResourceBindingResourceSpec set the PipelineResourceResourceSpec to the PipelineResourceBinding.
-func PipelineResourceBindingResourceSpec(spec *v1alpha1.PipelineResourceSpec) PipelineResourceBindingOp {
-	return func(b *v1alpha1.PipelineResourceBinding) {
-		b.ResourceSpec = spec
-	}
-}
+	// PipelineRunAffinity sets the affinity to the PipelineSpec.
+	PipelineRunAffinity = builder.PipelineRunAffinity
 
-// PipelineRunServiceAccount sets the service account to the PipelineRunSpec.
-func PipelineRunServiceAccountName(sa string) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.ServiceAccountName = sa
-	}
-}
+	// PipelineRunStatus sets the PipelineRunStatus to the PipelineRun.
+	// Any number of PipelineRunStatus modifier can be passed to transform it.
+	PipelineRunStatus = builder.PipelineRunStatus
 
-// PipelineRunServiceAccountTask configures the service account for given Task in PipelineRun.
-func PipelineRunServiceAccountNameTask(taskName, sa string) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.ServiceAccountNames = append(prs.ServiceAccountNames, v1alpha1.PipelineRunSpecServiceAccountName{
-			TaskName:           taskName,
-			ServiceAccountName: sa,
-		})
-	}
-}
+	// PipelineRunStatusCondition adds a StatusCondition to the TaskRunStatus.
+	PipelineRunStatusCondition = builder.PipelineRunStatusCondition
 
-// PipelineRunParam add a param, with specified name and value, to the PipelineRunSpec.
-func PipelineRunParam(name string, value string, additionalValues ...string) PipelineRunSpecOp {
-	arrayOrString := ArrayOrString(value, additionalValues...)
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.Params = append(prs.Params, v1alpha1.Param{
-			Name:  name,
-			Value: *arrayOrString,
-		})
-	}
-}
+	// PipelineRunStartTime sets the start time to the PipelineRunStatus.
+	PipelineRunStartTime = builder.PipelineRunStartTime
 
-// PipelineRunTimeout sets the timeout to the PipelineRunSpec.
-func PipelineRunTimeout(duration time.Duration) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.Timeout = &metav1.Duration{Duration: duration}
-	}
-}
+	// PipelineRunCompletionTime sets the completion time  to the PipelineRunStatus.
+	PipelineRunCompletionTime = builder.PipelineRunCompletionTime
 
-// PipelineRunNilTimeout sets the timeout to nil on the PipelineRunSpec
-func PipelineRunNilTimeout(prs *v1alpha1.PipelineRunSpec) {
-	prs.Timeout = nil
-}
+	// PipelineRunTaskRunsStatus sets the status of TaskRun to the PipelineRunStatus.
+	PipelineRunTaskRunsStatus = builder.PipelineRunTaskRunsStatus
 
-// PipelineRunNodeSelector sets the Node selector to the PipelineSpec.
-func PipelineRunNodeSelector(values map[string]string) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.PodTemplate.NodeSelector = values
-	}
-}
+	// PipelineResource creates a PipelineResource with default values.
+	// Any number of PipelineResource modifier can be passed to transform it.
+	PipelineResource = builder.PipelineResource
 
-// PipelineRunTolerations sets the Node selector to the PipelineSpec.
-func PipelineRunTolerations(values []corev1.Toleration) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.PodTemplate.Tolerations = values
-	}
-}
+	// PipelineResourceSpec set the PipelineResourceSpec, with specified type, to the PipelineResource.
+	// Any number of PipelineResourceSpec modifier can be passed to transform it.
+	PipelineResourceSpec = builder.PipelineResourceSpec
 
-// PipelineRunAffinity sets the affinity to the PipelineSpec.
-func PipelineRunAffinity(affinity *corev1.Affinity) PipelineRunSpecOp {
-	return func(prs *v1alpha1.PipelineRunSpec) {
-		prs.PodTemplate.Affinity = affinity
-	}
-}
+	// PipelineResourceSpecParam adds a ResourceParam, with specified name and value, to the PipelineResourceSpec.
+	PipelineResourceSpecParam = builder.PipelineResourceSpecParam
 
-// PipelineRunStatus sets the PipelineRunStatus to the PipelineRun.
-// Any number of PipelineRunStatus modifier can be passed to transform it.
-func PipelineRunStatus(ops ...PipelineRunStatusOp) PipelineRunOp {
-	return func(pr *v1alpha1.PipelineRun) {
-		s := &v1alpha1.PipelineRunStatus{}
-		for _, op := range ops {
-			op(s)
-		}
-		pr.Status = *s
-	}
-}
-
-// PipelineRunStatusCondition adds a StatusCondition to the TaskRunStatus.
-func PipelineRunStatusCondition(condition apis.Condition) PipelineRunStatusOp {
-	return func(s *v1alpha1.PipelineRunStatus) {
-		s.Conditions = append(s.Conditions, condition)
-	}
-}
-
-// PipelineRunStartTime sets the start time to the PipelineRunStatus.
-func PipelineRunStartTime(startTime time.Time) PipelineRunStatusOp {
-	return func(s *v1alpha1.PipelineRunStatus) {
-		s.StartTime = &metav1.Time{Time: startTime}
-	}
-}
-
-// PipelineRunCompletionTime sets the completion time  to the PipelineRunStatus.
-func PipelineRunCompletionTime(t time.Time) PipelineRunStatusOp {
-	return func(s *v1alpha1.PipelineRunStatus) {
-		s.CompletionTime = &metav1.Time{Time: t}
-	}
-}
-
-// PipelineRunTaskRunsStatus sets the status of TaskRun to the PipelineRunStatus.
-func PipelineRunTaskRunsStatus(taskRunName string, status *v1alpha1.PipelineRunTaskRunStatus) PipelineRunStatusOp {
-	return func(s *v1alpha1.PipelineRunStatus) {
-		if s.TaskRuns == nil {
-			s.TaskRuns = make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
-		}
-		s.TaskRuns[taskRunName] = status
-	}
-}
-
-// PipelineResource creates a PipelineResource with default values.
-// Any number of PipelineResource modifier can be passed to transform it.
-func PipelineResource(name, namespace string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {
-	resource := &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-	}
-	for _, op := range ops {
-		op(resource)
-	}
-	return resource
-}
-
-// PipelineResourceSpec set the PipelineResourceSpec, with specified type, to the PipelineResource.
-// Any number of PipelineResourceSpec modifier can be passed to transform it.
-func PipelineResourceSpec(resourceType v1alpha1.PipelineResourceType, ops ...PipelineResourceSpecOp) PipelineResourceOp {
-	return func(r *v1alpha1.PipelineResource) {
-		spec := &r.Spec
-		spec.Type = resourceType
-		for _, op := range ops {
-			op(spec)
-		}
-		r.Spec = *spec
-	}
-}
-
-// PipelineResourceSpecParam adds a ResourceParam, with specified name and value, to the PipelineResourceSpec.
-func PipelineResourceSpecParam(name, value string) PipelineResourceSpecOp {
-	return func(spec *v1alpha1.PipelineResourceSpec) {
-		spec.Params = append(spec.Params, v1alpha1.ResourceParam{
-			Name:  name,
-			Value: value,
-		})
-	}
-}
-
-// PipelineResourceSpecSecretParam adds a SecretParam, with specified fieldname, secretKey and secretName, to the PipelineResourceSpec.
-func PipelineResourceSpecSecretParam(fieldname, secretName, secretKey string) PipelineResourceSpecOp {
-	return func(spec *v1alpha1.PipelineResourceSpec) {
-		spec.SecretParams = append(spec.SecretParams, v1alpha1.SecretParam{
-			FieldName:  fieldname,
-			SecretKey:  secretKey,
-			SecretName: secretName,
-		})
-	}
-}
+	// PipelineResourceSpecSecretParam adds a SecretParam, with specified fieldname, secretKey and secretName, to the PipelineResourceSpec.
+	PipelineResourceSpecSecretParam = builder.PipelineResourceSpecSecretParam
+)

--- a/test/builder/pod.go
+++ b/test/builder/pod.go
@@ -17,169 +17,59 @@ limitations under the License.
 package builder
 
 import (
-	"time"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
 )
 
 // PodOp is an operation which modifies a Pod struct.
-type PodOp func(*corev1.Pod)
+type PodOp = builder.PodOp
 
 // PodSpecOp is an operation which modifies a PodSpec struct.
-type PodSpecOp func(*corev1.PodSpec)
+type PodSpecOp = builder.PodSpecOp
 
 // PodStatusOp is an operation which modifies a PodStatus struct.
-type PodStatusOp func(status *corev1.PodStatus)
+type PodStatusOp = builder.PodStatusOp
 
-// Pod creates a Pod with default values.
-// Any number of Pod modifiers can be passed to transform it.
-func Pod(name, namespace string, ops ...PodOp) *corev1.Pod {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Annotations: map[string]string{},
-		},
-	}
-	for _, op := range ops {
-		op(pod)
-	}
-	return pod
-}
+var (
+	// Pod creates a Pod with default values.
+	// Any number of Pod modifiers can be passed to transform it.
+	Pod = builder.Pod
 
-// PodLabel adds an annotation to the Pod.
-func PodAnnotation(key, value string) PodOp {
-	return func(pod *corev1.Pod) {
-		if pod.ObjectMeta.Annotations == nil {
-			pod.ObjectMeta.Annotations = map[string]string{}
-		}
-		pod.ObjectMeta.Annotations[key] = value
-	}
-}
+	// PodAnnotation adds an annotation to the Pod.
+	PodAnnotation = builder.PodAnnotation
 
-// PodLabel adds a label to the Pod.
-func PodLabel(key, value string) PodOp {
-	return func(pod *corev1.Pod) {
-		if pod.ObjectMeta.Labels == nil {
-			pod.ObjectMeta.Labels = map[string]string{}
-		}
-		pod.ObjectMeta.Labels[key] = value
-	}
-}
+	// PodLabel adds a label to the Pod.
+	PodLabel = builder.PodLabel
 
-// PodOwnerReference adds an OwnerReference, with specified kind and name, to the Pod.
-func PodOwnerReference(kind, name string, ops ...OwnerReferenceOp) PodOp {
-	trueB := true
-	return func(pod *corev1.Pod) {
-		o := &metav1.OwnerReference{
-			Kind:               kind,
-			Name:               name,
-			Controller:         &trueB,
-			BlockOwnerDeletion: &trueB,
-		}
-		for _, op := range ops {
-			op(o)
-		}
-		pod.ObjectMeta.OwnerReferences = append(pod.ObjectMeta.OwnerReferences, *o)
-	}
-}
+	// PodOwnerReference adds an OwnerReference, with specified kind and name, to the Pod.
+	PodOwnerReference = builder.PodOwnerReference
 
-// PodSpec creates a PodSpec with default values.
-// Any number of PodSpec modifiers can be passed to transform it.
-func PodSpec(ops ...PodSpecOp) PodOp {
-	return func(pod *corev1.Pod) {
-		podSpec := &pod.Spec
-		for _, op := range ops {
-			op(podSpec)
-		}
-		pod.Spec = *podSpec
-	}
-}
+	// PodSpec creates a PodSpec with default values.
+	// Any number of PodSpec modifiers can be passed to transform it.
+	PodSpec = builder.PodSpec
 
-// PodRestartPolicy sets the restart policy on the PodSpec.
-func PodRestartPolicy(restartPolicy corev1.RestartPolicy) PodSpecOp {
-	return func(spec *corev1.PodSpec) {
-		spec.RestartPolicy = restartPolicy
-	}
-}
+	// PodRestartPolicy sets the restart policy on the PodSpec.
+	PodRestartPolicy = builder.PodRestartPolicy
 
-// PodServiceAccountName sets the service account on the PodSpec.
-func PodServiceAccountName(sa string) PodSpecOp {
-	return func(spec *corev1.PodSpec) {
-		spec.ServiceAccountName = sa
-	}
-}
+	// PodServiceAccountName sets the service account on the PodSpec.
+	PodServiceAccountName = builder.PodServiceAccountName
 
-// PodContainer adds a Container, with the specified name and image, to the PodSpec.
-// Any number of Container modifiers can be passed to transform it.
-func PodContainer(name, image string, ops ...ContainerOp) PodSpecOp {
-	return func(spec *corev1.PodSpec) {
-		c := &corev1.Container{
-			Name:  name,
-			Image: image,
-			// By default, containers request zero resources. Ops
-			// can override this.
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:              resource.MustParse("0"),
-					corev1.ResourceMemory:           resource.MustParse("0"),
-					corev1.ResourceEphemeralStorage: resource.MustParse("0"),
-				},
-			},
-		}
-		for _, op := range ops {
-			op(c)
-		}
-		spec.Containers = append(spec.Containers, *c)
-	}
-}
+	// PodContainer adds a Container, with the specified name and image, to the PodSpec.
+	// Any number of Container modifiers can be passed to transform it.
+	PodContainer = builder.PodContainer
 
-// PodInitContainer adds an InitContainer, with the specified name and image, to the PodSpec.
-// Any number of Container modifiers can be passed to transform it.
-func PodInitContainer(name, image string, ops ...ContainerOp) PodSpecOp {
-	return func(spec *corev1.PodSpec) {
-		c := &corev1.Container{
-			Name:  name,
-			Image: image,
-			Args:  []string{},
-		}
-		for _, op := range ops {
-			op(c)
-		}
-		spec.InitContainers = append(spec.InitContainers, *c)
-	}
-}
+	// PodInitContainer adds an InitContainer, with the specified name and image, to the PodSpec.
+	// Any number of Container modifiers can be passed to transform it.
+	PodInitContainer = builder.PodInitContainer
 
-// PodVolume sets the Volumes on the PodSpec.
-func PodVolumes(volumes ...corev1.Volume) PodSpecOp {
-	return func(spec *corev1.PodSpec) {
-		spec.Volumes = volumes
-	}
-}
+	// PodVolume sets the Volumes on the PodSpec.
+	PodVolumes = builder.PodVolumes
 
-// PodCreationTimestamp sets the creation time of the pod
-func PodCreationTimestamp(t time.Time) PodOp {
-	return func(p *corev1.Pod) {
-		p.CreationTimestamp = metav1.Time{Time: t}
-	}
-}
+	// PodCreationTimestamp sets the creation time of the pod
+	PodCreationTimestamp = builder.PodCreationTimestamp
 
-// PodStatus creates a PodStatus with default values.
-// Any number of PodStatus modifiers can be passed to transform it.
-func PodStatus(ops ...PodStatusOp) PodOp {
-	return func(pod *corev1.Pod) {
-		podStatus := &pod.Status
-		for _, op := range ops {
-			op(podStatus)
-		}
-		pod.Status = *podStatus
-	}
-}
+	// PodStatus creates a PodStatus with default values.
+	// Any number of PodStatus modifiers can be passed to transform it.
+	PodStatus = builder.PodStatus
 
-func PodStatusConditions(cond corev1.PodCondition) PodStatusOp {
-	return func(status *corev1.PodStatus) {
-		status.Conditions = append(status.Conditions, cond)
-	}
-}
+	PodStatusConditions = builder.PodStatusConditions
+)

--- a/test/builder/step.go
+++ b/test/builder/step.go
@@ -14,130 +14,52 @@ limitations under the License.
 package builder
 
 import (
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
 )
 
 // StepOp is an operation which modifies a Container struct.
-type StepOp func(*v1alpha1.Step)
+type StepOp = builder.StepOp
 
-// StepCommand sets the command to the Container (step in this case).
-func StepCommand(args ...string) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.Command = args
-	}
-}
+var (
+	// StepCommand sets the command to the Container (step in this case).
+	StepCommand = builder.StepCommand
 
-// StepSecurityContext sets the SecurityContext to the Step.
-func StepSecurityContext(context *corev1.SecurityContext) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.SecurityContext = context
-	}
-}
+	// StepSecurityContext sets the SecurityContext to the Step.
+	StepSecurityContext = builder.StepSecurityContext
 
-// StepArgs sets the command arguments to the Container (step in this case).
-func StepArgs(args ...string) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.Args = args
-	}
-}
+	// StepArgs sets the command arguments to the Container (step in this case).
+	StepArgs = builder.StepArgs
 
-// StepEnvVar add an environment variable, with specified name and value, to the Container (step).
-func StepEnvVar(name, value string) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.Env = append(step.Env, corev1.EnvVar{
-			Name:  name,
-			Value: value,
-		})
-	}
-}
+	// StepEnvVar add an environment variable, with specified name and value, to the Container (step).
+	StepEnvVar = builder.StepEnvVar
 
-// StepWorkingDir sets the WorkingDir on the Container.
-func StepWorkingDir(workingDir string) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.WorkingDir = workingDir
-	}
-}
+	// StepWorkingDir sets the WorkingDir on the Container.
+	StepWorkingDir = builder.StepWorkingDir
 
-// StepVolumeMount add a VolumeMount to the Container (step).
-func StepVolumeMount(name, mountPath string, ops ...VolumeMountOp) StepOp {
-	return func(step *v1alpha1.Step) {
-		mount := &corev1.VolumeMount{
-			Name:      name,
-			MountPath: mountPath,
-		}
-		for _, op := range ops {
-			op(mount)
-		}
-		step.VolumeMounts = append(step.VolumeMounts, *mount)
-	}
-}
+	// StepVolumeMount add a VolumeMount to the Container (step).
+	StepVolumeMount = builder.StepVolumeMount
 
-// StepResources adds ResourceRequirements to the Container (step).
-func StepResources(ops ...ResourceRequirementsOp) StepOp {
-	return func(step *v1alpha1.Step) {
-		rr := &corev1.ResourceRequirements{}
-		for _, op := range ops {
-			op(rr)
-		}
-		step.Resources = *rr
-	}
-}
+	// StepResources adds ResourceRequirements to the Container (step).
+	StepResources = builder.StepResources
 
-// StepLimits adds Limits to the ResourceRequirements.
-func StepLimits(ops ...ResourceListOp) ResourceRequirementsOp {
-	return func(rr *corev1.ResourceRequirements) {
-		limits := corev1.ResourceList{}
-		for _, op := range ops {
-			op(limits)
-		}
-		rr.Limits = limits
-	}
-}
+	// StepLimits adds Limits to the ResourceRequirements.
+	StepLimits = builder.StepLimits
 
-// StepRequests adds Requests to the ResourceRequirements.
-func StepRequests(ops ...ResourceListOp) ResourceRequirementsOp {
-	return func(rr *corev1.ResourceRequirements) {
-		requests := corev1.ResourceList{}
-		for _, op := range ops {
-			op(requests)
-		}
-		rr.Requests = requests
-	}
-}
+	// StepRequests adds Requests to the ResourceRequirements.
+	StepRequests = builder.StepRequests
 
-// StepCPU sets the CPU resource on the ResourceList.
-func StepCPU(val string) ResourceListOp {
-	return func(r corev1.ResourceList) {
-		r[corev1.ResourceCPU] = resource.MustParse(val)
-	}
-}
+	// StepCPU sets the CPU resource on the ResourceList.
+	StepCPU = builder.StepCPU
 
-// StepMemory sets the memory resource on the ResourceList.
-func StepMemory(val string) ResourceListOp {
-	return func(r corev1.ResourceList) {
-		r[corev1.ResourceMemory] = resource.MustParse(val)
-	}
-}
+	// StepMemory sets the memory resource on the ResourceList.
+	StepMemory = builder.StepMemory
 
-// StepEphemeralStorage sets the ephemeral storage resource on the ResourceList.
-func StepEphemeralStorage(val string) ResourceListOp {
-	return func(r corev1.ResourceList) {
-		r[corev1.ResourceEphemeralStorage] = resource.MustParse(val)
-	}
-}
+	// StepEphemeralStorage sets the ephemeral storage resource on the ResourceList.
+	StepEphemeralStorage = builder.StepEphemeralStorage
 
-// StepTerminationMessagePath sets the source of the termination message.
-func StepTerminationMessagePath(terminationMessagePath string) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.TerminationMessagePath = terminationMessagePath
-	}
-}
+	// StepTerminationMessagePath sets the source of the termination message.
+	StepTerminationMessagePath = builder.StepTerminationMessagePath
 
-// StepTerminationMessagePolicy sets the policy of the termination message.
-func StepTerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) StepOp {
-	return func(step *v1alpha1.Step) {
-		step.TerminationMessagePolicy = terminationMessagePolicy
-	}
-}
+	// StepTerminationMessagePolicy sets the policy of the termination message.
+	StepTerminationMessagePolicy = builder.StepTerminationMessagePolicy
+)

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -17,679 +17,252 @@ limitations under the License.
 package builder
 
 import (
-	"time"
-
-	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
 )
 
 // TaskOp is an operation which modify a Task struct.
-type TaskOp func(*v1alpha1.Task)
+type TaskOp = builder.TaskOp
 
 // ClusterTaskOp is an operation which modify a ClusterTask struct.
-type ClusterTaskOp func(*v1alpha1.ClusterTask)
+type ClusterTaskOp = builder.ClusterTaskOp
 
 // TaskSpeOp is an operation which modify a TaskSpec struct.
-type TaskSpecOp func(*v1alpha1.TaskSpec)
+type TaskSpecOp = builder.TaskSpecOp
 
 // InputsOp is an operation which modify an Inputs struct.
-type InputsOp func(*v1alpha1.Inputs)
+type InputsOp = builder.InputsOp
 
 // OutputsOp is an operation which modify an Outputs struct.
-type OutputsOp func(*v1alpha1.Outputs)
+type OutputsOp = builder.OutputsOp
 
 // TaskRunOp is an operation which modify a TaskRun struct.
-type TaskRunOp func(*v1alpha1.TaskRun)
+type TaskRunOp = builder.TaskRunOp
 
 // TaskRunSpecOp is an operation which modify a TaskRunSpec struct.
-type TaskRunSpecOp func(*v1alpha1.TaskRunSpec)
+type TaskRunSpecOp = builder.TaskRunSpecOp
 
 // TaskResourceOp is an operation which modify a TaskResource struct.
-type TaskResourceOp func(*v1alpha1.TaskResource)
+type TaskResourceOp = builder.TaskResourceOp
 
 // TaskResourceBindingOp is an operation which modify a TaskResourceBinding struct.
-type TaskResourceBindingOp func(*v1alpha1.TaskResourceBinding)
+type TaskResourceBindingOp = builder.TaskResourceBindingOp
 
 // TaskRunStatusOp is an operation which modify a TaskRunStatus struct.
-type TaskRunStatusOp func(*v1alpha1.TaskRunStatus)
+type TaskRunStatusOp = builder.TaskRunStatusOp
 
 // TaskRefOp is an operation which modify a TaskRef struct.
-type TaskRefOp func(*v1alpha1.TaskRef)
+type TaskRefOp = builder.TaskRefOp
 
 // TaskRunInputsOp is an operation which modify a TaskRunInputs struct.
-type TaskRunInputsOp func(*v1alpha1.TaskRunInputs)
+type TaskRunInputsOp = builder.TaskRunInputsOp
 
 // TaskRunOutputsOp is an operation which modify a TaskRunOutputs struct.
-type TaskRunOutputsOp func(*v1alpha1.TaskRunOutputs)
+type TaskRunOutputsOp = builder.TaskRunOutputsOp
 
 // ResolvedTaskResourcesOp is an operation which modify a ResolvedTaskResources struct.
-type ResolvedTaskResourcesOp func(*resources.ResolvedTaskResources)
+type ResolvedTaskResourcesOp = builder.ResolvedTaskResourcesOp
 
 // StepStateOp is an operation which modify a StepStep struct.
-type StepStateOp func(*v1alpha1.StepState)
+type StepStateOp = builder.StepStateOp
 
 // VolumeOp is an operation which modify a Volume struct.
-type VolumeOp func(*corev1.Volume)
+type VolumeOp = builder.VolumeOp
 
 var (
-	trueB = true
+	// Task creates a Task with default values.
+	// Any number of Task modifier can be passed to transform it.
+	Task = builder.Task
+
+	// ClusterTask creates a ClusterTask with default values.
+	// Any number of ClusterTask modifier can be passed to transform it.
+	ClusterTask = builder.ClusterTask
+
+	// ClusterTaskSpec sets the specified spec of the cluster task.
+	// Any number of TaskSpec modifier can be passed to create it.
+	ClusterTaskSpec = builder.ClusterTaskSpec
+
+	// TaskSpec sets the specified spec of the task.
+	// Any number of TaskSpec modifier can be passed to create/modify it.
+	TaskSpec = builder.TaskSpec
+
+	// Step adds a step with the specified name and image to the TaskSpec.
+	// Any number of Container modifier can be passed to transform it.
+	Step = builder.Step
+
+	Sidecar = builder.Sidecar
+
+	// TaskStepTemplate adds a base container for all steps in the task.
+	TaskStepTemplate = builder.TaskStepTemplate
+
+	// TaskVolume adds a volume with specified name to the TaskSpec.
+	// Any number of Volume modifier can be passed to transform it.
+	TaskVolume = builder.TaskVolume
+
+	// VolumeSource sets the VolumeSource to the Volume.
+	VolumeSource = builder.VolumeSource
+
+	// TaskInputs sets inputs to the TaskSpec.
+	// Any number of Inputs modifier can be passed to transform it.
+	TaskInputs = builder.TaskInputs
+
+	// TaskOutputs sets inputs to the TaskSpec.
+	// Any number of Outputs modifier can be passed to transform it.
+	TaskOutputs = builder.TaskOutputs
+
+	// InputsResource adds a resource, with specified name and type, to the Inputs.
+	// Any number of TaskResource modifier can be passed to transform it.
+	InputsResource = builder.InputsResource
+
+	ResourceTargetPath = builder.ResourceTargetPath
+
+	// OutputsResource adds a resource, with specified name and type, to the Outputs.
+	OutputsResource = builder.OutputsResource
+
+	// InputsParamSpec adds a ParamSpec, with specified name and type, to the Inputs.
+	// Any number of TaskParamSpec modifier can be passed to transform it.
+	InputsParamSpec = builder.InputsParamSpec
+
+	// TaskRun creates a TaskRun with default values.
+	// Any number of TaskRun modifier can be passed to transform it.
+	TaskRun = builder.TaskRun
+
+	// TaskRunStatus sets the TaskRunStatus to tshe TaskRun
+	TaskRunStatus = builder.TaskRunStatus
+
+	// PodName sets the Pod name to the TaskRunStatus.
+	PodName = builder.PodName
+
+	// StatusCondition adds a StatusCondition to the TaskRunStatus.
+	StatusCondition = builder.StatusCondition
+
+	Retry = builder.Retry
+
+	// StepState adds a StepState to the TaskRunStatus.
+	StepState = builder.StepState
+
+	// TaskRunStartTime sets the start time to the TaskRunStatus.
+	TaskRunStartTime = builder.TaskRunStartTime
+
+	// TaskRunCompletionTime sets the start time to the TaskRunStatus.
+	TaskRunCompletionTime = builder.TaskRunCompletionTime
+
+	// TaskRunCloudEvent adds an event to the TaskRunStatus.
+	TaskRunCloudEvent = builder.TaskRunCloudEvent
+
+	// TaskRunTimeout sets the timeout duration to the TaskRunSpec.
+	TaskRunTimeout = builder.TaskRunTimeout
+
+	// TaskRunNilTimeout sets the timeout duration to nil on the TaskRunSpec.
+	TaskRunNilTimeout = builder.TaskRunNilTimeout
+
+	// TaskRunNodeSelector sets the NodeSelector to the TaskRunSpec.
+	TaskRunNodeSelector = builder.TaskRunNodeSelector
+
+	// TaskRunTolerations sets the Tolerations to the TaskRunSpec.
+	TaskRunTolerations = builder.TaskRunTolerations
+
+	// TaskRunAffinity sets the Affinity to the TaskRunSpec.
+	TaskRunAffinity = builder.TaskRunAffinity
+
+	// TaskRunPodSecurityContext sets the SecurityContext to the TaskRunSpec (through PodTemplate).
+	TaskRunPodSecurityContext = builder.TaskRunPodSecurityContext
+
+	// StateTerminated sets Terminated to the StepState.
+	StateTerminated = builder.StateTerminated
+
+	// SetStepStateTerminated sets Terminated state of a step.
+	SetStepStateTerminated = builder.SetStepStateTerminated
+
+	// SetStepStateRunning sets Running state of a step.
+	SetStepStateRunning = builder.SetStepStateRunning
+
+	// SetStepStateWaiting sets Waiting state of a step.
+	SetStepStateWaiting = builder.SetStepStateWaiting
+
+	// TaskRunOwnerReference sets the OwnerReference, with specified kind and name, to the TaskRun.
+	TaskRunOwnerReference = builder.TaskRunOwnerReference
+
+	Controller = builder.Controller
+
+	BlockOwnerDeletion = builder.BlockOwnerDeletion
+
+	TaskRunLabel = builder.TaskRunLabel
+
+	TaskRunAnnotation = builder.TaskRunAnnotation
+
+	// TaskRunSelfLink adds a SelfLink
+	TaskRunSelfLink = builder.TaskRunSelfLink
+
+	// TaskRunSpec sets the specified spec of the TaskRun.
+	// Any number of TaskRunSpec modifier can be passed to transform it.
+	TaskRunSpec = builder.TaskRunSpec
+
+	// TaskRunCancelled sets the status to cancel to the TaskRunSpec.
+	TaskRunCancelled = builder.TaskRunCancelled
+
+	// TaskRunTaskRef sets the specified Task reference to the TaskRunSpec.
+	// Any number of TaskRef modifier can be passed to transform it.
+	TaskRunTaskRef = builder.TaskRunTaskRef
+
+	// TaskRunSpecStatus sets the Status in the Spec, used for operations
+	// such as cancelling executing TaskRuns.
+	TaskRunSpecStatus = builder.TaskRunSpecStatus
+
+	// TaskRefKind set the specified kind to the TaskRef.
+	TaskRefKind = builder.TaskRefKind
+
+	// TaskRefAPIVersion sets the specified api version to the TaskRef.
+	TaskRefAPIVersion = builder.TaskRefAPIVersion
+
+	// TaskRunTaskSpec sets the specified TaskRunSpec reference to the TaskRunSpec.
+	// Any number of TaskRunSpec modifier can be passed to transform it.
+	TaskRunTaskSpec = builder.TaskRunTaskSpec
+
+	// TaskRunServiceAccount sets the serviceAccount to the TaskRunSpec.
+	TaskRunServiceAccountName = builder.TaskRunServiceAccountName
+
+	// TaskRunInputs sets inputs to the TaskRunSpec.
+	// Any number of TaskRunInputs modifier can be passed to transform it.
+	TaskRunInputs = builder.TaskRunInputs
+
+	// TaskRunInputsParam add a param, with specified name and value, to the TaskRunInputs.
+	TaskRunInputsParam = builder.TaskRunInputsParam
+
+	// TaskRunInputsResource adds a resource, with specified name, to the TaskRunInputs.
+	// Any number of TaskResourceBinding modifier can be passed to transform it.
+	TaskRunInputsResource = builder.TaskRunInputsResource
+
+	// TaskResourceBindingRef set the PipelineResourceRef name to the TaskResourceBinding.
+	TaskResourceBindingRef = builder.TaskResourceBindingRef
+
+	// TaskResourceBindingResourceSpec set the PipelineResourceResourceSpec to the TaskResourceBinding.
+	TaskResourceBindingResourceSpec = builder.TaskResourceBindingResourceSpec
+
+	// TaskResourceBindingRefAPIVersion set the PipelineResourceRef APIVersion to the TaskResourceBinding.
+	TaskResourceBindingRefAPIVersion = builder.TaskResourceBindingRefAPIVersion
+
+	// TaskResourceBindingPaths add any number of path to the TaskResourceBinding.
+	TaskResourceBindingPaths = builder.TaskResourceBindingPaths
+
+	// TaskRunOutputs sets inputs to the TaskRunSpec.
+	// Any number of TaskRunOutputs modifier can be passed to transform it.
+	TaskRunOutputs = builder.TaskRunOutputs
+
+	// TaskRunOutputsResource adds a TaskResourceBinding, with specified name, to the TaskRunOutputs.
+	// Any number of TaskResourceBinding modifier can be passed to modifiy it.
+	TaskRunOutputsResource = builder.TaskRunOutputsResource
+
+	// ResolvedTaskResources creates a ResolvedTaskResources with default values.
+	// Any number of ResolvedTaskResources modifier can be passed to transform it.
+	ResolvedTaskResources = builder.ResolvedTaskResources
+
+	// ResolvedTaskResourcesTaskSpec sets a TaskSpec to the ResolvedTaskResources.
+	// Any number of TaskSpec modifier can be passed to transform it.
+	ResolvedTaskResourcesTaskSpec = builder.ResolvedTaskResourcesTaskSpec
+
+	// ResolvedTaskResourcesInputs adds an input PipelineResource, with specified name, to the ResolvedTaskResources.
+	ResolvedTaskResourcesInputs = builder.ResolvedTaskResourcesInputs
+
+	// ResolvedTaskResourcesOutputs adds an output PipelineResource, with specified name, to the ResolvedTaskResources.
+	ResolvedTaskResourcesOutputs = builder.ResolvedTaskResourcesOutputs
 )
-
-// Task creates a Task with default values.
-// Any number of Task modifier can be passed to transform it.
-func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
-	t := &v1alpha1.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
-
-	for _, op := range ops {
-		op(t)
-	}
-
-	return t
-}
-
-// ClusterTask creates a ClusterTask with default values.
-// Any number of ClusterTask modifier can be passed to transform it.
-func ClusterTask(name string, ops ...ClusterTaskOp) *v1alpha1.ClusterTask {
-	t := &v1alpha1.ClusterTask{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
-
-	for _, op := range ops {
-		op(t)
-	}
-
-	return t
-}
-
-// ClusterTaskSpec sets the specified spec of the cluster task.
-// Any number of TaskSpec modifier can be passed to create it.
-func ClusterTaskSpec(ops ...TaskSpecOp) ClusterTaskOp {
-	return func(t *v1alpha1.ClusterTask) {
-		spec := &t.Spec
-		for _, op := range ops {
-			op(spec)
-		}
-		t.Spec = *spec
-	}
-}
-
-// TaskSpec sets the specified spec of the task.
-// Any number of TaskSpec modifier can be passed to create/modify it.
-func TaskSpec(ops ...TaskSpecOp) TaskOp {
-	return func(t *v1alpha1.Task) {
-		spec := &t.Spec
-		for _, op := range ops {
-			op(spec)
-		}
-		t.Spec = *spec
-	}
-}
-
-// Step adds a step with the specified name and image to the TaskSpec.
-// Any number of Container modifier can be passed to transform it.
-func Step(name, image string, ops ...StepOp) TaskSpecOp {
-	return func(spec *v1alpha1.TaskSpec) {
-		if spec.Steps == nil {
-			spec.Steps = []v1alpha1.Step{}
-		}
-		step := v1alpha1.Step{Container: corev1.Container{
-			Name:  name,
-			Image: image,
-		}}
-		for _, op := range ops {
-			op(&step)
-		}
-		spec.Steps = append(spec.Steps, step)
-	}
-}
-
-func Sidecar(name, image string, ops ...ContainerOp) TaskSpecOp {
-	return func(spec *v1alpha1.TaskSpec) {
-		c := corev1.Container{
-			Name:  name,
-			Image: image,
-		}
-		for _, op := range ops {
-			op(&c)
-		}
-		spec.Sidecars = append(spec.Sidecars, c)
-	}
-}
-
-// TaskStepTemplate adds a base container for all steps in the task.
-func TaskStepTemplate(ops ...ContainerOp) TaskSpecOp {
-	return func(spec *v1alpha1.TaskSpec) {
-		base := &corev1.Container{}
-		for _, op := range ops {
-			op(base)
-		}
-		spec.StepTemplate = base
-	}
-}
-
-// TaskVolume adds a volume with specified name to the TaskSpec.
-// Any number of Volume modifier can be passed to transform it.
-func TaskVolume(name string, ops ...VolumeOp) TaskSpecOp {
-	return func(spec *v1alpha1.TaskSpec) {
-		v := &corev1.Volume{Name: name}
-		for _, op := range ops {
-			op(v)
-		}
-		spec.Volumes = append(spec.Volumes, *v)
-	}
-}
-
-// VolumeSource sets the VolumeSource to the Volume.
-func VolumeSource(s corev1.VolumeSource) VolumeOp {
-	return func(v *corev1.Volume) {
-		v.VolumeSource = s
-	}
-}
-
-// TaskInputs sets inputs to the TaskSpec.
-// Any number of Inputs modifier can be passed to transform it.
-func TaskInputs(ops ...InputsOp) TaskSpecOp {
-	return func(spec *v1alpha1.TaskSpec) {
-		if spec.Inputs == nil {
-			spec.Inputs = &v1alpha1.Inputs{}
-		}
-		for _, op := range ops {
-			op(spec.Inputs)
-		}
-	}
-}
-
-// TaskOutputs sets inputs to the TaskSpec.
-// Any number of Outputs modifier can be passed to transform it.
-func TaskOutputs(ops ...OutputsOp) TaskSpecOp {
-	return func(spec *v1alpha1.TaskSpec) {
-		if spec.Outputs == nil {
-			spec.Outputs = &v1alpha1.Outputs{}
-		}
-		for _, op := range ops {
-			op(spec.Outputs)
-		}
-	}
-}
-
-// InputsResource adds a resource, with specified name and type, to the Inputs.
-// Any number of TaskResource modifier can be passed to transform it.
-func InputsResource(name string, resourceType v1alpha1.PipelineResourceType, ops ...TaskResourceOp) InputsOp {
-	return func(i *v1alpha1.Inputs) {
-		r := &v1alpha1.TaskResource{
-			ResourceDeclaration: v1alpha1.ResourceDeclaration{
-				Name: name,
-				Type: resourceType,
-			}}
-		for _, op := range ops {
-			op(r)
-		}
-		i.Resources = append(i.Resources, *r)
-	}
-}
-
-func ResourceTargetPath(path string) TaskResourceOp {
-	return func(r *v1alpha1.TaskResource) {
-		r.TargetPath = path
-	}
-}
-
-// OutputsResource adds a resource, with specified name and type, to the Outputs.
-func OutputsResource(name string, resourceType v1alpha1.PipelineResourceType) OutputsOp {
-	return func(o *v1alpha1.Outputs) {
-		o.Resources = append(o.Resources, v1alpha1.TaskResource{
-			ResourceDeclaration: v1alpha1.ResourceDeclaration{
-				Name: name,
-				Type: resourceType,
-			}})
-	}
-}
-
-// InputsParamSpec adds a ParamSpec, with specified name and type, to the Inputs.
-// Any number of TaskParamSpec modifier can be passed to transform it.
-func InputsParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) InputsOp {
-	return func(i *v1alpha1.Inputs) {
-		ps := &v1alpha1.ParamSpec{Name: name, Type: pt}
-		for _, op := range ops {
-			op(ps)
-		}
-		i.Params = append(i.Params, *ps)
-	}
-}
-
-// TaskRun creates a TaskRun with default values.
-// Any number of TaskRun modifier can be passed to transform it.
-func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
-	tr := &v1alpha1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Annotations: map[string]string{},
-		},
-	}
-
-	for _, op := range ops {
-		op(tr)
-	}
-
-	return tr
-}
-
-// TaskRunStatus sets the TaskRunStatus to tshe TaskRun
-func TaskRunStatus(ops ...TaskRunStatusOp) TaskRunOp {
-	return func(tr *v1alpha1.TaskRun) {
-		status := &tr.Status
-		for _, op := range ops {
-			op(status)
-		}
-		tr.Status = *status
-	}
-}
-
-// PodName sets the Pod name to the TaskRunStatus.
-func PodName(name string) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		s.PodName = name
-	}
-}
-
-// StatusCondition adds a StatusCondition to the TaskRunStatus.
-func StatusCondition(condition apis.Condition) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		s.Conditions = append(s.Conditions, condition)
-	}
-}
-
-func Retry(retry v1alpha1.TaskRunStatus) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		s.RetriesStatus = append(s.RetriesStatus, retry)
-	}
-}
-
-// StepState adds a StepState to the TaskRunStatus.
-func StepState(ops ...StepStateOp) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		state := &v1alpha1.StepState{}
-		for _, op := range ops {
-			op(state)
-		}
-		s.Steps = append(s.Steps, *state)
-	}
-}
-
-// TaskRunStartTime sets the start time to the TaskRunStatus.
-func TaskRunStartTime(startTime time.Time) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		s.StartTime = &metav1.Time{Time: startTime}
-	}
-}
-
-// TaskRunCompletionTime sets the start time to the TaskRunStatus.
-func TaskRunCompletionTime(completionTime time.Time) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		s.CompletionTime = &metav1.Time{Time: completionTime}
-	}
-}
-
-// TaskRunCloudEvent adds an event to the TaskRunStatus.
-func TaskRunCloudEvent(target, error string, retryCount int32, condition v1alpha1.CloudEventCondition) TaskRunStatusOp {
-	return func(s *v1alpha1.TaskRunStatus) {
-		if len(s.CloudEvents) == 0 {
-			s.CloudEvents = make([]v1alpha1.CloudEventDelivery, 0)
-		}
-		cloudEvent := v1alpha1.CloudEventDelivery{
-			Target: target,
-			Status: v1alpha1.CloudEventDeliveryState{
-				Condition:  condition,
-				RetryCount: retryCount,
-				Error:      error,
-			},
-		}
-		s.CloudEvents = append(s.CloudEvents, cloudEvent)
-	}
-}
-
-// TaskRunTimeout sets the timeout duration to the TaskRunSpec.
-func TaskRunTimeout(d time.Duration) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		spec.Timeout = &metav1.Duration{Duration: d}
-	}
-}
-
-// TaskRunNilTimeout sets the timeout duration to nil on the TaskRunSpec.
-func TaskRunNilTimeout(spec *v1alpha1.TaskRunSpec) {
-	spec.Timeout = nil
-}
-
-// TaskRunNodeSelector sets the NodeSelector to the TaskRunSpec.
-func TaskRunNodeSelector(values map[string]string) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		spec.PodTemplate.NodeSelector = values
-	}
-}
-
-// TaskRunTolerations sets the Tolerations to the TaskRunSpec.
-func TaskRunTolerations(values []corev1.Toleration) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		spec.PodTemplate.Tolerations = values
-	}
-}
-
-// TaskRunAffinity sets the Affinity to the TaskRunSpec.
-func TaskRunAffinity(affinity *corev1.Affinity) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		spec.PodTemplate.Affinity = affinity
-	}
-}
-
-// TaskRunPodSecurityContext sets the SecurityContext to the TaskRunSpec (through PodTemplate).
-func TaskRunPodSecurityContext(context *corev1.PodSecurityContext) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		spec.PodTemplate.SecurityContext = context
-	}
-}
-
-// StateTerminated sets Terminated to the StepState.
-func StateTerminated(exitcode int) StepStateOp {
-	return func(s *v1alpha1.StepState) {
-		s.ContainerState = corev1.ContainerState{
-			Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(exitcode)},
-		}
-	}
-}
-
-// SetStepStateTerminated sets Terminated state of a step.
-func SetStepStateTerminated(terminated corev1.ContainerStateTerminated) StepStateOp {
-	return func(s *v1alpha1.StepState) {
-		s.ContainerState = corev1.ContainerState{
-			Terminated: &terminated,
-		}
-	}
-}
-
-// SetStepStateRunning sets Running state of a step.
-func SetStepStateRunning(running corev1.ContainerStateRunning) StepStateOp {
-	return func(s *v1alpha1.StepState) {
-		s.ContainerState = corev1.ContainerState{
-			Running: &running,
-		}
-	}
-}
-
-// SetStepStateWaiting sets Waiting state of a step.
-func SetStepStateWaiting(waiting corev1.ContainerStateWaiting) StepStateOp {
-	return func(s *v1alpha1.StepState) {
-		s.ContainerState = corev1.ContainerState{
-			Waiting: &waiting,
-		}
-	}
-}
-
-// TaskRunOwnerReference sets the OwnerReference, with specified kind and name, to the TaskRun.
-func TaskRunOwnerReference(kind, name string, ops ...OwnerReferenceOp) TaskRunOp {
-	return func(tr *v1alpha1.TaskRun) {
-		o := &metav1.OwnerReference{
-			Kind: kind,
-			Name: name,
-		}
-		for _, op := range ops {
-			op(o)
-		}
-		tr.ObjectMeta.OwnerReferences = append(tr.ObjectMeta.OwnerReferences, *o)
-	}
-}
-
-func Controller(o *metav1.OwnerReference) {
-	o.Controller = &trueB
-}
-
-func BlockOwnerDeletion(o *metav1.OwnerReference) {
-	o.BlockOwnerDeletion = &trueB
-}
-
-func TaskRunLabel(key, value string) TaskRunOp {
-	return func(tr *v1alpha1.TaskRun) {
-		if tr.ObjectMeta.Labels == nil {
-			tr.ObjectMeta.Labels = map[string]string{}
-		}
-		tr.ObjectMeta.Labels[key] = value
-	}
-}
-
-func TaskRunAnnotation(key, value string) TaskRunOp {
-	return func(tr *v1alpha1.TaskRun) {
-		if tr.ObjectMeta.Annotations == nil {
-			tr.ObjectMeta.Annotations = map[string]string{}
-		}
-		tr.ObjectMeta.Annotations[key] = value
-	}
-}
-
-// TaskRunSelfLink adds a SelfLink
-func TaskRunSelfLink(selflink string) TaskRunOp {
-	return func(tr *v1alpha1.TaskRun) {
-		tr.ObjectMeta.SelfLink = selflink
-	}
-}
-
-// TaskRunSpec sets the specified spec of the TaskRun.
-// Any number of TaskRunSpec modifier can be passed to transform it.
-func TaskRunSpec(ops ...TaskRunSpecOp) TaskRunOp {
-	return func(tr *v1alpha1.TaskRun) {
-		spec := &tr.Spec
-		// Set a default timeout
-		spec.Timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
-		for _, op := range ops {
-			op(spec)
-		}
-		tr.Spec = *spec
-	}
-}
-
-// TaskRunCancelled sets the status to cancel to the TaskRunSpec.
-func TaskRunCancelled(spec *v1alpha1.TaskRunSpec) {
-	spec.Status = v1alpha1.TaskRunSpecStatusCancelled
-}
-
-// TaskRunTaskRef sets the specified Task reference to the TaskRunSpec.
-// Any number of TaskRef modifier can be passed to transform it.
-func TaskRunTaskRef(name string, ops ...TaskRefOp) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		ref := &v1alpha1.TaskRef{Name: name}
-		for _, op := range ops {
-			op(ref)
-		}
-		spec.TaskRef = ref
-	}
-}
-
-// TaskRunSpecStatus sets the Status in the Spec, used for operations
-// such as cancelling executing TaskRuns.
-func TaskRunSpecStatus(status v1alpha1.TaskRunSpecStatus) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		spec.Status = status
-	}
-}
-
-// TaskRefKind set the specified kind to the TaskRef.
-func TaskRefKind(kind v1alpha1.TaskKind) TaskRefOp {
-	return func(ref *v1alpha1.TaskRef) {
-		ref.Kind = kind
-	}
-}
-
-// TaskRefAPIVersion sets the specified api version to the TaskRef.
-func TaskRefAPIVersion(version string) TaskRefOp {
-	return func(ref *v1alpha1.TaskRef) {
-		ref.APIVersion = version
-	}
-}
-
-// TaskRunTaskSpec sets the specified TaskRunSpec reference to the TaskRunSpec.
-// Any number of TaskRunSpec modifier can be passed to transform it.
-func TaskRunTaskSpec(ops ...TaskSpecOp) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		taskSpec := &v1alpha1.TaskSpec{}
-		for _, op := range ops {
-			op(taskSpec)
-		}
-		spec.TaskSpec = taskSpec
-	}
-}
-
-// TaskRunServiceAccount sets the serviceAccount to the TaskRunSpec.
-func TaskRunServiceAccountName(sa string) TaskRunSpecOp {
-	return func(trs *v1alpha1.TaskRunSpec) {
-		trs.ServiceAccountName = sa
-	}
-}
-
-// TaskRunInputs sets inputs to the TaskRunSpec.
-// Any number of TaskRunInputs modifier can be passed to transform it.
-func TaskRunInputs(ops ...TaskRunInputsOp) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		inputs := &spec.Inputs
-		for _, op := range ops {
-			op(inputs)
-		}
-		spec.Inputs = *inputs
-	}
-}
-
-// TaskRunInputsParam add a param, with specified name and value, to the TaskRunInputs.
-func TaskRunInputsParam(name, value string, additionalValues ...string) TaskRunInputsOp {
-	arrayOrString := ArrayOrString(value, additionalValues...)
-	return func(i *v1alpha1.TaskRunInputs) {
-		i.Params = append(i.Params, v1alpha1.Param{
-			Name:  name,
-			Value: *arrayOrString,
-		})
-	}
-}
-
-// TaskRunInputsResource adds a resource, with specified name, to the TaskRunInputs.
-// Any number of TaskResourceBinding modifier can be passed to transform it.
-func TaskRunInputsResource(name string, ops ...TaskResourceBindingOp) TaskRunInputsOp {
-	return func(i *v1alpha1.TaskRunInputs) {
-		binding := &v1alpha1.TaskResourceBinding{
-			PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-				Name: name,
-			},
-		}
-		for _, op := range ops {
-			op(binding)
-		}
-		i.Resources = append(i.Resources, *binding)
-	}
-}
-
-// TaskResourceBindingRef set the PipelineResourceRef name to the TaskResourceBinding.
-func TaskResourceBindingRef(name string) TaskResourceBindingOp {
-	return func(b *v1alpha1.TaskResourceBinding) {
-		b.ResourceRef = &v1alpha1.PipelineResourceRef{
-			Name: name,
-		}
-	}
-}
-
-// TaskResourceBindingResourceSpec set the PipelineResourceResourceSpec to the TaskResourceBinding.
-func TaskResourceBindingResourceSpec(spec *v1alpha1.PipelineResourceSpec) TaskResourceBindingOp {
-	return func(b *v1alpha1.TaskResourceBinding) {
-		b.ResourceSpec = spec
-	}
-}
-
-// TaskResourceBindingRefAPIVersion set the PipelineResourceRef APIVersion to the TaskResourceBinding.
-func TaskResourceBindingRefAPIVersion(version string) TaskResourceBindingOp {
-	return func(b *v1alpha1.TaskResourceBinding) {
-		b.ResourceRef.APIVersion = version
-	}
-}
-
-// TaskResourceBindingPaths add any number of path to the TaskResourceBinding.
-func TaskResourceBindingPaths(paths ...string) TaskResourceBindingOp {
-	return func(b *v1alpha1.TaskResourceBinding) {
-		b.Paths = paths
-	}
-}
-
-// TaskRunOutputs sets inputs to the TaskRunSpec.
-// Any number of TaskRunOutputs modifier can be passed to transform it.
-func TaskRunOutputs(ops ...TaskRunOutputsOp) TaskRunSpecOp {
-	return func(spec *v1alpha1.TaskRunSpec) {
-		outputs := &spec.Outputs
-		for _, op := range ops {
-			op(outputs)
-		}
-		spec.Outputs = *outputs
-	}
-}
-
-// TaskRunOutputsResource adds a TaskResourceBinding, with specified name, to the TaskRunOutputs.
-// Any number of TaskResourceBinding modifier can be passed to modifiy it.
-func TaskRunOutputsResource(name string, ops ...TaskResourceBindingOp) TaskRunOutputsOp {
-	return func(i *v1alpha1.TaskRunOutputs) {
-		binding := &v1alpha1.TaskResourceBinding{
-			PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
-				Name: name,
-			},
-		}
-		for _, op := range ops {
-			op(binding)
-		}
-		i.Resources = append(i.Resources, *binding)
-	}
-}
-
-// ResolvedTaskResources creates a ResolvedTaskResources with default values.
-// Any number of ResolvedTaskResources modifier can be passed to transform it.
-func ResolvedTaskResources(ops ...ResolvedTaskResourcesOp) *resources.ResolvedTaskResources {
-	resources := &resources.ResolvedTaskResources{}
-	for _, op := range ops {
-		op(resources)
-	}
-	return resources
-}
-
-// ResolvedTaskResourcesTaskSpec sets a TaskSpec to the ResolvedTaskResources.
-// Any number of TaskSpec modifier can be passed to transform it.
-func ResolvedTaskResourcesTaskSpec(ops ...TaskSpecOp) ResolvedTaskResourcesOp {
-	return func(r *resources.ResolvedTaskResources) {
-		spec := &v1alpha1.TaskSpec{}
-		for _, op := range ops {
-			op(spec)
-		}
-		r.TaskSpec = spec
-	}
-}
-
-// ResolvedTaskResourcesInputs adds an input PipelineResource, with specified name, to the ResolvedTaskResources.
-func ResolvedTaskResourcesInputs(name string, resource *v1alpha1.PipelineResource) ResolvedTaskResourcesOp {
-	return func(r *resources.ResolvedTaskResources) {
-		if r.Inputs == nil {
-			r.Inputs = map[string]*v1alpha1.PipelineResource{}
-		}
-		r.Inputs[name] = resource
-	}
-}
-
-// ResolvedTaskResourcesOutputs adds an output PipelineResource, with specified name, to the ResolvedTaskResources.
-func ResolvedTaskResourcesOutputs(name string, resource *v1alpha1.PipelineResource) ResolvedTaskResourcesOp {
-	return func(r *resources.ResolvedTaskResources) {
-		if r.Outputs == nil {
-			r.Outputs = map[string]*v1alpha1.PipelineResource{}
-		}
-		r.Outputs[name] = resource
-	}
-}

--- a/test/builder/v1alpha1/condition.go
+++ b/test/builder/v1alpha1/condition.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// ConditionOp is an operation which modifies a Condition struct.
+type ConditionOp func(*v1alpha1.Condition)
+
+// ConditionSpecOp is an operation which modifies a ConditionSpec struct.
+type ConditionSpecOp func(spec *v1alpha1.ConditionSpec)
+
+// Condition creates a Condition with default values.
+// Any number of Condition modifiers can be passed to transform it.
+func Condition(name, namespace string, ops ...ConditionOp) *v1alpha1.Condition {
+	condition := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+	for _, op := range ops {
+		op(condition)
+	}
+	return condition
+}
+
+// ConditionSpec creates a ConditionSpec with default values.
+// Any number of ConditionSpec modifiers can be passed to transform it.
+func ConditionSpec(ops ...ConditionSpecOp) ConditionOp {
+	return func(Condition *v1alpha1.Condition) {
+		ConditionSpec := &Condition.Spec
+		for _, op := range ops {
+			op(ConditionSpec)
+		}
+		Condition.Spec = *ConditionSpec
+	}
+}
+
+// ConditionSpecCheck adds a Container, with the specified name and image, to the Condition Spec Check.
+// Any number of Container modifiers can be passed to transform it.
+func ConditionSpecCheck(name, image string, ops ...ContainerOp) ConditionSpecOp {
+	return func(spec *v1alpha1.ConditionSpec) {
+		c := &corev1.Container{
+			Name:  name,
+			Image: image,
+		}
+		for _, op := range ops {
+			op(c)
+		}
+		spec.Check = *c
+	}
+}
+
+// ConditionParamSpec adds a param, with specified name, to the Spec.
+// Any number of ParamSpec modifiers can be passed to transform it.
+func ConditionParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) ConditionSpecOp {
+	return func(ps *v1alpha1.ConditionSpec) {
+		pp := &v1alpha1.ParamSpec{Name: name, Type: pt}
+		for _, op := range ops {
+			op(pp)
+		}
+		ps.Params = append(ps.Params, *pp)
+	}
+}
+
+// ConditionResource adds a resource with specified name, and type to the ConditionSpec.
+func ConditionResource(name string, resourceType v1alpha1.PipelineResourceType) ConditionSpecOp {
+	return func(spec *v1alpha1.ConditionSpec) {
+		r := v1alpha1.ResourceDeclaration{
+			Name: name,
+			Type: resourceType,
+		}
+		spec.Resources = append(spec.Resources, r)
+	}
+}

--- a/test/builder/v1alpha1/condition_test.go
+++ b/test/builder/v1alpha1/condition_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+)
+
+func TestCondition(t *testing.T) {
+	condition := tb.Condition("cond-name", "foo",
+		tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu", tb.Command("exit 0")),
+			tb.ConditionParamSpec("param-1", v1alpha1.ParamTypeString,
+				tb.ParamSpecDefault("default"),
+				tb.ParamSpecDescription("desc")),
+			tb.ConditionResource("git-resource", v1alpha1.PipelineResourceTypeGit),
+			tb.ConditionResource("pr", v1alpha1.PipelineResourceTypePullRequest),
+		),
+	)
+
+	expected := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cond-name",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: corev1.Container{
+				Image:   "ubuntu",
+				Command: []string{"exit 0"},
+			},
+			Params: []v1alpha1.ParamSpec{{
+				Name:        "param-1",
+				Type:        v1alpha1.ParamTypeString,
+				Description: "desc",
+				Default: &v1alpha1.ArrayOrString{
+					Type:      v1alpha1.ParamTypeString,
+					StringVal: "default",
+				}}},
+			Resources: []v1alpha1.ResourceDeclaration{{
+				Name: "git-resource",
+				Type: "git",
+			}, {
+				Name: "pr",
+				Type: "pullRequest",
+			}},
+		},
+	}
+
+	if d := cmp.Diff(expected, condition); d != "" {
+		t.Fatalf("Condition diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/v1alpha1/container.go
+++ b/test/builder/v1alpha1/container.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ContainerOp is an operation which modifies a Container struct.
+type ContainerOp func(*corev1.Container)
+
+// VolumeMountOp is an operation which modifies a VolumeMount struct.
+type VolumeMountOp func(*corev1.VolumeMount)
+
+// ResourceRequirementsOp is an operation which modifies a ResourceRequirements struct.
+type ResourceRequirementsOp func(*corev1.ResourceRequirements)
+
+// ResourceListOp is an operation which modifies a ResourceList struct.
+type ResourceListOp func(corev1.ResourceList)
+
+// Command sets the command to the Container (step in this case).
+func Command(args ...string) ContainerOp {
+	return func(container *corev1.Container) {
+		container.Command = args
+	}
+}
+
+// Args sets the command arguments to the Container (step in this case).
+func Args(args ...string) ContainerOp {
+	return func(container *corev1.Container) {
+		container.Args = args
+	}
+}
+
+// EnvVar add an environment variable, with specified name and value, to the Container (step).
+func EnvVar(name, value string) ContainerOp {
+	return func(c *corev1.Container) {
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
+// WorkingDir sets the WorkingDir on the Container.
+func WorkingDir(workingDir string) ContainerOp {
+	return func(c *corev1.Container) {
+		c.WorkingDir = workingDir
+	}
+}
+
+// VolumeMount add a VolumeMount to the Container (step).
+func VolumeMount(name, mountPath string, ops ...VolumeMountOp) ContainerOp {
+	return func(c *corev1.Container) {
+		mount := &corev1.VolumeMount{
+			Name:      name,
+			MountPath: mountPath,
+		}
+		for _, op := range ops {
+			op(mount)
+		}
+		c.VolumeMounts = append(c.VolumeMounts, *mount)
+	}
+}
+
+// Resources adds ResourceRequirements to the Container (step).
+func Resources(ops ...ResourceRequirementsOp) ContainerOp {
+	return func(c *corev1.Container) {
+		rr := &corev1.ResourceRequirements{}
+		for _, op := range ops {
+			op(rr)
+		}
+		c.Resources = *rr
+	}
+}
+
+// Limits adds Limits to the ResourceRequirements.
+func Limits(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		limits := corev1.ResourceList{}
+		for _, op := range ops {
+			op(limits)
+		}
+		rr.Limits = limits
+	}
+}
+
+// Requests adds Requests to the ResourceRequirements.
+func Requests(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		requests := corev1.ResourceList{}
+		for _, op := range ops {
+			op(requests)
+		}
+		rr.Requests = requests
+	}
+}
+
+// CPU sets the CPU resource on the ResourceList.
+func CPU(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceCPU] = resource.MustParse(val)
+	}
+}
+
+// Memory sets the memory resource on the ResourceList.
+func Memory(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceMemory] = resource.MustParse(val)
+	}
+}
+
+// EphemeralStorage sets the ephemeral storage resource on the ResourceList.
+func EphemeralStorage(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceEphemeralStorage] = resource.MustParse(val)
+	}
+}
+
+// TerminationMessagePolicy sets the policy of the termination message.
+func TerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) ContainerOp {
+	return func(c *corev1.Container) {
+		c.TerminationMessagePolicy = terminationMessagePolicy
+	}
+}

--- a/test/builder/v1alpha1/doc.go
+++ b/test/builder/v1alpha1/doc.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package builder holds Builder functions that can be used to create
+struct in tests with less noise.
+
+One of the most important characteristic of a unit test (and any type
+of test really) is readability. This means it should be easy to read
+but most importantly it should clearly show the intent of the
+test. The setup (and cleanup) of the tests should be as small as
+possible to avoid the noise. Those builders exists to help with that.
+
+There is two types of functions defined in that package :
+
+	* Builders: create and return a struct
+	* Modifiers: return a function
+	  that will operate on a given struct. They can be applied to other
+	  Modifiers or Builders.
+
+Most of the Builder (and Modifier) that accepts Modifiers defines a
+type (`TypeOp`) that can be satisfied by existing function in this
+package, from other package *or* inline. An example would be the
+following.
+
+	// Definition
+	type TaskOp func(*v1alpha1.Task)
+	func Task(name string, ops ...TaskOp) *v1alpha1.Task {
+		// […]
+	}
+	func TaskNamespace(namespace string) TaskOp {
+		return func(t *v1alpha1.Task) {
+			// […]
+		}
+	}
+	// Usage
+	t := Task("foo", TaskNamespace("bar"), func(t *v1alpha1.Task){
+		// Do something with the Task struct
+		// […]
+	})
+
+The main reason to define the `Op` type, and using it in the methods
+signatures is to group Modifier function together. It makes it easier
+to see what is a Modifier (or Builder) and on what it operates.
+
+By convention, this package is import with the "tb" as alias. The
+examples make that assumption.
+
+*/
+package v1alpha1

--- a/test/builder/v1alpha1/examples_test.go
+++ b/test/builder/v1alpha1/examples_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+)
+
+// This is a "hack" to make the example "look" like tests
+var t *testing.T
+
+func ExampleTask() {
+	// You can declare re-usable modifiers
+	myStep := tb.Step("my-step", "myimage")
+	// … and use them in a Task definition
+	myTask := tb.Task("my-task", "namespace", tb.TaskSpec(
+		tb.Step("simple-step", "myotherimage", tb.StepCommand("/mycmd")),
+		myStep,
+	))
+	// … and another one.
+	myOtherTask := tb.Task("my-other-task", "namespace",
+		tb.TaskSpec(myStep,
+			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
+		),
+	)
+	expectedTask := &v1alpha1.Task{
+		// […]
+	}
+	expectedOtherTask := &v1alpha1.Task{
+		// […]
+	}
+	// […]
+	if d := cmp.Diff(expectedTask, myTask); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+	if d := cmp.Diff(expectedOtherTask, myOtherTask); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}
+
+func ExampleClusterTask() {
+	myClusterTask := tb.ClusterTask("my-task", tb.ClusterTaskSpec(
+		tb.Step("simple-step", "myotherimage", tb.StepCommand("/mycmd")),
+	))
+	expectedClusterTask := &v1alpha1.Task{
+		// […]
+	}
+	// […]
+	if d := cmp.Diff(expectedClusterTask, myClusterTask); d != "" {
+		t.Fatalf("ClusterTask diff -want, +got: %v", d)
+	}
+}
+
+func ExampleTaskRun() {
+	// A simple definition, with a Task reference
+	myTaskRun := tb.TaskRun("my-taskrun", "namespace", tb.TaskRunSpec(
+		tb.TaskRunTaskRef("my-task"),
+	))
+	// … or a more complex one with inline TaskSpec
+	myTaskRunWithSpec := tb.TaskRun("my-taskrun-with-spec", "namespace", tb.TaskRunSpec(
+		tb.TaskRunInputs(
+			tb.TaskRunInputsParam("myarg", "foo"),
+			tb.TaskRunInputsResource("workspace", tb.TaskResourceBindingRef("git-resource")),
+		),
+		tb.TaskRunTaskSpec(
+			tb.TaskInputs(
+				tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
+				tb.InputsParamSpec("myarg", v1alpha1.ParamTypeString, tb.ParamSpecDefault("mydefault")),
+			),
+			tb.Step("mycontainer", "myimage", tb.StepCommand("/mycmd"),
+				tb.StepArgs("--my-arg=$(inputs.params.myarg)"),
+			),
+		),
+	))
+	expectedTaskRun := &v1alpha1.TaskRun{
+		// […]
+	}
+	expectedTaskRunWithSpec := &v1alpha1.TaskRun{
+		// […]
+	}
+	// […]
+	if d := cmp.Diff(expectedTaskRun, myTaskRun); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+	if d := cmp.Diff(expectedTaskRunWithSpec, myTaskRunWithSpec); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}
+
+func ExamplePipeline() {
+	pipeline := tb.Pipeline("tomatoes", "namespace",
+		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
+	)
+	expectedPipeline := &v1alpha1.Pipeline{
+		// […]
+	}
+	// […]
+	if d := cmp.Diff(expectedPipeline, pipeline); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}
+
+func ExamplePipelineRun() {
+	pipelineRun := tb.PipelineRun("pear", "namespace",
+		tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccountName("inexistent")),
+	)
+	expectedPipelineRun := &v1alpha1.PipelineRun{
+		// […]
+	}
+	// […]
+	if d := cmp.Diff(expectedPipelineRun, pipelineRun); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}
+
+func ExamplePipelineResource() {
+	gitResource := tb.PipelineResource("git-resource", "namespace", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
+	))
+	imageResource := tb.PipelineResource("image-resource", "namespace", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeImage, tb.PipelineResourceSpecParam("URL", "gcr.io/kristoff/sven"),
+	))
+	expectedGitResource := v1alpha1.PipelineResource{
+		// […]
+	}
+	expectedImageResource := v1alpha1.PipelineResource{
+		// […]
+	}
+	// […]
+	if d := cmp.Diff(expectedGitResource, gitResource); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+	if d := cmp.Diff(expectedImageResource, imageResource); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/v1alpha1/owner_reference.go
+++ b/test/builder/v1alpha1/owner_reference.go
@@ -14,16 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package builder
+package v1alpha1
 
 import (
-	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // OwnerReferenceOp is an operation which modifies an OwnerReference struct.
-type OwnerReferenceOp = builder.OwnerReferenceOp
+type OwnerReferenceOp func(*metav1.OwnerReference)
 
-var (
-	// OwnerReferenceAPIVersion sets the APIVersion to the OwnerReference.
-	OwnerReferenceAPIVersion = builder.OwnerReferenceAPIVersion
-)
+// OwnerReferenceAPIVersion sets the APIVersion to the OwnerReference.
+func OwnerReferenceAPIVersion(version string) OwnerReferenceOp {
+	return func(o *metav1.OwnerReference) {
+		o.APIVersion = version
+	}
+}

--- a/test/builder/v1alpha1/param.go
+++ b/test/builder/v1alpha1/param.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
+// ParamSpecOp is an operation which modify a ParamSpec struct.
+type ParamSpecOp func(*v1alpha1.ParamSpec)
+
+// ArrayOrString creates an ArrayOrString of type ParamTypeString or ParamTypeArray, based on
+// how many inputs are given (>1 input will create an array, not string).
+func ArrayOrString(value string, additionalValues ...string) *v1alpha1.ArrayOrString {
+	if len(additionalValues) > 0 {
+		additionalValues = append([]string{value}, additionalValues...)
+		return &v1alpha1.ArrayOrString{
+			Type:     v1alpha1.ParamTypeArray,
+			ArrayVal: additionalValues,
+		}
+	}
+	return &v1alpha1.ArrayOrString{
+		Type:      v1alpha1.ParamTypeString,
+		StringVal: value,
+	}
+}
+
+// ParamSpecDescription sets the description of a ParamSpec.
+func ParamSpecDescription(desc string) ParamSpecOp {
+	return func(ps *v1alpha1.ParamSpec) {
+		ps.Description = desc
+	}
+}
+
+// ParamSpecDefault sets the default value of a ParamSpec.
+func ParamSpecDefault(value string, additionalValues ...string) ParamSpecOp {
+	arrayOrString := ArrayOrString(value, additionalValues...)
+	return func(ps *v1alpha1.ParamSpec) {
+		ps.Default = arrayOrString
+	}
+}

--- a/test/builder/v1alpha1/param_test.go
+++ b/test/builder/v1alpha1/param_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	builder "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+)
+
+func TestGenerateString(t *testing.T) {
+	value := builder.ArrayOrString("somestring")
+	expectedValue := &v1alpha1.ArrayOrString{
+		Type:      v1alpha1.ParamTypeString,
+		StringVal: "somestring",
+	}
+	if d := cmp.Diff(expectedValue, value); d != "" {
+		t.Fatalf("ArrayOrString diff -want, +got: %v", d)
+	}
+}
+
+func TestGenerateArray(t *testing.T) {
+	value := builder.ArrayOrString("some", "array", "elements")
+	expectedValue := &v1alpha1.ArrayOrString{
+		Type:     v1alpha1.ParamTypeArray,
+		ArrayVal: []string{"some", "array", "elements"},
+	}
+	if d := cmp.Diff(expectedValue, value); d != "" {
+		t.Fatalf("ArrayOrString diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/v1alpha1/pipeline.go
+++ b/test/builder/v1alpha1/pipeline.go
@@ -1,0 +1,499 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+// PipelineOp is an operation which modify a Pipeline struct.
+type PipelineOp func(*v1alpha1.Pipeline)
+
+// PipelineSpecOp is an operation which modify a PipelineSpec struct.
+type PipelineSpecOp func(*v1alpha1.PipelineSpec)
+
+// PipelineTaskOp is an operation which modify a PipelineTask struct.
+type PipelineTaskOp func(*v1alpha1.PipelineTask)
+
+// PipelineRunOp is an operation which modify a PipelineRun struct.
+type PipelineRunOp func(*v1alpha1.PipelineRun)
+
+// PipelineRunSpecOp is an operation which modify a PipelineRunSpec struct.
+type PipelineRunSpecOp func(*v1alpha1.PipelineRunSpec)
+
+// PipelineResourceOp is an operation which modify a PipelineResource struct.
+type PipelineResourceOp func(*v1alpha1.PipelineResource)
+
+// PipelineResourceBindingOp is an operation which modify a PipelineResourceBinding struct.
+type PipelineResourceBindingOp func(*v1alpha1.PipelineResourceBinding)
+
+// PipelineResourceSpecOp is an operation which modify a PipelineResourceSpec struct.
+type PipelineResourceSpecOp func(*v1alpha1.PipelineResourceSpec)
+
+// PipelineTaskInputResourceOp is an operation which modifies a PipelineTaskInputResource.
+type PipelineTaskInputResourceOp func(*v1alpha1.PipelineTaskInputResource)
+
+// PipelineRunStatusOp is an operation which modifies a PipelineRunStatus
+type PipelineRunStatusOp func(*v1alpha1.PipelineRunStatus)
+
+// PipelineTaskConditionOp is an operation which modifies a PipelineTaskCondition
+type PipelineTaskConditionOp func(condition *v1alpha1.PipelineTaskCondition)
+
+// Pipeline creates a Pipeline with default values.
+// Any number of Pipeline modifier can be passed to transform it.
+func Pipeline(name, namespace string, ops ...PipelineOp) *v1alpha1.Pipeline {
+	p := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	for _, op := range ops {
+		op(p)
+	}
+
+	return p
+}
+
+// PipelineSpec sets the PipelineSpec to the Pipeline.
+// Any number of PipelineSpec modifier can be passed to transform it.
+func PipelineSpec(ops ...PipelineSpecOp) PipelineOp {
+	return func(p *v1alpha1.Pipeline) {
+		ps := &p.Spec
+
+		for _, op := range ops {
+			op(ps)
+		}
+
+		p.Spec = *ps
+	}
+}
+
+// PipelineCreationTimestamp sets the creation time of the pipeline
+func PipelineCreationTimestamp(t time.Time) PipelineOp {
+	return func(p *v1alpha1.Pipeline) {
+		p.CreationTimestamp = metav1.Time{Time: t}
+	}
+}
+
+// PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
+func PipelineRunCancelled(spec *v1alpha1.PipelineRunSpec) {
+	spec.Status = v1alpha1.PipelineRunSpecStatusCancelled
+}
+
+// PipelineDeclaredResource adds a resource declaration to the Pipeline Spec,
+// with the specified name and type.
+func PipelineDeclaredResource(name string, t v1alpha1.PipelineResourceType) PipelineSpecOp {
+	return func(ps *v1alpha1.PipelineSpec) {
+		r := v1alpha1.PipelineDeclaredResource{
+			Name: name,
+			Type: t,
+		}
+		ps.Resources = append(ps.Resources, r)
+	}
+}
+
+// PipelineParamSpec adds a param, with specified name and type, to the PipelineSpec.
+// Any number of PipelineParamSpec modifiers can be passed to transform it.
+func PipelineParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) PipelineSpecOp {
+	return func(ps *v1alpha1.PipelineSpec) {
+		pp := &v1alpha1.ParamSpec{Name: name, Type: pt}
+		for _, op := range ops {
+			op(pp)
+		}
+		ps.Params = append(ps.Params, *pp)
+	}
+}
+
+// PipelineTask adds a PipelineTask, with specified name and task name, to the PipelineSpec.
+// Any number of PipelineTask modifier can be passed to transform it.
+func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
+	return func(ps *v1alpha1.PipelineSpec) {
+		pTask := &v1alpha1.PipelineTask{
+			Name: name,
+			TaskRef: v1alpha1.TaskRef{
+				Name: taskName,
+			},
+		}
+		for _, op := range ops {
+			op(pTask)
+		}
+		ps.Tasks = append(ps.Tasks, *pTask)
+	}
+}
+
+func Retries(retries int) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.Retries = retries
+	}
+}
+
+// RunAfter will update the provided Pipeline Task to indicate that it
+// should be run after the provided list of Pipeline Task names.
+func RunAfter(tasks ...string) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.RunAfter = tasks
+	}
+}
+
+// PipelineTaskRefKind sets the TaskKind to the PipelineTaskRef.
+func PipelineTaskRefKind(kind v1alpha1.TaskKind) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.TaskRef.Kind = kind
+	}
+}
+
+// PipelineTaskParam adds a ResourceParam, with specified name and value, to the PipelineTask.
+func PipelineTaskParam(name string, value string, additionalValues ...string) PipelineTaskOp {
+	arrayOrString := ArrayOrString(value, additionalValues...)
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.Params = append(pt.Params, v1alpha1.Param{
+			Name:  name,
+			Value: *arrayOrString,
+		})
+	}
+}
+
+// From will update the provided PipelineTaskInputResource to indicate that it
+// should come from tasks.
+func From(tasks ...string) PipelineTaskInputResourceOp {
+	return func(r *v1alpha1.PipelineTaskInputResource) {
+		r.From = tasks
+	}
+}
+
+// PipelineTaskInputResource adds an input resource to the PipelineTask with the specified
+// name, pointing at the declared resource.
+// Any number of PipelineTaskInputResource modifies can be passed to transform it.
+func PipelineTaskInputResource(name, resource string, ops ...PipelineTaskInputResourceOp) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		r := v1alpha1.PipelineTaskInputResource{
+			Name:     name,
+			Resource: resource,
+		}
+		for _, op := range ops {
+			op(&r)
+		}
+		if pt.Resources == nil {
+			pt.Resources = &v1alpha1.PipelineTaskResources{}
+		}
+		pt.Resources.Inputs = append(pt.Resources.Inputs, r)
+	}
+}
+
+// PipelineTaskOutputResource adds an output resource to the PipelineTask with the specified
+// name, pointing at the declared resource.
+func PipelineTaskOutputResource(name, resource string) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		r := v1alpha1.PipelineTaskOutputResource{
+			Name:     name,
+			Resource: resource,
+		}
+		if pt.Resources == nil {
+			pt.Resources = &v1alpha1.PipelineTaskResources{}
+		}
+		pt.Resources.Outputs = append(pt.Resources.Outputs, r)
+	}
+}
+
+// PipelineTaskCondition adds a condition to the PipelineTask with the
+// specified conditionRef. Any number of PipelineTaskCondition modifiers can be passed
+// to transform it
+func PipelineTaskCondition(conditionRef string, ops ...PipelineTaskConditionOp) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		c := &v1alpha1.PipelineTaskCondition{
+			ConditionRef: conditionRef,
+		}
+		for _, op := range ops {
+			op(c)
+		}
+		pt.Conditions = append(pt.Conditions, *c)
+	}
+}
+
+// PipelineTaskConditionParam adds a parameter to a PipelineTaskCondition
+func PipelineTaskConditionParam(name, val string) PipelineTaskConditionOp {
+	return func(condition *v1alpha1.PipelineTaskCondition) {
+		if condition.Params == nil {
+			condition.Params = []v1alpha1.Param{}
+		}
+		condition.Params = append(condition.Params, v1alpha1.Param{
+			Name:  name,
+			Value: *ArrayOrString(val),
+		})
+	}
+}
+
+// PipelineTaskConditionResource adds a resource to a PipelineTaskCondition
+func PipelineTaskConditionResource(name, resource string) PipelineTaskConditionOp {
+	return func(condition *v1alpha1.PipelineTaskCondition) {
+		if condition.Resources == nil {
+			condition.Resources = []v1alpha1.PipelineConditionResource{}
+		}
+		condition.Resources = append(condition.Resources, v1alpha1.PipelineConditionResource{
+			Name:     name,
+			Resource: resource,
+		})
+	}
+}
+
+// PipelineRun creates a PipelineRun with default values.
+// Any number of PipelineRun modifier can be passed to transform it.
+func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
+	pr := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1alpha1.PipelineRunSpec{},
+	}
+
+	for _, op := range ops {
+		op(pr)
+	}
+
+	return pr
+}
+
+// PipelineRunSpec sets the PipelineRunSpec, references Pipeline with specified name, to the PipelineRun.
+// Any number of PipelineRunSpec modifier can be passed to transform it.
+func PipelineRunSpec(name string, ops ...PipelineRunSpecOp) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		prs := &pr.Spec
+
+		prs.PipelineRef = &v1alpha1.PipelineRef{
+			Name: name,
+		}
+		// Set a default timeout
+		prs.Timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
+
+		for _, op := range ops {
+			op(prs)
+		}
+
+		pr.Spec = *prs
+	}
+}
+
+// PipelineRunLabels adds a label to the PipelineRun.
+func PipelineRunLabel(key, value string) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		if pr.ObjectMeta.Labels == nil {
+			pr.ObjectMeta.Labels = map[string]string{}
+		}
+		pr.ObjectMeta.Labels[key] = value
+	}
+}
+
+// PipelineRunAnnotations adds a annotation to the PipelineRun.
+func PipelineRunAnnotation(key, value string) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		if pr.ObjectMeta.Annotations == nil {
+			pr.ObjectMeta.Annotations = map[string]string{}
+		}
+		pr.ObjectMeta.Annotations[key] = value
+	}
+}
+
+// PipelineRunResourceBinding adds bindings from actual instances to a Pipeline's declared resources.
+func PipelineRunResourceBinding(name string, ops ...PipelineResourceBindingOp) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		r := &v1alpha1.PipelineResourceBinding{
+			Name: name,
+		}
+		for _, op := range ops {
+			op(r)
+		}
+		prs.Resources = append(prs.Resources, *r)
+	}
+}
+
+// PipelineResourceBindingRef set the ResourceRef name to the Resource called Name.
+func PipelineResourceBindingRef(name string) PipelineResourceBindingOp {
+	return func(b *v1alpha1.PipelineResourceBinding) {
+		b.ResourceRef = &v1alpha1.PipelineResourceRef{
+			Name: name,
+		}
+	}
+}
+
+// PipelineResourceBindingResourceSpec set the PipelineResourceResourceSpec to the PipelineResourceBinding.
+func PipelineResourceBindingResourceSpec(spec *v1alpha1.PipelineResourceSpec) PipelineResourceBindingOp {
+	return func(b *v1alpha1.PipelineResourceBinding) {
+		b.ResourceSpec = spec
+	}
+}
+
+// PipelineRunServiceAccount sets the service account to the PipelineRunSpec.
+func PipelineRunServiceAccountName(sa string) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.ServiceAccountName = sa
+	}
+}
+
+// PipelineRunServiceAccountTask configures the service account for given Task in PipelineRun.
+func PipelineRunServiceAccountNameTask(taskName, sa string) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.ServiceAccountNames = append(prs.ServiceAccountNames, v1alpha1.PipelineRunSpecServiceAccountName{
+			TaskName:           taskName,
+			ServiceAccountName: sa,
+		})
+	}
+}
+
+// PipelineRunParam add a param, with specified name and value, to the PipelineRunSpec.
+func PipelineRunParam(name string, value string, additionalValues ...string) PipelineRunSpecOp {
+	arrayOrString := ArrayOrString(value, additionalValues...)
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.Params = append(prs.Params, v1alpha1.Param{
+			Name:  name,
+			Value: *arrayOrString,
+		})
+	}
+}
+
+// PipelineRunTimeout sets the timeout to the PipelineRunSpec.
+func PipelineRunTimeout(duration time.Duration) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.Timeout = &metav1.Duration{Duration: duration}
+	}
+}
+
+// PipelineRunNilTimeout sets the timeout to nil on the PipelineRunSpec
+func PipelineRunNilTimeout(prs *v1alpha1.PipelineRunSpec) {
+	prs.Timeout = nil
+}
+
+// PipelineRunNodeSelector sets the Node selector to the PipelineSpec.
+func PipelineRunNodeSelector(values map[string]string) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.PodTemplate.NodeSelector = values
+	}
+}
+
+// PipelineRunTolerations sets the Node selector to the PipelineSpec.
+func PipelineRunTolerations(values []corev1.Toleration) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.PodTemplate.Tolerations = values
+	}
+}
+
+// PipelineRunAffinity sets the affinity to the PipelineSpec.
+func PipelineRunAffinity(affinity *corev1.Affinity) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		prs.PodTemplate.Affinity = affinity
+	}
+}
+
+// PipelineRunStatus sets the PipelineRunStatus to the PipelineRun.
+// Any number of PipelineRunStatus modifier can be passed to transform it.
+func PipelineRunStatus(ops ...PipelineRunStatusOp) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		s := &v1alpha1.PipelineRunStatus{}
+		for _, op := range ops {
+			op(s)
+		}
+		pr.Status = *s
+	}
+}
+
+// PipelineRunStatusCondition adds a StatusCondition to the TaskRunStatus.
+func PipelineRunStatusCondition(condition apis.Condition) PipelineRunStatusOp {
+	return func(s *v1alpha1.PipelineRunStatus) {
+		s.Conditions = append(s.Conditions, condition)
+	}
+}
+
+// PipelineRunStartTime sets the start time to the PipelineRunStatus.
+func PipelineRunStartTime(startTime time.Time) PipelineRunStatusOp {
+	return func(s *v1alpha1.PipelineRunStatus) {
+		s.StartTime = &metav1.Time{Time: startTime}
+	}
+}
+
+// PipelineRunCompletionTime sets the completion time  to the PipelineRunStatus.
+func PipelineRunCompletionTime(t time.Time) PipelineRunStatusOp {
+	return func(s *v1alpha1.PipelineRunStatus) {
+		s.CompletionTime = &metav1.Time{Time: t}
+	}
+}
+
+// PipelineRunTaskRunsStatus sets the status of TaskRun to the PipelineRunStatus.
+func PipelineRunTaskRunsStatus(taskRunName string, status *v1alpha1.PipelineRunTaskRunStatus) PipelineRunStatusOp {
+	return func(s *v1alpha1.PipelineRunStatus) {
+		if s.TaskRuns == nil {
+			s.TaskRuns = make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
+		}
+		s.TaskRuns[taskRunName] = status
+	}
+}
+
+// PipelineResource creates a PipelineResource with default values.
+// Any number of PipelineResource modifier can be passed to transform it.
+func PipelineResource(name, namespace string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {
+	resource := &v1alpha1.PipelineResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	for _, op := range ops {
+		op(resource)
+	}
+	return resource
+}
+
+// PipelineResourceSpec set the PipelineResourceSpec, with specified type, to the PipelineResource.
+// Any number of PipelineResourceSpec modifier can be passed to transform it.
+func PipelineResourceSpec(resourceType v1alpha1.PipelineResourceType, ops ...PipelineResourceSpecOp) PipelineResourceOp {
+	return func(r *v1alpha1.PipelineResource) {
+		spec := &r.Spec
+		spec.Type = resourceType
+		for _, op := range ops {
+			op(spec)
+		}
+		r.Spec = *spec
+	}
+}
+
+// PipelineResourceSpecParam adds a ResourceParam, with specified name and value, to the PipelineResourceSpec.
+func PipelineResourceSpecParam(name, value string) PipelineResourceSpecOp {
+	return func(spec *v1alpha1.PipelineResourceSpec) {
+		spec.Params = append(spec.Params, v1alpha1.ResourceParam{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
+// PipelineResourceSpecSecretParam adds a SecretParam, with specified fieldname, secretKey and secretName, to the PipelineResourceSpec.
+func PipelineResourceSpecSecretParam(fieldname, secretName, secretKey string) PipelineResourceSpecOp {
+	return func(spec *v1alpha1.PipelineResourceSpec) {
+		spec.SecretParams = append(spec.SecretParams, v1alpha1.SecretParam{
+			FieldName:  fieldname,
+			SecretKey:  secretKey,
+			SecretName: secretName,
+		})
+	}
+}

--- a/test/builder/v1alpha1/pipeline_test.go
+++ b/test/builder/v1alpha1/pipeline_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+)
+
+func TestPipeline(t *testing.T) {
+	creationTime := time.Now()
+
+	pipeline := tb.Pipeline("tomatoes", "foo", tb.PipelineSpec(
+		tb.PipelineDeclaredResource("my-only-git-resource", "git"),
+		tb.PipelineDeclaredResource("my-only-image-resource", "image"),
+		tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value"), tb.ParamSpecDescription("default description")),
+		tb.PipelineTask("foo", "banana",
+			tb.PipelineTaskParam("stringparam", "value"),
+			tb.PipelineTaskParam("arrayparam", "array", "value"),
+			tb.PipelineTaskCondition("some-condition-ref",
+				tb.PipelineTaskConditionParam("param-name", "param-value"),
+				tb.PipelineTaskConditionResource("some-resource", "my-only-git-resource"),
+			),
+		),
+		tb.PipelineTask("bar", "chocolate",
+			tb.PipelineTaskRefKind(v1alpha1.ClusterTaskKind),
+			tb.PipelineTaskInputResource("some-repo", "my-only-git-resource", tb.From("foo")),
+			tb.PipelineTaskOutputResource("some-image", "my-only-image-resource"),
+		),
+		tb.PipelineTask("never-gonna", "give-you-up",
+			tb.RunAfter("foo"),
+		),
+	),
+		tb.PipelineCreationTimestamp(creationTime),
+	)
+	expectedPipeline := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tomatoes", Namespace: "foo",
+			CreationTimestamp: metav1.Time{Time: creationTime},
+		},
+		Spec: v1alpha1.PipelineSpec{
+			Resources: []v1alpha1.PipelineDeclaredResource{{
+				Name: "my-only-git-resource",
+				Type: "git",
+			}, {
+				Name: "my-only-image-resource",
+				Type: "image",
+			}},
+			Params: []v1alpha1.ParamSpec{{
+				Name:        "first-param",
+				Type:        v1alpha1.ParamTypeString,
+				Default:     tb.ArrayOrString("default-value"),
+				Description: "default description",
+			}},
+			Tasks: []v1alpha1.PipelineTask{{
+				Name:    "foo",
+				TaskRef: v1alpha1.TaskRef{Name: "banana"},
+				Params: []v1alpha1.Param{{
+					Name:  "stringparam",
+					Value: *tb.ArrayOrString("value"),
+				}, {
+					Name:  "arrayparam",
+					Value: *tb.ArrayOrString("array", "value"),
+				}},
+				Conditions: []v1alpha1.PipelineTaskCondition{{
+					ConditionRef: "some-condition-ref",
+					Params: []v1alpha1.Param{{
+						Name: "param-name",
+						Value: v1alpha1.ArrayOrString{
+							Type:      "string",
+							StringVal: "param-value",
+						},
+					}},
+					Resources: []v1alpha1.PipelineConditionResource{{
+						Name:     "some-resource",
+						Resource: "my-only-git-resource",
+					}},
+				}},
+			}, {
+				Name:    "bar",
+				TaskRef: v1alpha1.TaskRef{Name: "chocolate", Kind: v1alpha1.ClusterTaskKind},
+				Resources: &v1alpha1.PipelineTaskResources{
+					Inputs: []v1alpha1.PipelineTaskInputResource{{
+						Name:     "some-repo",
+						Resource: "my-only-git-resource",
+						From:     []string{"foo"},
+					}},
+					Outputs: []v1alpha1.PipelineTaskOutputResource{{
+						Name:     "some-image",
+						Resource: "my-only-image-resource",
+					}},
+				},
+			}, {
+				Name:     "never-gonna",
+				TaskRef:  v1alpha1.TaskRef{Name: "give-you-up"},
+				RunAfter: []string{"foo"},
+			}},
+		},
+	}
+	if d := cmp.Diff(expectedPipeline, pipeline); d != "" {
+		t.Fatalf("Pipeline diff -want, +got: %v", d)
+	}
+}
+
+func TestPipelineRun(t *testing.T) {
+	startTime := time.Now()
+	completedTime := startTime.Add(5 * time.Minute)
+
+	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
+		tb.PipelineRunParam("first-param-string", "first-value"),
+		tb.PipelineRunParam("second-param-array", "some", "array"),
+		tb.PipelineRunTimeout(1*time.Hour),
+		tb.PipelineRunResourceBinding("some-resource", tb.PipelineResourceBindingRef("my-special-resource")),
+		tb.PipelineRunServiceAccountNameTask("foo", "sa-2"),
+	), tb.PipelineRunStatus(tb.PipelineRunStatusCondition(
+		apis.Condition{Type: apis.ConditionSucceeded}),
+		tb.PipelineRunStartTime(startTime),
+		tb.PipelineRunCompletionTime(completedTime),
+		tb.PipelineRunTaskRunsStatus("trname", &v1alpha1.PipelineRunTaskRunStatus{
+			PipelineTaskName: "task-1",
+		}),
+	), tb.PipelineRunLabel("label-key", "label-value"))
+	expectedPipelineRun := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+			Labels: map[string]string{
+				"label-key": "label-value",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef:         &v1alpha1.PipelineRef{Name: "tomatoes"},
+			ServiceAccountName:  "sa",
+			ServiceAccountNames: []v1alpha1.PipelineRunSpecServiceAccountName{{TaskName: "foo", ServiceAccountName: "sa-2"}},
+			Params: []v1alpha1.Param{{
+				Name:  "first-param-string",
+				Value: *tb.ArrayOrString("first-value"),
+			}, {
+				Name:  "second-param-array",
+				Value: *tb.ArrayOrString("some", "array"),
+			}},
+			Timeout: &metav1.Duration{Duration: 1 * time.Hour},
+			Resources: []v1alpha1.PipelineResourceBinding{{
+				Name: "some-resource",
+				ResourceRef: &v1alpha1.PipelineResourceRef{
+					Name: "my-special-resource",
+				},
+			}},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+			},
+			StartTime:      &metav1.Time{Time: startTime},
+			CompletionTime: &metav1.Time{Time: completedTime},
+			TaskRuns: map[string]*v1alpha1.PipelineRunTaskRunStatus{
+				"trname": {PipelineTaskName: "task-1"},
+			},
+		},
+	}
+	if d := cmp.Diff(expectedPipelineRun, pipelineRun); d != "" {
+		t.Fatalf("PipelineRun diff -want, +got: %v", d)
+	}
+}
+
+func TestPipelineRunWithResourceSpec(t *testing.T) {
+	startTime := time.Now()
+	completedTime := startTime.Add(5 * time.Minute)
+
+	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
+		tb.PipelineRunParam("first-param-string", "first-value"),
+		tb.PipelineRunParam("second-param-array", "some", "array"),
+		tb.PipelineRunTimeout(1*time.Hour),
+		tb.PipelineRunResourceBinding("some-resource",
+			tb.PipelineResourceBindingResourceSpec(&v1alpha1.PipelineResourceSpec{
+				Type: v1alpha1.PipelineResourceTypeGit,
+				Params: []v1alpha1.ResourceParam{{
+					Name:  "url",
+					Value: "git",
+				}}})),
+		tb.PipelineRunServiceAccountNameTask("foo", "sa-2"),
+	), tb.PipelineRunStatus(tb.PipelineRunStatusCondition(
+		apis.Condition{Type: apis.ConditionSucceeded}),
+		tb.PipelineRunStartTime(startTime),
+		tb.PipelineRunCompletionTime(completedTime),
+		tb.PipelineRunTaskRunsStatus("trname", &v1alpha1.PipelineRunTaskRunStatus{
+			PipelineTaskName: "task-1",
+		}),
+	), tb.PipelineRunLabel("label-key", "label-value"))
+	expectedPipelineRun := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+			Labels: map[string]string{
+				"label-key": "label-value",
+			},
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef:         &v1alpha1.PipelineRef{Name: "tomatoes"},
+			ServiceAccountName:  "sa",
+			ServiceAccountNames: []v1alpha1.PipelineRunSpecServiceAccountName{{TaskName: "foo", ServiceAccountName: "sa-2"}},
+			Params: []v1alpha1.Param{{
+				Name:  "first-param-string",
+				Value: *tb.ArrayOrString("first-value"),
+			}, {
+				Name:  "second-param-array",
+				Value: *tb.ArrayOrString("some", "array"),
+			}},
+			Timeout: &metav1.Duration{Duration: 1 * time.Hour},
+			Resources: []v1alpha1.PipelineResourceBinding{{
+				Name: "some-resource",
+				ResourceSpec: &v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceType("git"),
+					Params: []v1alpha1.ResourceParam{{
+						Name:  "url",
+						Value: "git",
+					}},
+					SecretParams: nil,
+				},
+			}},
+		},
+		Status: v1alpha1.PipelineRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+			},
+			StartTime:      &metav1.Time{Time: startTime},
+			CompletionTime: &metav1.Time{Time: completedTime},
+			TaskRuns: map[string]*v1alpha1.PipelineRunTaskRunStatus{
+				"trname": {PipelineTaskName: "task-1"},
+			},
+		},
+	}
+	if d := cmp.Diff(expectedPipelineRun, pipelineRun); d != "" {
+		t.Fatalf("PipelineRun diff -want, +got: %v", d)
+	}
+}
+
+func TestPipelineResource(t *testing.T) {
+	pipelineResource := tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
+	))
+	expectedPipelineResource := &v1alpha1.PipelineResource{
+		ObjectMeta: metav1.ObjectMeta{Name: "git-resource", Namespace: "foo"},
+		Spec: v1alpha1.PipelineResourceSpec{
+			Type: v1alpha1.PipelineResourceTypeGit,
+			Params: []v1alpha1.ResourceParam{{
+				Name: "URL", Value: "https://foo.git",
+			}},
+		},
+	}
+	if d := cmp.Diff(expectedPipelineResource, pipelineResource); d != "" {
+		t.Fatalf("PipelineResource diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/v1alpha1/pod.go
+++ b/test/builder/v1alpha1/pod.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodOp is an operation which modifies a Pod struct.
+type PodOp func(*corev1.Pod)
+
+// PodSpecOp is an operation which modifies a PodSpec struct.
+type PodSpecOp func(*corev1.PodSpec)
+
+// PodStatusOp is an operation which modifies a PodStatus struct.
+type PodStatusOp func(status *corev1.PodStatus)
+
+// Pod creates a Pod with default values.
+// Any number of Pod modifiers can be passed to transform it.
+func Pod(name, namespace string, ops ...PodOp) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: map[string]string{},
+		},
+	}
+	for _, op := range ops {
+		op(pod)
+	}
+	return pod
+}
+
+// PodLabel adds an annotation to the Pod.
+func PodAnnotation(key, value string) PodOp {
+	return func(pod *corev1.Pod) {
+		if pod.ObjectMeta.Annotations == nil {
+			pod.ObjectMeta.Annotations = map[string]string{}
+		}
+		pod.ObjectMeta.Annotations[key] = value
+	}
+}
+
+// PodLabel adds a label to the Pod.
+func PodLabel(key, value string) PodOp {
+	return func(pod *corev1.Pod) {
+		if pod.ObjectMeta.Labels == nil {
+			pod.ObjectMeta.Labels = map[string]string{}
+		}
+		pod.ObjectMeta.Labels[key] = value
+	}
+}
+
+// PodOwnerReference adds an OwnerReference, with specified kind and name, to the Pod.
+func PodOwnerReference(kind, name string, ops ...OwnerReferenceOp) PodOp {
+	trueB := true
+	return func(pod *corev1.Pod) {
+		o := &metav1.OwnerReference{
+			Kind:               kind,
+			Name:               name,
+			Controller:         &trueB,
+			BlockOwnerDeletion: &trueB,
+		}
+		for _, op := range ops {
+			op(o)
+		}
+		pod.ObjectMeta.OwnerReferences = append(pod.ObjectMeta.OwnerReferences, *o)
+	}
+}
+
+// PodSpec creates a PodSpec with default values.
+// Any number of PodSpec modifiers can be passed to transform it.
+func PodSpec(ops ...PodSpecOp) PodOp {
+	return func(pod *corev1.Pod) {
+		podSpec := &pod.Spec
+		for _, op := range ops {
+			op(podSpec)
+		}
+		pod.Spec = *podSpec
+	}
+}
+
+// PodRestartPolicy sets the restart policy on the PodSpec.
+func PodRestartPolicy(restartPolicy corev1.RestartPolicy) PodSpecOp {
+	return func(spec *corev1.PodSpec) {
+		spec.RestartPolicy = restartPolicy
+	}
+}
+
+// PodServiceAccountName sets the service account on the PodSpec.
+func PodServiceAccountName(sa string) PodSpecOp {
+	return func(spec *corev1.PodSpec) {
+		spec.ServiceAccountName = sa
+	}
+}
+
+// PodContainer adds a Container, with the specified name and image, to the PodSpec.
+// Any number of Container modifiers can be passed to transform it.
+func PodContainer(name, image string, ops ...ContainerOp) PodSpecOp {
+	return func(spec *corev1.PodSpec) {
+		c := &corev1.Container{
+			Name:  name,
+			Image: image,
+			// By default, containers request zero resources. Ops
+			// can override this.
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:              resource.MustParse("0"),
+					corev1.ResourceMemory:           resource.MustParse("0"),
+					corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+				},
+			},
+		}
+		for _, op := range ops {
+			op(c)
+		}
+		spec.Containers = append(spec.Containers, *c)
+	}
+}
+
+// PodInitContainer adds an InitContainer, with the specified name and image, to the PodSpec.
+// Any number of Container modifiers can be passed to transform it.
+func PodInitContainer(name, image string, ops ...ContainerOp) PodSpecOp {
+	return func(spec *corev1.PodSpec) {
+		c := &corev1.Container{
+			Name:  name,
+			Image: image,
+			Args:  []string{},
+		}
+		for _, op := range ops {
+			op(c)
+		}
+		spec.InitContainers = append(spec.InitContainers, *c)
+	}
+}
+
+// PodVolume sets the Volumes on the PodSpec.
+func PodVolumes(volumes ...corev1.Volume) PodSpecOp {
+	return func(spec *corev1.PodSpec) {
+		spec.Volumes = volumes
+	}
+}
+
+// PodCreationTimestamp sets the creation time of the pod
+func PodCreationTimestamp(t time.Time) PodOp {
+	return func(p *corev1.Pod) {
+		p.CreationTimestamp = metav1.Time{Time: t}
+	}
+}
+
+// PodStatus creates a PodStatus with default values.
+// Any number of PodStatus modifiers can be passed to transform it.
+func PodStatus(ops ...PodStatusOp) PodOp {
+	return func(pod *corev1.Pod) {
+		podStatus := &pod.Status
+		for _, op := range ops {
+			op(podStatus)
+		}
+		pod.Status = *podStatus
+	}
+}
+
+func PodStatusConditions(cond corev1.PodCondition) PodStatusOp {
+	return func(status *corev1.PodStatus) {
+		status.Conditions = append(status.Conditions, cond)
+	}
+}

--- a/test/builder/v1alpha1/pod_test.go
+++ b/test/builder/v1alpha1/pod_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	tb "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPod(t *testing.T) {
+	trueB := true
+	resourceQuantityCmp := cmp.Comparer(func(x, y resource.Quantity) bool {
+		return x.Cmp(y) == 0
+	})
+	volume := corev1.Volume{
+		Name:         "tools-volume",
+		VolumeSource: corev1.VolumeSource{},
+	}
+	got := tb.Pod("foo-pod-123456", "foo",
+		tb.PodAnnotation("annotation", "annotation-value"),
+		tb.PodLabel("label", "label-value"),
+		tb.PodOwnerReference("TaskRun", "taskrun-foo",
+			tb.OwnerReferenceAPIVersion("a1")),
+		tb.PodSpec(
+			tb.PodServiceAccountName("sa"),
+			tb.PodRestartPolicy(corev1.RestartPolicyNever),
+			tb.PodContainer("nop", "nop:latest"),
+			tb.PodInitContainer("basic", "ubuntu",
+				tb.Command("ls", "-l"),
+				tb.Args(),
+				tb.WorkingDir("/workspace"),
+				tb.EnvVar("HOME", "/tekton/home"),
+				tb.VolumeMount("tools-volume", "/tools"),
+				tb.Resources(
+					tb.Limits(tb.Memory("1.5Gi")),
+					tb.Requests(
+						tb.CPU("100m"),
+						tb.Memory("1Gi"),
+						tb.EphemeralStorage("500Mi"),
+					),
+				),
+			),
+			tb.PodVolumes(volume),
+		),
+	)
+	want := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "foo",
+			Name:      "foo-pod-123456",
+			Annotations: map[string]string{
+				"annotation": "annotation-value",
+			},
+			Labels: map[string]string{
+				"label": "label-value",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind:               "TaskRun",
+				Name:               "taskrun-foo",
+				APIVersion:         "a1",
+				Controller:         &trueB,
+				BlockOwnerDeletion: &trueB,
+			}},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "sa",
+			RestartPolicy:      corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:  "nop",
+				Image: "nop:latest",
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("0"),
+						corev1.ResourceMemory:           resource.MustParse("0"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("0"),
+					},
+				},
+			}},
+			InitContainers: []corev1.Container{{
+				Name:       "basic",
+				Image:      "ubuntu",
+				Command:    []string{"ls", "-l"},
+				WorkingDir: "/workspace",
+				Env: []corev1.EnvVar{{
+					Name:  "HOME",
+					Value: "/tekton/home",
+				}},
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "tools-volume",
+					MountPath: "/tools",
+				}},
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("1.5Gi"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("100m"),
+						corev1.ResourceMemory:           resource.MustParse("1Gi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("500Mi"),
+					},
+				},
+			}},
+			Volumes: []corev1.Volume{volume},
+		},
+	}
+	if d := cmp.Diff(want, got, resourceQuantityCmp); d != "" {
+		t.Fatalf("Pod diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/v1alpha1/step.go
+++ b/test/builder/v1alpha1/step.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// StepOp is an operation which modifies a Container struct.
+type StepOp func(*v1alpha1.Step)
+
+// StepCommand sets the command to the Container (step in this case).
+func StepCommand(args ...string) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.Command = args
+	}
+}
+
+// StepSecurityContext sets the SecurityContext to the Step.
+func StepSecurityContext(context *corev1.SecurityContext) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.SecurityContext = context
+	}
+}
+
+// StepArgs sets the command arguments to the Container (step in this case).
+func StepArgs(args ...string) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.Args = args
+	}
+}
+
+// StepEnvVar add an environment variable, with specified name and value, to the Container (step).
+func StepEnvVar(name, value string) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.Env = append(step.Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
+// StepWorkingDir sets the WorkingDir on the Container.
+func StepWorkingDir(workingDir string) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.WorkingDir = workingDir
+	}
+}
+
+// StepVolumeMount add a VolumeMount to the Container (step).
+func StepVolumeMount(name, mountPath string, ops ...VolumeMountOp) StepOp {
+	return func(step *v1alpha1.Step) {
+		mount := &corev1.VolumeMount{
+			Name:      name,
+			MountPath: mountPath,
+		}
+		for _, op := range ops {
+			op(mount)
+		}
+		step.VolumeMounts = append(step.VolumeMounts, *mount)
+	}
+}
+
+// StepResources adds ResourceRequirements to the Container (step).
+func StepResources(ops ...ResourceRequirementsOp) StepOp {
+	return func(step *v1alpha1.Step) {
+		rr := &corev1.ResourceRequirements{}
+		for _, op := range ops {
+			op(rr)
+		}
+		step.Resources = *rr
+	}
+}
+
+// StepLimits adds Limits to the ResourceRequirements.
+func StepLimits(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		limits := corev1.ResourceList{}
+		for _, op := range ops {
+			op(limits)
+		}
+		rr.Limits = limits
+	}
+}
+
+// StepRequests adds Requests to the ResourceRequirements.
+func StepRequests(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		requests := corev1.ResourceList{}
+		for _, op := range ops {
+			op(requests)
+		}
+		rr.Requests = requests
+	}
+}
+
+// StepCPU sets the CPU resource on the ResourceList.
+func StepCPU(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceCPU] = resource.MustParse(val)
+	}
+}
+
+// StepMemory sets the memory resource on the ResourceList.
+func StepMemory(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceMemory] = resource.MustParse(val)
+	}
+}
+
+// StepEphemeralStorage sets the ephemeral storage resource on the ResourceList.
+func StepEphemeralStorage(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceEphemeralStorage] = resource.MustParse(val)
+	}
+}
+
+// StepTerminationMessagePath sets the source of the termination message.
+func StepTerminationMessagePath(terminationMessagePath string) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.TerminationMessagePath = terminationMessagePath
+	}
+}
+
+// StepTerminationMessagePolicy sets the policy of the termination message.
+func StepTerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) StepOp {
+	return func(step *v1alpha1.Step) {
+		step.TerminationMessagePolicy = terminationMessagePolicy
+	}
+}

--- a/test/builder/v1alpha1/task.go
+++ b/test/builder/v1alpha1/task.go
@@ -1,0 +1,695 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+// TaskOp is an operation which modify a Task struct.
+type TaskOp func(*v1alpha1.Task)
+
+// ClusterTaskOp is an operation which modify a ClusterTask struct.
+type ClusterTaskOp func(*v1alpha1.ClusterTask)
+
+// TaskSpeOp is an operation which modify a TaskSpec struct.
+type TaskSpecOp func(*v1alpha1.TaskSpec)
+
+// InputsOp is an operation which modify an Inputs struct.
+type InputsOp func(*v1alpha1.Inputs)
+
+// OutputsOp is an operation which modify an Outputs struct.
+type OutputsOp func(*v1alpha1.Outputs)
+
+// TaskRunOp is an operation which modify a TaskRun struct.
+type TaskRunOp func(*v1alpha1.TaskRun)
+
+// TaskRunSpecOp is an operation which modify a TaskRunSpec struct.
+type TaskRunSpecOp func(*v1alpha1.TaskRunSpec)
+
+// TaskResourceOp is an operation which modify a TaskResource struct.
+type TaskResourceOp func(*v1alpha1.TaskResource)
+
+// TaskResourceBindingOp is an operation which modify a TaskResourceBinding struct.
+type TaskResourceBindingOp func(*v1alpha1.TaskResourceBinding)
+
+// TaskRunStatusOp is an operation which modify a TaskRunStatus struct.
+type TaskRunStatusOp func(*v1alpha1.TaskRunStatus)
+
+// TaskRefOp is an operation which modify a TaskRef struct.
+type TaskRefOp func(*v1alpha1.TaskRef)
+
+// TaskRunInputsOp is an operation which modify a TaskRunInputs struct.
+type TaskRunInputsOp func(*v1alpha1.TaskRunInputs)
+
+// TaskRunOutputsOp is an operation which modify a TaskRunOutputs struct.
+type TaskRunOutputsOp func(*v1alpha1.TaskRunOutputs)
+
+// ResolvedTaskResourcesOp is an operation which modify a ResolvedTaskResources struct.
+type ResolvedTaskResourcesOp func(*resources.ResolvedTaskResources)
+
+// StepStateOp is an operation which modify a StepStep struct.
+type StepStateOp func(*v1alpha1.StepState)
+
+// VolumeOp is an operation which modify a Volume struct.
+type VolumeOp func(*corev1.Volume)
+
+var (
+	trueB = true
+)
+
+// Task creates a Task with default values.
+// Any number of Task modifier can be passed to transform it.
+func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
+	t := &v1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	for _, op := range ops {
+		op(t)
+	}
+
+	return t
+}
+
+// ClusterTask creates a ClusterTask with default values.
+// Any number of ClusterTask modifier can be passed to transform it.
+func ClusterTask(name string, ops ...ClusterTaskOp) *v1alpha1.ClusterTask {
+	t := &v1alpha1.ClusterTask{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+
+	for _, op := range ops {
+		op(t)
+	}
+
+	return t
+}
+
+// ClusterTaskSpec sets the specified spec of the cluster task.
+// Any number of TaskSpec modifier can be passed to create it.
+func ClusterTaskSpec(ops ...TaskSpecOp) ClusterTaskOp {
+	return func(t *v1alpha1.ClusterTask) {
+		spec := &t.Spec
+		for _, op := range ops {
+			op(spec)
+		}
+		t.Spec = *spec
+	}
+}
+
+// TaskSpec sets the specified spec of the task.
+// Any number of TaskSpec modifier can be passed to create/modify it.
+func TaskSpec(ops ...TaskSpecOp) TaskOp {
+	return func(t *v1alpha1.Task) {
+		spec := &t.Spec
+		for _, op := range ops {
+			op(spec)
+		}
+		t.Spec = *spec
+	}
+}
+
+// Step adds a step with the specified name and image to the TaskSpec.
+// Any number of Container modifier can be passed to transform it.
+func Step(name, image string, ops ...StepOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		if spec.Steps == nil {
+			spec.Steps = []v1alpha1.Step{}
+		}
+		step := v1alpha1.Step{Container: corev1.Container{
+			Name:  name,
+			Image: image,
+		}}
+		for _, op := range ops {
+			op(&step)
+		}
+		spec.Steps = append(spec.Steps, step)
+	}
+}
+
+func Sidecar(name, image string, ops ...ContainerOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		c := corev1.Container{
+			Name:  name,
+			Image: image,
+		}
+		for _, op := range ops {
+			op(&c)
+		}
+		spec.Sidecars = append(spec.Sidecars, c)
+	}
+}
+
+// TaskStepTemplate adds a base container for all steps in the task.
+func TaskStepTemplate(ops ...ContainerOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		base := &corev1.Container{}
+		for _, op := range ops {
+			op(base)
+		}
+		spec.StepTemplate = base
+	}
+}
+
+// TaskVolume adds a volume with specified name to the TaskSpec.
+// Any number of Volume modifier can be passed to transform it.
+func TaskVolume(name string, ops ...VolumeOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		v := &corev1.Volume{Name: name}
+		for _, op := range ops {
+			op(v)
+		}
+		spec.Volumes = append(spec.Volumes, *v)
+	}
+}
+
+// VolumeSource sets the VolumeSource to the Volume.
+func VolumeSource(s corev1.VolumeSource) VolumeOp {
+	return func(v *corev1.Volume) {
+		v.VolumeSource = s
+	}
+}
+
+// TaskInputs sets inputs to the TaskSpec.
+// Any number of Inputs modifier can be passed to transform it.
+func TaskInputs(ops ...InputsOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		if spec.Inputs == nil {
+			spec.Inputs = &v1alpha1.Inputs{}
+		}
+		for _, op := range ops {
+			op(spec.Inputs)
+		}
+	}
+}
+
+// TaskOutputs sets inputs to the TaskSpec.
+// Any number of Outputs modifier can be passed to transform it.
+func TaskOutputs(ops ...OutputsOp) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		if spec.Outputs == nil {
+			spec.Outputs = &v1alpha1.Outputs{}
+		}
+		for _, op := range ops {
+			op(spec.Outputs)
+		}
+	}
+}
+
+// InputsResource adds a resource, with specified name and type, to the Inputs.
+// Any number of TaskResource modifier can be passed to transform it.
+func InputsResource(name string, resourceType v1alpha1.PipelineResourceType, ops ...TaskResourceOp) InputsOp {
+	return func(i *v1alpha1.Inputs) {
+		r := &v1alpha1.TaskResource{
+			ResourceDeclaration: v1alpha1.ResourceDeclaration{
+				Name: name,
+				Type: resourceType,
+			}}
+		for _, op := range ops {
+			op(r)
+		}
+		i.Resources = append(i.Resources, *r)
+	}
+}
+
+func ResourceTargetPath(path string) TaskResourceOp {
+	return func(r *v1alpha1.TaskResource) {
+		r.TargetPath = path
+	}
+}
+
+// OutputsResource adds a resource, with specified name and type, to the Outputs.
+func OutputsResource(name string, resourceType v1alpha1.PipelineResourceType) OutputsOp {
+	return func(o *v1alpha1.Outputs) {
+		o.Resources = append(o.Resources, v1alpha1.TaskResource{
+			ResourceDeclaration: v1alpha1.ResourceDeclaration{
+				Name: name,
+				Type: resourceType,
+			}})
+	}
+}
+
+// InputsParamSpec adds a ParamSpec, with specified name and type, to the Inputs.
+// Any number of TaskParamSpec modifier can be passed to transform it.
+func InputsParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) InputsOp {
+	return func(i *v1alpha1.Inputs) {
+		ps := &v1alpha1.ParamSpec{Name: name, Type: pt}
+		for _, op := range ops {
+			op(ps)
+		}
+		i.Params = append(i.Params, *ps)
+	}
+}
+
+// TaskRun creates a TaskRun with default values.
+// Any number of TaskRun modifier can be passed to transform it.
+func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
+	tr := &v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: map[string]string{},
+		},
+	}
+
+	for _, op := range ops {
+		op(tr)
+	}
+
+	return tr
+}
+
+// TaskRunStatus sets the TaskRunStatus to tshe TaskRun
+func TaskRunStatus(ops ...TaskRunStatusOp) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		status := &tr.Status
+		for _, op := range ops {
+			op(status)
+		}
+		tr.Status = *status
+	}
+}
+
+// PodName sets the Pod name to the TaskRunStatus.
+func PodName(name string) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.PodName = name
+	}
+}
+
+// StatusCondition adds a StatusCondition to the TaskRunStatus.
+func StatusCondition(condition apis.Condition) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.Conditions = append(s.Conditions, condition)
+	}
+}
+
+func Retry(retry v1alpha1.TaskRunStatus) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.RetriesStatus = append(s.RetriesStatus, retry)
+	}
+}
+
+// StepState adds a StepState to the TaskRunStatus.
+func StepState(ops ...StepStateOp) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		state := &v1alpha1.StepState{}
+		for _, op := range ops {
+			op(state)
+		}
+		s.Steps = append(s.Steps, *state)
+	}
+}
+
+// TaskRunStartTime sets the start time to the TaskRunStatus.
+func TaskRunStartTime(startTime time.Time) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.StartTime = &metav1.Time{Time: startTime}
+	}
+}
+
+// TaskRunCompletionTime sets the start time to the TaskRunStatus.
+func TaskRunCompletionTime(completionTime time.Time) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		s.CompletionTime = &metav1.Time{Time: completionTime}
+	}
+}
+
+// TaskRunCloudEvent adds an event to the TaskRunStatus.
+func TaskRunCloudEvent(target, error string, retryCount int32, condition v1alpha1.CloudEventCondition) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		if len(s.CloudEvents) == 0 {
+			s.CloudEvents = make([]v1alpha1.CloudEventDelivery, 0)
+		}
+		cloudEvent := v1alpha1.CloudEventDelivery{
+			Target: target,
+			Status: v1alpha1.CloudEventDeliveryState{
+				Condition:  condition,
+				RetryCount: retryCount,
+				Error:      error,
+			},
+		}
+		s.CloudEvents = append(s.CloudEvents, cloudEvent)
+	}
+}
+
+// TaskRunTimeout sets the timeout duration to the TaskRunSpec.
+func TaskRunTimeout(d time.Duration) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.Timeout = &metav1.Duration{Duration: d}
+	}
+}
+
+// TaskRunNilTimeout sets the timeout duration to nil on the TaskRunSpec.
+func TaskRunNilTimeout(spec *v1alpha1.TaskRunSpec) {
+	spec.Timeout = nil
+}
+
+// TaskRunNodeSelector sets the NodeSelector to the TaskRunSpec.
+func TaskRunNodeSelector(values map[string]string) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.PodTemplate.NodeSelector = values
+	}
+}
+
+// TaskRunTolerations sets the Tolerations to the TaskRunSpec.
+func TaskRunTolerations(values []corev1.Toleration) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.PodTemplate.Tolerations = values
+	}
+}
+
+// TaskRunAffinity sets the Affinity to the TaskRunSpec.
+func TaskRunAffinity(affinity *corev1.Affinity) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.PodTemplate.Affinity = affinity
+	}
+}
+
+// TaskRunPodSecurityContext sets the SecurityContext to the TaskRunSpec (through PodTemplate).
+func TaskRunPodSecurityContext(context *corev1.PodSecurityContext) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.PodTemplate.SecurityContext = context
+	}
+}
+
+// StateTerminated sets Terminated to the StepState.
+func StateTerminated(exitcode int) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{ExitCode: int32(exitcode)},
+		}
+	}
+}
+
+// SetStepStateTerminated sets Terminated state of a step.
+func SetStepStateTerminated(terminated corev1.ContainerStateTerminated) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Terminated: &terminated,
+		}
+	}
+}
+
+// SetStepStateRunning sets Running state of a step.
+func SetStepStateRunning(running corev1.ContainerStateRunning) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Running: &running,
+		}
+	}
+}
+
+// SetStepStateWaiting sets Waiting state of a step.
+func SetStepStateWaiting(waiting corev1.ContainerStateWaiting) StepStateOp {
+	return func(s *v1alpha1.StepState) {
+		s.ContainerState = corev1.ContainerState{
+			Waiting: &waiting,
+		}
+	}
+}
+
+// TaskRunOwnerReference sets the OwnerReference, with specified kind and name, to the TaskRun.
+func TaskRunOwnerReference(kind, name string, ops ...OwnerReferenceOp) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		o := &metav1.OwnerReference{
+			Kind: kind,
+			Name: name,
+		}
+		for _, op := range ops {
+			op(o)
+		}
+		tr.ObjectMeta.OwnerReferences = append(tr.ObjectMeta.OwnerReferences, *o)
+	}
+}
+
+func Controller(o *metav1.OwnerReference) {
+	o.Controller = &trueB
+}
+
+func BlockOwnerDeletion(o *metav1.OwnerReference) {
+	o.BlockOwnerDeletion = &trueB
+}
+
+func TaskRunLabel(key, value string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		if tr.ObjectMeta.Labels == nil {
+			tr.ObjectMeta.Labels = map[string]string{}
+		}
+		tr.ObjectMeta.Labels[key] = value
+	}
+}
+
+func TaskRunAnnotation(key, value string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		if tr.ObjectMeta.Annotations == nil {
+			tr.ObjectMeta.Annotations = map[string]string{}
+		}
+		tr.ObjectMeta.Annotations[key] = value
+	}
+}
+
+// TaskRunSelfLink adds a SelfLink
+func TaskRunSelfLink(selflink string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		tr.ObjectMeta.SelfLink = selflink
+	}
+}
+
+// TaskRunSpec sets the specified spec of the TaskRun.
+// Any number of TaskRunSpec modifier can be passed to transform it.
+func TaskRunSpec(ops ...TaskRunSpecOp) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		spec := &tr.Spec
+		// Set a default timeout
+		spec.Timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
+		for _, op := range ops {
+			op(spec)
+		}
+		tr.Spec = *spec
+	}
+}
+
+// TaskRunCancelled sets the status to cancel to the TaskRunSpec.
+func TaskRunCancelled(spec *v1alpha1.TaskRunSpec) {
+	spec.Status = v1alpha1.TaskRunSpecStatusCancelled
+}
+
+// TaskRunTaskRef sets the specified Task reference to the TaskRunSpec.
+// Any number of TaskRef modifier can be passed to transform it.
+func TaskRunTaskRef(name string, ops ...TaskRefOp) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		ref := &v1alpha1.TaskRef{Name: name}
+		for _, op := range ops {
+			op(ref)
+		}
+		spec.TaskRef = ref
+	}
+}
+
+// TaskRunSpecStatus sets the Status in the Spec, used for operations
+// such as cancelling executing TaskRuns.
+func TaskRunSpecStatus(status v1alpha1.TaskRunSpecStatus) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		spec.Status = status
+	}
+}
+
+// TaskRefKind set the specified kind to the TaskRef.
+func TaskRefKind(kind v1alpha1.TaskKind) TaskRefOp {
+	return func(ref *v1alpha1.TaskRef) {
+		ref.Kind = kind
+	}
+}
+
+// TaskRefAPIVersion sets the specified api version to the TaskRef.
+func TaskRefAPIVersion(version string) TaskRefOp {
+	return func(ref *v1alpha1.TaskRef) {
+		ref.APIVersion = version
+	}
+}
+
+// TaskRunTaskSpec sets the specified TaskRunSpec reference to the TaskRunSpec.
+// Any number of TaskRunSpec modifier can be passed to transform it.
+func TaskRunTaskSpec(ops ...TaskSpecOp) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		taskSpec := &v1alpha1.TaskSpec{}
+		for _, op := range ops {
+			op(taskSpec)
+		}
+		spec.TaskSpec = taskSpec
+	}
+}
+
+// TaskRunServiceAccount sets the serviceAccount to the TaskRunSpec.
+func TaskRunServiceAccountName(sa string) TaskRunSpecOp {
+	return func(trs *v1alpha1.TaskRunSpec) {
+		trs.ServiceAccountName = sa
+	}
+}
+
+// TaskRunInputs sets inputs to the TaskRunSpec.
+// Any number of TaskRunInputs modifier can be passed to transform it.
+func TaskRunInputs(ops ...TaskRunInputsOp) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		inputs := &spec.Inputs
+		for _, op := range ops {
+			op(inputs)
+		}
+		spec.Inputs = *inputs
+	}
+}
+
+// TaskRunInputsParam add a param, with specified name and value, to the TaskRunInputs.
+func TaskRunInputsParam(name, value string, additionalValues ...string) TaskRunInputsOp {
+	arrayOrString := ArrayOrString(value, additionalValues...)
+	return func(i *v1alpha1.TaskRunInputs) {
+		i.Params = append(i.Params, v1alpha1.Param{
+			Name:  name,
+			Value: *arrayOrString,
+		})
+	}
+}
+
+// TaskRunInputsResource adds a resource, with specified name, to the TaskRunInputs.
+// Any number of TaskResourceBinding modifier can be passed to transform it.
+func TaskRunInputsResource(name string, ops ...TaskResourceBindingOp) TaskRunInputsOp {
+	return func(i *v1alpha1.TaskRunInputs) {
+		binding := &v1alpha1.TaskResourceBinding{
+			PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+				Name: name,
+			},
+		}
+		for _, op := range ops {
+			op(binding)
+		}
+		i.Resources = append(i.Resources, *binding)
+	}
+}
+
+// TaskResourceBindingRef set the PipelineResourceRef name to the TaskResourceBinding.
+func TaskResourceBindingRef(name string) TaskResourceBindingOp {
+	return func(b *v1alpha1.TaskResourceBinding) {
+		b.ResourceRef = &v1alpha1.PipelineResourceRef{
+			Name: name,
+		}
+	}
+}
+
+// TaskResourceBindingResourceSpec set the PipelineResourceResourceSpec to the TaskResourceBinding.
+func TaskResourceBindingResourceSpec(spec *v1alpha1.PipelineResourceSpec) TaskResourceBindingOp {
+	return func(b *v1alpha1.TaskResourceBinding) {
+		b.ResourceSpec = spec
+	}
+}
+
+// TaskResourceBindingRefAPIVersion set the PipelineResourceRef APIVersion to the TaskResourceBinding.
+func TaskResourceBindingRefAPIVersion(version string) TaskResourceBindingOp {
+	return func(b *v1alpha1.TaskResourceBinding) {
+		b.ResourceRef.APIVersion = version
+	}
+}
+
+// TaskResourceBindingPaths add any number of path to the TaskResourceBinding.
+func TaskResourceBindingPaths(paths ...string) TaskResourceBindingOp {
+	return func(b *v1alpha1.TaskResourceBinding) {
+		b.Paths = paths
+	}
+}
+
+// TaskRunOutputs sets inputs to the TaskRunSpec.
+// Any number of TaskRunOutputs modifier can be passed to transform it.
+func TaskRunOutputs(ops ...TaskRunOutputsOp) TaskRunSpecOp {
+	return func(spec *v1alpha1.TaskRunSpec) {
+		outputs := &spec.Outputs
+		for _, op := range ops {
+			op(outputs)
+		}
+		spec.Outputs = *outputs
+	}
+}
+
+// TaskRunOutputsResource adds a TaskResourceBinding, with specified name, to the TaskRunOutputs.
+// Any number of TaskResourceBinding modifier can be passed to modifiy it.
+func TaskRunOutputsResource(name string, ops ...TaskResourceBindingOp) TaskRunOutputsOp {
+	return func(i *v1alpha1.TaskRunOutputs) {
+		binding := &v1alpha1.TaskResourceBinding{
+			PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+				Name: name,
+			},
+		}
+		for _, op := range ops {
+			op(binding)
+		}
+		i.Resources = append(i.Resources, *binding)
+	}
+}
+
+// ResolvedTaskResources creates a ResolvedTaskResources with default values.
+// Any number of ResolvedTaskResources modifier can be passed to transform it.
+func ResolvedTaskResources(ops ...ResolvedTaskResourcesOp) *resources.ResolvedTaskResources {
+	resources := &resources.ResolvedTaskResources{}
+	for _, op := range ops {
+		op(resources)
+	}
+	return resources
+}
+
+// ResolvedTaskResourcesTaskSpec sets a TaskSpec to the ResolvedTaskResources.
+// Any number of TaskSpec modifier can be passed to transform it.
+func ResolvedTaskResourcesTaskSpec(ops ...TaskSpecOp) ResolvedTaskResourcesOp {
+	return func(r *resources.ResolvedTaskResources) {
+		spec := &v1alpha1.TaskSpec{}
+		for _, op := range ops {
+			op(spec)
+		}
+		r.TaskSpec = spec
+	}
+}
+
+// ResolvedTaskResourcesInputs adds an input PipelineResource, with specified name, to the ResolvedTaskResources.
+func ResolvedTaskResourcesInputs(name string, resource *v1alpha1.PipelineResource) ResolvedTaskResourcesOp {
+	return func(r *resources.ResolvedTaskResources) {
+		if r.Inputs == nil {
+			r.Inputs = map[string]*v1alpha1.PipelineResource{}
+		}
+		r.Inputs[name] = resource
+	}
+}
+
+// ResolvedTaskResourcesOutputs adds an output PipelineResource, with specified name, to the ResolvedTaskResources.
+func ResolvedTaskResourcesOutputs(name string, resource *v1alpha1.PipelineResource) ResolvedTaskResourcesOp {
+	return func(r *resources.ResolvedTaskResources) {
+		if r.Outputs == nil {
+			r.Outputs = map[string]*v1alpha1.PipelineResource{}
+		}
+		r.Outputs[name] = resource
+	}
+}

--- a/test/builder/v1alpha1/task_test.go
+++ b/test/builder/v1alpha1/task_test.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	tb "github.com/tektoncd/pipeline/test/builder/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+var (
+	gitResource = tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
+	))
+	anotherGitResource = tb.PipelineResource("another-git-resource", "foo", tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foobar.git"),
+	))
+)
+
+func TestTask(t *testing.T) {
+	task := tb.Task("test-task", "foo", tb.TaskSpec(
+		tb.TaskInputs(
+			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceTargetPath("/foo/bar")),
+			tb.InputsParamSpec("param", v1alpha1.ParamTypeString, tb.ParamSpecDescription("mydesc"), tb.ParamSpecDefault("default")),
+			tb.InputsParamSpec("array-param", v1alpha1.ParamTypeString, tb.ParamSpecDescription("desc"), tb.ParamSpecDefault("array", "values")),
+		),
+		tb.TaskOutputs(tb.OutputsResource("myotherimage", v1alpha1.PipelineResourceTypeImage)),
+		tb.Step("mycontainer", "myimage", tb.StepCommand("/mycmd"), tb.StepArgs(
+			"--my-other-arg=$(inputs.resources.workspace.url)",
+		)),
+		tb.TaskVolume("foo", tb.VolumeSource(corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: "/foo/bar"},
+		})),
+		tb.TaskStepTemplate(
+			tb.EnvVar("FRUIT", "BANANA"),
+		),
+	))
+	expectedTask := &v1alpha1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-task", Namespace: "foo"},
+		Spec: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: corev1.Container{
+				Name:    "mycontainer",
+				Image:   "myimage",
+				Command: []string{"/mycmd"},
+				Args:    []string{"--my-other-arg=$(inputs.resources.workspace.url)"},
+			}}},
+			Inputs: &v1alpha1.Inputs{
+				Resources: []v1alpha1.TaskResource{{
+					ResourceDeclaration: v1alpha1.ResourceDeclaration{
+						Name:       "workspace",
+						Type:       v1alpha1.PipelineResourceTypeGit,
+						TargetPath: "/foo/bar",
+					}}},
+				Params: []v1alpha1.ParamSpec{{
+					Name:        "param",
+					Type:        v1alpha1.ParamTypeString,
+					Description: "mydesc",
+					Default:     tb.ArrayOrString("default"),
+				}, {
+					Name:        "array-param",
+					Type:        v1alpha1.ParamTypeString,
+					Description: "desc",
+					Default:     tb.ArrayOrString("array", "values"),
+				}}},
+			Outputs: &v1alpha1.Outputs{
+				Resources: []v1alpha1.TaskResource{{
+					ResourceDeclaration: v1alpha1.ResourceDeclaration{
+						Name: "myotherimage",
+						Type: v1alpha1.PipelineResourceTypeImage,
+					}}},
+			},
+			Volumes: []corev1.Volume{{
+				Name: "foo",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{Path: "/foo/bar"},
+				},
+			}},
+			StepTemplate: &corev1.Container{
+				Env: []corev1.EnvVar{{
+					Name:  "FRUIT",
+					Value: "BANANA",
+				}},
+			},
+		},
+	}
+	if d := cmp.Diff(expectedTask, task); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}
+
+func TestClusterTask(t *testing.T) {
+	task := tb.ClusterTask("test-clustertask", tb.ClusterTaskSpec(
+		tb.Step("mycontainer", "myimage", tb.StepCommand("/mycmd"), tb.StepArgs(
+			"--my-other-arg=$(inputs.resources.workspace.url)",
+		)),
+	))
+	expectedTask := &v1alpha1.ClusterTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-clustertask"},
+		Spec: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: corev1.Container{
+				Name:    "mycontainer",
+				Image:   "myimage",
+				Command: []string{"/mycmd"},
+				Args:    []string{"--my-other-arg=$(inputs.resources.workspace.url)"},
+			}}},
+		},
+	}
+	if d := cmp.Diff(expectedTask, task); d != "" {
+		t.Fatalf("Task diff -want, +got: %v", d)
+	}
+}
+
+func TestTaskRunWithTaskRef(t *testing.T) {
+	var trueB = true
+	taskRun := tb.TaskRun("test-taskrun", "foo",
+		tb.TaskRunOwnerReference("PipelineRun", "test",
+			tb.OwnerReferenceAPIVersion("a1"),
+			tb.Controller, tb.BlockOwnerDeletion,
+		),
+		tb.TaskRunLabel("label", "label-value"),
+		tb.TaskRunSpec(
+			tb.TaskRunTaskRef("task-output",
+				tb.TaskRefKind(v1alpha1.ClusterTaskKind),
+				tb.TaskRefAPIVersion("a1"),
+			),
+			tb.TaskRunInputs(
+				tb.TaskRunInputsResource(gitResource.Name,
+					tb.TaskResourceBindingRef("my-git"),
+					tb.TaskResourceBindingPaths("source-folder"),
+					tb.TaskResourceBindingRefAPIVersion("a1"),
+				),
+				tb.TaskRunInputsResource(anotherGitResource.Name,
+					tb.TaskResourceBindingPaths("source-folder"),
+					tb.TaskResourceBindingResourceSpec(&v1alpha1.PipelineResourceSpec{Type: v1alpha1.PipelineResourceTypeCluster}),
+				),
+				tb.TaskRunInputsParam("iparam", "ivalue"),
+				tb.TaskRunInputsParam("arrayparam", "array", "values"),
+			),
+			tb.TaskRunOutputs(
+				tb.TaskRunOutputsResource(gitResource.Name,
+					tb.TaskResourceBindingRef(gitResource.Name),
+					tb.TaskResourceBindingPaths("output-folder"),
+				),
+			),
+		),
+		tb.TaskRunStatus(
+			tb.PodName("my-pod-name"),
+			tb.StatusCondition(apis.Condition{Type: apis.ConditionSucceeded}),
+			tb.StepState(tb.StateTerminated(127)),
+		),
+	)
+	expectedTaskRun := &v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-taskrun", Namespace: "foo",
+			OwnerReferences: []metav1.OwnerReference{{
+				Name:               "test",
+				Kind:               "PipelineRun",
+				APIVersion:         "a1",
+				Controller:         &trueB,
+				BlockOwnerDeletion: &trueB,
+			}},
+			Labels:      map[string]string{"label": "label-value"},
+			Annotations: map[string]string{},
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			Inputs: v1alpha1.TaskRunInputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+						Name: "git-resource",
+						ResourceRef: &v1alpha1.PipelineResourceRef{
+							Name:       "my-git",
+							APIVersion: "a1",
+						},
+					},
+					Paths: []string{"source-folder"},
+				}, {
+					PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+						Name:         "another-git-resource",
+						ResourceSpec: &v1alpha1.PipelineResourceSpec{Type: v1alpha1.PipelineResourceType("cluster")},
+					},
+					Paths: []string{"source-folder"},
+				}},
+				Params: []v1alpha1.Param{{
+					Name:  "iparam",
+					Value: *tb.ArrayOrString("ivalue"),
+				}, {
+					Name:  "arrayparam",
+					Value: *tb.ArrayOrString("array", "values"),
+				}},
+			},
+			Outputs: v1alpha1.TaskRunOutputs{
+				Resources: []v1alpha1.TaskResourceBinding{{
+					PipelineResourceBinding: v1alpha1.PipelineResourceBinding{
+						Name: "git-resource",
+						ResourceRef: &v1alpha1.PipelineResourceRef{
+							Name: "git-resource",
+						},
+					},
+					Paths: []string{"output-folder"},
+				}},
+			},
+			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			TaskRef: &v1alpha1.TaskRef{
+				Name:       "task-output",
+				Kind:       v1alpha1.ClusterTaskKind,
+				APIVersion: "a1",
+			},
+		},
+		Status: v1alpha1.TaskRunStatus{
+			PodName: "my-pod-name",
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
+			},
+			Steps: []v1alpha1.StepState{{ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{ExitCode: 127},
+			}}},
+		},
+	}
+	if d := cmp.Diff(expectedTaskRun, taskRun); d != "" {
+		t.Fatalf("TaskRun diff -want, +got: %v", d)
+	}
+}
+
+func TestTaskRunWithTaskSpec(t *testing.T) {
+	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskSpec(
+			tb.Step("step", "image", tb.StepCommand("/mycmd")),
+		),
+		tb.TaskRunServiceAccountName("sa"),
+		tb.TaskRunTimeout(2*time.Minute),
+		tb.TaskRunSpecStatus(v1alpha1.TaskRunSpecStatusCancelled),
+	))
+	expectedTaskRun := &v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-taskrun", Namespace: "foo",
+			Annotations: map[string]string{},
+		},
+		Spec: v1alpha1.TaskRunSpec{
+			TaskSpec: &v1alpha1.TaskSpec{
+				Steps: []v1alpha1.Step{{Container: corev1.Container{
+					Name:    "step",
+					Image:   "image",
+					Command: []string{"/mycmd"},
+				}}},
+			},
+			ServiceAccountName: "sa",
+			Status:             v1alpha1.TaskRunSpecStatusCancelled,
+			Timeout:            &metav1.Duration{Duration: 2 * time.Minute},
+		},
+	}
+	if d := cmp.Diff(expectedTaskRun, taskRun); d != "" {
+		t.Fatalf("TaskRun diff -want, +got: %v", d)
+	}
+}
+
+func TestResolvedTaskResources(t *testing.T) {
+	resolvedTaskResources := tb.ResolvedTaskResources(
+		tb.ResolvedTaskResourcesTaskSpec(
+			tb.Step("step", "image", tb.StepCommand("/mycmd")),
+		),
+		tb.ResolvedTaskResourcesInputs("foo", tb.PipelineResource("bar", "baz")),
+		tb.ResolvedTaskResourcesOutputs("qux", tb.PipelineResource("quux", "quuz")),
+	)
+	expectedResolvedTaskResources := &resources.ResolvedTaskResources{
+		TaskSpec: &v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: corev1.Container{
+				Name:    "step",
+				Image:   "image",
+				Command: []string{"/mycmd"},
+			}}},
+		},
+		Inputs: map[string]*v1alpha1.PipelineResource{
+			"foo": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "baz",
+				},
+			},
+		},
+		Outputs: map[string]*v1alpha1.PipelineResource{
+			"qux": {
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "quux",
+					Namespace: "quuz",
+				},
+			},
+		},
+	}
+	if d := cmp.Diff(expectedResolvedTaskResources, resolvedTaskResources); d != "" {
+		t.Fatalf("ResolvedTaskResources diff -want, +got: %v", d)
+	}
+}

--- a/test/builder/v1alpha2/container.go
+++ b/test/builder/v1alpha2/container.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ContainerOp is an operation which modifies a Container struct.
+type ContainerOp func(*corev1.Container)
+
+// VolumeMountOp is an operation which modifies a VolumeMount struct.
+type VolumeMountOp func(*corev1.VolumeMount)
+
+// ResourceRequirementsOp is an operation which modifies a ResourceRequirements struct.
+type ResourceRequirementsOp func(*corev1.ResourceRequirements)
+
+// ResourceListOp is an operation which modifies a ResourceList struct.
+type ResourceListOp func(corev1.ResourceList)
+
+// Command sets the command to the Container (step in this case).
+func Command(args ...string) ContainerOp {
+	return func(container *corev1.Container) {
+		container.Command = args
+	}
+}
+
+// Args sets the command arguments to the Container (step in this case).
+func Args(args ...string) ContainerOp {
+	return func(container *corev1.Container) {
+		container.Args = args
+	}
+}
+
+// EnvVar add an environment variable, with specified name and value, to the Container (step).
+func EnvVar(name, value string) ContainerOp {
+	return func(c *corev1.Container) {
+		c.Env = append(c.Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
+// WorkingDir sets the WorkingDir on the Container.
+func WorkingDir(workingDir string) ContainerOp {
+	return func(c *corev1.Container) {
+		c.WorkingDir = workingDir
+	}
+}
+
+// VolumeMount add a VolumeMount to the Container (step).
+func VolumeMount(name, mountPath string, ops ...VolumeMountOp) ContainerOp {
+	return func(c *corev1.Container) {
+		mount := &corev1.VolumeMount{
+			Name:      name,
+			MountPath: mountPath,
+		}
+		for _, op := range ops {
+			op(mount)
+		}
+		c.VolumeMounts = append(c.VolumeMounts, *mount)
+	}
+}
+
+// Resources adds ResourceRequirements to the Container (step).
+func Resources(ops ...ResourceRequirementsOp) ContainerOp {
+	return func(c *corev1.Container) {
+		rr := &corev1.ResourceRequirements{}
+		for _, op := range ops {
+			op(rr)
+		}
+		c.Resources = *rr
+	}
+}
+
+// Limits adds Limits to the ResourceRequirements.
+func Limits(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		limits := corev1.ResourceList{}
+		for _, op := range ops {
+			op(limits)
+		}
+		rr.Limits = limits
+	}
+}
+
+// Requests adds Requests to the ResourceRequirements.
+func Requests(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		requests := corev1.ResourceList{}
+		for _, op := range ops {
+			op(requests)
+		}
+		rr.Requests = requests
+	}
+}
+
+// CPU sets the CPU resource on the ResourceList.
+func CPU(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceCPU] = resource.MustParse(val)
+	}
+}
+
+// Memory sets the memory resource on the ResourceList.
+func Memory(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceMemory] = resource.MustParse(val)
+	}
+}
+
+// EphemeralStorage sets the ephemeral storage resource on the ResourceList.
+func EphemeralStorage(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceEphemeralStorage] = resource.MustParse(val)
+	}
+}
+
+// TerminationMessagePolicy sets the policy of the termination message.
+func TerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) ContainerOp {
+	return func(c *corev1.Container) {
+		c.TerminationMessagePolicy = terminationMessagePolicy
+	}
+}

--- a/test/builder/v1alpha2/step.go
+++ b/test/builder/v1alpha2/step.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// StepOp is an operation which modifies a Container struct.
+type StepOp func(*v1alpha2.Step)
+
+// StepCommand sets the command to the Container (step in this case).
+func StepCommand(args ...string) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.Command = args
+	}
+}
+
+// StepSecurityContext sets the SecurityContext to the Step.
+func StepSecurityContext(context *corev1.SecurityContext) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.SecurityContext = context
+	}
+}
+
+// StepArgs sets the command arguments to the Container (step in this case).
+func StepArgs(args ...string) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.Args = args
+	}
+}
+
+// StepEnvVar add an environment variable, with specified name and value, to the Container (step).
+func StepEnvVar(name, value string) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.Env = append(step.Env, corev1.EnvVar{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
+// StepWorkingDir sets the WorkingDir on the Container.
+func StepWorkingDir(workingDir string) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.WorkingDir = workingDir
+	}
+}
+
+// StepVolumeMount add a VolumeMount to the Container (step).
+func StepVolumeMount(name, mountPath string, ops ...VolumeMountOp) StepOp {
+	return func(step *v1alpha2.Step) {
+		mount := &corev1.VolumeMount{
+			Name:      name,
+			MountPath: mountPath,
+		}
+		for _, op := range ops {
+			op(mount)
+		}
+		step.VolumeMounts = append(step.VolumeMounts, *mount)
+	}
+}
+
+// StepResources adds ResourceRequirements to the Container (step).
+func StepResources(ops ...ResourceRequirementsOp) StepOp {
+	return func(step *v1alpha2.Step) {
+		rr := &corev1.ResourceRequirements{}
+		for _, op := range ops {
+			op(rr)
+		}
+		step.Resources = *rr
+	}
+}
+
+// StepLimits adds Limits to the ResourceRequirements.
+func StepLimits(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		limits := corev1.ResourceList{}
+		for _, op := range ops {
+			op(limits)
+		}
+		rr.Limits = limits
+	}
+}
+
+// StepRequests adds Requests to the ResourceRequirements.
+func StepRequests(ops ...ResourceListOp) ResourceRequirementsOp {
+	return func(rr *corev1.ResourceRequirements) {
+		requests := corev1.ResourceList{}
+		for _, op := range ops {
+			op(requests)
+		}
+		rr.Requests = requests
+	}
+}
+
+// StepCPU sets the CPU resource on the ResourceList.
+func StepCPU(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceCPU] = resource.MustParse(val)
+	}
+}
+
+// StepMemory sets the memory resource on the ResourceList.
+func StepMemory(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceMemory] = resource.MustParse(val)
+	}
+}
+
+// StepEphemeralStorage sets the ephemeral storage resource on the ResourceList.
+func StepEphemeralStorage(val string) ResourceListOp {
+	return func(r corev1.ResourceList) {
+		r[corev1.ResourceEphemeralStorage] = resource.MustParse(val)
+	}
+}
+
+// StepTerminationMessagePath sets the source of the termination message.
+func StepTerminationMessagePath(terminationMessagePath string) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.TerminationMessagePath = terminationMessagePath
+	}
+}
+
+// StepTerminationMessagePolicy sets the policy of the termination message.
+func StepTerminationMessagePolicy(terminationMessagePolicy corev1.TerminationMessagePolicy) StepOp {
+	return func(step *v1alpha2.Step) {
+		step.TerminationMessagePolicy = terminationMessagePolicy
+	}
+}

--- a/test/builder/v1alpha2/task.go
+++ b/test/builder/v1alpha2/task.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TaskOp is an operation which modify a Task struct.
+type TaskOp func(*v1alpha2.Task)
+
+// TaskSpeOp is an operation which modify a TaskSpec struct.
+type TaskSpecOp func(*v1alpha2.TaskSpec)
+
+// TaskResourceOp is an operation which modify a TaskResource struct.
+type TaskResourceOp func(*v1alpha2.TaskResource)
+
+// VolumeOp is an operation which modify a Volume struct.
+type VolumeOp func(*corev1.Volume)
+
+var (
+	trueB = true
+)
+
+// Task creates a Task with default values.
+// Any number of Task modifier can be passed to transform it.
+func Task(name, namespace string, ops ...TaskOp) *v1alpha2.Task {
+	t := &v1alpha2.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+
+	for _, op := range ops {
+		op(t)
+	}
+
+	return t
+}
+
+// TaskSpec sets the specified spec of the task.
+// Any number of TaskSpec modifier can be passed to create/modify it.
+func TaskSpec(ops ...TaskSpecOp) TaskOp {
+	return func(t *v1alpha2.Task) {
+		spec := &t.Spec
+		for _, op := range ops {
+			op(spec)
+		}
+		t.Spec = *spec
+	}
+}
+
+// Step adds a step with the specified name and image to the TaskSpec.
+// Any number of Container modifier can be passed to transform it.
+func Step(name, image string, ops ...StepOp) TaskSpecOp {
+	return func(spec *v1alpha2.TaskSpec) {
+		if spec.Steps == nil {
+			spec.Steps = []v1alpha2.Step{}
+		}
+		step := v1alpha2.Step{Container: corev1.Container{
+			Name:  name,
+			Image: image,
+		}}
+		for _, op := range ops {
+			op(&step)
+		}
+		spec.Steps = append(spec.Steps, step)
+	}
+}
+
+func Sidecar(name, image string, ops ...ContainerOp) TaskSpecOp {
+	return func(spec *v1alpha2.TaskSpec) {
+		c := corev1.Container{
+			Name:  name,
+			Image: image,
+		}
+		for _, op := range ops {
+			op(&c)
+		}
+		spec.Sidecars = append(spec.Sidecars, c)
+	}
+}
+
+// TaskStepTemplate adds a base container for all steps in the task.
+func TaskStepTemplate(ops ...ContainerOp) TaskSpecOp {
+	return func(spec *v1alpha2.TaskSpec) {
+		base := &corev1.Container{}
+		for _, op := range ops {
+			op(base)
+		}
+		spec.StepTemplate = base
+	}
+}
+
+// TaskVolume adds a volume with specified name to the TaskSpec.
+// Any number of Volume modifier can be passed to transform it.
+func TaskVolume(name string, ops ...VolumeOp) TaskSpecOp {
+	return func(spec *v1alpha2.TaskSpec) {
+		v := &corev1.Volume{Name: name}
+		for _, op := range ops {
+			op(v)
+		}
+		spec.Volumes = append(spec.Volumes, *v)
+	}
+}
+
+// VolumeSource sets the VolumeSource to the Volume.
+func VolumeSource(s corev1.VolumeSource) VolumeOp {
+	return func(v *corev1.Volume) {
+		v.VolumeSource = s
+	}
+}
+
+func ResourceTargetPath(path string) TaskResourceOp {
+	return func(r *v1alpha2.TaskResource) {
+		r.TargetPath = path
+	}
+}
+
+func Controller(o *metav1.OwnerReference) {
+	o.Controller = &trueB
+}
+
+func BlockOwnerDeletion(o *metav1.OwnerReference) {
+	o.BlockOwnerDeletion = &trueB
+}


### PR DESCRIPTION
# Changes

- Migrate `test/builder` to `test/builder/v1alpha1` while keeping
default to `test/builder` to `v1alpha1` (for not breaking everybody).
- Add `Task` builders for `v1alpha1`

It shouldn't break any user of this package :angel: 

/cc @bobcatfish @ImJasonH :hugs: 

Still TODO either now or in a follow-up

- Update documentation
  - [ ] main README to describe the multiple version
  - [ ] `v1alpha2` README
  - [ ] maybe also update `builder` docstring to refer to `v1alpha1` instead

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
