### PR TITLE
Don't hard-code names of configmaps used for artifact persistence

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -61,6 +61,10 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        - name: CONFIG_ARTIFACT_BUCKET_NAME
+          value: config-artifact-bucket
+        - name: CONFIG_ARTIFACT_PVC_NAME
+          value: config-artifact-pvc
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
       volumes:

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -18,6 +18,7 @@ package artifacts
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -32,22 +33,14 @@ import (
 )
 
 const (
-	// PvcConfigName is the name of the configmap containing all
-	// customizations for the storage PVC.
-	PvcConfigName = "config-artifact-pvc"
+	// PVCSizeKey is the name of the configmap entry that specifies the size of the PVC to create
+	PVCSizeKey = "size"
 
-	// PvcSizeKey is the name of the configmap entry that specifies the size of the PVC to create
-	PvcSizeKey = "size"
+	// DefaultPVCSize is the default size of the PVC to create
+	DefaultPVCSize = "5Gi"
 
-	// DefaultPvcSize is the default size of the PVC to create
-	DefaultPvcSize = "5Gi"
-
-	// PvcStorageClassNameKey is the name of the configmap entry that specifies the storage class of the PVC to create
-	PvcStorageClassNameKey = "storageClassName"
-
-	// BucketConfigName is the name of the configmap containing all
-	// customizations for the storage bucket.
-	BucketConfigName = "config-artifact-bucket"
+	// PVCStorageClassNameKey is the name of the configmap entry that specifies the storage class of the PVC to create
+	PVCStorageClassNameKey = "storageClassName"
 
 	// BucketLocationKey is the name of the configmap entry that specifies
 	// loction of the bucket.
@@ -69,6 +62,24 @@ const (
 	// Valid values: GOOGLE_APPLICATION_CREDENTIALS, BOTO_CONFIG. Defaults to GOOGLE_APPLICATION_CREDENTIALS.
 	BucketServiceAccountFieldName = "bucket.service.account.field.name"
 )
+
+// GetBucketConfigName returns the name of the configmap containing all
+// customizations for the storage bucket.
+func GetBucketConfigName() string {
+	if e := os.Getenv("CONFIG_ARTIFACT_BUCKET_NAME"); e != "" {
+		return e
+	}
+	return "config-artifact-bucket"
+}
+
+// GetPVCConfigName returns the name of the configmap containing all
+// customizations for the storage PVC.
+func GetPVCConfigName() string {
+	if e := os.Getenv("CONFIG_ARTIFACT_PVC_NAME"); e != "" {
+		return e
+	}
+	return "config-artifact-pvc"
+}
 
 // ArtifactStorageInterface is an interface to define the steps to copy
 // an pipeline artifact to/from temporary storage
@@ -139,7 +150,7 @@ func InitializeArtifactStorage(images pipeline.Images, pr *v1alpha1.PipelineRun,
 		return &ArtifactStorageNone{}, nil
 	}
 
-	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(BucketConfigName, metav1.GetOptions{})
+	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(GetBucketConfigName(), metav1.GetOptions{})
 	shouldCreatePVC, err := ConfigMapNeedsPVC(configMap, err, logger)
 	if err != nil {
 		return nil, err
@@ -158,7 +169,7 @@ func InitializeArtifactStorage(images pipeline.Images, pr *v1alpha1.PipelineRun,
 // CleanupArtifactStorage will delete the PipelineRun's artifact storage PVC if it exists. The PVC is created for using
 // an output workspace or artifacts from one Task to another Task. No other PVCs will be impacted by this cleanup.
 func CleanupArtifactStorage(pr *v1alpha1.PipelineRun, c kubernetes.Interface, logger *zap.SugaredLogger) error {
-	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(BucketConfigName, metav1.GetOptions{})
+	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(GetBucketConfigName(), metav1.GetOptions{})
 	shouldCreatePVC, err := ConfigMapNeedsPVC(configMap, err, logger)
 	if err != nil {
 		return err
@@ -202,7 +213,7 @@ func ConfigMapNeedsPVC(configMap *corev1.ConfigMap, err error, logger *zap.Sugar
 // GetArtifactStorage returns the storage interface to enable
 // consumer code to get a container step for copy to/from storage
 func GetArtifactStorage(images pipeline.Images, prName string, c kubernetes.Interface, logger *zap.SugaredLogger) (ArtifactStorageInterface, error) {
-	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(BucketConfigName, metav1.GetOptions{})
+	configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(GetBucketConfigName(), metav1.GetOptions{})
 	pvc, err := ConfigMapNeedsPVC(configMap, err, logger)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't determine if PVC was needed from config map: %w", err)
@@ -249,18 +260,18 @@ func createPVC(pr *v1alpha1.PipelineRun, c kubernetes.Interface) (*corev1.Persis
 	if _, err := c.CoreV1().PersistentVolumeClaims(pr.Namespace).Get(GetPVCName(pr), metav1.GetOptions{}); err != nil {
 		if errors.IsNotFound(err) {
 
-			configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(PvcConfigName, metav1.GetOptions{})
+			configMap, err := c.CoreV1().ConfigMaps(system.GetNamespace()).Get(GetPVCConfigName(), metav1.GetOptions{})
 			if err != nil && !errors.IsNotFound(err) {
-				return nil, fmt.Errorf("failed to get PVC ConfigMap %s for %q due to error: %w", PvcConfigName, pr.Name, err)
+				return nil, fmt.Errorf("failed to get PVC ConfigMap %s for %q due to error: %w", GetPVCConfigName(), pr.Name, err)
 			}
 			var pvcSizeStr string
 			var pvcStorageClassNameStr string
 			if configMap != nil {
-				pvcSizeStr = configMap.Data[PvcSizeKey]
-				pvcStorageClassNameStr = configMap.Data[PvcStorageClassNameKey]
+				pvcSizeStr = configMap.Data[PVCSizeKey]
+				pvcStorageClassNameStr = configMap.Data[PVCStorageClassNameKey]
 			}
 			if pvcSizeStr == "" {
-				pvcSizeStr = DefaultPvcSize
+				pvcSizeStr = DefaultPVCSize
 			}
 			pvcSize, err := resource.ParseQuantity(pvcSizeStr)
 			if err != nil {

--- a/pkg/reconciler/pipelinerun/config/store.go
+++ b/pkg/reconciler/pipelinerun/config/store.go
@@ -53,7 +53,7 @@ func NewStore(images pipeline.Images, logger configmap.Logger) *Store {
 			"pipelinerun",
 			logger,
 			configmap.Constructors{
-				artifacts.BucketConfigName: artifacts.NewArtifactBucketConfigFromConfigMap(images),
+				artifacts.GetBucketConfigName(): artifacts.NewArtifactBucketConfigFromConfigMap(images),
 			},
 		),
 		images: images,
@@ -65,7 +65,7 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 }
 
 func (s *Store) Load() *Config {
-	ep := s.UntypedLoad(artifacts.BucketConfigName)
+	ep := s.UntypedLoad(artifacts.GetBucketConfigName())
 	if ep == nil {
 		return &Config{
 			ArtifactBucket: &v1alpha1.ArtifactBucket{

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -1173,7 +1173,7 @@ func TestAddStepsToTaskWithBucketFromConfigMap(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "tekton-pipelines",
-						Name:      artifacts.BucketConfigName,
+						Name:      artifacts.GetBucketConfigName(),
 					},
 					Data: map[string]string{
 						artifacts.BucketLocationKey:              "gs://fake-bucket",

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -1059,7 +1059,7 @@ func TestValidOutputResourcesWithBucketStorage(t *testing.T) {
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "tekton-pipelines",
-						Name:      artifacts.BucketConfigName,
+						Name:      artifacts.GetBucketConfigName(),
 					},
 					Data: map[string]string{
 						artifacts.BucketLocationKey: "gs://fake-bucket",

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -100,22 +100,22 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 
 	defer runTaskToDeleteBucket(c, t, namespace, bucketName, bucketSecretName, bucketSecretKey)
 
-	originalConfigMap, err := c.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get(artifacts.BucketConfigName, metav1.GetOptions{})
+	originalConfigMap, err := c.KubeClient.Kube.CoreV1().ConfigMaps(systemNamespace).Get(artifacts.GetBucketConfigName(), metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("Failed to get ConfigMap `%s`: %s", artifacts.BucketConfigName, err)
+		t.Fatalf("Failed to get ConfigMap `%s`: %s", artifacts.GetBucketConfigName(), err)
 	}
 	originalConfigMapData := originalConfigMap.Data
 
-	t.Logf("Creating ConfigMap %s", artifacts.BucketConfigName)
+	t.Logf("Creating ConfigMap %s", artifacts.GetBucketConfigName())
 	configMapData := map[string]string{
 		artifacts.BucketLocationKey:              fmt.Sprintf("gs://%s", bucketName),
 		artifacts.BucketServiceAccountSecretName: bucketSecretName,
 		artifacts.BucketServiceAccountSecretKey:  bucketSecretKey,
 	}
-	if err := updateConfigMap(c.KubeClient, systemNamespace, artifacts.BucketConfigName, configMapData); err != nil {
+	if err := updateConfigMap(c.KubeClient, systemNamespace, artifacts.GetBucketConfigName(), configMapData); err != nil {
 		t.Fatal(err)
 	}
-	defer resetConfigMap(t, c, systemNamespace, artifacts.BucketConfigName, originalConfigMapData)
+	defer resetConfigMap(t, c, systemNamespace, artifacts.GetBucketConfigName(), originalConfigMapData)
 
 	t.Logf("Creating Git PipelineResource %s", helloworldResourceName)
 	helloworldResource := tb.PipelineResource(helloworldResourceName, namespace, tb.PipelineResourceSpec(

--- a/test/wait.go
+++ b/test/wait.go
@@ -167,7 +167,7 @@ func TaskRunSucceed(name string) TaskRunStateFn {
 			if c.Status == corev1.ConditionTrue {
 				return true, nil
 			} else if c.Status == corev1.ConditionFalse {
-				return true, fmt.Errorf("task run %q failed!", name)
+				return true, fmt.Errorf("task run %q failed", name)
 			}
 		}
 		return false, nil
@@ -181,7 +181,7 @@ func TaskRunFailed(name string) TaskRunStateFn {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
-				return true, fmt.Errorf("task run %q succeeded!", name)
+				return true, fmt.Errorf("task run %q succeeded", name)
 			} else if c.Status == corev1.ConditionFalse {
 				return true, nil
 			}
@@ -199,7 +199,7 @@ func PipelineRunSucceed(name string) PipelineRunStateFn {
 			if c.Status == corev1.ConditionTrue {
 				return true, nil
 			} else if c.Status == corev1.ConditionFalse {
-				return true, fmt.Errorf("pipeline run %q failed!", name)
+				return true, fmt.Errorf("pipeline run %q failed", name)
 			}
 		}
 		return false, nil
@@ -213,7 +213,7 @@ func PipelineRunFailed(name string) PipelineRunStateFn {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
-				return true, fmt.Errorf("task run %q succeeded!", name)
+				return true, fmt.Errorf("task run %q succeeded", name)
 			} else if c.Status == corev1.ConditionFalse {
 				return true, nil
 			}


### PR DESCRIPTION
This allows users to rename the config maps so long as they also update
the env var value specified in controller.yaml

Progress toward #1713
cc @silverlyra 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
ConfigMaps used to configure artifact storage can have a name specified by the user
```
