### PR TITLE
Issue 1182: Add sslVerify flag to pipelineresource type git

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -34,6 +34,7 @@ func init() {
 	flag.StringVar(&fetchSpec.URL, "url", "", "Git origin URL to fetch")
 	flag.StringVar(&fetchSpec.Revision, "revision", "", "The Git revision to make the repository HEAD")
 	flag.StringVar(&fetchSpec.Path, "path", "", "Path of directory under which Git repository will be copied")
+	flag.BoolVar(&fetchSpec.SSLVerify, "sslVerify", true, "Enable/Disable SSL verification in the git config")
 	flag.BoolVar(&submodules, "submodules", true, "Initialize and fetch Git submodules")
 	flag.UintVar(&fetchSpec.Depth, "depth", 1, "Perform a shallow clone to this depth")
 	flag.StringVar(&terminationMessagePath, "terminationMessagePath", "/dev/termination-log", "Location of file containing termination message")

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -289,9 +289,12 @@ Params that can be added are the following:
 1.  `depth`: performs a [shallow clone][git-depth] where only the most recent
     commit(s) will be fetched. If set to `'0'`, all commits will be fetched.
     _If not specified, the default depth is 1._
+1.  `sslVerify`: defines if [http.sslVerify][git-http.sslVerify] should be set to `true` or `false`
+    in the global git config. _Defaults to `true` if omitted._
 
 [git-rev]: https://git-scm.com/docs/gitrevisions#_specifying_revisions
 [git-depth]: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---depthltdepthgt
+[git-http.sslVerify]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpsslVerify
 
 When used as an input, the Git resource includes the exact commit fetched in the
 `resourceResults` section of the `taskRun`'s status object:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/Azure/azure-sdk-for-go v36.1.0+incompatible // indirect
@@ -50,7 +51,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/api v0.10.0 // indirect
+	google.golang.org/api v0.10.0
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/apis/pipeline/v1alpha1/git_resource.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource.go
@@ -42,9 +42,9 @@ type GitResource struct {
 	Revision   string `json:"revision"`
 	Submodules bool   `json:"submodules"`
 
-	Depth uint `json:"depth"`
-
-	GitImage string `json:"-"`
+	Depth     uint   `json:"depth"`
+	SSLVerify bool   `json:"sslVerify"`
+	GitImage  string `json:"-"`
 }
 
 // NewGitResource creates a new git resource to pass to a Task
@@ -58,6 +58,7 @@ func NewGitResource(gitImage string, r *PipelineResource) (*GitResource, error) 
 		GitImage:   gitImage,
 		Submodules: true,
 		Depth:      1,
+		SSLVerify:  true,
 	}
 	for _, param := range r.Spec.Params {
 		switch {
@@ -69,6 +70,8 @@ func NewGitResource(gitImage string, r *PipelineResource) (*GitResource, error) 
 			gitResource.Submodules = toBool(param.Value, true)
 		case strings.EqualFold(param.Name, "Depth"):
 			gitResource.Depth = toUint(param.Value, 1)
+		case strings.EqualFold(param.Name, "SSLVerify"):
+			gitResource.SSLVerify = toBool(param.Value, true)
 		}
 	}
 	// default revision to master if nothing is provided
@@ -115,11 +118,12 @@ func (s *GitResource) GetURL() string {
 // Replacements is used for template replacement on a GitResource inside of a Taskrun.
 func (s *GitResource) Replacements() map[string]string {
 	return map[string]string{
-		"name":     s.Name,
-		"type":     string(s.Type),
-		"url":      s.URL,
-		"revision": s.Revision,
-		"depth":    strconv.FormatUint(uint64(s.Depth), 10),
+		"name":      s.Name,
+		"type":      string(s.Type),
+		"url":       s.URL,
+		"revision":  s.Revision,
+		"depth":     strconv.FormatUint(uint64(s.Depth), 10),
+		"sslVerify": strconv.FormatBool(s.SSLVerify),
 	}
 }
 
@@ -137,6 +141,9 @@ func (s *GitResource) GetInputTaskModifier(_ *TaskSpec, path string) (TaskModifi
 	if s.Depth != 1 {
 		args = append(args, "-depth", strconv.FormatUint(uint64(s.Depth), 10))
 	}
+	if !s.SSLVerify {
+		args = append(args, "-sslVerify=false")
+	}
 
 	step := Step{
 		Container: corev1.Container{
@@ -152,6 +159,7 @@ func (s *GitResource) GetInputTaskModifier(_ *TaskSpec, path string) (TaskModifi
 			}},
 		},
 	}
+
 	return &InternalTaskModifier{
 		StepsToPrepend: []Step{step},
 	}, nil

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
@@ -45,10 +46,11 @@ func run(logger *zap.SugaredLogger, dir string, args ...string) (string, error) 
 
 // FetchSpec describes how to initialize and fetch from a Git repository.
 type FetchSpec struct {
-	URL      string
-	Revision string
-	Path     string
-	Depth    uint
+	URL       string
+	Revision  string
+	Path      string
+	Depth     uint
+	SSLVerify bool
 }
 
 // Fetch fetches the specified git repository at the revision into path.
@@ -72,6 +74,10 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 	}
 	trimmedURL := strings.TrimSpace(spec.URL)
 	if _, err := run(logger, "", "remote", "add", "origin", trimmedURL); err != nil {
+		return err
+	}
+	if _, err := run(logger, "", "config", "--global", "http.sslVerify", strconv.FormatBool(spec.SSLVerify)); err != nil {
+		logger.Warnf("Failed to set http.sslVerify in git config: %s", err)
 		return err
 	}
 


### PR DESCRIPTION
# Changes

Enables the disabling in git config of http.sslVerify such that the git fetch can succeed against local gitlab installs with self signed certificates by specifying sslVerify as "false" in the pipelineresource.

Fixes #1182 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

The `sslVerify` parameter is now available on PipelineResource's of type `git`.  This property  defines whether http.sslVerify should be set to `true` or `false` in the global git config.  Setting the property to false will disable certificate validation during the running of the git fetch against the git server and will be of use to people hosting git servers with self signed certificates.
_The parameter sslVerify defaults to `true` if omitted._

Example usage:
```
apiVersion: tekton.dev/v1alpha1
kind: PipelineResource
metadata:
  name: wizzbang-git
  namespace: default
spec:
  type: git
  params:
    - name: url
      value: https://github.com/wizzbangcorp/wizzbang.git
    - name: revision
      value: master
    - name: sslVerify
      value: "false"
```