### PR TITLE
Fix golint error strings.

### DIFF
--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -32,7 +32,7 @@ func (*realWaiter) Wait(file string, expectContent bool) error {
 				return nil
 			}
 		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("Waiting for %q: %w", file, err)
+			return fmt.Errorf("waiting for %q: %w", file, err)
 		}
 		if _, err := os.Stat(file + ".err"); err == nil {
 			return skipError("error file present, bail and skip the step")

--- a/pkg/apis/pipeline/v1alpha1/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types.go
@@ -118,7 +118,7 @@ func ApplyTaskModifier(ts *TaskSpec, tm TaskModifier) error {
 			if volume.Name == v.Name {
 				// If a Volume with the same name but different contents has already been added, we can't add both
 				if d := cmp.Diff(volume, v); d != "" {
-					return fmt.Errorf("Tried to add volume %s already added but with different contents", volume.Name)
+					return fmt.Errorf("tried to add volume %s already added but with different contents", volume.Name)
 				}
 				// If an identical Volume has already been added, don't add it again
 				alreadyAdded = true

--- a/pkg/apis/pipeline/v1alpha2/resource_types.go
+++ b/pkg/apis/pipeline/v1alpha2/resource_types.go
@@ -153,7 +153,7 @@ func ApplyTaskModifier(ts *TaskSpec, tm TaskModifier) error {
 			if volume.Name == v.Name {
 				// If a Volume with the same name but different contents has already been added, we can't add both
 				if d := cmp.Diff(volume, v); d != "" {
-					return fmt.Errorf("Tried to add volume %s already added but with different contents", volume.Name)
+					return fmt.Errorf("tried to add volume %s already added but with different contents", volume.Name)
 				}
 				// If an identical Volume has already been added, don't add it again
 				alreadyAdded = true

--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -69,13 +69,13 @@ func (dc *basicDocker) String() string {
 func (dc *basicDocker) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {
-		return fmt.Errorf("Expect entries of the form secret=url, got: %v", value)
+		return fmt.Errorf("expect entries of the form secret=url, got: %v", value)
 	}
 	secret := parts[0]
 	url := parts[1]
 
 	if _, ok := dc.Entries[url]; ok {
-		return fmt.Errorf("Multiple entries for url: %v", url)
+		return fmt.Errorf("multiple entries for url: %v", url)
 	}
 
 	e, err := newEntry(secret)

--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -53,13 +53,13 @@ func (dc *basicGitConfig) String() string {
 func (dc *basicGitConfig) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {
-		return fmt.Errorf("Expect entries of the form secret=url, got: %v", value)
+		return fmt.Errorf("expect entries of the form secret=url, got: %v", value)
 	}
 	secret := parts[0]
 	url := parts[1]
 
 	if _, ok := dc.entries[url]; ok {
-		return fmt.Errorf("Multiple entries for url: %v", url)
+		return fmt.Errorf("multiple entries for url: %v", url)
 	}
 
 	e, err := newBasicEntry(url, secret)

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -57,7 +57,7 @@ func (dc *sshGitConfig) String() string {
 func (dc *sshGitConfig) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {
-		return fmt.Errorf("Expect entries of the form secret=url, got: %v", value)
+		return fmt.Errorf("expect entries of the form secret=url, got: %v", value)
 	}
 	secretName := parts[0]
 	url := parts[1]

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -57,7 +57,7 @@ func Fetch(logger *zap.SugaredLogger, revision, path, url string) error {
 			return err
 		}
 		if err := os.Chdir(path); err != nil {
-			return fmt.Errorf("Failed to change directory with path %s; err: %w", path, err)
+			return fmt.Errorf("failed to change directory with path %s; err: %w", path, err)
 		}
 	} else if _, err := run(logger, "", "init"); err != nil {
 		return err
@@ -97,7 +97,7 @@ func SubmoduleFetch(logger *zap.SugaredLogger, path string) error {
 
 	if path != "" {
 		if err := os.Chdir(path); err != nil {
-			return fmt.Errorf("Failed to change directory with path %s; err: %w", path, err)
+			return fmt.Errorf("failed to change directory with path %s; err: %w", path, err)
 		}
 	}
 	if _, err := run(logger, "", "submodule", "init"); err != nil {

--- a/pkg/list/diff.go
+++ b/pkg/list/diff.go
@@ -24,11 +24,11 @@ import "fmt"
 func IsSame(required, provided []string) error {
 	missing := DiffLeft(required, provided)
 	if len(missing) > 0 {
-		return fmt.Errorf("Didn't provide required values: %s", missing)
+		return fmt.Errorf("didn't provide required values: %s", missing)
 	}
 	extra := DiffLeft(provided, required)
 	if len(extra) > 0 {
-		return fmt.Errorf("Provided extra values: %s", extra)
+		return fmt.Errorf("provided extra values: %s", extra)
 	}
 	return nil
 }

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -141,7 +141,7 @@ func orderContainers(entrypointImage string, steps []corev1.Container) (corev1.C
 func UpdateReady(kubeclient kubernetes.Interface, pod corev1.Pod) error {
 	newPod, err := kubeclient.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Error getting Pod %q when updating ready annotation: %w", pod.Name, err)
+		return fmt.Errorf("error getting Pod %q when updating ready annotation: %w", pod.Name, err)
 	}
 
 	// Update the Pod's "READY" annotation to signal the first step to
@@ -152,7 +152,7 @@ func UpdateReady(kubeclient kubernetes.Interface, pod corev1.Pod) error {
 	if newPod.ObjectMeta.Annotations[readyAnnotation] != readyAnnotationValue {
 		newPod.ObjectMeta.Annotations[readyAnnotation] = readyAnnotationValue
 		if _, err := kubeclient.CoreV1().Pods(newPod.Namespace).Update(newPod); err != nil {
-			return fmt.Errorf("Error adding ready annotation to Pod %q: %w", pod.Name, err)
+			return fmt.Errorf("error adding ready annotation to Pod %q: %w", pod.Name, err)
 		}
 	}
 	return nil
@@ -163,7 +163,7 @@ func UpdateReady(kubeclient kubernetes.Interface, pod corev1.Pod) error {
 func StopSidecars(nopImage string, kubeclient kubernetes.Interface, pod corev1.Pod) error {
 	newPod, err := kubeclient.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Error getting Pod %q when stopping sidecars: %w", pod.Name, err)
+		return fmt.Errorf("error getting Pod %q when stopping sidecars: %w", pod.Name, err)
 	}
 
 	updated := false
@@ -185,7 +185,7 @@ func StopSidecars(nopImage string, kubeclient kubernetes.Interface, pod corev1.P
 	}
 	if updated {
 		if _, err := kubeclient.CoreV1().Pods(newPod.Namespace).Update(newPod); err != nil {
-			return fmt.Errorf("Error adding ready annotation to Pod %q: %w", pod.Name, err)
+			return fmt.Errorf("error adding ready annotation to Pod %q: %w", pod.Name, err)
 		}
 	}
 	return nil

--- a/pkg/pod/entrypoint_lookup.go
+++ b/pkg/pod/entrypoint_lookup.go
@@ -89,11 +89,11 @@ func resolveEntrypoints(cache EntrypointCache, namespace, serviceAccountName str
 func imageData(ref name.Reference, img v1.Image) ([]string, name.Digest, error) {
 	digest, err := img.Digest()
 	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error getting image digest: %v", err)
+		return nil, name.Digest{}, fmt.Errorf("error getting image digest: %v", err)
 	}
 	cfg, err := img.ConfigFile()
 	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error getting image config: %v", err)
+		return nil, name.Digest{}, fmt.Errorf("error getting image config: %v", err)
 	}
 
 	// Entrypoint can be specified in either .Config.Entrypoint or
@@ -105,7 +105,7 @@ func imageData(ref name.Reference, img v1.Image) ([]string, name.Digest, error) 
 
 	d, err := name.NewDigest(ref.Context().String()+"@"+digest.String(), name.WeakValidation)
 	if err != nil {
-		return nil, name.Digest{}, fmt.Errorf("Error constructing resulting digest: %v", err)
+		return nil, name.Digest{}, fmt.Errorf("error constructing resulting digest: %v", err)
 	}
 	return ep, d, nil
 }

--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -64,12 +64,12 @@ func (e *entrypointCache) Get(ref name.Reference, namespace, serviceAccountName 
 		ServiceAccountName: serviceAccountName,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Error creating k8schain: %v", err)
+		return nil, fmt.Errorf("error creating k8schain: %v", err)
 	}
 	mkc := authn.NewMultiKeychain(kc)
 	img, err := remote.Image(ref, remote.WithAuthFromKeychain(mkc))
 	if err != nil {
-		return nil, fmt.Errorf("Error getting image manifest: %v", err)
+		return nil, fmt.Errorf("error getting image manifest: %v", err)
 	}
 	return img, nil
 }

--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -161,11 +161,11 @@ func getVisitedPath(path []string) string {
 func addLink(pt string, previousTask string, nodes map[string]*Node) error {
 	prev, ok := nodes[previousTask]
 	if !ok {
-		return fmt.Errorf("Task %s depends on %s but %s wasn't present in Pipeline", pt, previousTask, previousTask)
+		return fmt.Errorf("task %s depends on %s but %s wasn't present in Pipeline", pt, previousTask, previousTask)
 	}
 	next := nodes[pt]
 	if err := linkPipelineTasks(prev, next); err != nil {
-		return fmt.Errorf("Couldn't create link from %s to %s: %w", prev.Task.HashKey(), next.Task.HashKey(), err)
+		return fmt.Errorf("couldn't create link from %s to %s: %w", prev.Task.HashKey(), next.Task.HashKey(), err)
 	}
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -54,7 +54,7 @@ func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.Reso
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("Error cancelled PipelineRun's TaskRun(s): %s", strings.Join(errs, "\n"))
+		return fmt.Errorf("error cancelled PipelineRun's TaskRun(s): %s", strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -622,7 +622,7 @@ func getTaskRunTimeout(pr *v1alpha1.PipelineRun) *metav1.Duration {
 func (c *Reconciler) updateStatus(pr *v1alpha1.PipelineRun) (*v1alpha1.PipelineRun, error) {
 	newPr, err := c.pipelineRunLister.PipelineRuns(pr.Namespace).Get(pr.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting PipelineRun %s when updating status: %w", pr.Name, err)
+		return nil, fmt.Errorf("error getting PipelineRun %s when updating status: %w", pr.Name, err)
 	}
 	succeeded := pr.Status.GetCondition(apis.ConditionSucceeded)
 	if succeeded.Status == corev1.ConditionFalse || succeeded.Status == corev1.ConditionTrue {
@@ -640,7 +640,7 @@ func (c *Reconciler) updateStatus(pr *v1alpha1.PipelineRun) (*v1alpha1.PipelineR
 func (c *Reconciler) updateLabelsAndAnnotations(pr *v1alpha1.PipelineRun) (*v1alpha1.PipelineRun, error) {
 	newPr, err := c.pipelineRunLister.PipelineRuns(pr.Namespace).Get(pr.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting PipelineRun %s when updating labels/annotations: %w", pr.Name, err)
+		return nil, fmt.Errorf("error getting PipelineRun %s when updating labels/annotations: %w", pr.Name, err)
 	}
 	if !reflect.DeepEqual(pr.ObjectMeta.Labels, newPr.ObjectMeta.Labels) || !reflect.DeepEqual(pr.ObjectMeta.Annotations, newPr.ObjectMeta.Annotations) {
 		newPr.ObjectMeta.Labels = pr.ObjectMeta.Labels
@@ -656,7 +656,7 @@ func (c *Reconciler) makeConditionCheckContainer(rprt *resources.ResolvedPipelin
 
 	taskSpec, err := rcc.ConditionToTaskSpec()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get TaskSpec from Condition: %w", err)
+		return nil, fmt.Errorf("failed to get TaskSpec from Condition: %w", err)
 	}
 
 	tr := &v1alpha1.TaskRun{

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -113,7 +113,7 @@ func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() (*v1alpha1.TaskSpec, er
 	err := ApplyResourceSubstitution(&t.Steps[0], rcc.ResolvedResources, rcc.Condition.Spec.Resources, rcc.images)
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to replace resource template strings %w", err)
+		return nil, fmt.Errorf("failed to replace resource template strings %w", err)
 	}
 
 	return t, nil
@@ -137,7 +137,7 @@ func ApplyResourceSubstitution(step *v1alpha1.Step, resolvedResources map[string
 		if rSpec, ok := resolvedResources[cr.Name]; ok {
 			r, err := v1alpha1.ResourceFromType(rSpec, images)
 			if err != nil {
-				return fmt.Errorf("Error trying to create resource: %w", err)
+				return fmt.Errorf("error trying to create resource: %w", err)
 			}
 			for k, v := range r.Replacements() {
 				replacements[fmt.Sprintf("resources.%s.%s", cr.Name, k)] = v

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -177,7 +177,7 @@ func GetResourcesFromBindings(pr *v1alpha1.PipelineRun, getResource resources.Ge
 	for _, resource := range pr.Spec.Resources {
 		r, err := resources.GetResourceFromBinding(&resource, getResource)
 		if err != nil {
-			return rs, fmt.Errorf("Error following resource reference for %s: %w", resource.Name, err)
+			return rs, fmt.Errorf("error following resource reference for %s: %w", resource.Name, err)
 		}
 		rs[resource.Name] = r
 	}
@@ -195,7 +195,7 @@ func ValidateResourceBindings(p *v1alpha1.PipelineSpec, pr *v1alpha1.PipelineRun
 		provided = append(provided, resource.Name)
 	}
 	if err := list.IsSame(required, provided); err != nil {
-		return fmt.Errorf("PipelineRun bound resources didn't match Pipeline: %w", err)
+		return fmt.Errorf("pipelineRun bound resources didn't match Pipeline: %w", err)
 	}
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1047,7 +1047,7 @@ func TestGetResourcesFromBindings(t *testing.T) {
 	r := tb.PipelineResource("sweet-resource", "namespace")
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
 		if name != "sweet-resource" {
-			return nil, fmt.Errorf("Request for unexpected resource %s", name)
+			return nil, fmt.Errorf("request for unexpected resource %s", name)
 		}
 		return r, nil
 	}
@@ -1083,7 +1083,7 @@ func TestGetResourcesFromBindings_Missing(t *testing.T) {
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
-		return nil, fmt.Errorf("Request for unexpected resource %s", name)
+		return nil, fmt.Errorf("request for unexpected resource %s", name)
 	}
 	_, err := GetResourcesFromBindings(pr, getResource)
 	if err == nil {
@@ -1096,7 +1096,7 @@ func TestGetResourcesFromBindings_ErrorGettingResource(t *testing.T) {
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
-		return nil, fmt.Errorf("IT HAS ALL GONE WRONG")
+		return nil, fmt.Errorf("iT HAS ALL GONE WRONG")
 	}
 	_, err := GetResourcesFromBindings(pr, getResource)
 	if err == nil {

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec.go
@@ -45,7 +45,7 @@ func GetPipelineData(pipelineRun *v1alpha1.PipelineRun, getPipeline GetPipeline)
 		pipelineMeta = pipelineRun.ObjectMeta
 		pipelineSpec = *pipelineRun.Spec.PipelineSpec
 	default:
-		return nil, nil, fmt.Errorf("PipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
+		return nil, nil, fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
 	}
 	return &pipelineMeta, &pipelineSpec, nil
 }

--- a/pkg/reconciler/taskrun/resources/cloudevent/cloudevent.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloudevent.go
@@ -73,7 +73,7 @@ func SendCloudEvent(sinkURI, eventID, eventSourceURI string, data []byte, eventT
 	cloudEventSource := types.ParseURLRef(eventSourceURI)
 	if cloudEventSource == nil {
 		logger.Errorf("Invalid eventSourceURI: %s", eventSourceURI)
-		return event, fmt.Errorf("Invalid eventSourceURI: %s", eventSourceURI)
+		return event, fmt.Errorf("invalid eventSourceURI: %s", eventSourceURI)
 	}
 
 	event = cloudevents.Event{
@@ -122,7 +122,7 @@ func SendTaskRunCloudEvent(sinkURI string, taskRun *v1alpha1.TaskRun, logger *za
 	case taskRunStatus.IsTrue():
 		eventType = TektonTaskRunSuccessfulV1
 	default:
-		return event, fmt.Errorf("Unknown condition for in TaskRun.Status %s", taskRunStatus.Status)
+		return event, fmt.Errorf("unknown condition for in TaskRun.Status %s", taskRunStatus.Status)
 	}
 	eventSourceURI := taskRun.ObjectMeta.SelfLink
 	data, _ := json.Marshal(NewTektonCloudEventData(taskRun))

--- a/pkg/reconciler/taskrun/resources/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloudevent_test.go
@@ -87,7 +87,7 @@ func TestSendCloudEvent(t *testing.T) {
 		eventSourceURI:   invalidEventSourceURI,
 		cloudEventClient: defaultCloudEventClient,
 		wantErr:          true,
-		errRegexp:        fmt.Sprintf("Invalid eventSourceURI: %s", invalidEventSourceURI),
+		errRegexp:        fmt.Sprintf("invalid eventSourceURI: %s", invalidEventSourceURI),
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			logger, _ := logging.NewLogger("", "")
@@ -191,7 +191,7 @@ func TestSendTaskRunCloudEventErrors(t *testing.T) {
 		desc:          "send a cloud event with invalid status taskrun",
 		taskRun:       getTaskRunByCondition(invalidConditionSuccessStatus),
 		wantEventType: nilEventType,
-		errRegexp:     fmt.Sprintf("Unknown condition for in TaskRun.Status %s", invalidConditionSuccessStatus),
+		errRegexp:     fmt.Sprintf("unknown condition for in TaskRun.Status %s", invalidConditionSuccessStatus),
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			logger, _ := logging.NewLogger("", "")

--- a/pkg/reconciler/taskrun/resources/image_exporter.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter.go
@@ -41,17 +41,17 @@ func AddOutputImageDigestExporter(
 		for _, trb := range tr.Spec.Outputs.Resources {
 			boundResource, err := getBoundResource(trb.Name, tr.Spec.Outputs.Resources)
 			if err != nil {
-				return fmt.Errorf("Failed to get bound resource: %w while adding output image digest exporter", err)
+				return fmt.Errorf("failed to get bound resource: %w while adding output image digest exporter", err)
 			}
 
 			resource, err := GetResourceFromBinding(&boundResource.PipelineResourceBinding, gr)
 			if err != nil {
-				return fmt.Errorf("Failed to get output pipeline Resource for taskRun %q resource %v; error: %w while adding output image digest exporter", tr.Name, boundResource, err)
+				return fmt.Errorf("failed to get output pipeline Resource for taskRun %q resource %v; error: %w while adding output image digest exporter", tr.Name, boundResource, err)
 			}
 			if resource.Spec.Type == v1alpha1.PipelineResourceTypeImage {
 				imageResource, err := v1alpha1.NewImageResource(resource)
 				if err != nil {
-					return fmt.Errorf("Invalid Image Resource for taskRun %q resource %v; error: %w", tr.Name, boundResource, err)
+					return fmt.Errorf("invalid Image Resource for taskRun %q resource %v; error: %w", tr.Name, boundResource, err)
 				}
 				for _, o := range taskSpec.Outputs.Resources {
 					if o.Name == boundResource.Name {
@@ -71,7 +71,7 @@ func AddOutputImageDigestExporter(
 			augmentedSteps := []v1alpha1.Step{}
 			imagesJSON, err := json.Marshal(output)
 			if err != nil {
-				return fmt.Errorf("Failed to format image resource data for output image exporter: %w", err)
+				return fmt.Errorf("failed to format image resource data for output image exporter: %w", err)
 			}
 
 			augmentedSteps = append(augmentedSteps, taskSpec.Steps...)

--- a/pkg/reconciler/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/taskrun/resources/input_resources.go
@@ -114,7 +114,7 @@ func AddInputResource(
 				return nil, err
 			}
 			if err := v1alpha1.ApplyTaskModifier(taskSpec, modifier); err != nil {
-				return nil, fmt.Errorf("Unabled to apply Resource %s: %w", boundResource.Name, err)
+				return nil, fmt.Errorf("unabled to apply Resource %s: %w", boundResource.Name, err)
 			}
 		}
 	}

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -49,7 +49,7 @@ func GetTaskData(taskRun *v1alpha1.TaskRun, getTask GetTask) (*metav1.ObjectMeta
 		taskMeta = taskRun.ObjectMeta
 		taskSpec = *taskRun.Spec.TaskSpec
 	default:
-		return nil, nil, fmt.Errorf("TaskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
+		return nil, nil, fmt.Errorf("taskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
 	}
 	return &taskMeta, &taskSpec, nil
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -410,7 +410,7 @@ func updateTaskRunResourceResult(taskRun *v1alpha1.TaskRun, pod *corev1.Pod, log
 func updateTaskRunStatusWithResourceResult(taskRun *v1alpha1.TaskRun, logContent []byte) error {
 	results := []v1alpha1.PipelineResourceResult{}
 	if err := json.Unmarshal(logContent, &results); err != nil {
-		return fmt.Errorf("Failed to unmarshal output image exporter JSON output: %w", err)
+		return fmt.Errorf("failed to unmarshal output image exporter JSON output: %w", err)
 	}
 	taskRun.Status.ResourcesResult = append(taskRun.Status.ResourcesResult, results...)
 	return nil
@@ -419,7 +419,7 @@ func updateTaskRunStatusWithResourceResult(taskRun *v1alpha1.TaskRun, logContent
 func (c *Reconciler) updateStatus(taskrun *v1alpha1.TaskRun) (*v1alpha1.TaskRun, error) {
 	newtaskrun, err := c.taskRunLister.TaskRuns(taskrun.Namespace).Get(taskrun.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting TaskRun %s when updating status: %w", taskrun.Name, err)
+		return nil, fmt.Errorf("error getting TaskRun %s when updating status: %w", taskrun.Name, err)
 	}
 	if !reflect.DeepEqual(taskrun.Status, newtaskrun.Status) {
 		newtaskrun.Status = taskrun.Status
@@ -431,7 +431,7 @@ func (c *Reconciler) updateStatus(taskrun *v1alpha1.TaskRun) (*v1alpha1.TaskRun,
 func (c *Reconciler) updateLabelsAndAnnotations(tr *v1alpha1.TaskRun) (*v1alpha1.TaskRun, error) {
 	newTr, err := c.taskRunLister.TaskRuns(tr.Namespace).Get(tr.Name)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting TaskRun %s when updating labels/annotations: %w", tr.Name, err)
+		return nil, fmt.Errorf("error getting TaskRun %s when updating labels/annotations: %w", tr.Name, err)
 	}
 	if !reflect.DeepEqual(tr.ObjectMeta.Labels, newTr.ObjectMeta.Labels) || !reflect.DeepEqual(tr.ObjectMeta.Annotations, newTr.ObjectMeta.Annotations) {
 		newTr.ObjectMeta.Labels = tr.ObjectMeta.Labels

--- a/pkg/reconciler/taskrun/validate_resources.go
+++ b/pkg/reconciler/taskrun/validate_resources.go
@@ -49,7 +49,7 @@ func validateResources(requiredResources []v1alpha1.TaskResource, providedResour
 	}
 	err := list.IsSame(required, provided)
 	if err != nil {
-		return fmt.Errorf("TaskRun's declared resources didn't match usage in Task: %w", err)
+		return fmt.Errorf("taskRun's declared resources didn't match usage in Task: %w", err)
 	}
 	for _, resource := range requiredResources {
 		r := providedResources[resource.Name]

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -124,7 +124,7 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 				return false, nil
 			}
 			if resp != nil && resp.StatusCode != http.StatusOK {
-				return true, fmt.Errorf("Expected 200 but received %d response code from service at http://%s:8080", resp.StatusCode, serviceIP)
+				return true, fmt.Errorf("expected 200 but received %d response code from service at http://%s:8080", resp.StatusCode, serviceIP)
 			}
 			return true, nil
 		})

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -213,7 +213,7 @@ func TestPipelineRun(t *testing.T) {
 				// Check to make sure the PipelineRun's artifact storage PVC has been "deleted" at the end of the run.
 				pvc, errWait := c.KubeClient.Kube.CoreV1().PersistentVolumeClaims(namespace).Get(artifacts.GetPVCName(pipelineRun), metav1.GetOptions{})
 				if errWait != nil && !errors.IsNotFound(errWait) {
-					return true, fmt.Errorf("Error looking up PVC %s for PipelineRun %s: %s", artifacts.GetPVCName(pipelineRun), prName, errWait)
+					return true, fmt.Errorf("error looking up PVC %s for PipelineRun %s: %s", artifacts.GetPVCName(pipelineRun), prName, errWait)
 				}
 				// If we are not found then we are okay since it got cleaned up
 				if errors.IsNotFound(errWait) {

--- a/test/wait.go
+++ b/test/wait.go
@@ -213,7 +213,7 @@ func PipelineRunFailed(name string) PipelineRunStateFn {
 		c := tr.Status.GetCondition(apis.ConditionSucceeded)
 		if c != nil {
 			if c.Status == corev1.ConditionTrue {
-				return true, fmt.Errorf("task run %q succeeded!", name)
+				return true, fmt.Errorf("task run %q succeeded", name)
 			} else if c.Status == corev1.ConditionFalse {
 				return true, nil
 			}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

```
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) or end with punctuation, since they are usually printed following other context.
```

See https://github.com/golang/go/wiki/CodeReviewComments#error-strings
for more details.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).