### PR TITLE
Call `gcloud auth activate-service-account` if GOOGLE_APPLICATION_CREDENTIALS is set

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/Azure/azure-sdk-for-go v36.1.0+incompatible // indirect
@@ -50,7 +51,7 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
 	golang.org/x/sys v0.0.0-20191110163157-d32e6e3b99c4 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/api v0.10.0 // indirect
+	google.golang.org/api v0.10.0
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -582,12 +582,19 @@ func TestAddResourceToTask(t *testing.T) {
 				Name:    "create-dir-storage1-9l9zj",
 				Image:   "busybox",
 				Command: []string{"mkdir", "-p", "/workspace/gcs-dir"},
-			}}, {Container: corev1.Container{
-				Name:    "fetch-storage1-mz4c7",
-				Image:   "google/cloud-sdk",
-				Command: []string{"gsutil"},
-				Args:    []string{"cp", "gs://fake-bucket/rules.zip", "/workspace/gcs-dir"},
-			}}},
+			}}, {
+				Script: `#!/usr/bin/env bash
+if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+  echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+  gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+fi
+gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
+`,
+				Container: corev1.Container{
+					Name:  "fetch-storage1-mz4c7",
+					Image: "google/cloud-sdk",
+				},
+			}},
 		},
 	}, {
 		desc: "storage resource as input from previous task",
@@ -942,12 +949,19 @@ func TestStorageInputResource(t *testing.T) {
 				Name:    "create-dir-gcs-input-resource-9l9zj",
 				Image:   "busybox",
 				Command: []string{"mkdir", "-p", "/workspace/gcs-input-resource"},
-			}}, {Container: corev1.Container{
-				Name:    "fetch-gcs-input-resource-mz4c7",
-				Image:   "google/cloud-sdk",
-				Command: []string{"gsutil"},
-				Args:    []string{"cp", "gs://fake-bucket/rules.zip", "/workspace/gcs-input-resource"},
-			}}},
+			}}, {
+				Script: `#!/usr/bin/env bash
+if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+  echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+  gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+fi
+gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-input-resource
+`,
+				Container: corev1.Container{
+					Name:  "fetch-gcs-input-resource-mz4c7",
+					Image: "google/cloud-sdk",
+				},
+			}},
 		},
 	}, {
 		desc: "no inputs",
@@ -1001,18 +1015,25 @@ func TestStorageInputResource(t *testing.T) {
 				Name:    "create-dir-storage-gcs-keys-9l9zj",
 				Image:   "busybox",
 				Command: []string{"mkdir", "-p", "/workspace/gcs-input-resource"},
-			}}, {Container: corev1.Container{
-				Name:    "fetch-storage-gcs-keys-mz4c7",
-				Image:   "google/cloud-sdk",
-				Command: []string{"gsutil"},
-				Args:    []string{"rsync", "-d", "-r", "gs://fake-bucket/rules.zip", "/workspace/gcs-input-resource"},
-				VolumeMounts: []corev1.VolumeMount{
-					{Name: "volume-storage-gcs-keys-secret-name", MountPath: "/var/secret/secret-name"},
+			}}, {
+				Script: `#!/usr/bin/env bash
+if [[ "${GOOGLE_APPLICATION_CREDENTIALS}" != "" ]]; then
+  echo GOOGLE_APPLICATION_CREDENTIALS is set, activating Service Account...
+  gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+fi
+gsutil rsync -d -r gs://fake-bucket/rules.zip /workspace/gcs-input-resource
+`,
+				Container: corev1.Container{
+					Name:  "fetch-storage-gcs-keys-mz4c7",
+					Image: "google/cloud-sdk",
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: "volume-storage-gcs-keys-secret-name", MountPath: "/var/secret/secret-name"},
+					},
+					Env: []corev1.EnvVar{
+						{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secret-name/key.json"},
+					},
 				},
-				Env: []corev1.EnvVar{
-					{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secret-name/key.json"},
-				},
-			}}},
+			}},
 			Volumes: []corev1.Volume{{
 				Name:         "volume-storage-gcs-keys-secret-name",
 				VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "secret-name"}},


### PR DESCRIPTION
This used to be done by our own gsutil image. When that image was replaced
by the vanilla `google/cloud-sdk` image, this documented behavior broke.

By adding this as a step added by the resource, the behavior is
maintained without needing to maintain our own image to perform
activation.

Fixes #1748
/hold needs e2e test
cc @dustym

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix regression in v0.9 whereby GOOGLE_APPLICATION_CREDENTIALS were ignored when using the GCS resource
```
