### PR TITLE
Fixes flaky metrics unit tests

### DIFF
--- a/pkg/reconciler/pipelinerun/metrics_test.go
+++ b/pkg/reconciler/pipelinerun/metrics_test.go
@@ -93,7 +93,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 
 	for _, test := range testData {
 		t.Run(test.name, func(t *testing.T) {
-			defer unregisterMetrics()
+			unregisterMetrics()
 
 			metrics, err := NewRecorder()
 			assertErrIsNil(err, "Recorder initialization failed", t)
@@ -102,12 +102,13 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 			assertErrIsNil(err, "DurationAndCount recording recording got an error", t)
 			metricstest.CheckDistributionData(t, "pipelinerun_duration_seconds", test.expectedTags, 1, test.expectedDuration, test.expectedDuration)
 			metricstest.CheckCountData(t, "pipelinerun_count", test.expectedTags, test.expectedCount)
+
 		})
 	}
 }
 
 func TestRecordRunningPipelineRunsCount(t *testing.T) {
-	defer unregisterMetrics()
+	unregisterMetrics()
 
 	ctx, _ := rtesting.SetupFakeContext(t)
 	informer := fakepipelineruninformer.Get(ctx)
@@ -121,6 +122,7 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 	err = metrics.RunningPipelineRuns(informer.Lister())
 	assertErrIsNil(err, "RunningPrsCount recording expected to return nil but got error", t)
 	metricstest.CheckLastValueData(t, "running_pipelineruns_count", map[string]string{}, 1)
+
 }
 
 func addPipelineRun(informer alpha1.PipelineRunInformer, run, pipeline, ns string, status corev1.ConditionStatus, t *testing.T) {
@@ -156,4 +158,5 @@ func assertErrIsNil(err error, message string, t *testing.T) {
 
 func unregisterMetrics() {
 	metricstest.Unregister("pipelinerun_duration_seconds", "pipelinerun_count", "running_pipelineruns_count")
+
 }

--- a/pkg/reconciler/taskrun/metrics_test.go
+++ b/pkg/reconciler/taskrun/metrics_test.go
@@ -101,7 +101,7 @@ func TestRecordTaskrunDurationCount(t *testing.T) {
 
 	for _, test := range testData {
 		t.Run(test.name, func(t *testing.T) {
-			defer unregisterMetrics()
+			unregisterMetrics()
 
 			metrics, err := NewRecorder()
 			assertErrIsNil(err, "Recorder initialization failed", t)
@@ -110,6 +110,7 @@ func TestRecordTaskrunDurationCount(t *testing.T) {
 			assertErrIsNil(err, "DurationAndCount recording got an error", t)
 			metricstest.CheckDistributionData(t, "taskrun_duration_seconds", test.expectedTags, 1, test.expectedDuration, test.expectedDuration)
 			metricstest.CheckCountData(t, "taskrun_count", test.expectedTags, test.expectedCount)
+
 		})
 	}
 }
@@ -179,8 +180,7 @@ func TestRecordPipelinerunTaskrunDurationCount(t *testing.T) {
 
 	for _, test := range testData {
 		t.Run(test.name, func(t *testing.T) {
-			defer unregisterMetrics()
-
+			unregisterMetrics()
 			metrics, err := NewRecorder()
 			assertErrIsNil(err, "Recorder initialization failed", t)
 
@@ -188,12 +188,13 @@ func TestRecordPipelinerunTaskrunDurationCount(t *testing.T) {
 			assertErrIsNil(err, "DurationAndCount recording got an error", t)
 			metricstest.CheckDistributionData(t, "pipelinerun_taskrun_duration_seconds", test.expectedTags, 1, test.expectedDuration, test.expectedDuration)
 			metricstest.CheckCountData(t, "taskrun_count", test.expectedTags, test.expectedCount)
+
 		})
 	}
 }
 
 func TestRecordRunningTaskrunsCount(t *testing.T) {
-	defer unregisterMetrics()
+	unregisterMetrics()
 
 	ctx, _ := rtesting.SetupFakeContext(t)
 	informer := faketaskruninformer.Get(ctx)
@@ -255,7 +256,7 @@ func TestRecordPodLatency(t *testing.T) {
 
 	for _, td := range testData {
 		t.Run(td.name, func(t *testing.T) {
-			defer unregisterMetrics()
+			unregisterMetrics()
 
 			metrics, err := NewRecorder()
 			assertErrIsNil(err, "Recorder initialization failed", t)
@@ -267,6 +268,7 @@ func TestRecordPodLatency(t *testing.T) {
 			}
 			assertErrIsNil(err, "RecordPodLatency recording expected to return nil but got error", t)
 			metricstest.CheckLastValueData(t, "taskruns_pod_latency", td.expectedTags, td.expectedValue)
+
 		})
 	}
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Quite often unit test failure showing "*** a different view
with the same name is already registered" messages at many places.
At the beginning of every metrics test, it tries to register respective
metrics views(metrics data it want present), publish metrics and
uniregister views. Uniregister view is important becuase for next
test it dont need to hold the old metrics data.
unregister() views were getting called using `defer` in
table test for loop, just like
for _, td := range tests {
	defer unregister()
	.......
}
This were resulting unwanted execution behaviour
for unregister() views function, which umtimately faling tests.
Its better to unregister() views before start executing the
tests.

This patch fixes the behaviour by calling uniregister() views function
at the end of loop.

Fixes #1659

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._