### PR TITLE
[WIP] Fix PipelineRun.IsDone() using CompletionTime

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -247,6 +247,8 @@ func (pr *PipelineRun) IsFailed() bool {
 	return pr.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
 }
 
+// Fail sets the PipelineRun's condition to failed and the CompletionTime to the
+// current time.
 func (pr *PipelineRun) Fail(reason, msg string) {
 	pr.Status.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -109,13 +109,13 @@ func TestInitializeConditions(t *testing.T) {
 
 func TestPipelineRunIsDone(t *testing.T) {
 	params := []struct {
-		name          string
-		prStatus      v1alpha1.PipelineRunStatus
-		expectedValue bool
+		name     string
+		prStatus v1alpha1.PipelineRunStatus
+		expected bool
 	}{{
-		name:          "prWithNoCompletionTime",
-		prStatus:      v1alpha1.PipelineRunStatus{},
-		expectedValue: false,
+		name:     "prWithNoCompletionTime",
+		prStatus: v1alpha1.PipelineRunStatus{},
+		expected: false,
 	}, {
 		name: "prWithCompletionTime",
 		prStatus: v1alpha1.PipelineRunStatus{
@@ -123,7 +123,7 @@ func TestPipelineRunIsDone(t *testing.T) {
 				CompletionTime: &metav1.Time{Time: time.Now()},
 			},
 		},
-		expectedValue: true,
+		expected: true,
 	}, {
 		name: "prWithZeroCompletionTime",
 		prStatus: v1alpha1.PipelineRunStatus{
@@ -131,7 +131,7 @@ func TestPipelineRunIsDone(t *testing.T) {
 				StartTime: &metav1.Time{},
 			},
 		},
-		expectedValue: false,
+		expected: false,
 	}}
 	for _, tc := range params {
 		t.Run(tc.name, func(t *testing.T) {
@@ -142,8 +142,8 @@ func TestPipelineRunIsDone(t *testing.T) {
 				},
 				Status: tc.prStatus,
 			}
-			if pr.IsDone() != tc.expectedValue {
-				t.Fatalf("Expected pipelinerun IsDone() to return %t but got %t", tc.expectedValue, pr.IsDone())
+			if pr.IsDone() != tc.expected {
+				t.Fatalf("Expected pipelinerun IsDone() to return %t but got %t", tc.expected, pr.IsDone())
 			}
 		})
 	}
@@ -162,38 +162,38 @@ func TestPipelineRunIsCancelled(t *testing.T) {
 
 func TestPipelineRunIsFailed(t *testing.T) {
 	params := []struct {
-		name          string
-		prStatus      v1alpha1.PipelineRunStatus
-		expectedValue bool
+		name     string
+		prStatus v1alpha1.PipelineRunStatus
+		expected bool
 	}{
 		{
-			"prWithNoStatus",
-			func() (status v1alpha1.PipelineRunStatus) {
+			name: "prWithNoStatus",
+			prStatus: func() (status v1alpha1.PipelineRunStatus) {
 				return status
 			}(),
-			false,
+			expected: false,
 		},
 		{
-			"prWithStatusSucceededFalse",
-			func() (status v1alpha1.PipelineRunStatus) {
+			name: "prWithStatusSucceededFalse",
+			prStatus: func() (status v1alpha1.PipelineRunStatus) {
 				status.SetCondition(&apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionFalse,
 				})
 				return status
 			}(),
-			true,
+			expected: true,
 		},
 		{
-			"prWithStatusSucceededTrue",
-			func() (status v1alpha1.PipelineRunStatus) {
+			name: "prWithStatusSucceededTrue",
+			prStatus: func() (status v1alpha1.PipelineRunStatus) {
 				status.SetCondition(&apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionTrue,
 				})
 				return status
 			}(),
-			false,
+			expected: false,
 		},
 	}
 	for _, tc := range params {
@@ -205,8 +205,8 @@ func TestPipelineRunIsFailed(t *testing.T) {
 				},
 				Status: tc.prStatus,
 			}
-			if pr.IsFailed() != tc.expectedValue {
-				t.Fatalf("Expected pipelinerun IsFailed() to return %t but got %t", tc.expectedValue, pr.IsFailed())
+			if pr.IsFailed() != tc.expected {
+				t.Fatalf("Expected pipelinerun IsFailed() to return %t but got %t", tc.expected, pr.IsFailed())
 			}
 		})
 	}
@@ -214,38 +214,38 @@ func TestPipelineRunIsFailed(t *testing.T) {
 
 func TestPipelineRunIsSuccessful(t *testing.T) {
 	params := []struct {
-		name          string
-		prStatus      v1alpha1.PipelineRunStatus
-		expectedValue bool
+		name     string
+		prStatus v1alpha1.PipelineRunStatus
+		expected bool
 	}{
 		{
-			"prWithNoStatus",
-			func() (status v1alpha1.PipelineRunStatus) {
+			name: "prWithNoStatus",
+			prStatus: func() (status v1alpha1.PipelineRunStatus) {
 				return status
 			}(),
-			false,
+			expected: false,
 		},
 		{
-			"prWithStatusSucceededFalse",
-			func() (status v1alpha1.PipelineRunStatus) {
+			name: "prWithStatusSucceededFalse",
+			prStatus: func() (status v1alpha1.PipelineRunStatus) {
 				status.SetCondition(&apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionFalse,
 				})
 				return status
 			}(),
-			false,
+			expected: false,
 		},
 		{
-			"prWithStatusSucceededTrue",
-			func() (status v1alpha1.PipelineRunStatus) {
+			name: "prWithStatusSucceededTrue",
+			prStatus: func() (status v1alpha1.PipelineRunStatus) {
 				status.SetCondition(&apis.Condition{
 					Type:   apis.ConditionSucceeded,
 					Status: corev1.ConditionTrue,
 				})
 				return status
 			}(),
-			true,
+			expected: true,
 		},
 	}
 	for _, tc := range params {
@@ -257,8 +257,8 @@ func TestPipelineRunIsSuccessful(t *testing.T) {
 				},
 				Status: tc.prStatus,
 			}
-			if pr.IsSuccessful() != tc.expectedValue {
-				t.Fatalf("Expected pipelinerun IsSuccessful() to return %t but got %t", tc.expectedValue, pr.IsSuccessful())
+			if pr.IsSuccessful() != tc.expected {
+				t.Fatalf("Expected pipelinerun IsSuccessful() to return %t but got %t", tc.expected, pr.IsSuccessful())
 			}
 		})
 	}
@@ -274,13 +274,13 @@ func TestPipelineRunKey(t *testing.T) {
 
 func TestPipelineRunHasStarted(t *testing.T) {
 	params := []struct {
-		name          string
-		prStatus      v1alpha1.PipelineRunStatus
-		expectedValue bool
+		name     string
+		prStatus v1alpha1.PipelineRunStatus
+		expected bool
 	}{{
-		name:          "prWithNoStartTime",
-		prStatus:      v1alpha1.PipelineRunStatus{},
-		expectedValue: false,
+		name:     "prWithNoStartTime",
+		prStatus: v1alpha1.PipelineRunStatus{},
+		expected: false,
 	}, {
 		name: "prWithStartTime",
 		prStatus: v1alpha1.PipelineRunStatus{
@@ -288,7 +288,7 @@ func TestPipelineRunHasStarted(t *testing.T) {
 				StartTime: &metav1.Time{Time: time.Now()},
 			},
 		},
-		expectedValue: true,
+		expected: true,
 	}, {
 		name: "prWithZeroStartTime",
 		prStatus: v1alpha1.PipelineRunStatus{
@@ -296,7 +296,7 @@ func TestPipelineRunHasStarted(t *testing.T) {
 				StartTime: &metav1.Time{},
 			},
 		},
-		expectedValue: false,
+		expected: false,
 	}}
 	for _, tc := range params {
 		t.Run(tc.name, func(t *testing.T) {
@@ -307,8 +307,8 @@ func TestPipelineRunHasStarted(t *testing.T) {
 				},
 				Status: tc.prStatus,
 			}
-			if pr.HasStarted() != tc.expectedValue {
-				t.Fatalf("Expected pipelinerun HasStarted() to return %t but got %t", tc.expectedValue, pr.HasStarted())
+			if pr.HasStarted() != tc.expected {
+				t.Fatalf("Expected pipelinerun HasStarted() to return %t but got %t", tc.expected, pr.HasStarted())
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -19,26 +19,15 @@ package pipelinerun
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
 )
 
 // cancelPipelineRun makrs the PipelineRun as cancelled and any resolved taskrun too.
 func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask, clientSet clientset.Interface) error {
-	pr.Status.SetCondition(&apis.Condition{
-		Type:    apis.ConditionSucceeded,
-		Status:  corev1.ConditionFalse,
-		Reason:  "PipelineRunCancelled",
-		Message: fmt.Sprintf("PipelineRun %q was cancelled", pr.Name),
-	})
-	// update pr completed time
-	pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	pr.Fail("PipelineRunCancelled", fmt.Sprintf("PipelineRun %q was cancelled", pr.Name))
 	errs := []string{}
 	for _, rprt := range pipelineState {
 		if rprt.TaskRun == nil {

--- a/pkg/reconciler/pipelinerun/metrics_test.go
+++ b/pkg/reconciler/pipelinerun/metrics_test.go
@@ -112,9 +112,9 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 
 	ctx, _ := rtesting.SetupFakeContext(t)
 	informer := fakepipelineruninformer.Get(ctx)
-	addPipelineRun(informer, "pipelinerun-1", "pipeline-1", "ns", corev1.ConditionTrue, t)
-	addPipelineRun(informer, "pipelinerun-2", "pipeline-2", "ns", corev1.ConditionFalse, t)
-	addPipelineRun(informer, "pipelinerun-3", "pipeline-3", "ns", corev1.ConditionUnknown, t)
+	addPipelineRun(informer, "pipelinerun-1", "pipeline-1", "ns", time.Time{}, t)
+	addPipelineRun(informer, "pipelinerun-2", "pipeline-2", "ns", time.Now(), t)
+	addPipelineRun(informer, "pipelinerun-3", "pipeline-3", "ns", time.Now(), t)
 
 	metrics, err := NewRecorder()
 	assertErrIsNil(err, "Recorder initialization failed", t)
@@ -125,16 +125,13 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 
 }
 
-func addPipelineRun(informer alpha1.PipelineRunInformer, run, pipeline, ns string, status corev1.ConditionStatus, t *testing.T) {
+func addPipelineRun(informer alpha1.PipelineRunInformer, run, pipeline, ns string, completionTime time.Time, t *testing.T) {
 	t.Helper()
 
 	err := informer.Informer().GetIndexer().Add(tb.PipelineRun(run, ns,
 		tb.PipelineRunSpec(pipeline),
 		tb.PipelineRunStatus(
-			tb.PipelineRunStatusCondition(apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: status,
-			}),
+			tb.PipelineRunCompletionTime(completionTime),
 		)))
 
 	if err != nil {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -236,8 +236,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	if err != nil {
 		c.Logger.Errorf("Failed to determine Pipeline spec to use for pipelinerun %s: %v", pr.Name, err)
 		pr.Fail(ReasonCouldntGetPipeline,
-			fmt.Sprintf("Error retrieving pipeline for pipelinerun %s: %s",
-				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), err))
+			fmt.Sprintf("Error retrieving pipeline for pipelinerun %s/%s: %s", pr.Namespace, pr.Name, err))
 		return nil
 	}
 
@@ -262,32 +261,32 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	if err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Fail(ReasonInvalidGraph,
-			fmt.Sprintf("PipelineRun %s's Pipeline DAG is invalid: %s",
-				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), err))
+			fmt.Sprintf("PipelineRun %s/%s's Pipeline DAG is invalid: %s",
+				pr.Namespace, pr.Name, err))
 		return nil
 	}
 
 	if err := pipelineSpec.Validate(ctx); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Fail(ReasonFailedValidation,
-			fmt.Sprintf("Pipeline %s can't be Run; it has an invalid spec: %s",
-				fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pr.Name), err))
+			fmt.Sprintf("Pipeline %s/%s can't be Run; it has an invalid spec: %s",
+				pipelineMeta.Namespace, pr.Name, err))
 		return nil
 	}
 
 	if err := resources.ValidateResourceBindings(pipelineSpec, pr); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Fail(ReasonInvalidBindings,
-			fmt.Sprintf("PipelineRun %s doesn't bind Pipeline %s's PipelineResources correctly: %s",
-				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), fmt.Sprintf("%s/%s", pr.Namespace, pr.Spec.PipelineRef.Name), err))
+			fmt.Sprintf("PipelineRun %s/%s doesn't bind Pipeline %s/%s's PipelineResources correctly: %s",
+				pr.Namespace, pr.Name, pr.Namespace, pr.Spec.PipelineRef.Name, err))
 		return nil
 	}
 	providedResources, err := resources.GetResourcesFromBindings(pr, c.resourceLister.PipelineResources(pr.Namespace).Get)
 	if err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Fail(ReasonCouldntGetResource,
-			fmt.Sprintf("PipelineRun %s can't be Run; it tries to bind Resources that don't exist: %s",
-				fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pr.Name), err))
+			fmt.Sprintf("PipelineRun %s/%s can't be Run; it tries to bind Resources that don't exist: %s",
+				pipelineMeta.Namespace, pr.Name, err))
 		return nil
 	}
 
