### PR TITLE
Move context*.go to pkg/contexts and add tests 🎐

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -24,6 +24,7 @@ import (
 
 	apiconfig "github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	tklogging "github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/pkg/system"
 	"go.uber.org/zap"
@@ -110,7 +111,7 @@ func main() {
 
 	// Decorate contexts with the current state of the config.
 	ctxFunc := func(ctx context.Context) context.Context {
-		return v1alpha1.WithDefaultConfigurationName(store.ToContext(ctx))
+		return contexts.WithDefaultConfigurationName(store.ToContext(ctx))
 	}
 
 	controller, err := webhook.New(kubeClient, options, admissionControllers, logger, ctxFunc)

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -35,7 +36,7 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil {
 		var timeout *metav1.Duration
-		if IsUpgradeViaDefaulting(ctx) {
+		if contexts.IsUpgradeViaDefaulting(ctx) {
 			// This case is for preexisting `TaskRun` before 0.5.0, so let's
 			// add the old default timeout.
 			// Most likely those TaskRun passing here are already done and/or already running

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -97,7 +98,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 				Timeout:     &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
+		wc: contexts.WithUpgradeViaDefaulting,
 	}, {
 		name: "PipelineRef default config context",
 		in: &v1alpha1.PipelineRun{

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -39,7 +40,7 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 
 	if trs.Timeout == nil {
 		var timeout *metav1.Duration
-		if IsUpgradeViaDefaulting(ctx) {
+		if contexts.IsUpgradeViaDefaulting(ctx) {
 			// This case is for preexisting `TaskRun` before 0.5.0, so let's
 			// add the old default timeout.
 			// Most likely those TaskRun passing here are already done and/or already running

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
@@ -138,7 +139,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
-		wc: v1alpha1.WithUpgradeViaDefaulting,
+		wc: contexts.WithUpgradeViaDefaulting,
 	}, {
 		name: "TaskRef default config context",
 		in: &v1alpha1.TaskRun{

--- a/pkg/contexts/contexts.go
+++ b/pkg/contexts/contexts.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package contexts
 
 import "context"
 

--- a/pkg/contexts/contexts_test.go
+++ b/pkg/contexts/contexts_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package contexts
+
+import (
+	"context"
+	"testing"
+)
+
+func TestContexts(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		check func(context.Context) bool
+		want  bool
+	}{{
+		name:  "has default config name",
+		ctx:   WithDefaultConfigurationName(ctx),
+		check: HasDefaultConfigurationName,
+		want:  true,
+	}, {
+		name:  "doesn't have default config name",
+		ctx:   ctx,
+		check: HasDefaultConfigurationName,
+		want:  false,
+	}, {
+		name:  "are upgrading via defaulting",
+		ctx:   WithUpgradeViaDefaulting(ctx),
+		check: IsUpgradeViaDefaulting,
+		want:  true,
+	}, {
+		name:  "aren't upgrading via defaulting",
+		ctx:   ctx,
+		check: IsUpgradeViaDefaulting,
+		want:  false,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.check(tc.ctx)
+			if tc.want != got {
+				t.Errorf("check() = %v, wanted %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/artifacts"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
@@ -230,7 +231,7 @@ func (c *Reconciler) getPipelineFunc(tr *v1alpha1.PipelineRun) resources.GetPipe
 func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) error {
 	// We may be reading a version of the object that was stored at an older version
 	// and may not have had all of the assumed default specified.
-	pr.SetDefaults(v1alpha1.WithUpgradeViaDefaulting(ctx))
+	pr.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
 
 	getPipelineFunc := c.getPipelineFunc(pr)
 	pipelineMeta, pipelineSpec, err := resources.GetPipelineData(pr, getPipelineFunc)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/contexts"
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
@@ -223,7 +224,7 @@ func (c *Reconciler) getTaskFunc(tr *v1alpha1.TaskRun) (resources.GetTask, v1alp
 func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error {
 	// We may be reading a version of the object that was stored at an older version
 	// and may not have had all of the assumed default specified.
-	tr.SetDefaults(v1alpha1.WithUpgradeViaDefaulting(ctx))
+	tr.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
 
 	// If the taskrun is cancelled, kill resources and update status
 	if tr.IsCancelled() {


### PR DESCRIPTION
# Changes

The package it is on doesn't really matter, so adding it to the
latests api version. Also adding quick tests for this file.

This is in preparation of using it in `v1alpha1` and `v1alpha2`. We could also move it on it's own package if the make more sense :stuck_out_tongue: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compa tible-changes-first).
