### PR TITLE
Increase the linter timeout to 5m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
   skip-dirs:
   - vendor
   - pkg/client/clientset/(.*)/fake
+  timeout: 5m
 linters-settings:
   errcheck:
     exclude: .errcheck.txt

--- a/test/wait.go
+++ b/test/wait.go
@@ -167,7 +167,7 @@ func TaskRunSucceed(name string) TaskRunStateFn {
 			if c.Status == corev1.ConditionTrue {
 				return true, nil
 			} else if c.Status == corev1.ConditionFalse {
-				return true, fmt.Errorf("task run %q failed!", name)
+				return true, fmt.Errorf("task run %q failed", name)
 			}
 		}
 		return false, nil
@@ -181,7 +181,7 @@ func TaskRunFailed(name string) TaskRunStateFn {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
-				return true, fmt.Errorf("task run %q succeeded!", name)
+				return true, fmt.Errorf("task run %q succeeded", name)
 			} else if c.Status == corev1.ConditionFalse {
 				return true, nil
 			}
@@ -199,7 +199,7 @@ func PipelineRunSucceed(name string) PipelineRunStateFn {
 			if c.Status == corev1.ConditionTrue {
 				return true, nil
 			} else if c.Status == corev1.ConditionFalse {
-				return true, fmt.Errorf("pipeline run %q failed!", name)
+				return true, fmt.Errorf("pipeline run %q failed", name)
 			}
 		}
 		return false, nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Setting the linter timeout to 5m in .golangci.yaml so that it's
picked up by the linter executed in the release pipeline.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