@@ -297,8 +296,8 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 	if err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Fail(ReasonParameterTypeMismatch,
-			fmt.Sprintf("PipelineRun %s parameters have mismatching types with Pipeline %s's parameters: %s",
-				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), fmt.Sprintf("%s/%s", pr.Namespace, pr.Spec.PipelineRef.Name), err))
+			fmt.Sprintf("PipelineRun %s/%s parameters have mismatching types with Pipeline %s/%s's parameters: %s",
+				pr.Namespace, pr.Name, pr.Namespace, pr.Spec.PipelineRef.Name, err))
 		return nil
 	}
 
@@ -327,16 +326,16 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 		switch err := err.(type) {
 		case *resources.TaskNotFoundError:
 			pr.Fail(ReasonCouldntGetTask,
-				fmt.Sprintf("Pipeline %s can't be Run; it contains Tasks that don't exist: %s",
-					fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pipelineMeta.Name), err))
+				fmt.Sprintf("Pipeline %s/%s can't be Run; it contains Tasks that don't exist: %s",
+					pipelineMeta.Namespace, pipelineMeta.Name, err))
 		case *resources.ConditionNotFoundError:
 			pr.Fail(ReasonCouldntGetCondition,
-				fmt.Sprintf("PipelineRun %s can't be Run; it contains Conditions that don't exist:  %s",
-					fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pr.Name), err))
+				fmt.Sprintf("PipelineRun %s/%s can't be Run; it contains Conditions that don't exist:  %s",
+					pipelineMeta.Namespace, pr.Name, err))
 		default:
 			pr.Fail(ReasonFailedValidation,
-				fmt.Sprintf("PipelineRun %s can't be Run; couldn't resolve all references: %s",
-					fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pr.Name), err))
+				fmt.Sprintf("PipelineRun %s/%s can't be Run; couldn't resolve all references: %s",
+					pipelineMeta.Namespace, pr.Name, err))
 		}
 		return nil
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -717,7 +717,6 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 
 	expectedTaskRunsStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
 	expectedTaskRunsStatus[taskRunName] = &v1alpha1.PipelineRunTaskRunStatus{
-
 		PipelineTaskName: "hello-world-1",
 		Status: &v1alpha1.TaskRunStatus{
 			TaskRunStatusFields: v1alpha1.TaskRunStatusFields{

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -377,8 +377,9 @@ func GetPipelineConditionStatus(pr *v1alpha1.PipelineRun, state PipelineRunState
 	}
 }
 
-// GetPipelineCompletionTime will return the CompletionTime that the PipelineRun pr should be
-// updated with, based on the status and CompletionTime of the TaskRuns in state.
+// GetPipelineCompletionTime will return the CompletionTime that the PipelineRun
+// pr should be updated with, based on the status and CompletionTime of the
+// TaskRuns in state. If the PipelineRun is not completed yet, nil is returned.
 func GetPipelineCompletionTime(pr *v1alpha1.PipelineRun, state PipelineRunState, logger *zap.SugaredLogger, dag *dag.Graph) *metav1.Time {
 	if pr.IsTimedOut() {
 		return &metav1.Time{Time: pr.Status.StartTime.Add(pr.Spec.Timeout.Duration)}


### PR DESCRIPTION
See https://github.com/tektoncd/pipeline/issues/1680

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
