### PR TITLE
Script mode set -xe by default when no shebang used

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -156,11 +156,16 @@ If this field is present, the step cannot specify `command`.
 When specified, a `script` gets invoked as if it were the contents of a file in
 the container. Any `args` are passed to the script file.
 
-Scripts that do not start with a shebang
-[shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) line will use a default
-value of `#!/bin/sh`, although users can override this by starting their script
-with a shebang to declare what tool should be used to interpret the script.
-That tool must then also be available within the step's container.
+Scripts that do not start with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix))
+line will use the following default preamble:
+
+```bash
+#!/bin/sh
+set -xe
+```
+Users can override this by starting their script with a shebang to declare what
+tool should be used to interpret the script. That tool must then also be
+available within the step's container.
 
 This allows you to execute a Bash script, if the image includes `bash`:
 

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	scriptsVolumeName = "scripts"
-	scriptsDir        = "/tekton/scripts"
-	defaultShebang    = "#!/bin/sh\n"
+	scriptsVolumeName     = "scripts"
+	scriptsDir            = "/tekton/scripts"
+	defaultScriptPreamble = "#!/bin/sh\nset -xe\n"
 )
 
 var (
@@ -77,7 +77,7 @@ func convertScripts(shellImage string, steps []v1alpha1.Step) (*corev1.Container
 
 		script := s.Script
 		if !hasShebang {
-			script = defaultShebang + s.Script
+			script = defaultScriptPreamble + s.Script
 		}
 
 		// At least one step uses a script, so we should return a

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -101,6 +101,7 @@ tmpfile="/tekton/scripts/script-3-j2tds"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'script-heredoc-randomly-generated-vr6ds'
 #!/bin/sh
+set -xe
 no-shebang
 script-heredoc-randomly-generated-vr6ds
 `},


### PR DESCRIPTION
# Changes

Fixes #1735

When I use script mode without a #! the current behaviour is to insert
one for me - `#!/bin/sh`. This is helpful and removes an unneccessary
line from my script. In addition I'd like two things by default: First
I want the script to error out if any of the commands error out. Second
I'd like to see the commands the script runs before their output. These
two features are baked into `sh` with the `set -xe` flags.

After this change the default behaviour of script mode when no shebang
is provided is to insert both the default shebang as well as the flags
required to make shell errors and shell echos happen.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Updates [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Script mode will now insert `set -xe` to scripts that don't include a shebang #!, which will in turn fail scripts with commands that error our and also print the command that is about to run. This default behaviour can be disabled by simply specifying your own #! at the top of the script.
```
