### PR TITLE
Restrict length of volumes generated from secret names

### DIFF
--- a/pkg/names/generate.go
+++ b/pkg/names/generate.go
@@ -58,13 +58,14 @@ func (simpleNameGenerator) RestrictLengthWithRandomSuffix(base string) string {
 	return fmt.Sprintf("%s-%s", base, utilrand.String(randomLength))
 }
 
+var alphaNumericRE = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+
 func (simpleNameGenerator) RestrictLength(base string) string {
 	if len(base) > maxNameLength {
 		base = base[:maxNameLength]
 	}
-	var isAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString
 
-	for !isAlphaNumeric(base[len(base)-1:]) {
+	for !alphaNumericRE.MatchString(base[len(base)-1:]) {
 		base = base[:len(base)-1]
 	}
 	return base

--- a/pkg/names/generate_test.go
+++ b/pkg/names/generate_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package names
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pipeline/test/names"
+)
+
+func TestRestrictLengthWithRandomSuffix(t *testing.T) {
+	for _, c := range []struct {
+		in, want string
+	}{{
+		in:   "hello",
+		want: "hello-9l9zj",
+	}, {
+		in:   strings.Repeat("a", 100),
+		want: strings.Repeat("a", 57) + "-9l9zj",
+	}} {
+		t.Run(c.in, func(t *testing.T) {
+			names.TestingSeed()
+			got := SimpleNameGenerator.RestrictLengthWithRandomSuffix(c.in)
+			if got != c.want {
+				t.Errorf("RestrictLengthWithRandomSuffix:\n got %q\nwant %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRestrictLength(t *testing.T) {
+	for _, c := range []struct {
+		in, want string
+	}{{
+		in:   "hello",
+		want: "hello",
+	}, {
+		in:   strings.Repeat("a", 100),
+		want: strings.Repeat("a", maxNameLength),
+	}, {
+		// Values that don't end with an alphanumeric value are
+		// trimmed until they do.
+		in:   "abcdefg   !@#!$",
+		want: "abcdefg",
+	}} {
+		t.Run(c.in, func(t *testing.T) {
+			got := SimpleNameGenerator.RestrictLength(c.in)
+			if got != c.want {
+				t.Errorf("RestrictLength:\n got %q\nwant %q", got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -22,6 +22,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
 	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
+	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -64,7 +65,7 @@ func credsInit(credsImage string, serviceAccountName, namespace string, kubeclie
 		}
 
 		if matched {
-			name := fmt.Sprintf("tekton-internal-secret-volume-%s", secret.Name)
+			name := names.SimpleNameGenerator.RestrictLength(fmt.Sprintf("tekton-internal-secret-volume-%s", secret.Name))
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      name,
 				MountPath: credentials.VolumeName(secret.Name),

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -30,10 +30,8 @@ import (
 )
 
 const (
-	workspaceVolumeName = "tekton-internal-workspace"
-	homeVolumeName      = "tekton-internal-home"
-	workspaceDir        = "/workspace"
-	homeDir             = "/tekton/home"
+	workspaceDir = "/workspace"
+	homeDir      = "/tekton/home"
 
 	taskRunLabelKey     = pipeline.GroupName + pipeline.TaskRunLabelKey
 	ManagedByLabelKey   = "app.kubernetes.io/managed-by"


### PR DESCRIPTION
#1701 removed this restriction leading to #1753 

This also adds tests to demonstrate/check the behavior of the names package.

Fixes #1753 
cc @dibbles 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
