### PR TITLE
Don't hard-code the name of the webhook service

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
 
 	apiconfig "github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -78,9 +79,14 @@ func main() {
 		logger.Fatalf("failed to start configuration manager: %v", err)
 	}
 
+	serviceName := os.Getenv("WEBHOOK_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "tekton-pipelines-webhook"
+	}
+
 	options := webhook.ControllerOptions{
-		ServiceName:                     "tekton-pipelines-webhook",
-		DeploymentName:                  "tekton-pipelines-webhook",
+		ServiceName:                     serviceName,
+		DeploymentName:                  serviceName,
 		Namespace:                       system.GetNamespace(),
 		Port:                            8443,
 		SecretName:                      "webhook-certs",

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -15,6 +15,9 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  # Note: the Deployment name must be the same as the Service name specified in
+  # config/400-webhook-service.yaml. If you change this name, you must also
+  # change the value of WEBHOOK_SERVICE_NAME below.
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
   labels:
@@ -48,6 +51,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: WEBHOOK_SERVICE_NAME
+          value: tekton-pipelines-webhook
       volumes:
         - name: config-logging
           configMap:


### PR DESCRIPTION
This allows users to rename the service and deployment, so long as they
also update the env var value specified in webhook.yaml

More progress toward #1713
cc @silverlyra

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The webhook service and deployment can have a name specified by the user.
```
