### PR TITLE
wip: Generate validate OpenAPIV3Schema 🏫

### DIFF
--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -29,3 +29,3051 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: ClusterTask is a Task with a cluster scope. ClusterTasks are used
+        to represent Tasks that should be publicly addressable from any namespace
+        in the cluster.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec holds the desired state of the Task from the client
+          type: object
+          properties:
+            inputs:
+              description: Inputs is an optional set of parameters and resources which
+                must be supplied by the user when a Task is executed by a TaskRun.
+              type: object
+              properties:
+                params:
+                  description: Params is a list of input parameters required to run
+                    the task. Params must be supplied as inputs in TaskRuns unless
+                    they declare a default value.
+                  type: array
+                  items:
+                    description: ParamSpec defines arbitrary parameters needed beyond
+                      typed inputs (such as resources). Parameter values are provided
+                      by users as inputs on a TaskRun or PipelineRun.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      default:
+                        description: Default is the value a parameter takes if no
+                          input value is supplied. If default is set, a Task may be
+                          executed without a supplied value for the parameter.
+                        type: object
+                        required:
+                        - type
+                        properties:
+                          type:
+                            description: ParamType indicates the type of an input
+                              parameter; Used to distinguish between a single string
+                              and an array of strings.
+                            type: string
+                      description:
+                        description: Description is a user-facing description of the
+                          parameter that may be used to populate a UI.
+                        type: string
+                      name:
+                        description: Name declares the name by which a parameter is
+                          referenced.
+                        type: string
+                      type:
+                        description: Type is the user-specified type of the parameter.
+                          The possible types are currently "string" and "array", and
+                          "string" is the default.
+                        type: string
+                resources:
+                  description: Resources is a list of the input resources required
+                    to run the task. Resources are represented in TaskRuns as bindings
+                    to instances of PipelineResources.
+                  type: array
+                  items:
+                    description: TaskResource defines an input or output Resource
+                      declared as a requirement by a Task. The Name field will be
+                      used to refer to these Resources within the Task definition,
+                      and when provided as an Input, the Name will be the path to
+                      the volume mounted containing this Resource as an input (e.g.
+                      an input Resource named `workspace` will be mounted at `/workspace`).
+                    type: object
+                    required:
+                    - name
+                    - type
+                    properties:
+                      name:
+                        description: Name declares the name by which a resource is
+                          referenced in the definition. Resources may be referenced
+                          by name in the definition of a Task's steps.
+                        type: string
+                      optional:
+                        description: 'Optional declares the resource as optional.
+                          By default optional is set to false which makes a resource
+                          required. optional: true - the resource is considered optional
+                          optional: false - the resource is considered required (equivalent
+                          of not specifying it)'
+                        type: boolean
+                      targetPath:
+                        description: TargetPath is the path in workspace directory
+                          where the resource will be copied.
+                        type: string
+                      type:
+                        description: Type is the type of this resource;
+                        type: string
+            outputs:
+              description: Outputs is an optional set of resources and results produced
+                when this Task is run.
+              type: object
+              properties:
+                resources:
+                  type: array
+                  items:
+                    description: TaskResource defines an input or output Resource
+                      declared as a requirement by a Task. The Name field will be
+                      used to refer to these Resources within the Task definition,
+                      and when provided as an Input, the Name will be the path to
+                      the volume mounted containing this Resource as an input (e.g.
+                      an input Resource named `workspace` will be mounted at `/workspace`).
+                    type: object
+                    required:
+                    - name
+                    - type
+                    properties:
+                      name:
+                        description: Name declares the name by which a resource is
+                          referenced in the definition. Resources may be referenced
+                          by name in the definition of a Task's steps.
+                        type: string
+                      optional:
+                        description: 'Optional declares the resource as optional.
+                          By default optional is set to false which makes a resource
+                          required. optional: true - the resource is considered optional
+                          optional: false - the resource is considered required (equivalent
+                          of not specifying it)'
+                        type: boolean
+                      targetPath:
+                        description: TargetPath is the path in workspace directory
+                          where the resource will be copied.
+                        type: string
+                      type:
+                        description: Type is the type of this resource;
+                        type: string
+                results:
+                  type: array
+                  items:
+                    description: TestResult allows a task to specify the location
+                      where test logs can be found and what format they will be in.
+                    type: object
+                    required:
+                    - format
+                    - name
+                    - path
+                    properties:
+                      format:
+                        description: 'TODO: maybe this is an enum with types like
+                          "go test", "junit", etc.'
+                        type: string
+                      name:
+                        description: Name declares the name by which a result is referenced
+                          in the Task's definition. Results may be referenced by name
+                          in the definition of a Task's steps.
+                        type: string
+                      path:
+                        type: string
+            sidecars:
+              description: Sidecars are run alongside the Task's step containers.
+                They begin before the steps start and end after the steps complete.
+              type: array
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                type: object
+                required:
+                - name
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    type: array
+                    items:
+                      type: string
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    type: array
+                    items:
+                      type: string
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    type: array
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              type: object
+                              required:
+                              - key
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, metadata.labels, metadata.annotations,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP.'
+                              type: object
+                              required:
+                              - fieldPath
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              type: object
+                              required:
+                              - resource
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              type: object
+                              required:
+                              - key
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    type: array
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      type: object
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          type: object
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          type: object
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Actions that the management system should take in
+                      response to container lifecycle events. Cannot be updated.
+                    type: object
+                    properties:
+                      postStart:
+                        description: 'PostStart is called immediately after a container
+                          is created. If the handler fails, the container is terminated
+                          and restarted according to its restart policy. Other management
+                          of the container blocks until the hook completes. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        type: object
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  type: object
+                                  required:
+                                  - name
+                                  - value
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                      preStop:
+                        description: 'PreStop is called immediately before a container
+                          is terminated. The container is terminated after the handler
+                          completes. The reason for termination is passed to the handler.
+                          Regardless of the outcome of the handler, the container
+                          is eventually terminated. Other management of the container
+                          blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        type: object
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  type: object
+                                  required:
+                                  - name
+                                  - value
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                  livenessProbe:
+                    description: 'Periodic probe of container liveness. Container
+                      will be restarted if the probe fails. Cannot be updated. More
+                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    type: object
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        type: object
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            type: array
+                            items:
+                              type: string
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            type: array
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              type: object
+                              required:
+                              - name
+                              - value
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    type: array
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      type: object
+                      required:
+                      - containerPort
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          type: integer
+                          format: int32
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          type: integer
+                          format: int32
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                  readinessProbe:
+                    description: 'Periodic probe of container service readiness. Container
+                      will be removed from service endpoints if the probe fails. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    type: object
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        type: object
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            type: array
+                            items:
+                              type: string
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            type: array
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              type: object
+                              required:
+                              - name
+                              - value
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                  resources:
+                    description: 'Compute Resources required by this container. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        additionalProperties:
+                          type: string
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        additionalProperties:
+                          type: string
+                  securityContext:
+                    description: 'Security options the pod should run with. More info:
+                      https://kubernetes.io/docs/concepts/policy/security-context/
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                    type: object
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        type: object
+                        properties:
+                          add:
+                            description: Added capabilities
+                            type: array
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                          drop:
+                            description: Removed capabilities
+                            type: array
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        type: integer
+                        format: int64
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: integer
+                        format: int64
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        type: object
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    type: array
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      type: object
+                      required:
+                      - devicePath
+                      - name
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    type: array
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      type: object
+                      required:
+                      - mountPath
+                      - name
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+            stepTemplate:
+              description: StepTemplate can be used as the basis for all step containers
+                within the Task, so that the steps inherit settings on the base container.
+              type: object
+              required:
+              - name
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  type: array
+                  items:
+                    type: string
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  type: array
+                  items:
+                    type: string
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, metadata.labels, metadata.annotations,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP.'
+                            type: object
+                            required:
+                            - fieldPath
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            type: object
+                            required:
+                            - resource
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  type: array
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    type: object
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  type: object
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated. The container is terminated after the handler
+                        completes. The reason for termination is passed to the handler.
+                        Regardless of the outcome of the handler, the container is
+                        eventually terminated. Other management of the container blocks
+                        until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  type: object
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      type: object
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          type: array
+                          items:
+                            type: string
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      type: integer
+                      format: int32
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          type: array
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP
+                        port. TCP hooks not yet supported TODO: implement a realistic
+                        TCP lifecycle hook'
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    type: object
+                    required:
+                    - containerPort
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        type: integer
+                        format: int32
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        type: integer
+                        format: int32
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  type: object
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      type: object
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          type: array
+                          items:
+                            type: string
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      type: integer
+                      format: int32
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          type: array
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP
+                        port. TCP hooks not yet supported TODO: implement a realistic
+                        TCP lifecycle hook'
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  type: object
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      type: object
+                      properties:
+                        add:
+                          description: Added capabilities
+                          type: array
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                        drop:
+                          description: Removed capabilities
+                          type: array
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      type: integer
+                      format: int64
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      type: integer
+                      format: int64
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: object
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container. This is a beta feature.
+                  type: array
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    type: object
+                    required:
+                    - devicePath
+                    - name
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    type: object
+                    required:
+                    - mountPath
+                    - name
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+            steps:
+              description: Steps are the steps of the build; each step is run sequentially
+                with the source mounted into /workspace.
+              type: array
+              items:
+                description: Step embeds the Container type, which allows it to include
+                  fields not provided by Container.
+                type: object
+                properties:
+                  script:
+                    description: "Script is the contents of an executable file to
+                      execute. \n If Script is not empty, the Step cannot have an
+                      Command or Args."
+                    type: string
+            volumes:
+              description: Volumes is a collection of volumes that are available to
+                mount into the steps of the build.
+              type: array
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                type: object
+                required:
+                - name
+                properties:
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: object
+                    required:
+                    - volumeID
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
+                        type: integer
+                        format: int32
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    type: object
+                    required:
+                    - diskName
+                    - diskURI
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                        type: string
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    type: object
+                    required:
+                    - secretName
+                    - shareName
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    type: object
+                    required:
+                    - monitors
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: array
+                        items:
+                          type: string
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                    type: object
+                    required:
+                    - volumeID
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    type: object
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        type: integer
+                        format: int32
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
+                        type: array
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          type: object
+                          required:
+                          - key
+                          - path
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              type: integer
+                              format: int32
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or it's keys must
+                          be defined
+                        type: boolean
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
+                    type: object
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        type: integer
+                        format: int32
+                      items:
+                        description: Items is a list of downward API volume file
+                        type: array
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          type: object
+                          required:
+                          - path
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
+                              type: object
+                              required:
+                              - fieldPath
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              type: integer
+                              format: int32
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              type: object
+                              required:
+                              - resource
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    type: object
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    type: object
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        type: integer
+                        format: int32
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        type: array
+                        items:
+                          type: string
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        type: array
+                        items:
+                          type: string
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    type: object
+                    required:
+                    - driver
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                        additionalProperties:
+                          type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    type: object
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: object
+                    required:
+                    - pdName
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: integer
+                        format: int32
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    type: object
+                    required:
+                    - repository
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md'
+                    type: object
+                    required:
+                    - endpoints
+                    - path
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    type: object
+                    required:
+                    - path
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md'
+                    type: object
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        type: integer
+                        format: int32
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        type: array
+                        items:
+                          type: string
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: object
+                    required:
+                    - path
+                    - server
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    type: object
+                    required:
+                    - claimName
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    type: object
+                    required:
+                    - pdID
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    type: object
+                    required:
+                    - volumeID
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    type: object
+                    required:
+                    - sources
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        type: integer
+                        format: int32
+                      sources:
+                        description: list of volume projections
+                        type: array
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          type: object
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              type: object
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  type: array
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    keys must be defined
+                                  type: boolean
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              type: object
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  type: array
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    type: object
+                                    required:
+                                    - path
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        type: object
+                                        required:
+                                        - fieldPath
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        type: object
+                                        required:
+                                        - resource
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                            secret:
+                              description: information about the secret data to project
+                              type: object
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  type: array
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  type: integer
+                                  format: int64
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    type: object
+                    required:
+                    - registry
+                    - volume
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md'
+                    type: object
+                    required:
+                    - image
+                    - monitors
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: array
+                        items:
+                          type: string
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    type: object
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    type: object
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        type: integer
+                        format: int32
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        type: array
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          type: object
+                          required:
+                          - key
+                          - path
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              type: integer
+                              format: int32
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                      optional:
+                        description: Specify whether the Secret or it's keys must
+                          be defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    type: object
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    type: object
+                    required:
+                    - volumePath
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+            workspaces:
+              description: Workspaces are the volumes that this Task requires.
+              type: array
+              items:
+                description: WorkspaceDeclaration is a declaration of a volume that
+                  a Task requires.
+                type: object
+                required:
+                - name
+                properties:
+                  description:
+                    description: Description is an optional human readable description
+                      of this volume.
+                    type: string
+                  mountPath:
+                    description: MountPath overrides the directory that the volume
+                      will be made available at.
+                    type: string
+                  name:
+                    description: Name is the name by which you can bind the volume
+                      at runtime.
+                    type: string

--- a/config/300-condition.yaml
+++ b/config/300-condition.yaml
@@ -21,11 +21,957 @@ spec:
     kind: Condition
     plural: conditions
     categories:
-      - all
-      - tekton-pipelines
+    - all
+    - tekton-pipelines
   scope: Namespaced
   # Opt into the status subresource so metadata.generation
   # starts to increment
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: Condition declares a step that is used to gate the execution of
+        a Task in a Pipeline. A condition execution (ConditionCheck) evaluates to
+        either true or false
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec holds the desired state of the Condition from the client
+          type: object
+          properties:
+            check:
+              description: Check declares container whose exit code determines where
+                a condition is true or false
+              type: object
+              required:
+              - name
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  type: array
+                  items:
+                    type: string
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  type: array
+                  items:
+                    type: string
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, metadata.labels, metadata.annotations,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP.'
+                            type: object
+                            required:
+                            - fieldPath
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            type: object
+                            required:
+                            - resource
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  type: array
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    type: object
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  type: object
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated. The container is terminated after the handler
+                        completes. The reason for termination is passed to the handler.
+                        Regardless of the outcome of the handler, the container is
+                        eventually terminated. Other management of the container blocks
+                        until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  type: object
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      type: object
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          type: array
+                          items:
+                            type: string
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      type: integer
+                      format: int32
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          type: array
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP
+                        port. TCP hooks not yet supported TODO: implement a realistic
+                        TCP lifecycle hook'
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    type: object
+                    required:
+                    - containerPort
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        type: integer
+                        format: int32
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        type: integer
+                        format: int32
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  type: object
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      type: object
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          type: array
+                          items:
+                            type: string
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      type: integer
+                      format: int32
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          type: array
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP
+                        port. TCP hooks not yet supported TODO: implement a realistic
+                        TCP lifecycle hook'
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  type: object
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      type: object
+                      properties:
+                        add:
+                          description: Added capabilities
+                          type: array
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                        drop:
+                          description: Removed capabilities
+                          type: array
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      type: integer
+                      format: int64
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      type: integer
+                      format: int64
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: object
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container. This is a beta feature.
+                  type: array
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    type: object
+                    required:
+                    - devicePath
+                    - name
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    type: object
+                    required:
+                    - mountPath
+                    - name
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+            params:
+              description: Params is an optional set of parameters which must be supplied
+                by the user when a Condition is evaluated
+              type: array
+              items:
+                description: ParamSpec defines arbitrary parameters needed beyond
+                  typed inputs (such as resources). Parameter values are provided
+                  by users as inputs on a TaskRun or PipelineRun.
+                type: object
+                required:
+                - name
+                properties:
+                  default:
+                    description: Default is the value a parameter takes if no input
+                      value is supplied. If default is set, a Task may be executed
+                      without a supplied value for the parameter.
+                    type: object
+                    required:
+                    - type
+                    properties:
+                      type:
+                        description: ParamType indicates the type of an input parameter;
+                          Used to distinguish between a single string and an array
+                          of strings.
+                        type: string
+                  description:
+                    description: Description is a user-facing description of the parameter
+                      that may be used to populate a UI.
+                    type: string
+                  name:
+                    description: Name declares the name by which a parameter is referenced.
+                    type: string
+                  type:
+                    description: Type is the user-specified type of the parameter.
+                      The possible types are currently "string" and "array", and "string"
+                      is the default.
+                    type: string
+            resources:
+              description: Resources is a list of the ConditionResources required
+                to run the condition.
+              type: array
+              items:
+                description: ResourceDeclaration defines an input or output PipelineResource
+                  declared as a requirement by another type such as a Task or Condition.
+                  The Name field will be used to refer to these PipelineResources
+                  within the type's definition, and when provided as an Input, the
+                  Name will be the path to the volume mounted containing this PipelineResource
+                  as an input (e.g. an input Resource named `workspace` will be mounted
+                  at `/workspace`).
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    description: Name declares the name by which a resource is referenced
+                      in the definition. Resources may be referenced by name in the
+                      definition of a Task's steps.
+                    type: string
+                  optional:
+                    description: 'Optional declares the resource as optional. By default
+                      optional is set to false which makes a resource required. optional:
+                      true - the resource is considered optional optional: false -
+                      the resource is considered required (equivalent of not specifying
+                      it)'
+                    type: boolean
+                  targetPath:
+                    description: TargetPath is the path in workspace directory where
+                      the resource will be copied.
+                    type: string
+                  type:
+                    description: Type is the type of this resource;
+                    type: string

--- a/config/300-imagecache.yaml
+++ b/config/300-imagecache.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -26,10 +25,10 @@ spec:
     plural: images
     singular: image
     categories:
-      - knative-internal
-      - caching
+    - knative-internal
+    - caching
     shortNames:
-      - img
+    - img
   scope: Namespaced
   subresources:
     status: {}

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -29,3 +29,283 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: Pipeline describes a list of Tasks to execute. It expresses how
+        outputs of tasks feed into inputs of subsequent tasks.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec holds the desired state of the Pipeline from the client
+          type: object
+          properties:
+            params:
+              description: Params declares a list of input parameters that must be
+                supplied when this Pipeline is run.
+              type: array
+              items:
+                description: ParamSpec defines arbitrary parameters needed beyond
+                  typed inputs (such as resources). Parameter values are provided
+                  by users as inputs on a TaskRun or PipelineRun.
+                type: object
+                required:
+                - name
+                properties:
+                  default:
+                    description: Default is the value a parameter takes if no input
+                      value is supplied. If default is set, a Task may be executed
+                      without a supplied value for the parameter.
+                    type: object
+                    required:
+                    - type
+                    properties:
+                      type:
+                        description: ParamType indicates the type of an input parameter;
+                          Used to distinguish between a single string and an array
+                          of strings.
+                        type: string
+                  description:
+                    description: Description is a user-facing description of the parameter
+                      that may be used to populate a UI.
+                    type: string
+                  name:
+                    description: Name declares the name by which a parameter is referenced.
+                    type: string
+                  type:
+                    description: Type is the user-specified type of the parameter.
+                      The possible types are currently "string" and "array", and "string"
+                      is the default.
+                    type: string
+            resources:
+              description: Resources declares the names and types of the resources
+                given to the Pipeline's tasks as inputs and outputs.
+              type: array
+              items:
+                description: PipelineDeclaredResource is used by a Pipeline to declare
+                  the types of the PipelineResources that it will required to run
+                  and names which can be used to refer to these PipelineResources
+                  in PipelineTaskResourceBindings.
+                type: object
+                required:
+                - name
+                - type
+                properties:
+                  name:
+                    description: Name is the name that will be used by the Pipeline
+                      to refer to this resource. It does not directly correspond to
+                      the name of any PipelineResources Task inputs or outputs, and
+                      it does not correspond to the actual names of the PipelineResources
+                      that will be bound in the PipelineRun.
+                    type: string
+                  type:
+                    description: Type is the type of the PipelineResource.
+                    type: string
+            tasks:
+              description: Tasks declares the graph of Tasks that execute when this
+                Pipeline is run.
+              type: array
+              items:
+                description: PipelineTask defines a task in a Pipeline, passing inputs
+                  from both Params and from the output of previous tasks.
+                type: object
+                required:
+                - taskRef
+                properties:
+                  conditions:
+                    description: Conditions is a list of conditions that need to be
+                      true for the task to run
+                    type: array
+                    items:
+                      description: PipelineTaskCondition allows a PipelineTask to
+                        declare a Condition to be evaluated before the Task is run.
+                      type: object
+                      required:
+                      - conditionRef
+                      properties:
+                        conditionRef:
+                          description: ConditionRef is the name of the Condition to
+                            use for the conditionCheck
+                          type: string
+                        params:
+                          description: Params declare parameters passed to this Condition
+                          type: array
+                          items:
+                            description: Param declares an ArrayOrString to use for
+                              the parameter called name.
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                description: ArrayOrString is a type that can hold
+                                  a single string or string array. Used in JSON unmarshalling
+                                  so that a single JSON field can accept either an
+                                  individual string or an array of strings.
+                                type: object
+                                required:
+                                - type
+                                properties:
+                                  type:
+                                    description: ParamType indicates the type of an
+                                      input parameter; Used to distinguish between
+                                      a single string and an array of strings.
+                                    type: string
+                        resources:
+                          description: Resources declare the resources provided to
+                            this Condition as input
+                          type: array
+                          items:
+                            description: PipelineConditionResource allows a Pipeline
+                              to declare how its DeclaredPipelineResources should
+                              be provided to a Condition as its inputs.
+                            type: object
+                            required:
+                            - name
+                            - resource
+                            properties:
+                              name:
+                                description: Name is the name of the PipelineResource
+                                  as declared by the Condition.
+                                type: string
+                              resource:
+                                description: Resource is the name of the DeclaredPipelineResource
+                                  to use.
+                                type: string
+                  name:
+                    description: Name is the name of this task within the context
+                      of a Pipeline. Name is used as a coordinate with the `from`
+                      and `runAfter` fields to establish the execution order of tasks
+                      relative to one another.
+                    type: string
+                  params:
+                    description: Parameters declares parameters passed to this task.
+                    type: array
+                    items:
+                      description: Param declares an ArrayOrString to use for the
+                        parameter called name.
+                      type: object
+                      required:
+                      - name
+                      - value
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          description: ArrayOrString is a type that can hold a single
+                            string or string array. Used in JSON unmarshalling so
+                            that a single JSON field can accept either an individual
+                            string or an array of strings.
+                          type: object
+                          required:
+                          - type
+                          properties:
+                            type:
+                              description: ParamType indicates the type of an input
+                                parameter; Used to distinguish between a single string
+                                and an array of strings.
+                              type: string
+                  resources:
+                    description: Resources declares the resources given to this task
+                      as inputs and outputs.
+                    type: object
+                    properties:
+                      inputs:
+                        description: Inputs holds the mapping from the PipelineResources
+                          declared in DeclaredPipelineResources to the input PipelineResources
+                          required by the Task.
+                        type: array
+                        items:
+                          description: PipelineTaskInputResource maps the name of
+                            a declared PipelineResource input dependency in a Task
+                            to the resource in the Pipeline's DeclaredPipelineResources
+                            that should be used. This input may come from a previous
+                            task.
+                          type: object
+                          required:
+                          - name
+                          - resource
+                          properties:
+                            from:
+                              description: From is the list of PipelineTask names
+                                that the resource has to come from. (Implies an ordering
+                                in the execution graph.)
+                              type: array
+                              items:
+                                type: string
+                            name:
+                              description: Name is the name of the PipelineResource
+                                as declared by the Task.
+                              type: string
+                            resource:
+                              description: Resource is the name of the DeclaredPipelineResource
+                                to use.
+                              type: string
+                      outputs:
+                        description: Outputs holds the mapping from the PipelineResources
+                          declared in DeclaredPipelineResources to the input PipelineResources
+                          required by the Task.
+                        type: array
+                        items:
+                          description: PipelineTaskOutputResource maps the name of
+                            a declared PipelineResource output dependency in a Task
+                            to the resource in the Pipeline's DeclaredPipelineResources
+                            that should be used.
+                          type: object
+                          required:
+                          - name
+                          - resource
+                          properties:
+                            name:
+                              description: Name is the name of the PipelineResource
+                                as declared by the Task.
+                              type: string
+                            resource:
+                              description: Resource is the name of the DeclaredPipelineResource
+                                to use.
+                              type: string
+                  retries:
+                    description: 'Retries represents how many times this task should
+                      be retried in case of task failure: ConditionSucceeded set to
+                      False'
+                    type: integer
+                  runAfter:
+                    description: RunAfter is the list of PipelineTask names that should
+                      be executed before this Task executes. (Used to force a specific
+                      ordering in graph execution.)
+                    type: array
+                    items:
+                      type: string
+                  taskRef:
+                    description: TaskRef is a reference to a task definition.
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: TaskKind inficates the kind of the task, namespaced
+                          or cluster scoped.
+                        type: string
+                      name:
+                        description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+        status:
+          description: Status is deprecated. It usually is used to communicate the
+            observed state of the Pipeline from the controller, but was unused as
+            there is no controller for Pipeline.
+          type: object

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -28,20 +28,2382 @@ spec:
     - prs
   scope: Namespaced
   additionalPrinterColumns:
-    - name: Succeeded
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
-    - name: Reason
-      type: string
-      JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
-    - name: StartTime
-      type: date
-      JSONPath: .status.startTime
-    - name: CompletionTime
-      type: date
-      JSONPath: .status.completionTime
+  - name: Succeeded
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+  - name: StartTime
+    type: date
+    JSONPath: .status.startTime
+  - name: CompletionTime
+    type: date
+    JSONPath: .status.completionTime
   # Opt into the status subresource so metadata.generation
   # starts to increment
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: PipelineRun represents a single execution of a Pipeline. PipelineRuns
+        are how the graph of Tasks declared in a Pipeline are executed; they specify
+        inputs to Pipelines such as parameter values and capture operational aspects
+        of the Tasks execution such as service account and tolerations. Creating a
+        PipelineRun creates TaskRuns for Tasks in the referenced Pipeline.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PipelineRunSpec defines the desired state of PipelineRun
+          type: object
+          properties:
+            params:
+              description: Params is a list of parameter names and values.
+              type: array
+              items:
+                description: Param declares an ArrayOrString to use for the parameter
+                  called name.
+                type: object
+                required:
+                - name
+                - value
+                properties:
+                  name:
+                    type: string
+                  value:
+                    description: ArrayOrString is a type that can hold a single string
+                      or string array. Used in JSON unmarshalling so that a single
+                      JSON field can accept either an individual string or an array
+                      of strings.
+                    type: object
+                    required:
+                    - type
+                    properties:
+                      type:
+                        description: ParamType indicates the type of an input parameter;
+                          Used to distinguish between a single string and an array
+                          of strings.
+                        type: string
+            pipelineRef:
+              description: 'PipelineRef can be used to refer to a specific instance
+                of a Pipeline. Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64'
+              type: object
+              properties:
+                apiVersion:
+                  description: API version of the referent
+                  type: string
+                name:
+                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+            pipelineSpec:
+              description: PipelineSpec defines the desired state of Pipeline.
+              type: object
+              properties:
+                params:
+                  description: Params declares a list of input parameters that must
+                    be supplied when this Pipeline is run.
+                  type: array
+                  items:
+                    description: ParamSpec defines arbitrary parameters needed beyond
+                      typed inputs (such as resources). Parameter values are provided
+                      by users as inputs on a TaskRun or PipelineRun.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      default:
+                        description: Default is the value a parameter takes if no
+                          input value is supplied. If default is set, a Task may be
+                          executed without a supplied value for the parameter.
+                        type: object
+                        required:
+                        - type
+                        properties:
+                          type:
+                            description: ParamType indicates the type of an input
+                              parameter; Used to distinguish between a single string
+                              and an array of strings.
+                            type: string
+                      description:
+                        description: Description is a user-facing description of the
+                          parameter that may be used to populate a UI.
+                        type: string
+                      name:
+                        description: Name declares the name by which a parameter is
+                          referenced.
+                        type: string
+                      type:
+                        description: Type is the user-specified type of the parameter.
+                          The possible types are currently "string" and "array", and
+                          "string" is the default.
+                        type: string
+                resources:
+                  description: Resources declares the names and types of the resources
+                    given to the Pipeline's tasks as inputs and outputs.
+                  type: array
+                  items:
+                    description: PipelineDeclaredResource is used by a Pipeline to
+                      declare the types of the PipelineResources that it will required
+                      to run and names which can be used to refer to these PipelineResources
+                      in PipelineTaskResourceBindings.
+                    type: object
+                    required:
+                    - name
+                    - type
+                    properties:
+                      name:
+                        description: Name is the name that will be used by the Pipeline
+                          to refer to this resource. It does not directly correspond
+                          to the name of any PipelineResources Task inputs or outputs,
+                          and it does not correspond to the actual names of the PipelineResources
+                          that will be bound in the PipelineRun.
+                        type: string
+                      type:
+                        description: Type is the type of the PipelineResource.
+                        type: string
+                tasks:
+                  description: Tasks declares the graph of Tasks that execute when
+                    this Pipeline is run.
+                  type: array
+                  items:
+                    description: PipelineTask defines a task in a Pipeline, passing
+                      inputs from both Params and from the output of previous tasks.
+                    type: object
+                    required:
+                    - taskRef
+                    properties:
+                      conditions:
+                        description: Conditions is a list of conditions that need
+                          to be true for the task to run
+                        type: array
+                        items:
+                          description: PipelineTaskCondition allows a PipelineTask
+                            to declare a Condition to be evaluated before the Task
+                            is run.
+                          type: object
+                          required:
+                          - conditionRef
+                          properties:
+                            conditionRef:
+                              description: ConditionRef is the name of the Condition
+                                to use for the conditionCheck
+                              type: string
+                            params:
+                              description: Params declare parameters passed to this
+                                Condition
+                              type: array
+                              items:
+                                description: Param declares an ArrayOrString to use
+                                  for the parameter called name.
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    description: ArrayOrString is a type that can
+                                      hold a single string or string array. Used in
+                                      JSON unmarshalling so that a single JSON field
+                                      can accept either an individual string or an
+                                      array of strings.
+                                    type: object
+                                    required:
+                                    - type
+                                    properties:
+                                      type:
+                                        description: ParamType indicates the type
+                                          of an input parameter; Used to distinguish
+                                          between a single string and an array of
+                                          strings.
+                                        type: string
+                            resources:
+                              description: Resources declare the resources provided
+                                to this Condition as input
+                              type: array
+                              items:
+                                description: PipelineConditionResource allows a Pipeline
+                                  to declare how its DeclaredPipelineResources should
+                                  be provided to a Condition as its inputs.
+                                type: object
+                                required:
+                                - name
+                                - resource
+                                properties:
+                                  name:
+                                    description: Name is the name of the PipelineResource
+                                      as declared by the Condition.
+                                    type: string
+                                  resource:
+                                    description: Resource is the name of the DeclaredPipelineResource
+                                      to use.
+                                    type: string
+                      name:
+                        description: Name is the name of this task within the context
+                          of a Pipeline. Name is used as a coordinate with the `from`
+                          and `runAfter` fields to establish the execution order of
+                          tasks relative to one another.
+                        type: string
+                      params:
+                        description: Parameters declares parameters passed to this
+                          task.
+                        type: array
+                        items:
+                          description: Param declares an ArrayOrString to use for
+                            the parameter called name.
+                          type: object
+                          required:
+                          - name
+                          - value
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              description: ArrayOrString is a type that can hold a
+                                single string or string array. Used in JSON unmarshalling
+                                so that a single JSON field can accept either an individual
+                                string or an array of strings.
+                              type: object
+                              required:
+                              - type
+                              properties:
+                                type:
+                                  description: ParamType indicates the type of an
+                                    input parameter; Used to distinguish between a
+                                    single string and an array of strings.
+                                  type: string
+                      resources:
+                        description: Resources declares the resources given to this
+                          task as inputs and outputs.
+                        type: object
+                        properties:
+                          inputs:
+                            description: Inputs holds the mapping from the PipelineResources
+                              declared in DeclaredPipelineResources to the input PipelineResources
+                              required by the Task.
+                            type: array
+                            items:
+                              description: PipelineTaskInputResource maps the name
+                                of a declared PipelineResource input dependency in
+                                a Task to the resource in the Pipeline's DeclaredPipelineResources
+                                that should be used. This input may come from a previous
+                                task.
+                              type: object
+                              required:
+                              - name
+                              - resource
+                              properties:
+                                from:
+                                  description: From is the list of PipelineTask names
+                                    that the resource has to come from. (Implies an
+                                    ordering in the execution graph.)
+                                  type: array
+                                  items:
+                                    type: string
+                                name:
+                                  description: Name is the name of the PipelineResource
+                                    as declared by the Task.
+                                  type: string
+                                resource:
+                                  description: Resource is the name of the DeclaredPipelineResource
+                                    to use.
+                                  type: string
+                          outputs:
+                            description: Outputs holds the mapping from the PipelineResources
+                              declared in DeclaredPipelineResources to the input PipelineResources
+                              required by the Task.
+                            type: array
+                            items:
+                              description: PipelineTaskOutputResource maps the name
+                                of a declared PipelineResource output dependency in
+                                a Task to the resource in the Pipeline's DeclaredPipelineResources
+                                that should be used.
+                              type: object
+                              required:
+                              - name
+                              - resource
+                              properties:
+                                name:
+                                  description: Name is the name of the PipelineResource
+                                    as declared by the Task.
+                                  type: string
+                                resource:
+                                  description: Resource is the name of the DeclaredPipelineResource
+                                    to use.
+                                  type: string
+                      retries:
+                        description: 'Retries represents how many times this task
+                          should be retried in case of task failure: ConditionSucceeded
+                          set to False'
+                        type: integer
+                      runAfter:
+                        description: RunAfter is the list of PipelineTask names that
+                          should be executed before this Task executes. (Used to force
+                          a specific ordering in graph execution.)
+                        type: array
+                        items:
+                          type: string
+                      taskRef:
+                        description: TaskRef is a reference to a task definition.
+                        type: object
+                        properties:
+                          apiVersion:
+                            description: API version of the referent
+                            type: string
+                          kind:
+                            description: TaskKind inficates the kind of the task,
+                              namespaced or cluster scoped.
+                            type: string
+                          name:
+                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                            type: string
+            podTemplate:
+              description: PodTemplate holds pod specific configuration
+              type: object
+              properties:
+                affinity:
+                  description: If specified, the pod's scheduling constraints
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            matches the corresponding matchExpressions; the node(s)
+                            with the highest sum are the most preferred.
+                          type: array
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects
+                              (i.e. is also a no-op).
+                            type: object
+                            required:
+                            - preference
+                            - weight
+                            properties:
+                              preference:
+                                description: A node selector term, associated with
+                                  the corresponding weight.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                type: integer
+                                format: int32
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its
+                            node.
+                          type: object
+                          required:
+                          - nodeSelectorTerms
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              type: array
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          type: array
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            type: object
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                type: object
+                                required:
+                                - topologyKey
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        type: array
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          type: object
+                                          required:
+                                          - key
+                                          - operator
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                type: integer
+                                format: int32
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          type: array
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            type: object
+                            required:
+                            - topologyKey
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    type: array
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling anti-affinity
+                            expressions, etc.), compute a sum by iterating through
+                            the elements of this field and adding "weight" to the
+                            sum if the node has pods which matches the corresponding
+                            podAffinityTerm; the node(s) with the highest sum are
+                            the most preferred.
+                          type: array
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            type: object
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                type: object
+                                required:
+                                - topologyKey
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        type: array
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          type: object
+                                          required:
+                                          - key
+                                          - operator
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                type: integer
+                                format: int32
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified
+                            by this field are not met at scheduling time, the pod
+                            will not be scheduled onto the node. If the anti-affinity
+                            requirements specified by this field cease to be met at
+                            some point during pod execution (e.g. due to a pod label
+                            update), the system may or may not try to eventually evict
+                            the pod from its node. When there are multiple elements,
+                            the lists of nodes corresponding to each podAffinityTerm
+                            are intersected, i.e. all terms must be satisfied.
+                          type: array
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            type: object
+                            required:
+                            - topologyKey
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    type: array
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                nodeSelector:
+                  description: 'NodeSelector is a selector which must be true for
+                    the pod to fit on a node. Selector which must match a node''s
+                    labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: object
+                  additionalProperties:
+                    type: string
+                runtimeClassName:
+                  description: 'RuntimeClassName refers to a RuntimeClass object in
+                    the node.k8s.io group, which should be used to run this pod. If
+                    no RuntimeClass resource matches the named class, the pod will
+                    not be run. If unset or empty, the "legacy" RuntimeClass will
+                    be used, which is an implicit class with an empty definition that
+                    uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                    This is a beta feature as of Kubernetes v1.14.'
+                  type: string
+                securityContext:
+                  description: 'SecurityContext holds pod-level security attributes
+                    and common container settings. Optional: Defaults to empty.  See
+                    type description for default values of each field.'
+                  type: object
+                  properties:
+                    fsGroup:
+                      description: "A special supplemental group that applies to all
+                        containers in a pod. Some volume types allow the Kubelet to
+                        change the ownership of that volume to be owned by the pod:
+                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                        is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw---- \n If unset,
+                        the Kubelet will not modify the ownership and permissions
+                        of any volume."
+                      type: integer
+                      format: int64
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence for
+                        that container.
+                      type: integer
+                      format: int64
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                      type: integer
+                      format: int64
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                      type: object
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary
+                        GID.  If unspecified, no groups will be added to any container.
+                      type: array
+                      items:
+                        type: integer
+                        format: int64
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used
+                        for the pod. Pods with unsupported sysctls (by the container
+                        runtime) might fail to launch.
+                      type: array
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        type: object
+                        required:
+                        - name
+                        - value
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                tolerations:
+                  description: If specified, the pod's tolerations.
+                  type: array
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    type: object
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        type: integer
+                        format: int64
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                volumes:
+                  description: 'List of volumes that can be mounted by containers
+                    belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                  type: array
+                  items:
+                    description: Volume represents a named volume in a pod that may
+                      be accessed by any container in the pod.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      awsElasticBlockStore:
+                        description: 'AWSElasticBlockStore represents an AWS Disk
+                          resource that is attached to a kubelet''s host machine and
+                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).'
+                            type: integer
+                            format: int32
+                          readOnly:
+                            description: 'Specify "true" to force and set the ReadOnly
+                              property in VolumeMounts to "true". If omitted, the
+                              default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'Unique ID of the persistent disk resource
+                              in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                      azureDisk:
+                        description: AzureDisk represents an Azure Data Disk mount
+                          on the host and bind mount to the pod.
+                        type: object
+                        required:
+                        - diskName
+                        - diskURI
+                        properties:
+                          cachingMode:
+                            description: 'Host Caching mode: None, Read Only, Read
+                              Write.'
+                            type: string
+                          diskName:
+                            description: The Name of the data disk in the blob storage
+                            type: string
+                          diskURI:
+                            description: The URI the data disk in the blob storage
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'Expected values Shared: multiple blob disks
+                              per storage account  Dedicated: single blob disk per
+                              storage account  Managed: azure managed data disk (only
+                              in managed availability set). defaults to shared'
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                      azureFile:
+                        description: AzureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        type: object
+                        required:
+                        - secretName
+                        - shareName
+                        properties:
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: the name of secret that contains Azure Storage
+                              Account Name and Key
+                            type: string
+                          shareName:
+                            description: Share Name
+                            type: string
+                      cephfs:
+                        description: CephFS represents a Ceph FS mount on the host
+                          that shares a pod's lifetime
+                        type: object
+                        required:
+                        - monitors
+                        properties:
+                          monitors:
+                            description: 'Required: Monitors is a collection of Ceph
+                              monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: array
+                            items:
+                              type: string
+                          path:
+                            description: 'Optional: Used as the mounted root, rather
+                              than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'Optional: SecretFile is the path to key
+                              ring for User, default is /etc/ceph/user.secret More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              authentication secret for User, default is empty. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          user:
+                            description: 'Optional: User is the rados user name, default
+                              is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                      cinder:
+                        description: 'Cinder represents a cinder volume attached and
+                          mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: points to a secret object containing
+                              parameters used to connect to OpenStack.'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          volumeID:
+                            description: 'volume id used to identify the volume in
+                              cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: string
+                      configMap:
+                        description: ConfigMap represents a configMap that should
+                          populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: If unspecified, each key-value pair in the
+                              Data field of the referenced ConfigMap will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the ConfigMap, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                              - key
+                              - path
+                              properties:
+                                key:
+                                  description: The key to project.
+                                  type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: The relative path of the file to map
+                                    the key to. May not be an absolute path. May not
+                                    contain the path element '..'. May not start with
+                                    the string '..'.
+                                  type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap or it's keys
+                              must be defined
+                            type: boolean
+                      downwardAPI:
+                        description: DownwardAPI represents downward API about the
+                          pod that should populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: Items is a list of downward API volume file
+                            type: array
+                            items:
+                              description: DownwardAPIVolumeFile represents information
+                                to create the file containing the pod field
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                fieldRef:
+                                  description: 'Required: Selects a field of the pod:
+                                    only annotations, labels, name and namespace are
+                                    supported.'
+                                  type: object
+                                  required:
+                                  - fieldPath
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: 'Required: Path is  the relative path
+                                    name of the file to be created. Must not be absolute
+                                    or contain the ''..'' path. Must be utf-8 encoded.
+                                    The first item of the relative path must not start
+                                    with ''..'''
+                                  type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, requests.cpu and requests.memory)
+                                    are currently supported.'
+                                  type: object
+                                  required:
+                                  - resource
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      type: string
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                      emptyDir:
+                        description: 'EmptyDir represents a temporary directory that
+                          shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: object
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back
+                              this directory. The default is "" which means to use
+                              the node''s default medium. Must be an empty string
+                              (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit:
+                            description: 'Total amount of local storage required for
+                              this EmptyDir volume. The size limit is also applicable
+                              for memory medium. The maximum usage on memory medium
+                              EmptyDir would be the minimum value between the SizeLimit
+                              specified here and the sum of memory limits of all containers
+                              in a pod. The default is nil which means that the limit
+                              is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                            type: string
+                      fc:
+                        description: FC represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to
+                          the pod.
+                        type: object
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          lun:
+                            description: 'Optional: FC target lun number'
+                            type: integer
+                            format: int32
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'Optional: FC target worldwide names (WWNs)'
+                            type: array
+                            items:
+                              type: string
+                          wwids:
+                            description: 'Optional: FC volume world wide identifiers
+                              (wwids) Either wwids or combination of targetWWNs and
+                              lun must be set, but not both simultaneously.'
+                            type: array
+                            items:
+                              type: string
+                      flexVolume:
+                        description: FlexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        type: object
+                        required:
+                        - driver
+                        properties:
+                          driver:
+                            description: Driver is the name of the driver to use for
+                              this volume.
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". The default filesystem depends on FlexVolume
+                              script.
+                            type: string
+                          options:
+                            description: 'Optional: Extra command options if any.'
+                            type: object
+                            additionalProperties:
+                              type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              secret object containing sensitive information to pass
+                              to the plugin scripts. This may be empty if no secret
+                              object is specified. If the secret object contains more
+                              than one secret, all secrets are passed to the plugin
+                              scripts.'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                      flocker:
+                        description: Flocker represents a Flocker volume attached
+                          to a kubelet's host machine. This depends on the Flocker
+                          control service being running
+                        type: object
+                        properties:
+                          datasetName:
+                            description: Name of the dataset stored as metadata ->
+                              name on the dataset for Flocker should be considered
+                              as deprecated
+                            type: string
+                          datasetUUID:
+                            description: UUID of the dataset. This is unique identifier
+                              of a Flocker dataset
+                            type: string
+                      gcePersistentDisk:
+                        description: 'GCEPersistentDisk represents a GCE Disk resource
+                          that is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: object
+                        required:
+                        - pdName
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: integer
+                            format: int32
+                          pdName:
+                            description: 'Unique name of the PD resource in GCE. Used
+                              to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                      gitRepo:
+                        description: 'GitRepo represents a git repository at a particular
+                          revision. DEPRECATED: GitRepo is deprecated. To provision
+                          a container with a git repo, mount an EmptyDir into an InitContainer
+                          that clones the repo using git, then mount the EmptyDir
+                          into the Pod''s container.'
+                        type: object
+                        required:
+                        - repository
+                        properties:
+                          directory:
+                            description: Target directory name. Must not contain or
+                              start with '..'.  If '.' is supplied, the volume directory
+                              will be the git repository.  Otherwise, if specified,
+                              the volume will contain the git repository in the subdirectory
+                              with the given name.
+                            type: string
+                          repository:
+                            description: Repository URL
+                            type: string
+                          revision:
+                            description: Commit hash for the specified revision.
+                            type: string
+                      glusterfs:
+                        description: 'Glusterfs represents a Glusterfs mount on the
+                          host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md'
+                        type: object
+                        required:
+                        - endpoints
+                        - path
+                        properties:
+                          endpoints:
+                            description: 'EndpointsName is the endpoint name that
+                              details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'Path is the Glusterfs volume path. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the Glusterfs volume
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                      hostPath:
+                        description: 'HostPath represents a pre-existing file or directory
+                          on the host machine that is directly exposed to the container.
+                          This is generally used for system agents or other privileged
+                          things that are allowed to see the host machine. Most containers
+                          will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          --- TODO(jonesdl) We need to restrict who can use host directory
+                          mounts and who can/can not mount host directories as read/write.'
+                        type: object
+                        required:
+                        - path
+                        properties:
+                          path:
+                            description: 'Path of the directory on the host. If the
+                              path is a symlink, it will follow the link to the real
+                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'Type for HostPath Volume Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                      iscsi:
+                        description: 'ISCSI represents an ISCSI Disk resource that
+                          is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md'
+                        type: object
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        properties:
+                          chapAuthDiscovery:
+                            description: whether support iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: whether support iSCSI Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          initiatorName:
+                            description: Custom iSCSI Initiator Name. If initiatorName
+                              is specified with iscsiInterface simultaneously, new
+                              iSCSI interface <target portal>:<volume name> will be
+                              created for the connection.
+                            type: string
+                          iqn:
+                            description: Target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iSCSI Interface Name that uses an iSCSI transport.
+                              Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: iSCSI Target Lun number.
+                            type: integer
+                            format: int32
+                          portals:
+                            description: iSCSI Target Portal List. The portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: array
+                            items:
+                              type: string
+                          readOnly:
+                            description: ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: CHAP Secret for iSCSI target and initiator
+                              authentication
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          targetPortal:
+                            description: iSCSI Target Portal. The Portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: string
+                      name:
+                        description: 'Volume''s name. Must be a DNS_LABEL and unique
+                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      nfs:
+                        description: 'NFS represents an NFS mount on the host that
+                          shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: object
+                        required:
+                        - path
+                        - server
+                        properties:
+                          path:
+                            description: 'Path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the NFS export
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'Server is the hostname or IP address of
+                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                      persistentVolumeClaim:
+                        description: 'PersistentVolumeClaimVolumeSource represents
+                          a reference to a PersistentVolumeClaim in the same namespace.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: object
+                        required:
+                        - claimName
+                        properties:
+                          claimName:
+                            description: 'ClaimName is the name of a PersistentVolumeClaim
+                              in the same namespace as the pod using this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            type: string
+                          readOnly:
+                            description: Will force the ReadOnly setting in VolumeMounts.
+                              Default false.
+                            type: boolean
+                      photonPersistentDisk:
+                        description: PhotonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - pdID
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: ID that identifies Photon Controller persistent
+                              disk
+                            type: string
+                      portworxVolume:
+                        description: PortworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: FSType represents the filesystem type to
+                              mount Must be a filesystem type supported by the host
+                              operating system. Ex. "ext4", "xfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: VolumeID uniquely identifies a Portworx volume
+                            type: string
+                      projected:
+                        description: Items for all in one resources secrets, configmaps,
+                          and downward API
+                        type: object
+                        required:
+                        - sources
+                        properties:
+                          defaultMode:
+                            description: Mode bits to use on created files by default.
+                              Must be a value between 0 and 0777. Directories within
+                              the path are not affected by this setting. This might
+                              be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode
+                              bits set.
+                            type: integer
+                            format: int32
+                          sources:
+                            description: list of volume projections
+                            type: array
+                            items:
+                              description: Projection that may be projected along
+                                with other supported volume types
+                              type: object
+                              properties:
+                                configMap:
+                                  description: information about the configMap data
+                                    to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced ConfigMap
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the ConfigMap, the
+                                        volume setup will error unless it is marked
+                                        optional. Paths must be relative and may not
+                                        contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        type: object
+                                        required:
+                                        - key
+                                        - path
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path. May not contain the path
+                                              element '..'. May not start with the
+                                              string '..'.
+                                            type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        it's keys must be defined
+                                      type: boolean
+                                downwardAPI:
+                                  description: information about the downwardAPI data
+                                    to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume
+                                        file
+                                      type: array
+                                      items:
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
+                                        type: object
+                                        required:
+                                        - path
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field
+                                              of the pod: only annotations, labels,
+                                              name and namespace are supported.'
+                                            type: object
+                                            required:
+                                            - fieldPath
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: 'Required: Path is  the relative
+                                              path name of the file to be created.
+                                              Must not be absolute or contain the
+                                              ''..'' path. Must be utf-8 encoded.
+                                              The first item of the relative path
+                                              must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.memory,
+                                              requests.cpu and requests.memory) are
+                                              currently supported.'
+                                            type: object
+                                            required:
+                                            - resource
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                type: string
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                secret:
+                                  description: information about the secret data to
+                                    project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced Secret
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the Secret, the volume
+                                        setup will error unless it is marked optional.
+                                        Paths must be relative and may not contain
+                                        the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        type: object
+                                        required:
+                                        - key
+                                        - path
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path. May not contain the path
+                                              element '..'. May not start with the
+                                              string '..'.
+                                            type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                serviceAccountToken:
+                                  description: information about the serviceAccountToken
+                                    data to project
+                                  type: object
+                                  required:
+                                  - path
+                                  properties:
+                                    audience:
+                                      description: Audience is the intended audience
+                                        of the token. A recipient of a token must
+                                        identify itself with an identifier specified
+                                        in the audience of the token, and otherwise
+                                        should reject the token. The audience defaults
+                                        to the identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: ExpirationSeconds is the requested
+                                        duration of validity of the service account
+                                        token. As the token approaches expiration,
+                                        the kubelet volume plugin will proactively
+                                        rotate the service account token. The kubelet
+                                        will start trying to rotate the token if the
+                                        token is older than 80 percent of its time
+                                        to live or if the token is older than 24 hours.Defaults
+                                        to 1 hour and must be at least 10 minutes.
+                                      type: integer
+                                      format: int64
+                                    path:
+                                      description: Path is the path relative to the
+                                        mount point of the file to project the token
+                                        into.
+                                      type: string
+                      quobyte:
+                        description: Quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        type: object
+                        required:
+                        - registry
+                        - volume
+                        properties:
+                          group:
+                            description: Group to map volume access to Default is
+                              no group
+                            type: string
+                          readOnly:
+                            description: ReadOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: Registry represents a single or multiple
+                              Quobyte Registry services specified as a string as host:port
+                              pair (multiple entries are separated with commas) which
+                              acts as the central registry for volumes
+                            type: string
+                          user:
+                            description: User to map volume access to Defaults to
+                              serivceaccount user
+                            type: string
+                          volume:
+                            description: Volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                      rbd:
+                        description: 'RBD represents a Rados Block Device mount on
+                          the host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md'
+                        type: object
+                        required:
+                        - image
+                        - monitors
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          image:
+                            description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'Keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'A collection of Ceph monitors. More info:
+                              https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: array
+                            items:
+                              type: string
+                          pool:
+                            description: 'The rados pool name. Default is rbd. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'SecretRef is name of the authentication
+                              secret for RBDUser. If provided overrides keyring. Default
+                              is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          user:
+                            description: 'The rados user name. Default is admin. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                      scaleIO:
+                        description: ScaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        type: object
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Default is "xfs".
+                            type: string
+                          gateway:
+                            description: The host address of the ScaleIO API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: The name of the ScaleIO Protection Domain
+                              for the configured storage.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not
+                              provided, Login operation will fail.
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          sslEnabled:
+                            description: Flag to enable/disable SSL communication
+                              with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: Indicates whether the storage for a volume
+                              should be ThickProvisioned or ThinProvisioned. Default
+                              is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: The ScaleIO Storage Pool associated with
+                              the protection domain.
+                            type: string
+                          system:
+                            description: The name of the storage system as configured
+                              in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: The name of a volume already created in the
+                              ScaleIO system that is associated with this volume source.
+                            type: string
+                      secret:
+                        description: 'Secret represents a secret that should populate
+                          this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: If unspecified, each key-value pair in the
+                              Data field of the referenced Secret will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the Secret, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                              - key
+                              - path
+                              properties:
+                                key:
+                                  description: The key to project.
+                                  type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: The relative path of the file to map
+                                    the key to. May not be an absolute path. May not
+                                    contain the path element '..'. May not start with
+                                    the string '..'.
+                                  type: string
+                          optional:
+                            description: Specify whether the Secret or it's keys must
+                              be defined
+                            type: boolean
+                          secretName:
+                            description: 'Name of the secret in the pod''s namespace
+                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            type: string
+                      storageos:
+                        description: StorageOS represents a StorageOS volume attached
+                          and mounted on Kubernetes nodes.
+                        type: object
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef specifies the secret to use for
+                              obtaining the StorageOS API credentials.  If not specified,
+                              default values will be attempted.
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          volumeName:
+                            description: VolumeName is the human-readable name of
+                              the StorageOS volume.  Volume names are only unique
+                              within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: VolumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows
+                              the Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name
+                              to override the default behaviour. Set to "default"
+                              if you are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                      vsphereVolume:
+                        description: VsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - volumePath
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: Storage Policy Based Management (SPBM) profile
+                              ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: Storage Policy Based Management (SPBM) profile
+                              name.
+                            type: string
+                          volumePath:
+                            description: Path that identifies vSphere volume vmdk
+                            type: string
+            resources:
+              description: Resources is a list of bindings specifying which actual
+                instances of PipelineResources to use for the resources the Pipeline
+                has declared it needs.
+              type: array
+              items:
+                description: PipelineResourceBinding connects a reference to an instance
+                  of a PipelineResource with a PipelineResource dependency that the
+                  Pipeline has declared
+                type: object
+                properties:
+                  name:
+                    description: Name is the name of the PipelineResource in the Pipeline's
+                      declaration
+                    type: string
+                  resourceRef:
+                    description: ResourceRef is a reference to the instance of the
+                      actual PipelineResource that should be used
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      name:
+                        description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                  resourceSpec:
+                    description: ResourceSpec is specification of a resource that
+                      should be created and consumed by the task
+                    type: object
+                    required:
+                    - params
+                    - type
+                    properties:
+                      params:
+                        type: array
+                        items:
+                          description: ResourceParam declares a string value to use
+                            for the parameter called Name, and is used in the specific
+                            context of PipelineResources.
+                          type: object
+                          required:
+                          - name
+                          - value
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                      secrets:
+                        description: Secrets to fetch to populate some of resource
+                          fields
+                        type: array
+                        items:
+                          description: SecretParam indicates which secret can be used
+                            to populate a field of the resource
+                          type: object
+                          required:
+                          - fieldName
+                          - secretKey
+                          - secretName
+                          properties:
+                            fieldName:
+                              type: string
+                            secretKey:
+                              type: string
+                            secretName:
+                              type: string
+                      type:
+                        description: PipelineResourceType represents the type of endpoint
+                          the pipelineResource is, so that the controller will know
+                          this pipelineResource should be fetched and optionally what
+                          additional metatdata should be provided for it.
+                        type: string
+            serviceAccountName:
+              type: string
+            serviceAccountNames:
+              type: array
+              items:
+                description: PipelineRunSpecServiceAccountName can be used to configure
+                  specific ServiceAccountName for a concrete Task
+                type: object
+                properties:
+                  serviceAccountName:
+                    type: string
+                  taskName:
+                    type: string
+            status:
+              description: Used for cancelling a pipelinerun (and maybe more later
+                on)
+              type: string
+            timeout:
+              description: 'Time after which the Pipeline times out. Defaults to never.
+                Refer to Go''s ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration'
+              type: string
+        status:
+          description: PipelineRunStatus defines the observed state of PipelineRun
+          type: object
+          properties:
+            completionTime:
+              description: CompletionTime is the time the PipelineRun completed.
+              type: string
+              format: date-time
+            conditions:
+              $ref: '#/definitions/knative.dev~1pkg~1apis~0Conditions'
+              description: Conditions the latest available observations of a resource's
+                current state.
+            observedGeneration:
+              description: ObservedGeneration is the 'Generation' of the Service that
+                was last processed by the controller.
+              type: integer
+              format: int64
+            startTime:
+              description: StartTime is the time the PipelineRun is actually started.
+              type: string
+              format: date-time
+            taskRuns:
+              description: map of PipelineRunTaskRunStatus with the taskRun name as
+                the key

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -29,3 +29,72 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: PipelineResource describes a resource that is an input to or output
+        from a Task.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec holds the desired state of the PipelineResource from the
+            client
+          type: object
+          required:
+          - params
+          - type
+          properties:
+            params:
+              type: array
+              items:
+                description: ResourceParam declares a string value to use for the
+                  parameter called Name, and is used in the specific context of PipelineResources.
+                type: object
+                required:
+                - name
+                - value
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+            secrets:
+              description: Secrets to fetch to populate some of resource fields
+              type: array
+              items:
+                description: SecretParam indicates which secret can be used to populate
+                  a field of the resource
+                type: object
+                required:
+                - fieldName
+                - secretKey
+                - secretName
+                properties:
+                  fieldName:
+                    type: string
+                  secretKey:
+                    type: string
+                  secretName:
+                    type: string
+            type:
+              description: PipelineResourceType represents the type of endpoint the
+                pipelineResource is, so that the controller will know this pipelineResource
+                should be fetched and optionally what additional metatdata should
+                be provided for it.
+              type: string
+        status:
+          description: Status is deprecated. It usually is used to communicate the
+            observed state of the PipelineResource from the controller, but was unused
+            as there is no controller for PipelineResource.
+          type: object

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -29,3 +29,3052 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: Task represents a collection of sequential steps that are run as
+        part of a Pipeline using a set of inputs and producing a set of outputs. Tasks
+        execute when TaskRuns are created that provide the input parameters and resources
+        and output resources the Task requires.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec holds the desired state of the Task from the client
+          type: object
+          properties:
+            inputs:
+              description: Inputs is an optional set of parameters and resources which
+                must be supplied by the user when a Task is executed by a TaskRun.
+              type: object
+              properties:
+                params:
+                  description: Params is a list of input parameters required to run
+                    the task. Params must be supplied as inputs in TaskRuns unless
+                    they declare a default value.
+                  type: array
+                  items:
+                    description: ParamSpec defines arbitrary parameters needed beyond
+                      typed inputs (such as resources). Parameter values are provided
+                      by users as inputs on a TaskRun or PipelineRun.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      default:
+                        description: Default is the value a parameter takes if no
+                          input value is supplied. If default is set, a Task may be
+                          executed without a supplied value for the parameter.
+                        type: object
+                        required:
+                        - type
+                        properties:
+                          type:
+                            description: ParamType indicates the type of an input
+                              parameter; Used to distinguish between a single string
+                              and an array of strings.
+                            type: string
+                      description:
+                        description: Description is a user-facing description of the
+                          parameter that may be used to populate a UI.
+                        type: string
+                      name:
+                        description: Name declares the name by which a parameter is
+                          referenced.
+                        type: string
+                      type:
+                        description: Type is the user-specified type of the parameter.
+                          The possible types are currently "string" and "array", and
+                          "string" is the default.
+                        type: string
+                resources:
+                  description: Resources is a list of the input resources required
+                    to run the task. Resources are represented in TaskRuns as bindings
+                    to instances of PipelineResources.
+                  type: array
+                  items:
+                    description: TaskResource defines an input or output Resource
+                      declared as a requirement by a Task. The Name field will be
+                      used to refer to these Resources within the Task definition,
+                      and when provided as an Input, the Name will be the path to
+                      the volume mounted containing this Resource as an input (e.g.
+                      an input Resource named `workspace` will be mounted at `/workspace`).
+                    type: object
+                    required:
+                    - name
+                    - type
+                    properties:
+                      name:
+                        description: Name declares the name by which a resource is
+                          referenced in the definition. Resources may be referenced
+                          by name in the definition of a Task's steps.
+                        type: string
+                      optional:
+                        description: 'Optional declares the resource as optional.
+                          By default optional is set to false which makes a resource
+                          required. optional: true - the resource is considered optional
+                          optional: false - the resource is considered required (equivalent
+                          of not specifying it)'
+                        type: boolean
+                      targetPath:
+                        description: TargetPath is the path in workspace directory
+                          where the resource will be copied.
+                        type: string
+                      type:
+                        description: Type is the type of this resource;
+                        type: string
+            outputs:
+              description: Outputs is an optional set of resources and results produced
+                when this Task is run.
+              type: object
+              properties:
+                resources:
+                  type: array
+                  items:
+                    description: TaskResource defines an input or output Resource
+                      declared as a requirement by a Task. The Name field will be
+                      used to refer to these Resources within the Task definition,
+                      and when provided as an Input, the Name will be the path to
+                      the volume mounted containing this Resource as an input (e.g.
+                      an input Resource named `workspace` will be mounted at `/workspace`).
+                    type: object
+                    required:
+                    - name
+                    - type
+                    properties:
+                      name:
+                        description: Name declares the name by which a resource is
+                          referenced in the definition. Resources may be referenced
+                          by name in the definition of a Task's steps.
+                        type: string
+                      optional:
+                        description: 'Optional declares the resource as optional.
+                          By default optional is set to false which makes a resource
+                          required. optional: true - the resource is considered optional
+                          optional: false - the resource is considered required (equivalent
+                          of not specifying it)'
+                        type: boolean
+                      targetPath:
+                        description: TargetPath is the path in workspace directory
+                          where the resource will be copied.
+                        type: string
+                      type:
+                        description: Type is the type of this resource;
+                        type: string
+                results:
+                  type: array
+                  items:
+                    description: TestResult allows a task to specify the location
+                      where test logs can be found and what format they will be in.
+                    type: object
+                    required:
+                    - format
+                    - name
+                    - path
+                    properties:
+                      format:
+                        description: 'TODO: maybe this is an enum with types like
+                          "go test", "junit", etc.'
+                        type: string
+                      name:
+                        description: Name declares the name by which a result is referenced
+                          in the Task's definition. Results may be referenced by name
+                          in the definition of a Task's steps.
+                        type: string
+                      path:
+                        type: string
+            sidecars:
+              description: Sidecars are run alongside the Task's step containers.
+                They begin before the steps start and end after the steps complete.
+              type: array
+              items:
+                description: A single application container that you want to run within
+                  a pod.
+                type: object
+                required:
+                - name
+                properties:
+                  args:
+                    description: 'Arguments to the entrypoint. The docker image''s
+                      CMD is used if this is not provided. Variable references $(VAR_NAME)
+                      are expanded using the container''s environment. If a variable
+                      cannot be resolved, the reference in the input string will be
+                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                      regardless of whether the variable exists or not. Cannot be
+                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    type: array
+                    items:
+                      type: string
+                  command:
+                    description: 'Entrypoint array. Not executed within a shell. The
+                      docker image''s ENTRYPOINT is used if this is not provided.
+                      Variable references $(VAR_NAME) are expanded using the container''s
+                      environment. If a variable cannot be resolved, the reference
+                      in the input string will be unchanged. The $(VAR_NAME) syntax
+                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                      will never be expanded, regardless of whether the variable exists
+                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                    type: array
+                    items:
+                      type: string
+                  env:
+                    description: List of environment variables to set in the container.
+                      Cannot be updated.
+                    type: array
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      type: object
+                      required:
+                      - name
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          type: object
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              type: object
+                              required:
+                              - key
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    key must be defined
+                                  type: boolean
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, metadata.labels, metadata.annotations,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP.'
+                              type: object
+                              required:
+                              - fieldPath
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              type: object
+                              required:
+                              - resource
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              type: object
+                              required:
+                              - key
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
+                                  type: boolean
+                  envFrom:
+                    description: List of sources to populate environment variables
+                      in the container. The keys defined within a source must be a
+                      C_IDENTIFIER. All invalid keys will be reported as an event
+                      when the container is starting. When a key exists in multiple
+                      sources, the value associated with the last source will take
+                      precedence. Values defined by an Env with a duplicate key will
+                      take precedence. Cannot be updated.
+                    type: array
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps
+                      type: object
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          type: object
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                        prefix:
+                          description: An optional identifier to prepend to each key
+                            in the ConfigMap. Must be a C_IDENTIFIER.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          type: object
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                  image:
+                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                      This field is optional to allow higher level config management
+                      to default or override container images in workload controllers
+                      like Deployments and StatefulSets.'
+                    type: string
+                  imagePullPolicy:
+                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                      Defaults to Always if :latest tag is specified, or IfNotPresent
+                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                    type: string
+                  lifecycle:
+                    description: Actions that the management system should take in
+                      response to container lifecycle events. Cannot be updated.
+                    type: object
+                    properties:
+                      postStart:
+                        description: 'PostStart is called immediately after a container
+                          is created. If the handler fails, the container is terminated
+                          and restarted according to its restart policy. Other management
+                          of the container blocks until the hook completes. More info:
+                          https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        type: object
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  type: object
+                                  required:
+                                  - name
+                                  - value
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                      preStop:
+                        description: 'PreStop is called immediately before a container
+                          is terminated. The container is terminated after the handler
+                          completes. The reason for termination is passed to the handler.
+                          Regardless of the outcome of the handler, the container
+                          is eventually terminated. Other management of the container
+                          blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        type: object
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  type: object
+                                  required:
+                                  - name
+                                  - value
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                  livenessProbe:
+                    description: 'Periodic probe of container liveness. Container
+                      will be restarted if the probe fails. Cannot be updated. More
+                      info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    type: object
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        type: object
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            type: array
+                            items:
+                              type: string
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            type: array
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              type: object
+                              required:
+                              - name
+                              - value
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                  name:
+                    description: Name of the container specified as a DNS_LABEL. Each
+                      container in a pod must have a unique name (DNS_LABEL). Cannot
+                      be updated.
+                    type: string
+                  ports:
+                    description: List of ports to expose from the container. Exposing
+                      a port here gives the system additional information about the
+                      network connections a container uses, but is primarily informational.
+                      Not specifying a port here DOES NOT prevent that port from being
+                      exposed. Any port which is listening on the default "0.0.0.0"
+                      address inside a container will be accessible from the network.
+                      Cannot be updated.
+                    type: array
+                    items:
+                      description: ContainerPort represents a network port in a single
+                        container.
+                      type: object
+                      required:
+                      - containerPort
+                      properties:
+                        containerPort:
+                          description: Number of port to expose on the pod's IP address.
+                            This must be a valid port number, 0 < x < 65536.
+                          type: integer
+                          format: int32
+                        hostIP:
+                          description: What host IP to bind the external port to.
+                          type: string
+                        hostPort:
+                          description: Number of port to expose on the host. If specified,
+                            this must be a valid port number, 0 < x < 65536. If HostNetwork
+                            is specified, this must match ContainerPort. Most containers
+                            do not need this.
+                          type: integer
+                          format: int32
+                        name:
+                          description: If specified, this must be an IANA_SVC_NAME
+                            and unique within the pod. Each named port in a pod must
+                            have a unique name. Name for the port that can be referred
+                            to by services.
+                          type: string
+                        protocol:
+                          description: Protocol for port. Must be UDP, TCP, or SCTP.
+                            Defaults to "TCP".
+                          type: string
+                  readinessProbe:
+                    description: 'Periodic probe of container service readiness. Container
+                      will be removed from service endpoints if the probe fails. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    type: object
+                    properties:
+                      exec:
+                        description: One and only one of the following should be specified.
+                          Exec specifies the action to take.
+                        type: object
+                        properties:
+                          command:
+                            description: Command is the command line to execute inside
+                              the container, the working directory for the command  is
+                              root ('/') in the container's filesystem. The command
+                              is simply exec'd, it is not run inside a shell, so traditional
+                              shell instructions ('|', etc) won't work. To use a shell,
+                              you need to explicitly call out to that shell. Exit
+                              status of 0 is treated as live/healthy and non-zero
+                              is unhealthy.
+                            type: array
+                            items:
+                              type: string
+                      failureThreshold:
+                        description: Minimum consecutive failures for the probe to
+                          be considered failed after having succeeded. Defaults to
+                          3. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      httpGet:
+                        description: HTTPGet specifies the http request to perform.
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: Host name to connect to, defaults to the
+                              pod IP. You probably want to set "Host" in httpHeaders
+                              instead.
+                            type: string
+                          httpHeaders:
+                            description: Custom headers to set in the request. HTTP
+                              allows repeated headers.
+                            type: array
+                            items:
+                              description: HTTPHeader describes a custom header to
+                                be used in HTTP probes
+                              type: object
+                              required:
+                              - name
+                              - value
+                              properties:
+                                name:
+                                  description: The header field name
+                                  type: string
+                                value:
+                                  description: The header field value
+                                  type: string
+                          path:
+                            description: Path to access on the HTTP server.
+                            type: string
+                          port:
+                            description: Name or number of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                          scheme:
+                            description: Scheme to use for connecting to the host.
+                              Defaults to HTTP.
+                            type: string
+                      initialDelaySeconds:
+                        description: 'Number of seconds after the container has started
+                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                      periodSeconds:
+                        description: How often (in seconds) to perform the probe.
+                          Default to 10 seconds. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      successThreshold:
+                        description: Minimum consecutive successes for the probe to
+                          be considered successful after having failed. Defaults to
+                          1. Must be 1 for liveness. Minimum value is 1.
+                        type: integer
+                        format: int32
+                      tcpSocket:
+                        description: 'TCPSocket specifies an action involving a TCP
+                          port. TCP hooks not yet supported TODO: implement a realistic
+                          TCP lifecycle hook'
+                        type: object
+                        required:
+                        - port
+                        properties:
+                          host:
+                            description: 'Optional: Host name to connect to, defaults
+                              to the pod IP.'
+                            type: string
+                          port:
+                            description: Number or name of the port to access on the
+                              container. Number must be in the range 1 to 65535. Name
+                              must be an IANA_SVC_NAME.
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            x-kubernetes-int-or-string: true
+                      timeoutSeconds:
+                        description: 'Number of seconds after which the probe times
+                          out. Defaults to 1 second. Minimum value is 1. More info:
+                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: integer
+                        format: int32
+                  resources:
+                    description: 'Compute Resources required by this container. Cannot
+                      be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                    properties:
+                      limits:
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        additionalProperties:
+                          type: string
+                      requests:
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        additionalProperties:
+                          type: string
+                  securityContext:
+                    description: 'Security options the pod should run with. More info:
+                      https://kubernetes.io/docs/concepts/policy/security-context/
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                    type: object
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: 'AllowPrivilegeEscalation controls whether a
+                          process can gain more privileges than its parent process.
+                          This bool directly controls if the no_new_privs flag will
+                          be set on the container process. AllowPrivilegeEscalation
+                          is true always when the container is: 1) run as Privileged
+                          2) has CAP_SYS_ADMIN'
+                        type: boolean
+                      capabilities:
+                        description: The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the
+                          container runtime.
+                        type: object
+                        properties:
+                          add:
+                            description: Added capabilities
+                            type: array
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                          drop:
+                            description: Removed capabilities
+                            type: array
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                      privileged:
+                        description: Run container in privileged mode. Processes in
+                          privileged containers are essentially equivalent to root
+                          on the host. Defaults to false.
+                        type: boolean
+                      procMount:
+                        description: procMount denotes the type of proc mount to use
+                          for the containers. The default is DefaultProcMount which
+                          uses the container runtime defaults for readonly paths and
+                          masked paths. This requires the ProcMountType feature flag
+                          to be enabled.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: Whether this container has a read-only root filesystem.
+                          Default is false.
+                        type: boolean
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set
+                          in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        type: integer
+                        format: int64
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail
+                          to start the container if it does. If unset or false, no
+                          such validation will be performed. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if
+                          unspecified. May also be set in PodSecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the
+                          value specified in SecurityContext takes precedence.
+                        type: integer
+                        format: int64
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in
+                          PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext
+                          takes precedence.
+                        type: object
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                  stdin:
+                    description: Whether this container should allocate a buffer for
+                      stdin in the container runtime. If this is not set, reads from
+                      stdin in the container will always result in EOF. Default is
+                      false.
+                    type: boolean
+                  stdinOnce:
+                    description: Whether the container runtime should close the stdin
+                      channel after it has been opened by a single attach. When stdin
+                      is true the stdin stream will remain open across multiple attach
+                      sessions. If stdinOnce is set to true, stdin is opened on container
+                      start, is empty until the first client attaches to stdin, and
+                      then remains open and accepts data until the client disconnects,
+                      at which time stdin is closed and remains closed until the container
+                      is restarted. If this flag is false, a container processes that
+                      reads from stdin will never receive an EOF. Default is false
+                    type: boolean
+                  terminationMessagePath:
+                    description: 'Optional: Path at which the file to which the container''s
+                      termination message will be written is mounted into the container''s
+                      filesystem. Message written is intended to be brief final status,
+                      such as an assertion failure message. Will be truncated by the
+                      node if greater than 4096 bytes. The total message length across
+                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                      Cannot be updated.'
+                    type: string
+                  terminationMessagePolicy:
+                    description: Indicate how the termination message should be populated.
+                      File will use the contents of terminationMessagePath to populate
+                      the container status message on both success and failure. FallbackToLogsOnError
+                      will use the last chunk of container log output if the termination
+                      message file is empty and the container exited with an error.
+                      The log output is limited to 2048 bytes or 80 lines, whichever
+                      is smaller. Defaults to File. Cannot be updated.
+                    type: string
+                  tty:
+                    description: Whether this container should allocate a TTY for
+                      itself, also requires 'stdin' to be true. Default is false.
+                    type: boolean
+                  volumeDevices:
+                    description: volumeDevices is the list of block devices to be
+                      used by the container. This is a beta feature.
+                    type: array
+                    items:
+                      description: volumeDevice describes a mapping of a raw block
+                        device within a container.
+                      type: object
+                      required:
+                      - devicePath
+                      - name
+                      properties:
+                        devicePath:
+                          description: devicePath is the path inside of the container
+                            that the device will be mapped to.
+                          type: string
+                        name:
+                          description: name must match the name of a persistentVolumeClaim
+                            in the pod
+                          type: string
+                  volumeMounts:
+                    description: Pod volumes to mount into the container's filesystem.
+                      Cannot be updated.
+                    type: array
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within
+                        a container.
+                      type: object
+                      required:
+                      - mountPath
+                      - name
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume
+                            should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are
+                            propagated from the host to container and the other way
+                            around. When not set, MountPropagationNone is used. This
+                            field is beta in 1.10.
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise
+                            (false or unspecified). Defaults to false.
+                          type: boolean
+                        subPath:
+                          description: Path within the volume from which the container's
+                            volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                  workingDir:
+                    description: Container's working directory. If not specified,
+                      the container runtime's default will be used, which might be
+                      configured in the container image. Cannot be updated.
+                    type: string
+            stepTemplate:
+              description: StepTemplate can be used as the basis for all step containers
+                within the Task, so that the steps inherit settings on the base container.
+              type: object
+              required:
+              - name
+              properties:
+                args:
+                  description: 'Arguments to the entrypoint. The docker image''s CMD
+                    is used if this is not provided. Variable references $(VAR_NAME)
+                    are expanded using the container''s environment. If a variable
+                    cannot be resolved, the reference in the input string will be
+                    unchanged. The $(VAR_NAME) syntax can be escaped with a double
+                    $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
+                    regardless of whether the variable exists or not. Cannot be updated.
+                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  type: array
+                  items:
+                    type: string
+                command:
+                  description: 'Entrypoint array. Not executed within a shell. The
+                    docker image''s ENTRYPOINT is used if this is not provided. Variable
+                    references $(VAR_NAME) are expanded using the container''s environment.
+                    If a variable cannot be resolved, the reference in the input string
+                    will be unchanged. The $(VAR_NAME) syntax can be escaped with
+                    a double $$, ie: $$(VAR_NAME). Escaped references will never be
+                    expanded, regardless of whether the variable exists or not. Cannot
+                    be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                  type: array
+                  items:
+                    type: string
+                env:
+                  description: List of environment variables to set in the container.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        type: object
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or it's
+                                  key must be defined
+                                type: boolean
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, metadata.labels, metadata.annotations,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP.'
+                            type: object
+                            required:
+                            - fieldPath
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            type: object
+                            required:
+                            - resource
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                type: string
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            type: object
+                            required:
+                            - key
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or it's key
+                                  must be defined
+                                type: boolean
+                envFrom:
+                  description: List of sources to populate environment variables in
+                    the container. The keys defined within a source must be a C_IDENTIFIER.
+                    All invalid keys will be reported as an event when the container
+                    is starting. When a key exists in multiple sources, the value
+                    associated with the last source will take precedence. Values defined
+                    by an Env with a duplicate key will take precedence. Cannot be
+                    updated.
+                  type: array
+                  items:
+                    description: EnvFromSource represents the source of a set of ConfigMaps
+                    type: object
+                    properties:
+                      configMapRef:
+                        description: The ConfigMap to select from
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap must be defined
+                            type: boolean
+                      prefix:
+                        description: An optional identifier to prepend to each key
+                          in the ConfigMap. Must be a C_IDENTIFIER.
+                        type: string
+                      secretRef:
+                        description: The Secret to select from
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret must be defined
+                            type: boolean
+                image:
+                  description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                    This field is optional to allow higher level config management
+                    to default or override container images in workload controllers
+                    like Deployments and StatefulSets.'
+                  type: string
+                imagePullPolicy:
+                  description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                    Defaults to Always if :latest tag is specified, or IfNotPresent
+                    otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                  type: string
+                lifecycle:
+                  description: Actions that the management system should take in response
+                    to container lifecycle events. Cannot be updated.
+                  type: object
+                  properties:
+                    postStart:
+                      description: 'PostStart is called immediately after a container
+                        is created. If the handler fails, the container is terminated
+                        and restarted according to its restart policy. Other management
+                        of the container blocks until the hook completes. More info:
+                        https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                    preStop:
+                      description: 'PreStop is called immediately before a container
+                        is terminated. The container is terminated after the handler
+                        completes. The reason for termination is passed to the handler.
+                        Regardless of the outcome of the handler, the container is
+                        eventually terminated. Other management of the container blocks
+                        until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                livenessProbe:
+                  description: 'Periodic probe of container liveness. Container will
+                    be restarted if the probe fails. Cannot be updated. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  type: object
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      type: object
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          type: array
+                          items:
+                            type: string
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      type: integer
+                      format: int32
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          type: array
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP
+                        port. TCP hooks not yet supported TODO: implement a realistic
+                        TCP lifecycle hook'
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                name:
+                  description: Name of the container specified as a DNS_LABEL. Each
+                    container in a pod must have a unique name (DNS_LABEL). Cannot
+                    be updated.
+                  type: string
+                ports:
+                  description: List of ports to expose from the container. Exposing
+                    a port here gives the system additional information about the
+                    network connections a container uses, but is primarily informational.
+                    Not specifying a port here DOES NOT prevent that port from being
+                    exposed. Any port which is listening on the default "0.0.0.0"
+                    address inside a container will be accessible from the network.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: ContainerPort represents a network port in a single
+                      container.
+                    type: object
+                    required:
+                    - containerPort
+                    properties:
+                      containerPort:
+                        description: Number of port to expose on the pod's IP address.
+                          This must be a valid port number, 0 < x < 65536.
+                        type: integer
+                        format: int32
+                      hostIP:
+                        description: What host IP to bind the external port to.
+                        type: string
+                      hostPort:
+                        description: Number of port to expose on the host. If specified,
+                          this must be a valid port number, 0 < x < 65536. If HostNetwork
+                          is specified, this must match ContainerPort. Most containers
+                          do not need this.
+                        type: integer
+                        format: int32
+                      name:
+                        description: If specified, this must be an IANA_SVC_NAME and
+                          unique within the pod. Each named port in a pod must have
+                          a unique name. Name for the port that can be referred to
+                          by services.
+                        type: string
+                      protocol:
+                        description: Protocol for port. Must be UDP, TCP, or SCTP.
+                          Defaults to "TCP".
+                        type: string
+                readinessProbe:
+                  description: 'Periodic probe of container service readiness. Container
+                    will be removed from service endpoints if the probe fails. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                  type: object
+                  properties:
+                    exec:
+                      description: One and only one of the following should be specified.
+                        Exec specifies the action to take.
+                      type: object
+                      properties:
+                        command:
+                          description: Command is the command line to execute inside
+                            the container, the working directory for the command  is
+                            root ('/') in the container's filesystem. The command
+                            is simply exec'd, it is not run inside a shell, so traditional
+                            shell instructions ('|', etc) won't work. To use a shell,
+                            you need to explicitly call out to that shell. Exit status
+                            of 0 is treated as live/healthy and non-zero is unhealthy.
+                          type: array
+                          items:
+                            type: string
+                    failureThreshold:
+                      description: Minimum consecutive failures for the probe to be
+                        considered failed after having succeeded. Defaults to 3. Minimum
+                        value is 1.
+                      type: integer
+                      format: int32
+                    httpGet:
+                      description: HTTPGet specifies the http request to perform.
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: Host name to connect to, defaults to the pod
+                            IP. You probably want to set "Host" in httpHeaders instead.
+                          type: string
+                        httpHeaders:
+                          description: Custom headers to set in the request. HTTP
+                            allows repeated headers.
+                          type: array
+                          items:
+                            description: HTTPHeader describes a custom header to be
+                              used in HTTP probes
+                            type: object
+                            required:
+                            - name
+                            - value
+                            properties:
+                              name:
+                                description: The header field name
+                                type: string
+                              value:
+                                description: The header field value
+                                type: string
+                        path:
+                          description: Path to access on the HTTP server.
+                          type: string
+                        port:
+                          description: Name or number of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                        scheme:
+                          description: Scheme to use for connecting to the host. Defaults
+                            to HTTP.
+                          type: string
+                    initialDelaySeconds:
+                      description: 'Number of seconds after the container has started
+                        before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                    periodSeconds:
+                      description: How often (in seconds) to perform the probe. Default
+                        to 10 seconds. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    successThreshold:
+                      description: Minimum consecutive successes for the probe to
+                        be considered successful after having failed. Defaults to
+                        1. Must be 1 for liveness. Minimum value is 1.
+                      type: integer
+                      format: int32
+                    tcpSocket:
+                      description: 'TCPSocket specifies an action involving a TCP
+                        port. TCP hooks not yet supported TODO: implement a realistic
+                        TCP lifecycle hook'
+                      type: object
+                      required:
+                      - port
+                      properties:
+                        host:
+                          description: 'Optional: Host name to connect to, defaults
+                            to the pod IP.'
+                          type: string
+                        port:
+                          description: Number or name of the port to access on the
+                            container. Number must be in the range 1 to 65535. Name
+                            must be an IANA_SVC_NAME.
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          x-kubernetes-int-or-string: true
+                    timeoutSeconds:
+                      description: 'Number of seconds after which the probe times
+                        out. Defaults to 1 second. Minimum value is 1. More info:
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: integer
+                      format: int32
+                resources:
+                  description: 'Compute Resources required by this container. Cannot
+                    be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                  properties:
+                    limits:
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                    requests:
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      additionalProperties:
+                        type: string
+                securityContext:
+                  description: 'Security options the pod should run with. More info:
+                    https://kubernetes.io/docs/concepts/policy/security-context/ More
+                    info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                  type: object
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                        can gain more privileges than its parent process. This bool
+                        directly controls if the no_new_privs flag will be set on
+                        the container process. AllowPrivilegeEscalation is true always
+                        when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the
+                        container runtime.
+                      type: object
+                      properties:
+                        add:
+                          description: Added capabilities
+                          type: array
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                        drop:
+                          description: Removed capabilities
+                          type: array
+                          items:
+                            description: Capability represent POSIX capabilities type
+                            type: string
+                    privileged:
+                      description: Run container in privileged mode. Processes in
+                        privileged containers are essentially equivalent to root on
+                        the host. Defaults to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use
+                        for the containers. The default is DefaultProcMount which
+                        uses the container runtime defaults for readonly paths and
+                        masked paths. This requires the ProcMountType feature flag
+                        to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        PodSecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      type: integer
+                      format: int64
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      type: integer
+                      format: int64
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: object
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                stdin:
+                  description: Whether this container should allocate a buffer for
+                    stdin in the container runtime. If this is not set, reads from
+                    stdin in the container will always result in EOF. Default is false.
+                  type: boolean
+                stdinOnce:
+                  description: Whether the container runtime should close the stdin
+                    channel after it has been opened by a single attach. When stdin
+                    is true the stdin stream will remain open across multiple attach
+                    sessions. If stdinOnce is set to true, stdin is opened on container
+                    start, is empty until the first client attaches to stdin, and
+                    then remains open and accepts data until the client disconnects,
+                    at which time stdin is closed and remains closed until the container
+                    is restarted. If this flag is false, a container processes that
+                    reads from stdin will never receive an EOF. Default is false
+                  type: boolean
+                terminationMessagePath:
+                  description: 'Optional: Path at which the file to which the container''s
+                    termination message will be written is mounted into the container''s
+                    filesystem. Message written is intended to be brief final status,
+                    such as an assertion failure message. Will be truncated by the
+                    node if greater than 4096 bytes. The total message length across
+                    all containers will be limited to 12kb. Defaults to /dev/termination-log.
+                    Cannot be updated.'
+                  type: string
+                terminationMessagePolicy:
+                  description: Indicate how the termination message should be populated.
+                    File will use the contents of terminationMessagePath to populate
+                    the container status message on both success and failure. FallbackToLogsOnError
+                    will use the last chunk of container log output if the termination
+                    message file is empty and the container exited with an error.
+                    The log output is limited to 2048 bytes or 80 lines, whichever
+                    is smaller. Defaults to File. Cannot be updated.
+                  type: string
+                tty:
+                  description: Whether this container should allocate a TTY for itself,
+                    also requires 'stdin' to be true. Default is false.
+                  type: boolean
+                volumeDevices:
+                  description: volumeDevices is the list of block devices to be used
+                    by the container. This is a beta feature.
+                  type: array
+                  items:
+                    description: volumeDevice describes a mapping of a raw block device
+                      within a container.
+                    type: object
+                    required:
+                    - devicePath
+                    - name
+                    properties:
+                      devicePath:
+                        description: devicePath is the path inside of the container
+                          that the device will be mapped to.
+                        type: string
+                      name:
+                        description: name must match the name of a persistentVolumeClaim
+                          in the pod
+                        type: string
+                volumeMounts:
+                  description: Pod volumes to mount into the container's filesystem.
+                    Cannot be updated.
+                  type: array
+                  items:
+                    description: VolumeMount describes a mounting of a Volume within
+                      a container.
+                    type: object
+                    required:
+                    - mountPath
+                    - name
+                    properties:
+                      mountPath:
+                        description: Path within the container at which the volume
+                          should be mounted.  Must not contain ':'.
+                        type: string
+                      mountPropagation:
+                        description: mountPropagation determines how mounts are propagated
+                          from the host to container and the other way around. When
+                          not set, MountPropagationNone is used. This field is beta
+                          in 1.10.
+                        type: string
+                      name:
+                        description: This must match the Name of a Volume.
+                        type: string
+                      readOnly:
+                        description: Mounted read-only if true, read-write otherwise
+                          (false or unspecified). Defaults to false.
+                        type: boolean
+                      subPath:
+                        description: Path within the volume from which the container's
+                          volume should be mounted. Defaults to "" (volume's root).
+                        type: string
+                workingDir:
+                  description: Container's working directory. If not specified, the
+                    container runtime's default will be used, which might be configured
+                    in the container image. Cannot be updated.
+                  type: string
+            steps:
+              description: Steps are the steps of the build; each step is run sequentially
+                with the source mounted into /workspace.
+              type: array
+              items:
+                description: Step embeds the Container type, which allows it to include
+                  fields not provided by Container.
+                type: object
+                properties:
+                  script:
+                    description: "Script is the contents of an executable file to
+                      execute. \n If Script is not empty, the Step cannot have an
+                      Command or Args."
+                    type: string
+            volumes:
+              description: Volumes is a collection of volumes that are available to
+                mount into the steps of the build.
+              type: array
+              items:
+                description: Volume represents a named volume in a pod that may be
+                  accessed by any container in the pod.
+                type: object
+                required:
+                - name
+                properties:
+                  awsElasticBlockStore:
+                    description: 'AWSElasticBlockStore represents an AWS Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                    type: object
+                    required:
+                    - volumeID
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty).'
+                        type: integer
+                        format: int32
+                      readOnly:
+                        description: 'Specify "true" to force and set the ReadOnly
+                          property in VolumeMounts to "true". If omitted, the default
+                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: boolean
+                      volumeID:
+                        description: 'Unique ID of the persistent disk resource in
+                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: string
+                  azureDisk:
+                    description: AzureDisk represents an Azure Data Disk mount on
+                      the host and bind mount to the pod.
+                    type: object
+                    required:
+                    - diskName
+                    - diskURI
+                    properties:
+                      cachingMode:
+                        description: 'Host Caching mode: None, Read Only, Read Write.'
+                        type: string
+                      diskName:
+                        description: The Name of the data disk in the blob storage
+                        type: string
+                      diskURI:
+                        description: The URI the data disk in the blob storage
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      kind:
+                        description: 'Expected values Shared: multiple blob disks
+                          per storage account  Dedicated: single blob disk per storage
+                          account  Managed: azure managed data disk (only in managed
+                          availability set). defaults to shared'
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                  azureFile:
+                    description: AzureFile represents an Azure File Service mount
+                      on the host and bind mount to the pod.
+                    type: object
+                    required:
+                    - secretName
+                    - shareName
+                    properties:
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretName:
+                        description: the name of secret that contains Azure Storage
+                          Account Name and Key
+                        type: string
+                      shareName:
+                        description: Share Name
+                        type: string
+                  cephfs:
+                    description: CephFS represents a Ceph FS mount on the host that
+                      shares a pod's lifetime
+                    type: object
+                    required:
+                    - monitors
+                    properties:
+                      monitors:
+                        description: 'Required: Monitors is a collection of Ceph monitors
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: array
+                        items:
+                          type: string
+                      path:
+                        description: 'Optional: Used as the mounted root, rather than
+                          the full Ceph tree, default is /'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: boolean
+                      secretFile:
+                        description: 'Optional: SecretFile is the path to key ring
+                          for User, default is /etc/ceph/user.secret More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the authentication
+                          secret for User, default is empty. More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      user:
+                        description: 'Optional: User is the rados user name, default
+                          is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                        type: string
+                  cinder:
+                    description: 'Cinder represents a cinder volume attached and mounted
+                      on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                    type: object
+                    required:
+                    - volumeID
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Examples: "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts. More
+                          info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: points to a secret object containing
+                          parameters used to connect to OpenStack.'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      volumeID:
+                        description: 'volume id used to identify the volume in cinder
+                          More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: string
+                  configMap:
+                    description: ConfigMap represents a configMap that should populate
+                      this volume
+                    type: object
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        type: integer
+                        format: int32
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced ConfigMap will be projected into
+                          the volume as a file whose name is the key and content is
+                          the value. If specified, the listed keys will be projected
+                          into the specified paths, and unlisted keys will not be
+                          present. If a key is specified which is not present in the
+                          ConfigMap, the volume setup will error unless it is marked
+                          optional. Paths must be relative and may not contain the
+                          '..' path or start with '..'.
+                        type: array
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          type: object
+                          required:
+                          - key
+                          - path
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              type: integer
+                              format: int32
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the ConfigMap or it's keys must
+                          be defined
+                        type: boolean
+                  downwardAPI:
+                    description: DownwardAPI represents downward API about the pod
+                      that should populate this volume
+                    type: object
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        type: integer
+                        format: int32
+                      items:
+                        description: Items is a list of downward API volume file
+                        type: array
+                        items:
+                          description: DownwardAPIVolumeFile represents information
+                            to create the file containing the pod field
+                          type: object
+                          required:
+                          - path
+                          properties:
+                            fieldRef:
+                              description: 'Required: Selects a field of the pod:
+                                only annotations, labels, name and namespace are supported.'
+                              type: object
+                              required:
+                              - fieldPath
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              type: integer
+                              format: int32
+                            path:
+                              description: 'Required: Path is  the relative path name
+                                of the file to be created. Must not be absolute or
+                                contain the ''..'' path. Must be utf-8 encoded. The
+                                first item of the relative path must not start with
+                                ''..'''
+                              type: string
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                requests.cpu and requests.memory) are currently supported.'
+                              type: object
+                              required:
+                              - resource
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  type: string
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                    type: object
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                  fc:
+                    description: FC represents a Fibre Channel resource that is attached
+                      to a kubelet's host machine and then exposed to the pod.
+                    type: object
+                    properties:
+                      fsType:
+                        description: 'Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      lun:
+                        description: 'Optional: FC target lun number'
+                        type: integer
+                        format: int32
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      targetWWNs:
+                        description: 'Optional: FC target worldwide names (WWNs)'
+                        type: array
+                        items:
+                          type: string
+                      wwids:
+                        description: 'Optional: FC volume world wide identifiers (wwids)
+                          Either wwids or combination of targetWWNs and lun must be
+                          set, but not both simultaneously.'
+                        type: array
+                        items:
+                          type: string
+                  flexVolume:
+                    description: FlexVolume represents a generic volume resource that
+                      is provisioned/attached using an exec based plugin.
+                    type: object
+                    required:
+                    - driver
+                    properties:
+                      driver:
+                        description: Driver is the name of the driver to use for this
+                          volume.
+                        type: string
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". The default filesystem depends on FlexVolume
+                          script.
+                        type: string
+                      options:
+                        description: 'Optional: Extra command options if any.'
+                        type: object
+                        additionalProperties:
+                          type: string
+                      readOnly:
+                        description: 'Optional: Defaults to false (read/write). ReadOnly
+                          here will force the ReadOnly setting in VolumeMounts.'
+                        type: boolean
+                      secretRef:
+                        description: 'Optional: SecretRef is reference to the secret
+                          object containing sensitive information to pass to the plugin
+                          scripts. This may be empty if no secret object is specified.
+                          If the secret object contains more than one secret, all
+                          secrets are passed to the plugin scripts.'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                  flocker:
+                    description: Flocker represents a Flocker volume attached to a
+                      kubelet's host machine. This depends on the Flocker control
+                      service being running
+                    type: object
+                    properties:
+                      datasetName:
+                        description: Name of the dataset stored as metadata -> name
+                          on the dataset for Flocker should be considered as deprecated
+                        type: string
+                      datasetUUID:
+                        description: UUID of the dataset. This is unique identifier
+                          of a Flocker dataset
+                        type: string
+                  gcePersistentDisk:
+                    description: 'GCEPersistentDisk represents a GCE Disk resource
+                      that is attached to a kubelet''s host machine and then exposed
+                      to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                    type: object
+                    required:
+                    - pdName
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      partition:
+                        description: 'The partition in the volume that you want to
+                          mount. If omitted, the default is to mount by volume name.
+                          Examples: For volume /dev/sda1, you specify the partition
+                          as "1". Similarly, the volume partition for /dev/sda is
+                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: integer
+                        format: int32
+                      pdName:
+                        description: 'Unique name of the PD resource in GCE. Used
+                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: boolean
+                  gitRepo:
+                    description: 'GitRepo represents a git repository at a particular
+                      revision. DEPRECATED: GitRepo is deprecated. To provision a
+                      container with a git repo, mount an EmptyDir into an InitContainer
+                      that clones the repo using git, then mount the EmptyDir into
+                      the Pod''s container.'
+                    type: object
+                    required:
+                    - repository
+                    properties:
+                      directory:
+                        description: Target directory name. Must not contain or start
+                          with '..'.  If '.' is supplied, the volume directory will
+                          be the git repository.  Otherwise, if specified, the volume
+                          will contain the git repository in the subdirectory with
+                          the given name.
+                        type: string
+                      repository:
+                        description: Repository URL
+                        type: string
+                      revision:
+                        description: Commit hash for the specified revision.
+                        type: string
+                  glusterfs:
+                    description: 'Glusterfs represents a Glusterfs mount on the host
+                      that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md'
+                    type: object
+                    required:
+                    - endpoints
+                    - path
+                    properties:
+                      endpoints:
+                        description: 'EndpointsName is the endpoint name that details
+                          Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      path:
+                        description: 'Path is the Glusterfs volume path. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the Glusterfs volume
+                          to be mounted with read-only permissions. Defaults to false.
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                        type: boolean
+                  hostPath:
+                    description: 'HostPath represents a pre-existing file or directory
+                      on the host machine that is directly exposed to the container.
+                      This is generally used for system agents or other privileged
+                      things that are allowed to see the host machine. Most containers
+                      will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      --- TODO(jonesdl) We need to restrict who can use host directory
+                      mounts and who can/can not mount host directories as read/write.'
+                    type: object
+                    required:
+                    - path
+                    properties:
+                      path:
+                        description: 'Path of the directory on the host. If the path
+                          is a symlink, it will follow the link to the real path.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                      type:
+                        description: 'Type for HostPath Volume Defaults to "" More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        type: string
+                  iscsi:
+                    description: 'ISCSI represents an ISCSI Disk resource that is
+                      attached to a kubelet''s host machine and then exposed to the
+                      pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md'
+                    type: object
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    properties:
+                      chapAuthDiscovery:
+                        description: whether support iSCSI Discovery CHAP authentication
+                        type: boolean
+                      chapAuthSession:
+                        description: whether support iSCSI Session CHAP authentication
+                        type: boolean
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      initiatorName:
+                        description: Custom iSCSI Initiator Name. If initiatorName
+                          is specified with iscsiInterface simultaneously, new iSCSI
+                          interface <target portal>:<volume name> will be created
+                          for the connection.
+                        type: string
+                      iqn:
+                        description: Target iSCSI Qualified Name.
+                        type: string
+                      iscsiInterface:
+                        description: iSCSI Interface Name that uses an iSCSI transport.
+                          Defaults to 'default' (tcp).
+                        type: string
+                      lun:
+                        description: iSCSI Target Lun number.
+                        type: integer
+                        format: int32
+                      portals:
+                        description: iSCSI Target Portal List. The portal is either
+                          an IP or ip_addr:port if the port is other than default
+                          (typically TCP ports 860 and 3260).
+                        type: array
+                        items:
+                          type: string
+                      readOnly:
+                        description: ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false.
+                        type: boolean
+                      secretRef:
+                        description: CHAP Secret for iSCSI target and initiator authentication
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      targetPortal:
+                        description: iSCSI Target Portal. The Portal is either an
+                          IP or ip_addr:port if the port is other than default (typically
+                          TCP ports 860 and 3260).
+                        type: string
+                  name:
+                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
+                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  nfs:
+                    description: 'NFS represents an NFS mount on the host that shares
+                      a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                    type: object
+                    required:
+                    - path
+                    - server
+                    properties:
+                      path:
+                        description: 'Path that is exported by the NFS server. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the NFS export to be
+                          mounted with read-only permissions. Defaults to false. More
+                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: boolean
+                      server:
+                        description: 'Server is the hostname or IP address of the
+                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: string
+                  persistentVolumeClaim:
+                    description: 'PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. More info:
+                      https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                    type: object
+                    required:
+                    - claimName
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                  photonPersistentDisk:
+                    description: PhotonPersistentDisk represents a PhotonController
+                      persistent disk attached and mounted on kubelets host machine
+                    type: object
+                    required:
+                    - pdID
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      pdID:
+                        description: ID that identifies Photon Controller persistent
+                          disk
+                        type: string
+                  portworxVolume:
+                    description: PortworxVolume represents a portworx volume attached
+                      and mounted on kubelets host machine
+                    type: object
+                    required:
+                    - volumeID
+                    properties:
+                      fsType:
+                        description: FSType represents the filesystem type to mount
+                          Must be a filesystem type supported by the host operating
+                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
+                          if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      volumeID:
+                        description: VolumeID uniquely identifies a Portworx volume
+                        type: string
+                  projected:
+                    description: Items for all in one resources secrets, configmaps,
+                      and downward API
+                    type: object
+                    required:
+                    - sources
+                    properties:
+                      defaultMode:
+                        description: Mode bits to use on created files by default.
+                          Must be a value between 0 and 0777. Directories within the
+                          path are not affected by this setting. This might be in
+                          conflict with other options that affect the file mode, like
+                          fsGroup, and the result can be other mode bits set.
+                        type: integer
+                        format: int32
+                      sources:
+                        description: list of volume projections
+                        type: array
+                        items:
+                          description: Projection that may be projected along with
+                            other supported volume types
+                          type: object
+                          properties:
+                            configMap:
+                              description: information about the configMap data to
+                                project
+                              type: object
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  type: array
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or it's
+                                    keys must be defined
+                                  type: boolean
+                            downwardAPI:
+                              description: information about the downwardAPI data
+                                to project
+                              type: object
+                              properties:
+                                items:
+                                  description: Items is a list of DownwardAPIVolume
+                                    file
+                                  type: array
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    type: object
+                                    required:
+                                    - path
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        type: object
+                                        required:
+                                        - fieldPath
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        type: object
+                                        required:
+                                        - resource
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            type: string
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                            secret:
+                              description: information about the secret data to project
+                              type: object
+                              properties:
+                                items:
+                                  description: If unspecified, each key-value pair
+                                    in the Data field of the referenced Secret will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  type: array
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    type: object
+                                    required:
+                                    - key
+                                    - path
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits to use on
+                                          this file, must be a value between 0 and
+                                          0777. If not specified, the volume defaultMode
+                                          will be used. This might be in conflict
+                                          with other options that affect the file
+                                          mode, like fsGroup, and the result can be
+                                          other mode bits set.'
+                                        type: integer
+                                        format: int32
+                                      path:
+                                        description: The relative path of the file
+                                          to map the key to. May not be an absolute
+                                          path. May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                            serviceAccountToken:
+                              description: information about the serviceAccountToken
+                                data to project
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                audience:
+                                  description: Audience is the intended audience of
+                                    the token. A recipient of a token must identify
+                                    itself with an identifier specified in the audience
+                                    of the token, and otherwise should reject the
+                                    token. The audience defaults to the identifier
+                                    of the apiserver.
+                                  type: string
+                                expirationSeconds:
+                                  description: ExpirationSeconds is the requested
+                                    duration of validity of the service account token.
+                                    As the token approaches expiration, the kubelet
+                                    volume plugin will proactively rotate the service
+                                    account token. The kubelet will start trying to
+                                    rotate the token if the token is older than 80
+                                    percent of its time to live or if the token is
+                                    older than 24 hours.Defaults to 1 hour and must
+                                    be at least 10 minutes.
+                                  type: integer
+                                  format: int64
+                                path:
+                                  description: Path is the path relative to the mount
+                                    point of the file to project the token into.
+                                  type: string
+                  quobyte:
+                    description: Quobyte represents a Quobyte mount on the host that
+                      shares a pod's lifetime
+                    type: object
+                    required:
+                    - registry
+                    - volume
+                    properties:
+                      group:
+                        description: Group to map volume access to Default is no group
+                        type: string
+                      readOnly:
+                        description: ReadOnly here will force the Quobyte volume to
+                          be mounted with read-only permissions. Defaults to false.
+                        type: boolean
+                      registry:
+                        description: Registry represents a single or multiple Quobyte
+                          Registry services specified as a string as host:port pair
+                          (multiple entries are separated with commas) which acts
+                          as the central registry for volumes
+                        type: string
+                      user:
+                        description: User to map volume access to Defaults to serivceaccount
+                          user
+                        type: string
+                      volume:
+                        description: Volume is a string that references an already
+                          created Quobyte volume by name.
+                        type: string
+                  rbd:
+                    description: 'RBD represents a Rados Block Device mount on the
+                      host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md'
+                    type: object
+                    required:
+                    - image
+                    - monitors
+                    properties:
+                      fsType:
+                        description: 'Filesystem type of the volume that you want
+                          to mount. Tip: Ensure that the filesystem type is supported
+                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
+                          Implicitly inferred to be "ext4" if unspecified. More info:
+                          https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          TODO: how do we prevent errors in the filesystem from compromising
+                          the machine'
+                        type: string
+                      image:
+                        description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      keyring:
+                        description: 'Keyring is the path to key ring for RBDUser.
+                          Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      monitors:
+                        description: 'A collection of Ceph monitors. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: array
+                        items:
+                          type: string
+                      pool:
+                        description: 'The rados pool name. Default is rbd. More info:
+                          https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                      readOnly:
+                        description: 'ReadOnly here will force the ReadOnly setting
+                          in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: boolean
+                      secretRef:
+                        description: 'SecretRef is name of the authentication secret
+                          for RBDUser. If provided overrides keyring. Default is nil.
+                          More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      user:
+                        description: 'The rados user name. Default is admin. More
+                          info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                        type: string
+                  scaleIO:
+                    description: ScaleIO represents a ScaleIO persistent volume attached
+                      and mounted on Kubernetes nodes.
+                    type: object
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Default is "xfs".
+                        type: string
+                      gateway:
+                        description: The host address of the ScaleIO API Gateway.
+                        type: string
+                      protectionDomain:
+                        description: The name of the ScaleIO Protection Domain for
+                          the configured storage.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef references to the secret for ScaleIO
+                          user and other sensitive information. If this is not provided,
+                          Login operation will fail.
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      sslEnabled:
+                        description: Flag to enable/disable SSL communication with
+                          Gateway, default false
+                        type: boolean
+                      storageMode:
+                        description: Indicates whether the storage for a volume should
+                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                        type: string
+                      storagePool:
+                        description: The ScaleIO Storage Pool associated with the
+                          protection domain.
+                        type: string
+                      system:
+                        description: The name of the storage system as configured
+                          in ScaleIO.
+                        type: string
+                      volumeName:
+                        description: The name of a volume already created in the ScaleIO
+                          system that is associated with this volume source.
+                        type: string
+                  secret:
+                    description: 'Secret represents a secret that should populate
+                      this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                    type: object
+                    properties:
+                      defaultMode:
+                        description: 'Optional: mode bits to use on created files
+                          by default. Must be a value between 0 and 0777. Defaults
+                          to 0644. Directories within the path are not affected by
+                          this setting. This might be in conflict with other options
+                          that affect the file mode, like fsGroup, and the result
+                          can be other mode bits set.'
+                        type: integer
+                        format: int32
+                      items:
+                        description: If unspecified, each key-value pair in the Data
+                          field of the referenced Secret will be projected into the
+                          volume as a file whose name is the key and content is the
+                          value. If specified, the listed keys will be projected into
+                          the specified paths, and unlisted keys will not be present.
+                          If a key is specified which is not present in the Secret,
+                          the volume setup will error unless it is marked optional.
+                          Paths must be relative and may not contain the '..' path
+                          or start with '..'.
+                        type: array
+                        items:
+                          description: Maps a string key to a path within a volume.
+                          type: object
+                          required:
+                          - key
+                          - path
+                          properties:
+                            key:
+                              description: The key to project.
+                              type: string
+                            mode:
+                              description: 'Optional: mode bits to use on this file,
+                                must be a value between 0 and 0777. If not specified,
+                                the volume defaultMode will be used. This might be
+                                in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode
+                                bits set.'
+                              type: integer
+                              format: int32
+                            path:
+                              description: The relative path of the file to map the
+                                key to. May not be an absolute path. May not contain
+                                the path element '..'. May not start with the string
+                                '..'.
+                              type: string
+                      optional:
+                        description: Specify whether the Secret or it's keys must
+                          be defined
+                        type: boolean
+                      secretName:
+                        description: 'Name of the secret in the pod''s namespace to
+                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: string
+                  storageos:
+                    description: StorageOS represents a StorageOS volume attached
+                      and mounted on Kubernetes nodes.
+                    type: object
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      readOnly:
+                        description: Defaults to false (read/write). ReadOnly here
+                          will force the ReadOnly setting in VolumeMounts.
+                        type: boolean
+                      secretRef:
+                        description: SecretRef specifies the secret to use for obtaining
+                          the StorageOS API credentials.  If not specified, default
+                          values will be attempted.
+                        type: object
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                      volumeName:
+                        description: VolumeName is the human-readable name of the
+                          StorageOS volume.  Volume names are only unique within a
+                          namespace.
+                        type: string
+                      volumeNamespace:
+                        description: VolumeNamespace specifies the scope of the volume
+                          within StorageOS.  If no namespace is specified then the
+                          Pod's namespace will be used.  This allows the Kubernetes
+                          name scoping to be mirrored within StorageOS for tighter
+                          integration. Set VolumeName to any name to override the
+                          default behaviour. Set to "default" if you are not using
+                          namespaces within StorageOS. Namespaces that do not pre-exist
+                          within StorageOS will be created.
+                        type: string
+                  vsphereVolume:
+                    description: VsphereVolume represents a vSphere volume attached
+                      and mounted on kubelets host machine
+                    type: object
+                    required:
+                    - volumePath
+                    properties:
+                      fsType:
+                        description: Filesystem type to mount. Must be a filesystem
+                          type supported by the host operating system. Ex. "ext4",
+                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                        type: string
+                      storagePolicyID:
+                        description: Storage Policy Based Management (SPBM) profile
+                          ID associated with the StoragePolicyName.
+                        type: string
+                      storagePolicyName:
+                        description: Storage Policy Based Management (SPBM) profile
+                          name.
+                        type: string
+                      volumePath:
+                        description: Path that identifies vSphere volume vmdk
+                        type: string
+            workspaces:
+              description: Workspaces are the volumes that this Task requires.
+              type: array
+              items:
+                description: WorkspaceDeclaration is a declaration of a volume that
+                  a Task requires.
+                type: object
+                required:
+                - name
+                properties:
+                  description:
+                    description: Description is an optional human readable description
+                      of this volume.
+                    type: string
+                  mountPath:
+                    description: MountPath overrides the directory that the volume
+                      will be made available at.
+                    type: string
+                  name:
+                    description: Name is the name by which you can bind the volume
+                      at runtime.
+                    type: string

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -45,3 +45,5345 @@ spec:
   subresources:
     status: {}
   version: v1alpha1
+  "validation":
+    "openAPIV3Schema":
+      description: TaskRun represents a single execution of a Task. TaskRuns are how
+        the steps specified in a Task are executed; they specify the parameters and
+        resources used to run the steps in a Task.
+      type: object
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TaskRunSpec defines the desired state of TaskRun
+          type: object
+          properties:
+            inputs:
+              description: TaskRunInputs holds the input values that this task was
+                invoked with.
+              type: object
+              properties:
+                params:
+                  type: array
+                  items:
+                    description: Param declares an ArrayOrString to use for the parameter
+                      called name.
+                    type: object
+                    required:
+                    - name
+                    - value
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        description: ArrayOrString is a type that can hold a single
+                          string or string array. Used in JSON unmarshalling so that
+                          a single JSON field can accept either an individual string
+                          or an array of strings.
+                        type: object
+                        required:
+                        - type
+                        properties:
+                          type:
+                            description: ParamType indicates the type of an input
+                              parameter; Used to distinguish between a single string
+                              and an array of strings.
+                            type: string
+                resources:
+                  type: array
+                  items:
+                    description: TaskResourceBinding points to the PipelineResource
+                      that will be used for the Task input or output called Name.
+                    type: object
+                    properties:
+                      paths:
+                        description: 'Paths will probably be removed in #1284, and
+                          then PipelineResourceBinding can be used instead. The optional
+                          Path field corresponds to a path on disk at which the Resource
+                          can be found (used when providing the resource via mounted
+                          volume, overriding the default logic to fetch the Resource).'
+                        type: array
+                        items:
+                          type: string
+            outputs:
+              description: TaskRunOutputs holds the output values that this task was
+                invoked with.
+              type: object
+              properties:
+                resources:
+                  type: array
+                  items:
+                    description: TaskResourceBinding points to the PipelineResource
+                      that will be used for the Task input or output called Name.
+                    type: object
+                    properties:
+                      paths:
+                        description: 'Paths will probably be removed in #1284, and
+                          then PipelineResourceBinding can be used instead. The optional
+                          Path field corresponds to a path on disk at which the Resource
+                          can be found (used when providing the resource via mounted
+                          volume, overriding the default logic to fetch the Resource).'
+                        type: array
+                        items:
+                          type: string
+            podTemplate:
+              description: PodTemplate holds pod specific configuration
+              type: object
+              properties:
+                affinity:
+                  description: If specified, the pod's scheduling constraints
+                  type: object
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            matches the corresponding matchExpressions; the node(s)
+                            with the highest sum are the most preferred.
+                          type: array
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects
+                              (i.e. is also a no-op).
+                            type: object
+                            required:
+                            - preference
+                            - weight
+                            properties:
+                              preference:
+                                description: A node selector term, associated with
+                                  the corresponding weight.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                type: integer
+                                format: int32
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its
+                            node.
+                          type: object
+                          required:
+                          - nodeSelectorTerms
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              type: array
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    type: array
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          type: array
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            type: object
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                type: object
+                                required:
+                                - topologyKey
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        type: array
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          type: object
+                                          required:
+                                          - key
+                                          - operator
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                type: integer
+                                format: int32
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          type: array
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            type: object
+                            required:
+                            - topologyKey
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    type: array
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      type: object
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling anti-affinity
+                            expressions, etc.), compute a sum by iterating through
+                            the elements of this field and adding "weight" to the
+                            sum if the node has pods which matches the corresponding
+                            podAffinityTerm; the node(s) with the highest sum are
+                            the most preferred.
+                          type: array
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            type: object
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                type: object
+                                required:
+                                - topologyKey
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    type: object
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        type: array
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          type: object
+                                          required:
+                                          - key
+                                          - operator
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              type: array
+                                              items:
+                                                type: string
+                                      matchLabels:
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                        additionalProperties:
+                                          type: string
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    type: array
+                                    items:
+                                      type: string
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                type: integer
+                                format: int32
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified
+                            by this field are not met at scheduling time, the pod
+                            will not be scheduled onto the node. If the anti-affinity
+                            requirements specified by this field cease to be met at
+                            some point during pod execution (e.g. due to a pod label
+                            update), the system may or may not try to eventually evict
+                            the pod from its node. When there are multiple elements,
+                            the lists of nodes corresponding to each podAffinityTerm
+                            are intersected, i.e. all terms must be satisfied.
+                          type: array
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            type: object
+                            required:
+                            - topologyKey
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                type: object
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    type: array
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      type: object
+                                      required:
+                                      - key
+                                      - operator
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          type: array
+                                          items:
+                                            type: string
+                                  matchLabels:
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                type: array
+                                items:
+                                  type: string
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                nodeSelector:
+                  description: 'NodeSelector is a selector which must be true for
+                    the pod to fit on a node. Selector which must match a node''s
+                    labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                  type: object
+                  additionalProperties:
+                    type: string
+                runtimeClassName:
+                  description: 'RuntimeClassName refers to a RuntimeClass object in
+                    the node.k8s.io group, which should be used to run this pod. If
+                    no RuntimeClass resource matches the named class, the pod will
+                    not be run. If unset or empty, the "legacy" RuntimeClass will
+                    be used, which is an implicit class with an empty definition that
+                    uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+                    This is a beta feature as of Kubernetes v1.14.'
+                  type: string
+                securityContext:
+                  description: 'SecurityContext holds pod-level security attributes
+                    and common container settings. Optional: Defaults to empty.  See
+                    type description for default values of each field.'
+                  type: object
+                  properties:
+                    fsGroup:
+                      description: "A special supplemental group that applies to all
+                        containers in a pod. Some volume types allow the Kubelet to
+                        change the ownership of that volume to be owned by the pod:
+                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                        is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw---- \n If unset,
+                        the Kubelet will not modify the ownership and permissions
+                        of any volume."
+                      type: integer
+                      format: int64
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence for
+                        that container.
+                      type: integer
+                      format: int64
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                      type: integer
+                      format: int64
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                      type: object
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary
+                        GID.  If unspecified, no groups will be added to any container.
+                      type: array
+                      items:
+                        type: integer
+                        format: int64
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used
+                        for the pod. Pods with unsupported sysctls (by the container
+                        runtime) might fail to launch.
+                      type: array
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        type: object
+                        required:
+                        - name
+                        - value
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                tolerations:
+                  description: If specified, the pod's tolerations.
+                  type: array
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    type: object
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        type: integer
+                        format: int64
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                volumes:
+                  description: 'List of volumes that can be mounted by containers
+                    belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
+                  type: array
+                  items:
+                    description: Volume represents a named volume in a pod that may
+                      be accessed by any container in the pod.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      awsElasticBlockStore:
+                        description: 'AWSElasticBlockStore represents an AWS Disk
+                          resource that is attached to a kubelet''s host machine and
+                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).'
+                            type: integer
+                            format: int32
+                          readOnly:
+                            description: 'Specify "true" to force and set the ReadOnly
+                              property in VolumeMounts to "true". If omitted, the
+                              default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'Unique ID of the persistent disk resource
+                              in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                      azureDisk:
+                        description: AzureDisk represents an Azure Data Disk mount
+                          on the host and bind mount to the pod.
+                        type: object
+                        required:
+                        - diskName
+                        - diskURI
+                        properties:
+                          cachingMode:
+                            description: 'Host Caching mode: None, Read Only, Read
+                              Write.'
+                            type: string
+                          diskName:
+                            description: The Name of the data disk in the blob storage
+                            type: string
+                          diskURI:
+                            description: The URI the data disk in the blob storage
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'Expected values Shared: multiple blob disks
+                              per storage account  Dedicated: single blob disk per
+                              storage account  Managed: azure managed data disk (only
+                              in managed availability set). defaults to shared'
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                      azureFile:
+                        description: AzureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        type: object
+                        required:
+                        - secretName
+                        - shareName
+                        properties:
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: the name of secret that contains Azure Storage
+                              Account Name and Key
+                            type: string
+                          shareName:
+                            description: Share Name
+                            type: string
+                      cephfs:
+                        description: CephFS represents a Ceph FS mount on the host
+                          that shares a pod's lifetime
+                        type: object
+                        required:
+                        - monitors
+                        properties:
+                          monitors:
+                            description: 'Required: Monitors is a collection of Ceph
+                              monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: array
+                            items:
+                              type: string
+                          path:
+                            description: 'Optional: Used as the mounted root, rather
+                              than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'Optional: SecretFile is the path to key
+                              ring for User, default is /etc/ceph/user.secret More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              authentication secret for User, default is empty. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          user:
+                            description: 'Optional: User is the rados user name, default
+                              is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                      cinder:
+                        description: 'Cinder represents a cinder volume attached and
+                          mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: points to a secret object containing
+                              parameters used to connect to OpenStack.'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          volumeID:
+                            description: 'volume id used to identify the volume in
+                              cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: string
+                      configMap:
+                        description: ConfigMap represents a configMap that should
+                          populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: If unspecified, each key-value pair in the
+                              Data field of the referenced ConfigMap will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the ConfigMap, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                              - key
+                              - path
+                              properties:
+                                key:
+                                  description: The key to project.
+                                  type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: The relative path of the file to map
+                                    the key to. May not be an absolute path. May not
+                                    contain the path element '..'. May not start with
+                                    the string '..'.
+                                  type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap or it's keys
+                              must be defined
+                            type: boolean
+                      downwardAPI:
+                        description: DownwardAPI represents downward API about the
+                          pod that should populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: Items is a list of downward API volume file
+                            type: array
+                            items:
+                              description: DownwardAPIVolumeFile represents information
+                                to create the file containing the pod field
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                fieldRef:
+                                  description: 'Required: Selects a field of the pod:
+                                    only annotations, labels, name and namespace are
+                                    supported.'
+                                  type: object
+                                  required:
+                                  - fieldPath
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: 'Required: Path is  the relative path
+                                    name of the file to be created. Must not be absolute
+                                    or contain the ''..'' path. Must be utf-8 encoded.
+                                    The first item of the relative path must not start
+                                    with ''..'''
+                                  type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, requests.cpu and requests.memory)
+                                    are currently supported.'
+                                  type: object
+                                  required:
+                                  - resource
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      type: string
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                      emptyDir:
+                        description: 'EmptyDir represents a temporary directory that
+                          shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: object
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back
+                              this directory. The default is "" which means to use
+                              the node''s default medium. Must be an empty string
+                              (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit:
+                            description: 'Total amount of local storage required for
+                              this EmptyDir volume. The size limit is also applicable
+                              for memory medium. The maximum usage on memory medium
+                              EmptyDir would be the minimum value between the SizeLimit
+                              specified here and the sum of memory limits of all containers
+                              in a pod. The default is nil which means that the limit
+                              is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                            type: string
+                      fc:
+                        description: FC represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to
+                          the pod.
+                        type: object
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          lun:
+                            description: 'Optional: FC target lun number'
+                            type: integer
+                            format: int32
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'Optional: FC target worldwide names (WWNs)'
+                            type: array
+                            items:
+                              type: string
+                          wwids:
+                            description: 'Optional: FC volume world wide identifiers
+                              (wwids) Either wwids or combination of targetWWNs and
+                              lun must be set, but not both simultaneously.'
+                            type: array
+                            items:
+                              type: string
+                      flexVolume:
+                        description: FlexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        type: object
+                        required:
+                        - driver
+                        properties:
+                          driver:
+                            description: Driver is the name of the driver to use for
+                              this volume.
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". The default filesystem depends on FlexVolume
+                              script.
+                            type: string
+                          options:
+                            description: 'Optional: Extra command options if any.'
+                            type: object
+                            additionalProperties:
+                              type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              secret object containing sensitive information to pass
+                              to the plugin scripts. This may be empty if no secret
+                              object is specified. If the secret object contains more
+                              than one secret, all secrets are passed to the plugin
+                              scripts.'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                      flocker:
+                        description: Flocker represents a Flocker volume attached
+                          to a kubelet's host machine. This depends on the Flocker
+                          control service being running
+                        type: object
+                        properties:
+                          datasetName:
+                            description: Name of the dataset stored as metadata ->
+                              name on the dataset for Flocker should be considered
+                              as deprecated
+                            type: string
+                          datasetUUID:
+                            description: UUID of the dataset. This is unique identifier
+                              of a Flocker dataset
+                            type: string
+                      gcePersistentDisk:
+                        description: 'GCEPersistentDisk represents a GCE Disk resource
+                          that is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: object
+                        required:
+                        - pdName
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: integer
+                            format: int32
+                          pdName:
+                            description: 'Unique name of the PD resource in GCE. Used
+                              to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                      gitRepo:
+                        description: 'GitRepo represents a git repository at a particular
+                          revision. DEPRECATED: GitRepo is deprecated. To provision
+                          a container with a git repo, mount an EmptyDir into an InitContainer
+                          that clones the repo using git, then mount the EmptyDir
+                          into the Pod''s container.'
+                        type: object
+                        required:
+                        - repository
+                        properties:
+                          directory:
+                            description: Target directory name. Must not contain or
+                              start with '..'.  If '.' is supplied, the volume directory
+                              will be the git repository.  Otherwise, if specified,
+                              the volume will contain the git repository in the subdirectory
+                              with the given name.
+                            type: string
+                          repository:
+                            description: Repository URL
+                            type: string
+                          revision:
+                            description: Commit hash for the specified revision.
+                            type: string
+                      glusterfs:
+                        description: 'Glusterfs represents a Glusterfs mount on the
+                          host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md'
+                        type: object
+                        required:
+                        - endpoints
+                        - path
+                        properties:
+                          endpoints:
+                            description: 'EndpointsName is the endpoint name that
+                              details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'Path is the Glusterfs volume path. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the Glusterfs volume
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                      hostPath:
+                        description: 'HostPath represents a pre-existing file or directory
+                          on the host machine that is directly exposed to the container.
+                          This is generally used for system agents or other privileged
+                          things that are allowed to see the host machine. Most containers
+                          will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          --- TODO(jonesdl) We need to restrict who can use host directory
+                          mounts and who can/can not mount host directories as read/write.'
+                        type: object
+                        required:
+                        - path
+                        properties:
+                          path:
+                            description: 'Path of the directory on the host. If the
+                              path is a symlink, it will follow the link to the real
+                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'Type for HostPath Volume Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                      iscsi:
+                        description: 'ISCSI represents an ISCSI Disk resource that
+                          is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md'
+                        type: object
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        properties:
+                          chapAuthDiscovery:
+                            description: whether support iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: whether support iSCSI Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          initiatorName:
+                            description: Custom iSCSI Initiator Name. If initiatorName
+                              is specified with iscsiInterface simultaneously, new
+                              iSCSI interface <target portal>:<volume name> will be
+                              created for the connection.
+                            type: string
+                          iqn:
+                            description: Target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iSCSI Interface Name that uses an iSCSI transport.
+                              Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: iSCSI Target Lun number.
+                            type: integer
+                            format: int32
+                          portals:
+                            description: iSCSI Target Portal List. The portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: array
+                            items:
+                              type: string
+                          readOnly:
+                            description: ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: CHAP Secret for iSCSI target and initiator
+                              authentication
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          targetPortal:
+                            description: iSCSI Target Portal. The Portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: string
+                      name:
+                        description: 'Volume''s name. Must be a DNS_LABEL and unique
+                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      nfs:
+                        description: 'NFS represents an NFS mount on the host that
+                          shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: object
+                        required:
+                        - path
+                        - server
+                        properties:
+                          path:
+                            description: 'Path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the NFS export
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'Server is the hostname or IP address of
+                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                      persistentVolumeClaim:
+                        description: 'PersistentVolumeClaimVolumeSource represents
+                          a reference to a PersistentVolumeClaim in the same namespace.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: object
+                        required:
+                        - claimName
+                        properties:
+                          claimName:
+                            description: 'ClaimName is the name of a PersistentVolumeClaim
+                              in the same namespace as the pod using this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            type: string
+                          readOnly:
+                            description: Will force the ReadOnly setting in VolumeMounts.
+                              Default false.
+                            type: boolean
+                      photonPersistentDisk:
+                        description: PhotonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - pdID
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: ID that identifies Photon Controller persistent
+                              disk
+                            type: string
+                      portworxVolume:
+                        description: PortworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: FSType represents the filesystem type to
+                              mount Must be a filesystem type supported by the host
+                              operating system. Ex. "ext4", "xfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: VolumeID uniquely identifies a Portworx volume
+                            type: string
+                      projected:
+                        description: Items for all in one resources secrets, configmaps,
+                          and downward API
+                        type: object
+                        required:
+                        - sources
+                        properties:
+                          defaultMode:
+                            description: Mode bits to use on created files by default.
+                              Must be a value between 0 and 0777. Directories within
+                              the path are not affected by this setting. This might
+                              be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode
+                              bits set.
+                            type: integer
+                            format: int32
+                          sources:
+                            description: list of volume projections
+                            type: array
+                            items:
+                              description: Projection that may be projected along
+                                with other supported volume types
+                              type: object
+                              properties:
+                                configMap:
+                                  description: information about the configMap data
+                                    to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced ConfigMap
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the ConfigMap, the
+                                        volume setup will error unless it is marked
+                                        optional. Paths must be relative and may not
+                                        contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        type: object
+                                        required:
+                                        - key
+                                        - path
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path. May not contain the path
+                                              element '..'. May not start with the
+                                              string '..'.
+                                            type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        it's keys must be defined
+                                      type: boolean
+                                downwardAPI:
+                                  description: information about the downwardAPI data
+                                    to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume
+                                        file
+                                      type: array
+                                      items:
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
+                                        type: object
+                                        required:
+                                        - path
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field
+                                              of the pod: only annotations, labels,
+                                              name and namespace are supported.'
+                                            type: object
+                                            required:
+                                            - fieldPath
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: 'Required: Path is  the relative
+                                              path name of the file to be created.
+                                              Must not be absolute or contain the
+                                              ''..'' path. Must be utf-8 encoded.
+                                              The first item of the relative path
+                                              must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.memory,
+                                              requests.cpu and requests.memory) are
+                                              currently supported.'
+                                            type: object
+                                            required:
+                                            - resource
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                type: string
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                secret:
+                                  description: information about the secret data to
+                                    project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced Secret
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the Secret, the volume
+                                        setup will error unless it is marked optional.
+                                        Paths must be relative and may not contain
+                                        the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        type: object
+                                        required:
+                                        - key
+                                        - path
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path. May not contain the path
+                                              element '..'. May not start with the
+                                              string '..'.
+                                            type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                serviceAccountToken:
+                                  description: information about the serviceAccountToken
+                                    data to project
+                                  type: object
+                                  required:
+                                  - path
+                                  properties:
+                                    audience:
+                                      description: Audience is the intended audience
+                                        of the token. A recipient of a token must
+                                        identify itself with an identifier specified
+                                        in the audience of the token, and otherwise
+                                        should reject the token. The audience defaults
+                                        to the identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: ExpirationSeconds is the requested
+                                        duration of validity of the service account
+                                        token. As the token approaches expiration,
+                                        the kubelet volume plugin will proactively
+                                        rotate the service account token. The kubelet
+                                        will start trying to rotate the token if the
+                                        token is older than 80 percent of its time
+                                        to live or if the token is older than 24 hours.Defaults
+                                        to 1 hour and must be at least 10 minutes.
+                                      type: integer
+                                      format: int64
+                                    path:
+                                      description: Path is the path relative to the
+                                        mount point of the file to project the token
+                                        into.
+                                      type: string
+                      quobyte:
+                        description: Quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        type: object
+                        required:
+                        - registry
+                        - volume
+                        properties:
+                          group:
+                            description: Group to map volume access to Default is
+                              no group
+                            type: string
+                          readOnly:
+                            description: ReadOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: Registry represents a single or multiple
+                              Quobyte Registry services specified as a string as host:port
+                              pair (multiple entries are separated with commas) which
+                              acts as the central registry for volumes
+                            type: string
+                          user:
+                            description: User to map volume access to Defaults to
+                              serivceaccount user
+                            type: string
+                          volume:
+                            description: Volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                      rbd:
+                        description: 'RBD represents a Rados Block Device mount on
+                          the host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md'
+                        type: object
+                        required:
+                        - image
+                        - monitors
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          image:
+                            description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'Keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'A collection of Ceph monitors. More info:
+                              https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: array
+                            items:
+                              type: string
+                          pool:
+                            description: 'The rados pool name. Default is rbd. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'SecretRef is name of the authentication
+                              secret for RBDUser. If provided overrides keyring. Default
+                              is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          user:
+                            description: 'The rados user name. Default is admin. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                      scaleIO:
+                        description: ScaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        type: object
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Default is "xfs".
+                            type: string
+                          gateway:
+                            description: The host address of the ScaleIO API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: The name of the ScaleIO Protection Domain
+                              for the configured storage.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not
+                              provided, Login operation will fail.
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          sslEnabled:
+                            description: Flag to enable/disable SSL communication
+                              with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: Indicates whether the storage for a volume
+                              should be ThickProvisioned or ThinProvisioned. Default
+                              is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: The ScaleIO Storage Pool associated with
+                              the protection domain.
+                            type: string
+                          system:
+                            description: The name of the storage system as configured
+                              in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: The name of a volume already created in the
+                              ScaleIO system that is associated with this volume source.
+                            type: string
+                      secret:
+                        description: 'Secret represents a secret that should populate
+                          this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: If unspecified, each key-value pair in the
+                              Data field of the referenced Secret will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the Secret, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                              - key
+                              - path
+                              properties:
+                                key:
+                                  description: The key to project.
+                                  type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: The relative path of the file to map
+                                    the key to. May not be an absolute path. May not
+                                    contain the path element '..'. May not start with
+                                    the string '..'.
+                                  type: string
+                          optional:
+                            description: Specify whether the Secret or it's keys must
+                              be defined
+                            type: boolean
+                          secretName:
+                            description: 'Name of the secret in the pod''s namespace
+                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            type: string
+                      storageos:
+                        description: StorageOS represents a StorageOS volume attached
+                          and mounted on Kubernetes nodes.
+                        type: object
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef specifies the secret to use for
+                              obtaining the StorageOS API credentials.  If not specified,
+                              default values will be attempted.
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          volumeName:
+                            description: VolumeName is the human-readable name of
+                              the StorageOS volume.  Volume names are only unique
+                              within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: VolumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows
+                              the Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name
+                              to override the default behaviour. Set to "default"
+                              if you are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                      vsphereVolume:
+                        description: VsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - volumePath
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: Storage Policy Based Management (SPBM) profile
+                              ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: Storage Policy Based Management (SPBM) profile
+                              name.
+                            type: string
+                          volumePath:
+                            description: Path that identifies vSphere volume vmdk
+                            type: string
+            serviceAccountName:
+              type: string
+            status:
+              description: Used for cancelling a taskrun (and maybe more later on)
+              type: string
+            taskRef:
+              description: no more than one of the TaskRef and TaskSpec may be specified.
+              type: object
+              properties:
+                apiVersion:
+                  description: API version of the referent
+                  type: string
+                kind:
+                  description: TaskKind inficates the kind of the task, namespaced
+                    or cluster scoped.
+                  type: string
+                name:
+                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+            taskSpec:
+              description: TaskSpec defines the desired state of Task.
+              type: object
+              properties:
+                inputs:
+                  description: Inputs is an optional set of parameters and resources
+                    which must be supplied by the user when a Task is executed by
+                    a TaskRun.
+                  type: object
+                  properties:
+                    params:
+                      description: Params is a list of input parameters required to
+                        run the task. Params must be supplied as inputs in TaskRuns
+                        unless they declare a default value.
+                      type: array
+                      items:
+                        description: ParamSpec defines arbitrary parameters needed
+                          beyond typed inputs (such as resources). Parameter values
+                          are provided by users as inputs on a TaskRun or PipelineRun.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          default:
+                            description: Default is the value a parameter takes if
+                              no input value is supplied. If default is set, a Task
+                              may be executed without a supplied value for the parameter.
+                            type: object
+                            required:
+                            - type
+                            properties:
+                              type:
+                                description: ParamType indicates the type of an input
+                                  parameter; Used to distinguish between a single
+                                  string and an array of strings.
+                                type: string
+                          description:
+                            description: Description is a user-facing description
+                              of the parameter that may be used to populate a UI.
+                            type: string
+                          name:
+                            description: Name declares the name by which a parameter
+                              is referenced.
+                            type: string
+                          type:
+                            description: Type is the user-specified type of the parameter.
+                              The possible types are currently "string" and "array",
+                              and "string" is the default.
+                            type: string
+                    resources:
+                      description: Resources is a list of the input resources required
+                        to run the task. Resources are represented in TaskRuns as
+                        bindings to instances of PipelineResources.
+                      type: array
+                      items:
+                        description: TaskResource defines an input or output Resource
+                          declared as a requirement by a Task. The Name field will
+                          be used to refer to these Resources within the Task definition,
+                          and when provided as an Input, the Name will be the path
+                          to the volume mounted containing this Resource as an input
+                          (e.g. an input Resource named `workspace` will be mounted
+                          at `/workspace`).
+                        type: object
+                        required:
+                        - name
+                        - type
+                        properties:
+                          name:
+                            description: Name declares the name by which a resource
+                              is referenced in the definition. Resources may be referenced
+                              by name in the definition of a Task's steps.
+                            type: string
+                          optional:
+                            description: 'Optional declares the resource as optional.
+                              By default optional is set to false which makes a resource
+                              required. optional: true - the resource is considered
+                              optional optional: false - the resource is considered
+                              required (equivalent of not specifying it)'
+                            type: boolean
+                          targetPath:
+                            description: TargetPath is the path in workspace directory
+                              where the resource will be copied.
+                            type: string
+                          type:
+                            description: Type is the type of this resource;
+                            type: string
+                outputs:
+                  description: Outputs is an optional set of resources and results
+                    produced when this Task is run.
+                  type: object
+                  properties:
+                    resources:
+                      type: array
+                      items:
+                        description: TaskResource defines an input or output Resource
+                          declared as a requirement by a Task. The Name field will
+                          be used to refer to these Resources within the Task definition,
+                          and when provided as an Input, the Name will be the path
+                          to the volume mounted containing this Resource as an input
+                          (e.g. an input Resource named `workspace` will be mounted
+                          at `/workspace`).
+                        type: object
+                        required:
+                        - name
+                        - type
+                        properties:
+                          name:
+                            description: Name declares the name by which a resource
+                              is referenced in the definition. Resources may be referenced
+                              by name in the definition of a Task's steps.
+                            type: string
+                          optional:
+                            description: 'Optional declares the resource as optional.
+                              By default optional is set to false which makes a resource
+                              required. optional: true - the resource is considered
+                              optional optional: false - the resource is considered
+                              required (equivalent of not specifying it)'
+                            type: boolean
+                          targetPath:
+                            description: TargetPath is the path in workspace directory
+                              where the resource will be copied.
+                            type: string
+                          type:
+                            description: Type is the type of this resource;
+                            type: string
+                    results:
+                      type: array
+                      items:
+                        description: TestResult allows a task to specify the location
+                          where test logs can be found and what format they will be
+                          in.
+                        type: object
+                        required:
+                        - format
+                        - name
+                        - path
+                        properties:
+                          format:
+                            description: 'TODO: maybe this is an enum with types like
+                              "go test", "junit", etc.'
+                            type: string
+                          name:
+                            description: Name declares the name by which a result
+                              is referenced in the Task's definition. Results may
+                              be referenced by name in the definition of a Task's
+                              steps.
+                            type: string
+                          path:
+                            type: string
+                sidecars:
+                  description: Sidecars are run alongside the Task's step containers.
+                    They begin before the steps start and end after the steps complete.
+                  type: array
+                  items:
+                    description: A single application container that you want to run
+                      within a pod.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      args:
+                        description: 'Arguments to the entrypoint. The docker image''s
+                          CMD is used if this is not provided. Variable references
+                          $(VAR_NAME) are expanded using the container''s environment.
+                          If a variable cannot be resolved, the reference in the input
+                          string will be unchanged. The $(VAR_NAME) syntax can be
+                          escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                          will never be expanded, regardless of whether the variable
+                          exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        type: array
+                        items:
+                          type: string
+                      command:
+                        description: 'Entrypoint array. Not executed within a shell.
+                          The docker image''s ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container''s
+                          environment. If a variable cannot be resolved, the reference
+                          in the input string will be unchanged. The $(VAR_NAME) syntax
+                          can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                          references will never be expanded, regardless of whether
+                          the variable exists or not. Cannot be updated. More info:
+                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        type: array
+                        items:
+                          type: string
+                      env:
+                        description: List of environment variables to set in the container.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          type: object
+                          required:
+                          - name
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              type: object
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  type: object
+                                  required:
+                                  - key
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        it's key must be defined
+                                      type: boolean
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, metadata.labels,
+                                    metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                    status.hostIP, status.podIP.'
+                                  type: object
+                                  required:
+                                  - fieldPath
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
+                                  type: object
+                                  required:
+                                  - resource
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      type: string
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  type: object
+                                  required:
+                                  - key
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or it's
+                                        key must be defined
+                                      type: boolean
+                      envFrom:
+                        description: List of sources to populate environment variables
+                          in the container. The keys defined within a source must
+                          be a C_IDENTIFIER. All invalid keys will be reported as
+                          an event when the container is starting. When a key exists
+                          in multiple sources, the value associated with the last
+                          source will take precedence. Values defined by an Env with
+                          a duplicate key will take precedence. Cannot be updated.
+                        type: array
+                        items:
+                          description: EnvFromSource represents the source of a set
+                            of ConfigMaps
+                          type: object
+                          properties:
+                            configMapRef:
+                              description: The ConfigMap to select from
+                              type: object
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap must
+                                    be defined
+                                  type: boolean
+                            prefix:
+                              description: An optional identifier to prepend to each
+                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              type: string
+                            secretRef:
+                              description: The Secret to select from
+                              type: object
+                              properties:
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret must be
+                                    defined
+                                  type: boolean
+                      image:
+                        description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management
+                          to default or override container images in workload controllers
+                          like Deployments and StatefulSets.'
+                        type: string
+                      imagePullPolicy:
+                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent
+                          otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        type: string
+                      lifecycle:
+                        description: Actions that the management system should take
+                          in response to container lifecycle events. Cannot be updated.
+                        type: object
+                        properties:
+                          postStart:
+                            description: 'PostStart is called immediately after a
+                              container is created. If the handler fails, the container
+                              is terminated and restarted according to its restart
+                              policy. Other management of the container blocks until
+                              the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            type: object
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                type: object
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    type: array
+                                    items:
+                                      type: string
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                type: object
+                                required:
+                                - port
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    type: array
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      type: object
+                                      required:
+                                      - name
+                                      - value
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                type: object
+                                required:
+                                - port
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                          preStop:
+                            description: 'PreStop is called immediately before a container
+                              is terminated. The container is terminated after the
+                              handler completes. The reason for termination is passed
+                              to the handler. Regardless of the outcome of the handler,
+                              the container is eventually terminated. Other management
+                              of the container blocks until the hook completes. More
+                              info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            type: object
+                            properties:
+                              exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
+                                type: object
+                                properties:
+                                  command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory
+                                      for the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it
+                                      is not run inside a shell, so traditional shell
+                                      instructions ('|', etc) won't work. To use a
+                                      shell, you need to explicitly call out to that
+                                      shell. Exit status of 0 is treated as live/healthy
+                                      and non-zero is unhealthy.
+                                    type: array
+                                    items:
+                                      type: string
+                              httpGet:
+                                description: HTTPGet specifies the http request to
+                                  perform.
+                                type: object
+                                required:
+                                - port
+                                properties:
+                                  host:
+                                    description: Host name to connect to, defaults
+                                      to the pod IP. You probably want to set "Host"
+                                      in httpHeaders instead.
+                                    type: string
+                                  httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
+                                    type: array
+                                    items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
+                                      type: object
+                                      required:
+                                      - name
+                                      - value
+                                      properties:
+                                        name:
+                                          description: The header field name
+                                          type: string
+                                        value:
+                                          description: The header field value
+                                          type: string
+                                  path:
+                                    description: Path to access on the HTTP server.
+                                    type: string
+                                  port:
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
+                                    type: string
+                              tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                  a TCP port. TCP hooks not yet supported TODO: implement
+                                  a realistic TCP lifecycle hook'
+                                type: object
+                                required:
+                                - port
+                                properties:
+                                  host:
+                                    description: 'Optional: Host name to connect to,
+                                      defaults to the pod IP.'
+                                    type: string
+                                  port:
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                      livenessProbe:
+                        description: 'Periodic probe of container liveness. Container
+                          will be restarted if the probe fails. Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: object
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  type: object
+                                  required:
+                                  - name
+                                  - value
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            type: integer
+                            format: int32
+                      name:
+                        description: Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
+                        type: string
+                      ports:
+                        description: List of ports to expose from the container. Exposing
+                          a port here gives the system additional information about
+                          the network connections a container uses, but is primarily
+                          informational. Not specifying a port here DOES NOT prevent
+                          that port from being exposed. Any port which is listening
+                          on the default "0.0.0.0" address inside a container will
+                          be accessible from the network. Cannot be updated.
+                        type: array
+                        items:
+                          description: ContainerPort represents a network port in
+                            a single container.
+                          type: object
+                          required:
+                          - containerPort
+                          properties:
+                            containerPort:
+                              description: Number of port to expose on the pod's IP
+                                address. This must be a valid port number, 0 < x <
+                                65536.
+                              type: integer
+                              format: int32
+                            hostIP:
+                              description: What host IP to bind the external port
+                                to.
+                              type: string
+                            hostPort:
+                              description: Number of port to expose on the host. If
+                                specified, this must be a valid port number, 0 < x
+                                < 65536. If HostNetwork is specified, this must match
+                                ContainerPort. Most containers do not need this.
+                              type: integer
+                              format: int32
+                            name:
+                              description: If specified, this must be an IANA_SVC_NAME
+                                and unique within the pod. Each named port in a pod
+                                must have a unique name. Name for the port that can
+                                be referred to by services.
+                              type: string
+                            protocol:
+                              description: Protocol for port. Must be UDP, TCP, or
+                                SCTP. Defaults to "TCP".
+                              type: string
+                      readinessProbe:
+                        description: 'Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the
+                          probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        type: object
+                        properties:
+                          exec:
+                            description: One and only one of the following should
+                              be specified. Exec specifies the action to take.
+                            type: object
+                            properties:
+                              command:
+                                description: Command is the command line to execute
+                                  inside the container, the working directory for
+                                  the command  is root ('/') in the container's filesystem.
+                                  The command is simply exec'd, it is not run inside
+                                  a shell, so traditional shell instructions ('|',
+                                  etc) won't work. To use a shell, you need to explicitly
+                                  call out to that shell. Exit status of 0 is treated
+                                  as live/healthy and non-zero is unhealthy.
+                                type: array
+                                items:
+                                  type: string
+                          failureThreshold:
+                            description: Minimum consecutive failures for the probe
+                              to be considered failed after having succeeded. Defaults
+                              to 3. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          httpGet:
+                            description: HTTPGet specifies the http request to perform.
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to
+                                  the pod IP. You probably want to set "Host" in httpHeaders
+                                  instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request.
+                                  HTTP allows repeated headers.
+                                type: array
+                                items:
+                                  description: HTTPHeader describes a custom header
+                                    to be used in HTTP probes
+                                  type: object
+                                  required:
+                                  - name
+                                  - value
+                                  properties:
+                                    name:
+                                      description: The header field name
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host.
+                                  Defaults to HTTP.
+                                type: string
+                          initialDelaySeconds:
+                            description: 'Number of seconds after the container has
+                              started before liveness probes are initiated. More info:
+                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            type: integer
+                            format: int32
+                          periodSeconds:
+                            description: How often (in seconds) to perform the probe.
+                              Default to 10 seconds. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          successThreshold:
+                            description: Minimum consecutive successes for the probe
+                              to be considered successful after having failed. Defaults
+                              to 1. Must be 1 for liveness. Minimum value is 1.
+                            type: integer
+                            format: int32
+                          tcpSocket:
+                            description: 'TCPSocket specifies an action involving
+                              a TCP port. TCP hooks not yet supported TODO: implement
+                              a realistic TCP lifecycle hook'
+                            type: object
+                            required:
+                            - port
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults
+                                  to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access
+                                  on the container. Number must be in the range 1
+                                  to 65535. Name must be an IANA_SVC_NAME.
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                          timeoutSeconds:
+                            description: 'Number of seconds after which the probe
+                              times out. Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            type: integer
+                            format: int32
+                      resources:
+                        description: 'Compute Resources required by this container.
+                          Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                        properties:
+                          limits:
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                            additionalProperties:
+                              type: string
+                          requests:
+                            description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                            additionalProperties:
+                              type: string
+                      securityContext:
+                        description: 'Security options the pod should run with. More
+                          info: https://kubernetes.io/docs/concepts/policy/security-context/
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        type: object
+                        properties:
+                          allowPrivilegeEscalation:
+                            description: 'AllowPrivilegeEscalation controls whether
+                              a process can gain more privileges than its parent process.
+                              This bool directly controls if the no_new_privs flag
+                              will be set on the container process. AllowPrivilegeEscalation
+                              is true always when the container is: 1) run as Privileged
+                              2) has CAP_SYS_ADMIN'
+                            type: boolean
+                          capabilities:
+                            description: The capabilities to add/drop when running
+                              containers. Defaults to the default set of capabilities
+                              granted by the container runtime.
+                            type: object
+                            properties:
+                              add:
+                                description: Added capabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                              drop:
+                                description: Removed capabilities
+                                type: array
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                          privileged:
+                            description: Run container in privileged mode. Processes
+                              in privileged containers are essentially equivalent
+                              to root on the host. Defaults to false.
+                            type: boolean
+                          procMount:
+                            description: procMount denotes the type of proc mount
+                              to use for the containers. The default is DefaultProcMount
+                              which uses the container runtime defaults for readonly
+                              paths and masked paths. This requires the ProcMountType
+                              feature flag to be enabled.
+                            type: string
+                          readOnlyRootFilesystem:
+                            description: Whether this container has a read-only root
+                              filesystem. Default is false.
+                            type: boolean
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be
+                              set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: integer
+                            format: int64
+                          runAsNonRoot:
+                            description: Indicates that the container must run as
+                              a non-root user. If true, the Kubelet will validate
+                              the image at runtime to ensure that it does not run
+                              as UID 0 (root) and fail to start the container if it
+                              does. If unset or false, no such validation will be
+                              performed. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in PodSecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: integer
+                            format: int64
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to the
+                              container. If unspecified, the container runtime will
+                              allocate a random SELinux context for each container.  May
+                              also be set in PodSecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: object
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                      stdin:
+                        description: Whether this container should allocate a buffer
+                          for stdin in the container runtime. If this is not set,
+                          reads from stdin in the container will always result in
+                          EOF. Default is false.
+                        type: boolean
+                      stdinOnce:
+                        description: Whether the container runtime should close the
+                          stdin channel after it has been opened by a single attach.
+                          When stdin is true the stdin stream will remain open across
+                          multiple attach sessions. If stdinOnce is set to true, stdin
+                          is opened on container start, is empty until the first client
+                          attaches to stdin, and then remains open and accepts data
+                          until the client disconnects, at which time stdin is closed
+                          and remains closed until the container is restarted. If
+                          this flag is false, a container processes that reads from
+                          stdin will never receive an EOF. Default is false
+                        type: boolean
+                      terminationMessagePath:
+                        description: 'Optional: Path at which the file to which the
+                          container''s termination message will be written is mounted
+                          into the container''s filesystem. Message written is intended
+                          to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes.
+                          The total message length across all containers will be limited
+                          to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        type: string
+                      terminationMessagePolicy:
+                        description: Indicate how the termination message should be
+                          populated. File will use the contents of terminationMessagePath
+                          to populate the container status message on both success
+                          and failure. FallbackToLogsOnError will use the last chunk
+                          of container log output if the termination message file
+                          is empty and the container exited with an error. The log
+                          output is limited to 2048 bytes or 80 lines, whichever is
+                          smaller. Defaults to File. Cannot be updated.
+                        type: string
+                      tty:
+                        description: Whether this container should allocate a TTY
+                          for itself, also requires 'stdin' to be true. Default is
+                          false.
+                        type: boolean
+                      volumeDevices:
+                        description: volumeDevices is the list of block devices to
+                          be used by the container. This is a beta feature.
+                        type: array
+                        items:
+                          description: volumeDevice describes a mapping of a raw block
+                            device within a container.
+                          type: object
+                          required:
+                          - devicePath
+                          - name
+                          properties:
+                            devicePath:
+                              description: devicePath is the path inside of the container
+                                that the device will be mapped to.
+                              type: string
+                            name:
+                              description: name must match the name of a persistentVolumeClaim
+                                in the pod
+                              type: string
+                      volumeMounts:
+                        description: Pod volumes to mount into the container's filesystem.
+                          Cannot be updated.
+                        type: array
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          type: object
+                          required:
+                          - mountPath
+                          - name
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the
+                                volume should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts
+                                are propagated from the host to container and the
+                                other way around. When not set, MountPropagationNone
+                                is used. This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's
+                                root).
+                              type: string
+                      workingDir:
+                        description: Container's working directory. If not specified,
+                          the container runtime's default will be used, which might
+                          be configured in the container image. Cannot be updated.
+                        type: string
+                stepTemplate:
+                  description: StepTemplate can be used as the basis for all step
+                    containers within the Task, so that the steps inherit settings
+                    on the base container.
+                  type: object
+                  required:
+                  - name
+                  properties:
+                    args:
+                      description: 'Arguments to the entrypoint. The docker image''s
+                        CMD is used if this is not provided. Variable references $(VAR_NAME)
+                        are expanded using the container''s environment. If a variable
+                        cannot be resolved, the reference in the input string will
+                        be unchanged. The $(VAR_NAME) syntax can be escaped with a
+                        double $$, ie: $$(VAR_NAME). Escaped references will never
+                        be expanded, regardless of whether the variable exists or
+                        not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      type: array
+                      items:
+                        type: string
+                    command:
+                      description: 'Entrypoint array. Not executed within a shell.
+                        The docker image''s ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container''s
+                        environment. If a variable cannot be resolved, the reference
+                        in the input string will be unchanged. The $(VAR_NAME) syntax
+                        can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                        references will never be expanded, regardless of whether the
+                        variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                      type: array
+                      items:
+                        type: string
+                    env:
+                      description: List of environment variables to set in the container.
+                        Cannot be updated.
+                      type: array
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        type: object
+                        required:
+                        - name
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            type: object
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                type: object
+                                required:
+                                - key
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      it's key must be defined
+                                    type: boolean
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, metadata.labels,
+                                  metadata.annotations, spec.nodeName, spec.serviceAccountName,
+                                  status.hostIP, status.podIP.'
+                                type: object
+                                required:
+                                - fieldPath
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                type: object
+                                required:
+                                - resource
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    type: string
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                type: object
+                                required:
+                                - key
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or it's
+                                      key must be defined
+                                    type: boolean
+                    envFrom:
+                      description: List of sources to populate environment variables
+                        in the container. The keys defined within a source must be
+                        a C_IDENTIFIER. All invalid keys will be reported as an event
+                        when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take
+                        precedence. Values defined by an Env with a duplicate key
+                        will take precedence. Cannot be updated.
+                      type: array
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        type: object
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                    image:
+                      description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management
+                        to default or override container images in workload controllers
+                        like Deployments and StatefulSets.'
+                      type: string
+                    imagePullPolicy:
+                      description: 'Image pull policy. One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent
+                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                      type: string
+                    lifecycle:
+                      description: Actions that the management system should take
+                        in response to container lifecycle events. Cannot be updated.
+                      type: object
+                      properties:
+                        postStart:
+                          description: 'PostStart is called immediately after a container
+                            is created. If the handler fails, the container is terminated
+                            and restarted according to its restart policy. Other management
+                            of the container blocks until the hook completes. More
+                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          type: object
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              type: object
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  type: array
+                                  items:
+                                    type: string
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              type: object
+                              required:
+                              - port
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  type: array
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    type: object
+                                    required:
+                                    - name
+                                    - value
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              type: object
+                              required:
+                              - port
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                        preStop:
+                          description: 'PreStop is called immediately before a container
+                            is terminated. The container is terminated after the handler
+                            completes. The reason for termination is passed to the
+                            handler. Regardless of the outcome of the handler, the
+                            container is eventually terminated. Other management of
+                            the container blocks until the hook completes. More info:
+                            https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                          type: object
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              type: object
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's
+                                    filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions
+                                    ('|', etc) won't work. To use a shell, you need
+                                    to explicitly call out to that shell. Exit status
+                                    of 0 is treated as live/healthy and non-zero is
+                                    unhealthy.
+                                  type: array
+                                  items:
+                                    type: string
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              type: object
+                              required:
+                              - port
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in
+                                    httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  type: array
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    type: object
+                                    required:
+                                    - name
+                                    - value
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the
+                                    host. Defaults to HTTP.
+                                  type: string
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              type: object
+                              required:
+                              - port
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range
+                                    1 to 65535. Name must be an IANA_SVC_NAME.
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                    livenessProbe:
+                      description: 'Periodic probe of container liveness. Container
+                        will be restarted if the probe fails. Cannot be updated. More
+                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          type: integer
+                          format: int32
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          type: integer
+                          format: int32
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          type: integer
+                          format: int32
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          type: integer
+                          format: int32
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          type: integer
+                          format: int32
+                    name:
+                      description: Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: List of ports to expose from the container. Exposing
+                        a port here gives the system additional information about
+                        the network connections a container uses, but is primarily
+                        informational. Not specifying a port here DOES NOT prevent
+                        that port from being exposed. Any port which is listening
+                        on the default "0.0.0.0" address inside a container will be
+                        accessible from the network. Cannot be updated.
+                      type: array
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        type: object
+                        required:
+                        - containerPort
+                        properties:
+                          containerPort:
+                            description: Number of port to expose on the pod's IP
+                              address. This must be a valid port number, 0 < x < 65536.
+                            type: integer
+                            format: int32
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: Number of port to expose on the host. If
+                              specified, this must be a valid port number, 0 < x <
+                              65536. If HostNetwork is specified, this must match
+                              ContainerPort. Most containers do not need this.
+                            type: integer
+                            format: int32
+                          name:
+                            description: If specified, this must be an IANA_SVC_NAME
+                              and unique within the pod. Each named port in a pod
+                              must have a unique name. Name for the port that can
+                              be referred to by services.
+                            type: string
+                          protocol:
+                            description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                    readinessProbe:
+                      description: 'Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe
+                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      type: object
+                      properties:
+                        exec:
+                          description: One and only one of the following should be
+                            specified. Exec specifies the action to take.
+                          type: object
+                          properties:
+                            command:
+                              description: Command is the command line to execute
+                                inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem.
+                                The command is simply exec'd, it is not run inside
+                                a shell, so traditional shell instructions ('|', etc)
+                                won't work. To use a shell, you need to explicitly
+                                call out to that shell. Exit status of 0 is treated
+                                as live/healthy and non-zero is unhealthy.
+                              type: array
+                              items:
+                                type: string
+                        failureThreshold:
+                          description: Minimum consecutive failures for the probe
+                            to be considered failed after having succeeded. Defaults
+                            to 3. Minimum value is 1.
+                          type: integer
+                          format: int32
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: Host name to connect to, defaults to the
+                                pod IP. You probably want to set "Host" in httpHeaders
+                                instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              type: array
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                type: object
+                                required:
+                                - name
+                                - value
+                                properties:
+                                  name:
+                                    description: The header field name
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              description: Name or number of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                        initialDelaySeconds:
+                          description: 'Number of seconds after the container has
+                            started before liveness probes are initiated. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          type: integer
+                          format: int32
+                        periodSeconds:
+                          description: How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          type: integer
+                          format: int32
+                        successThreshold:
+                          description: Minimum consecutive successes for the probe
+                            to be considered successful after having failed. Defaults
+                            to 1. Must be 1 for liveness. Minimum value is 1.
+                          type: integer
+                          format: int32
+                        tcpSocket:
+                          description: 'TCPSocket specifies an action involving a
+                            TCP port. TCP hooks not yet supported TODO: implement
+                            a realistic TCP lifecycle hook'
+                          type: object
+                          required:
+                          - port
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              description: Number or name of the port to access on
+                                the container. Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                        timeoutSeconds:
+                          description: 'Number of seconds after which the probe times
+                            out. Defaults to 1 second. Minimum value is 1. More info:
+                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          type: integer
+                          format: int32
+                    resources:
+                      description: 'Compute Resources required by this container.
+                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                      properties:
+                        limits:
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                          additionalProperties:
+                            type: string
+                        requests:
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                          additionalProperties:
+                            type: string
+                    securityContext:
+                      description: 'Security options the pod should run with. More
+                        info: https://kubernetes.io/docs/concepts/policy/security-context/
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                      type: object
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: 'AllowPrivilegeEscalation controls whether
+                            a process can gain more privileges than its parent process.
+                            This bool directly controls if the no_new_privs flag will
+                            be set on the container process. AllowPrivilegeEscalation
+                            is true always when the container is: 1) run as Privileged
+                            2) has CAP_SYS_ADMIN'
+                          type: boolean
+                        capabilities:
+                          description: The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by
+                            the container runtime.
+                          type: object
+                          properties:
+                            add:
+                              description: Added capabilities
+                              type: array
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                            drop:
+                              description: Removed capabilities
+                              type: array
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                        privileged:
+                          description: Run container in privileged mode. Processes
+                            in privileged containers are essentially equivalent to
+                            root on the host. Defaults to false.
+                          type: boolean
+                        procMount:
+                          description: procMount denotes the type of proc mount to
+                            use for the containers. The default is DefaultProcMount
+                            which uses the container runtime defaults for readonly
+                            paths and masked paths. This requires the ProcMountType
+                            feature flag to be enabled.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: Whether this container has a read-only root
+                            filesystem. Default is false.
+                          type: boolean
+                        runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: integer
+                          format: int64
+                        runAsNonRoot:
+                          description: Indicates that the container must run as a
+                            non-root user. If true, the Kubelet will validate the
+                            image at runtime to ensure that it does not run as UID
+                            0 (root) and fail to start the container if it does. If
+                            unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both
+                            SecurityContext and PodSecurityContext, the value specified
+                            in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata
+                            if unspecified. May also be set in PodSecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: integer
+                          format: int64
+                        seLinuxOptions:
+                          description: The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a
+                            random SELinux context for each container.  May also be
+                            set in PodSecurityContext.  If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
+                          type: object
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                    stdin:
+                      description: Whether this container should allocate a buffer
+                        for stdin in the container runtime. If this is not set, reads
+                        from stdin in the container will always result in EOF. Default
+                        is false.
+                      type: boolean
+                    stdinOnce:
+                      description: Whether the container runtime should close the
+                        stdin channel after it has been opened by a single attach.
+                        When stdin is true the stdin stream will remain open across
+                        multiple attach sessions. If stdinOnce is set to true, stdin
+                        is opened on container start, is empty until the first client
+                        attaches to stdin, and then remains open and accepts data
+                        until the client disconnects, at which time stdin is closed
+                        and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin
+                        will never receive an EOF. Default is false
+                      type: boolean
+                    terminationMessagePath:
+                      description: 'Optional: Path at which the file to which the
+                        container''s termination message will be written is mounted
+                        into the container''s filesystem. Message written is intended
+                        to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes.
+                        The total message length across all containers will be limited
+                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                      type: string
+                    terminationMessagePolicy:
+                      description: Indicate how the termination message should be
+                        populated. File will use the contents of terminationMessagePath
+                        to populate the container status message on both success and
+                        failure. FallbackToLogsOnError will use the last chunk of
+                        container log output if the termination message file is empty
+                        and the container exited with an error. The log output is
+                        limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
+                        to File. Cannot be updated.
+                      type: string
+                    tty:
+                      description: Whether this container should allocate a TTY for
+                        itself, also requires 'stdin' to be true. Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container. This is a beta feature.
+                      type: array
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        type: object
+                        required:
+                        - devicePath
+                        - name
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                    volumeMounts:
+                      description: Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      type: array
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        type: object
+                        required:
+                        - mountPath
+                        - name
+                        properties:
+                          mountPath:
+                            description: Path within the container at which the volume
+                              should be mounted.  Must not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: mountPropagation determines how mounts are
+                              propagated from the host to container and the other
+                              way around. When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: Mounted read-only if true, read-write otherwise
+                              (false or unspecified). Defaults to false.
+                            type: boolean
+                          subPath:
+                            description: Path within the volume from which the container's
+                              volume should be mounted. Defaults to "" (volume's root).
+                            type: string
+                    workingDir:
+                      description: Container's working directory. If not specified,
+                        the container runtime's default will be used, which might
+                        be configured in the container image. Cannot be updated.
+                      type: string
+                steps:
+                  description: Steps are the steps of the build; each step is run
+                    sequentially with the source mounted into /workspace.
+                  type: array
+                  items:
+                    description: Step embeds the Container type, which allows it to
+                      include fields not provided by Container.
+                    type: object
+                    properties:
+                      script:
+                        description: "Script is the contents of an executable file
+                          to execute. \n If Script is not empty, the Step cannot have
+                          an Command or Args."
+                        type: string
+                volumes:
+                  description: Volumes is a collection of volumes that are available
+                    to mount into the steps of the build.
+                  type: array
+                  items:
+                    description: Volume represents a named volume in a pod that may
+                      be accessed by any container in the pod.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      awsElasticBlockStore:
+                        description: 'AWSElasticBlockStore represents an AWS Disk
+                          resource that is attached to a kubelet''s host machine and
+                          then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).'
+                            type: integer
+                            format: int32
+                          readOnly:
+                            description: 'Specify "true" to force and set the ReadOnly
+                              property in VolumeMounts to "true". If omitted, the
+                              default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'Unique ID of the persistent disk resource
+                              in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                      azureDisk:
+                        description: AzureDisk represents an Azure Data Disk mount
+                          on the host and bind mount to the pod.
+                        type: object
+                        required:
+                        - diskName
+                        - diskURI
+                        properties:
+                          cachingMode:
+                            description: 'Host Caching mode: None, Read Only, Read
+                              Write.'
+                            type: string
+                          diskName:
+                            description: The Name of the data disk in the blob storage
+                            type: string
+                          diskURI:
+                            description: The URI the data disk in the blob storage
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'Expected values Shared: multiple blob disks
+                              per storage account  Dedicated: single blob disk per
+                              storage account  Managed: azure managed data disk (only
+                              in managed availability set). defaults to shared'
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                      azureFile:
+                        description: AzureFile represents an Azure File Service mount
+                          on the host and bind mount to the pod.
+                        type: object
+                        required:
+                        - secretName
+                        - shareName
+                        properties:
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: the name of secret that contains Azure Storage
+                              Account Name and Key
+                            type: string
+                          shareName:
+                            description: Share Name
+                            type: string
+                      cephfs:
+                        description: CephFS represents a Ceph FS mount on the host
+                          that shares a pod's lifetime
+                        type: object
+                        required:
+                        - monitors
+                        properties:
+                          monitors:
+                            description: 'Required: Monitors is a collection of Ceph
+                              monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: array
+                            items:
+                              type: string
+                          path:
+                            description: 'Optional: Used as the mounted root, rather
+                              than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'Optional: SecretFile is the path to key
+                              ring for User, default is /etc/ceph/user.secret More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              authentication secret for User, default is empty. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          user:
+                            description: 'Optional: User is the rados user name, default
+                              is admin More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                      cinder:
+                        description: 'Cinder represents a cinder volume attached and
+                          mounted on kubelets host machine More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Examples:
+                              "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
+                              if unspecified. More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: points to a secret object containing
+                              parameters used to connect to OpenStack.'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          volumeID:
+                            description: 'volume id used to identify the volume in
+                              cinder More info: https://releases.k8s.io/HEAD/examples/mysql-cinder-pd/README.md'
+                            type: string
+                      configMap:
+                        description: ConfigMap represents a configMap that should
+                          populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: If unspecified, each key-value pair in the
+                              Data field of the referenced ConfigMap will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the ConfigMap, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                              - key
+                              - path
+                              properties:
+                                key:
+                                  description: The key to project.
+                                  type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: The relative path of the file to map
+                                    the key to. May not be an absolute path. May not
+                                    contain the path element '..'. May not start with
+                                    the string '..'.
+                                  type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap or it's keys
+                              must be defined
+                            type: boolean
+                      downwardAPI:
+                        description: DownwardAPI represents downward API about the
+                          pod that should populate this volume
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: Items is a list of downward API volume file
+                            type: array
+                            items:
+                              description: DownwardAPIVolumeFile represents information
+                                to create the file containing the pod field
+                              type: object
+                              required:
+                              - path
+                              properties:
+                                fieldRef:
+                                  description: 'Required: Selects a field of the pod:
+                                    only annotations, labels, name and namespace are
+                                    supported.'
+                                  type: object
+                                  required:
+                                  - fieldPath
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: 'Required: Path is  the relative path
+                                    name of the file to be created. Must not be absolute
+                                    or contain the ''..'' path. Must be utf-8 encoded.
+                                    The first item of the relative path must not start
+                                    with ''..'''
+                                  type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, requests.cpu and requests.memory)
+                                    are currently supported.'
+                                  type: object
+                                  required:
+                                  - resource
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      type: string
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                      emptyDir:
+                        description: 'EmptyDir represents a temporary directory that
+                          shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: object
+                        properties:
+                          medium:
+                            description: 'What type of storage medium should back
+                              this directory. The default is "" which means to use
+                              the node''s default medium. Must be an empty string
+                              (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit:
+                            description: 'Total amount of local storage required for
+                              this EmptyDir volume. The size limit is also applicable
+                              for memory medium. The maximum usage on memory medium
+                              EmptyDir would be the minimum value between the SizeLimit
+                              specified here and the sum of memory limits of all containers
+                              in a pod. The default is nil which means that the limit
+                              is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                            type: string
+                      fc:
+                        description: FC represents a Fibre Channel resource that is
+                          attached to a kubelet's host machine and then exposed to
+                          the pod.
+                        type: object
+                        properties:
+                          fsType:
+                            description: 'Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          lun:
+                            description: 'Optional: FC target lun number'
+                            type: integer
+                            format: int32
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'Optional: FC target worldwide names (WWNs)'
+                            type: array
+                            items:
+                              type: string
+                          wwids:
+                            description: 'Optional: FC volume world wide identifiers
+                              (wwids) Either wwids or combination of targetWWNs and
+                              lun must be set, but not both simultaneously.'
+                            type: array
+                            items:
+                              type: string
+                      flexVolume:
+                        description: FlexVolume represents a generic volume resource
+                          that is provisioned/attached using an exec based plugin.
+                        type: object
+                        required:
+                        - driver
+                        properties:
+                          driver:
+                            description: Driver is the name of the driver to use for
+                              this volume.
+                            type: string
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". The default filesystem depends on FlexVolume
+                              script.
+                            type: string
+                          options:
+                            description: 'Optional: Extra command options if any.'
+                            type: object
+                            additionalProperties:
+                              type: string
+                          readOnly:
+                            description: 'Optional: Defaults to false (read/write).
+                              ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'Optional: SecretRef is reference to the
+                              secret object containing sensitive information to pass
+                              to the plugin scripts. This may be empty if no secret
+                              object is specified. If the secret object contains more
+                              than one secret, all secrets are passed to the plugin
+                              scripts.'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                      flocker:
+                        description: Flocker represents a Flocker volume attached
+                          to a kubelet's host machine. This depends on the Flocker
+                          control service being running
+                        type: object
+                        properties:
+                          datasetName:
+                            description: Name of the dataset stored as metadata ->
+                              name on the dataset for Flocker should be considered
+                              as deprecated
+                            type: string
+                          datasetUUID:
+                            description: UUID of the dataset. This is unique identifier
+                              of a Flocker dataset
+                            type: string
+                      gcePersistentDisk:
+                        description: 'GCEPersistentDisk represents a GCE Disk resource
+                          that is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        type: object
+                        required:
+                        - pdName
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          partition:
+                            description: 'The partition in the volume that you want
+                              to mount. If omitted, the default is to mount by volume
+                              name. Examples: For volume /dev/sda1, you specify the
+                              partition as "1". Similarly, the volume partition for
+                              /dev/sda is "0" (or you can leave the property empty).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: integer
+                            format: int32
+                          pdName:
+                            description: 'Unique name of the PD resource in GCE. Used
+                              to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                      gitRepo:
+                        description: 'GitRepo represents a git repository at a particular
+                          revision. DEPRECATED: GitRepo is deprecated. To provision
+                          a container with a git repo, mount an EmptyDir into an InitContainer
+                          that clones the repo using git, then mount the EmptyDir
+                          into the Pod''s container.'
+                        type: object
+                        required:
+                        - repository
+                        properties:
+                          directory:
+                            description: Target directory name. Must not contain or
+                              start with '..'.  If '.' is supplied, the volume directory
+                              will be the git repository.  Otherwise, if specified,
+                              the volume will contain the git repository in the subdirectory
+                              with the given name.
+                            type: string
+                          repository:
+                            description: Repository URL
+                            type: string
+                          revision:
+                            description: Commit hash for the specified revision.
+                            type: string
+                      glusterfs:
+                        description: 'Glusterfs represents a Glusterfs mount on the
+                          host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md'
+                        type: object
+                        required:
+                        - endpoints
+                        - path
+                        properties:
+                          endpoints:
+                            description: 'EndpointsName is the endpoint name that
+                              details Glusterfs topology. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'Path is the Glusterfs volume path. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the Glusterfs volume
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                      hostPath:
+                        description: 'HostPath represents a pre-existing file or directory
+                          on the host machine that is directly exposed to the container.
+                          This is generally used for system agents or other privileged
+                          things that are allowed to see the host machine. Most containers
+                          will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          --- TODO(jonesdl) We need to restrict who can use host directory
+                          mounts and who can/can not mount host directories as read/write.'
+                        type: object
+                        required:
+                        - path
+                        properties:
+                          path:
+                            description: 'Path of the directory on the host. If the
+                              path is a symlink, it will follow the link to the real
+                              path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'Type for HostPath Volume Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                      iscsi:
+                        description: 'ISCSI represents an ISCSI Disk resource that
+                          is attached to a kubelet''s host machine and then exposed
+                          to the pod. More info: https://releases.k8s.io/HEAD/examples/volumes/iscsi/README.md'
+                        type: object
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        properties:
+                          chapAuthDiscovery:
+                            description: whether support iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: whether support iSCSI Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          initiatorName:
+                            description: Custom iSCSI Initiator Name. If initiatorName
+                              is specified with iscsiInterface simultaneously, new
+                              iSCSI interface <target portal>:<volume name> will be
+                              created for the connection.
+                            type: string
+                          iqn:
+                            description: Target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iSCSI Interface Name that uses an iSCSI transport.
+                              Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: iSCSI Target Lun number.
+                            type: integer
+                            format: int32
+                          portals:
+                            description: iSCSI Target Portal List. The portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: array
+                            items:
+                              type: string
+                          readOnly:
+                            description: ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: CHAP Secret for iSCSI target and initiator
+                              authentication
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          targetPortal:
+                            description: iSCSI Target Portal. The Portal is either
+                              an IP or ip_addr:port if the port is other than default
+                              (typically TCP ports 860 and 3260).
+                            type: string
+                      name:
+                        description: 'Volume''s name. Must be a DNS_LABEL and unique
+                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      nfs:
+                        description: 'NFS represents an NFS mount on the host that
+                          shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        type: object
+                        required:
+                        - path
+                        - server
+                        properties:
+                          path:
+                            description: 'Path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the NFS export
+                              to be mounted with read-only permissions. Defaults to
+                              false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'Server is the hostname or IP address of
+                              the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                      persistentVolumeClaim:
+                        description: 'PersistentVolumeClaimVolumeSource represents
+                          a reference to a PersistentVolumeClaim in the same namespace.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: object
+                        required:
+                        - claimName
+                        properties:
+                          claimName:
+                            description: 'ClaimName is the name of a PersistentVolumeClaim
+                              in the same namespace as the pod using this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            type: string
+                          readOnly:
+                            description: Will force the ReadOnly setting in VolumeMounts.
+                              Default false.
+                            type: boolean
+                      photonPersistentDisk:
+                        description: PhotonPersistentDisk represents a PhotonController
+                          persistent disk attached and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - pdID
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: ID that identifies Photon Controller persistent
+                              disk
+                            type: string
+                      portworxVolume:
+                        description: PortworxVolume represents a portworx volume attached
+                          and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - volumeID
+                        properties:
+                          fsType:
+                            description: FSType represents the filesystem type to
+                              mount Must be a filesystem type supported by the host
+                              operating system. Ex. "ext4", "xfs". Implicitly inferred
+                              to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: VolumeID uniquely identifies a Portworx volume
+                            type: string
+                      projected:
+                        description: Items for all in one resources secrets, configmaps,
+                          and downward API
+                        type: object
+                        required:
+                        - sources
+                        properties:
+                          defaultMode:
+                            description: Mode bits to use on created files by default.
+                              Must be a value between 0 and 0777. Directories within
+                              the path are not affected by this setting. This might
+                              be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode
+                              bits set.
+                            type: integer
+                            format: int32
+                          sources:
+                            description: list of volume projections
+                            type: array
+                            items:
+                              description: Projection that may be projected along
+                                with other supported volume types
+                              type: object
+                              properties:
+                                configMap:
+                                  description: information about the configMap data
+                                    to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced ConfigMap
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the ConfigMap, the
+                                        volume setup will error unless it is marked
+                                        optional. Paths must be relative and may not
+                                        contain the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        type: object
+                                        required:
+                                        - key
+                                        - path
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path. May not contain the path
+                                              element '..'. May not start with the
+                                              string '..'.
+                                            type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        it's keys must be defined
+                                      type: boolean
+                                downwardAPI:
+                                  description: information about the downwardAPI data
+                                    to project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume
+                                        file
+                                      type: array
+                                      items:
+                                        description: DownwardAPIVolumeFile represents
+                                          information to create the file containing
+                                          the pod field
+                                        type: object
+                                        required:
+                                        - path
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field
+                                              of the pod: only annotations, labels,
+                                              name and namespace are supported.'
+                                            type: object
+                                            required:
+                                            - fieldPath
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema
+                                                  the FieldPath is written in terms
+                                                  of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to
+                                                  select in the specified API version.
+                                                type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: 'Required: Path is  the relative
+                                              path name of the file to be created.
+                                              Must not be absolute or contain the
+                                              ''..'' path. Must be utf-8 encoded.
+                                              The first item of the relative path
+                                              must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the
+                                              container: only resources limits and
+                                              requests (limits.cpu, limits.memory,
+                                              requests.cpu and requests.memory) are
+                                              currently supported.'
+                                            type: object
+                                            required:
+                                            - resource
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required
+                                                  for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output
+                                                  format of the exposed resources,
+                                                  defaults to "1"
+                                                type: string
+                                              resource:
+                                                description: 'Required: resource to
+                                                  select'
+                                                type: string
+                                secret:
+                                  description: information about the secret data to
+                                    project
+                                  type: object
+                                  properties:
+                                    items:
+                                      description: If unspecified, each key-value
+                                        pair in the Data field of the referenced Secret
+                                        will be projected into the volume as a file
+                                        whose name is the key and content is the value.
+                                        If specified, the listed keys will be projected
+                                        into the specified paths, and unlisted keys
+                                        will not be present. If a key is specified
+                                        which is not present in the Secret, the volume
+                                        setup will error unless it is marked optional.
+                                        Paths must be relative and may not contain
+                                        the '..' path or start with '..'.
+                                      type: array
+                                      items:
+                                        description: Maps a string key to a path within
+                                          a volume.
+                                        type: object
+                                        required:
+                                        - key
+                                        - path
+                                        properties:
+                                          key:
+                                            description: The key to project.
+                                            type: string
+                                          mode:
+                                            description: 'Optional: mode bits to use
+                                              on this file, must be a value between
+                                              0 and 0777. If not specified, the volume
+                                              defaultMode will be used. This might
+                                              be in conflict with other options that
+                                              affect the file mode, like fsGroup,
+                                              and the result can be other mode bits
+                                              set.'
+                                            type: integer
+                                            format: int32
+                                          path:
+                                            description: The relative path of the
+                                              file to map the key to. May not be an
+                                              absolute path. May not contain the path
+                                              element '..'. May not start with the
+                                              string '..'.
+                                            type: string
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                serviceAccountToken:
+                                  description: information about the serviceAccountToken
+                                    data to project
+                                  type: object
+                                  required:
+                                  - path
+                                  properties:
+                                    audience:
+                                      description: Audience is the intended audience
+                                        of the token. A recipient of a token must
+                                        identify itself with an identifier specified
+                                        in the audience of the token, and otherwise
+                                        should reject the token. The audience defaults
+                                        to the identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: ExpirationSeconds is the requested
+                                        duration of validity of the service account
+                                        token. As the token approaches expiration,
+                                        the kubelet volume plugin will proactively
+                                        rotate the service account token. The kubelet
+                                        will start trying to rotate the token if the
+                                        token is older than 80 percent of its time
+                                        to live or if the token is older than 24 hours.Defaults
+                                        to 1 hour and must be at least 10 minutes.
+                                      type: integer
+                                      format: int64
+                                    path:
+                                      description: Path is the path relative to the
+                                        mount point of the file to project the token
+                                        into.
+                                      type: string
+                      quobyte:
+                        description: Quobyte represents a Quobyte mount on the host
+                          that shares a pod's lifetime
+                        type: object
+                        required:
+                        - registry
+                        - volume
+                        properties:
+                          group:
+                            description: Group to map volume access to Default is
+                              no group
+                            type: string
+                          readOnly:
+                            description: ReadOnly here will force the Quobyte volume
+                              to be mounted with read-only permissions. Defaults to
+                              false.
+                            type: boolean
+                          registry:
+                            description: Registry represents a single or multiple
+                              Quobyte Registry services specified as a string as host:port
+                              pair (multiple entries are separated with commas) which
+                              acts as the central registry for volumes
+                            type: string
+                          user:
+                            description: User to map volume access to Defaults to
+                              serivceaccount user
+                            type: string
+                          volume:
+                            description: Volume is a string that references an already
+                              created Quobyte volume by name.
+                            type: string
+                      rbd:
+                        description: 'RBD represents a Rados Block Device mount on
+                          the host that shares a pod''s lifetime. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md'
+                        type: object
+                        required:
+                        - image
+                        - monitors
+                        properties:
+                          fsType:
+                            description: 'Filesystem type of the volume that you want
+                              to mount. Tip: Ensure that the filesystem type is supported
+                              by the host operating system. Examples: "ext4", "xfs",
+                              "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              TODO: how do we prevent errors in the filesystem from
+                              compromising the machine'
+                            type: string
+                          image:
+                            description: 'The rados image name. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'Keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'A collection of Ceph monitors. More info:
+                              https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: array
+                            items:
+                              type: string
+                          pool:
+                            description: 'The rados pool name. Default is rbd. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'ReadOnly here will force the ReadOnly setting
+                              in VolumeMounts. Defaults to false. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'SecretRef is name of the authentication
+                              secret for RBDUser. If provided overrides keyring. Default
+                              is nil. More info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          user:
+                            description: 'The rados user name. Default is admin. More
+                              info: https://releases.k8s.io/HEAD/examples/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                      scaleIO:
+                        description: ScaleIO represents a ScaleIO persistent volume
+                          attached and mounted on Kubernetes nodes.
+                        type: object
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Default is "xfs".
+                            type: string
+                          gateway:
+                            description: The host address of the ScaleIO API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: The name of the ScaleIO Protection Domain
+                              for the configured storage.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef references to the secret for ScaleIO
+                              user and other sensitive information. If this is not
+                              provided, Login operation will fail.
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          sslEnabled:
+                            description: Flag to enable/disable SSL communication
+                              with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: Indicates whether the storage for a volume
+                              should be ThickProvisioned or ThinProvisioned. Default
+                              is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: The ScaleIO Storage Pool associated with
+                              the protection domain.
+                            type: string
+                          system:
+                            description: The name of the storage system as configured
+                              in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: The name of a volume already created in the
+                              ScaleIO system that is associated with this volume source.
+                            type: string
+                      secret:
+                        description: 'Secret represents a secret that should populate
+                          this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        type: object
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files
+                              by default. Must be a value between 0 and 0777. Defaults
+                              to 0644. Directories within the path are not affected
+                              by this setting. This might be in conflict with other
+                              options that affect the file mode, like fsGroup, and
+                              the result can be other mode bits set.'
+                            type: integer
+                            format: int32
+                          items:
+                            description: If unspecified, each key-value pair in the
+                              Data field of the referenced Secret will be projected
+                              into the volume as a file whose name is the key and
+                              content is the value. If specified, the listed keys
+                              will be projected into the specified paths, and unlisted
+                              keys will not be present. If a key is specified which
+                              is not present in the Secret, the volume setup will
+                              error unless it is marked optional. Paths must be relative
+                              and may not contain the '..' path or start with '..'.
+                            type: array
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              type: object
+                              required:
+                              - key
+                              - path
+                              properties:
+                                key:
+                                  description: The key to project.
+                                  type: string
+                                mode:
+                                  description: 'Optional: mode bits to use on this
+                                    file, must be a value between 0 and 0777. If not
+                                    specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  type: integer
+                                  format: int32
+                                path:
+                                  description: The relative path of the file to map
+                                    the key to. May not be an absolute path. May not
+                                    contain the path element '..'. May not start with
+                                    the string '..'.
+                                  type: string
+                          optional:
+                            description: Specify whether the Secret or it's keys must
+                              be defined
+                            type: boolean
+                          secretName:
+                            description: 'Name of the secret in the pod''s namespace
+                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            type: string
+                      storageos:
+                        description: StorageOS represents a StorageOS volume attached
+                          and mounted on Kubernetes nodes.
+                        type: object
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: Defaults to false (read/write). ReadOnly
+                              here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: SecretRef specifies the secret to use for
+                              obtaining the StorageOS API credentials.  If not specified,
+                              default values will be attempted.
+                            type: object
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                          volumeName:
+                            description: VolumeName is the human-readable name of
+                              the StorageOS volume.  Volume names are only unique
+                              within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: VolumeNamespace specifies the scope of the
+                              volume within StorageOS.  If no namespace is specified
+                              then the Pod's namespace will be used.  This allows
+                              the Kubernetes name scoping to be mirrored within StorageOS
+                              for tighter integration. Set VolumeName to any name
+                              to override the default behaviour. Set to "default"
+                              if you are not using namespaces within StorageOS. Namespaces
+                              that do not pre-exist within StorageOS will be created.
+                            type: string
+                      vsphereVolume:
+                        description: VsphereVolume represents a vSphere volume attached
+                          and mounted on kubelets host machine
+                        type: object
+                        required:
+                        - volumePath
+                        properties:
+                          fsType:
+                            description: Filesystem type to mount. Must be a filesystem
+                              type supported by the host operating system. Ex. "ext4",
+                              "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: Storage Policy Based Management (SPBM) profile
+                              ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: Storage Policy Based Management (SPBM) profile
+                              name.
+                            type: string
+                          volumePath:
+                            description: Path that identifies vSphere volume vmdk
+                            type: string
+                workspaces:
+                  description: Workspaces are the volumes that this Task requires.
+                  type: array
+                  items:
+                    description: WorkspaceDeclaration is a declaration of a volume
+                      that a Task requires.
+                    type: object
+                    required:
+                    - name
+                    properties:
+                      description:
+                        description: Description is an optional human readable description
+                          of this volume.
+                        type: string
+                      mountPath:
+                        description: MountPath overrides the directory that the volume
+                          will be made available at.
+                        type: string
+                      name:
+                        description: Name is the name by which you can bind the volume
+                          at runtime.
+                        type: string
+            timeout:
+              description: 'Time after which the build times out. Defaults to 10 minutes.
+                Specified build timeout should be less than 24h. Refer Go''s ParseDuration
+                documentation for expected format: https://golang.org/pkg/time/#ParseDuration'
+              type: string
+            workspaces:
+              description: Workspaces is a list of WorkspaceBindings from volumes
+                to workspaces.
+              type: array
+              items:
+                description: WorkspaceBinding maps a Task's declared workspace to
+                  a Volume. Currently we only support PersistentVolumeClaims and EmptyDir.
+                type: object
+                required:
+                - name
+                properties:
+                  emptyDir:
+                    description: 'EmptyDir represents a temporary directory that shares
+                      a Task''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                      Either this OR PersistentVolumeClaim can be used.'
+                    type: object
+                    properties:
+                      medium:
+                        description: 'What type of storage medium should back this
+                          directory. The default is "" which means to use the node''s
+                          default medium. Must be an empty string (default) or Memory.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        type: string
+                      sizeLimit:
+                        description: 'Total amount of local storage required for this
+                          EmptyDir volume. The size limit is also applicable for memory
+                          medium. The maximum usage on memory medium EmptyDir would
+                          be the minimum value between the SizeLimit specified here
+                          and the sum of memory limits of all containers in a pod.
+                          The default is nil which means that the limit is undefined.
+                          More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                        type: string
+                  name:
+                    description: Name is the name of the workspace populated by the
+                      volume.
+                    type: string
+                  persistentVolumeClaim:
+                    description: PersistentVolumeClaimVolumeSource represents a reference
+                      to a PersistentVolumeClaim in the same namespace. Either this
+                      OR EmptyDir can be used.
+                    type: object
+                    required:
+                    - claimName
+                    properties:
+                      claimName:
+                        description: 'ClaimName is the name of a PersistentVolumeClaim
+                          in the same namespace as the pod using this volume. More
+                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: string
+                      readOnly:
+                        description: Will force the ReadOnly setting in VolumeMounts.
+                          Default false.
+                        type: boolean
+                  subPath:
+                    description: SubPath is optionally a directory on the volume which
+                      should be used for this binding (i.e. the volume will be mounted
+                      at this sub directory).
+                    type: string
+        status:
+          description: TaskRunStatus defines the observed state of TaskRun
+          type: object
+          required:
+          - podName
+          properties:
+            cloudEvents:
+              description: CloudEvents describe the state of each cloud event requested
+                via a CloudEventResource.
+              type: array
+              items:
+                description: CloudEventDelivery is the target of a cloud event along
+                  with the state of delivery.
+                type: object
+                properties:
+                  status:
+                    description: CloudEventDeliveryState reports the state of a cloud
+                      event to be sent.
+                    type: object
+                    required:
+                    - message
+                    - retryCount
+                    properties:
+                      condition:
+                        description: Current status
+                        type: string
+                      message:
+                        description: Error is the text of error (if any)
+                        type: string
+                      retryCount:
+                        description: RetryCount is the number of attempts of sending
+                          the cloud event
+                        type: integer
+                        format: int32
+                      sentAt:
+                        description: SentAt is the time at which the last attempt
+                          to send the event was made
+                        type: string
+                        format: date-time
+                  target:
+                    description: Target points to an addressable
+                    type: string
+            completionTime:
+              description: CompletionTime is the time the build completed.
+              type: string
+              format: date-time
+            conditions:
+              $ref: '#/definitions/knative.dev~1pkg~1apis~0Conditions'
+              description: Conditions the latest available observations of a resource's
+                current state.
+            observedGeneration:
+              description: ObservedGeneration is the 'Generation' of the Service that
+                was last processed by the controller.
+              type: integer
+              format: int64
+            podName:
+              description: PodName is the name of the pod responsible for executing
+                this task's steps.
+              type: string
+            resourcesResult:
+              description: Results from Resources built during the taskRun. currently
+                includes the digest of build container images optional
+              type: array
+              items:
+                description: PipelineResourceResult used to export the image name
+                  and digest as json
+                type: object
+                required:
+                - digest
+                - key
+                - name
+                - value
+                properties:
+                  digest:
+                    type: string
+                  key:
+                    description: These will replace Name and Digest (https://github.com/tektoncd/pipeline/issues/1392)
+                    type: string
+                  name:
+                    description: Name and Digest are deprecated.
+                    type: string
+                  resourceRef:
+                    description: PipelineResourceRef can be used to refer to a specific
+                      instance of a Resource
+                    type: object
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      name:
+                        description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                  value:
+                    type: string
+            retriesStatus:
+              description: RetriesStatus contains the history of TaskRunStatus in
+                case of a retry in order to keep record of failures. All TaskRunStatus
+                stored in RetriesStatus will have no date within the RetriesStatus
+                as is redundant.
+              type: array
+              items: {}
+            sidecars:
+              description: The list has one entry per sidecar in the manifest. Each
+                entry is represents the imageid of the corresponding sidecar.
+              type: array
+              items:
+                description: SidecarState reports the results of sidecar in the Task.
+                type: object
+                properties:
+                  imageID:
+                    type: string
+                  name:
+                    type: string
+            startTime:
+              description: StartTime is the time the build is actually started.
+              type: string
+              format: date-time
+            steps:
+              description: Steps describes the state of each build step container.
+              type: array
+              items:
+                description: StepState reports the results of running a step in the
+                  Task.
+                type: object
+                properties:
+                  container:
+                    type: string
+                  imageID:
+                    type: string
+                  name:
+                    type: string

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,6 @@ require (
 	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.24.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
@@ -67,6 +66,7 @@ require (
 	knative.dev/caching v0.0.0-20190719140829-2032732871ff
 	knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b
 	knative.dev/pkg v0.0.0-20191111150521-6d806b998379
+	sigs.k8s.io/controller-tools v0.2.4
 )
 
 // Knative deps

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -159,6 +161,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/envy v1.7.1 h1:OQl5ys5MBea7OGCdvPbBJWRgnhC/fGona6QKfvFeau8=
 github.com/gobuffalo/envy v1.7.1/go.mod h1:FurDp9+EDPE4aIUS3ZLyD+7/9fpx7YRt/ukY6jIHf0w=
+github.com/gobuffalo/flect v0.1.5 h1:xpKq9ap8MbYfhuPCF0dBH854Gp9CxZjr/IocxELFflo=
+github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
@@ -290,6 +294,10 @@ github.com/markbates/inflect v1.0.4 h1:5fh1gzTFhfae06u3hzHYO9xe3l3v3nW5Pwt3naLTP
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a h1:+J2gw7Bw77w/fbK7wnNJJDKmw1IbWft2Ul5BzrG1Qm8=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -388,6 +396,7 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5 h1:f0B+LkLX6DtmRH1isoNA9VTtNUK9K8xYd28JNNfOv/s=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
@@ -510,6 +519,7 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190219203350-90b0e4468f99/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -630,6 +640,8 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5 h1:ymVxjfMaHvXD8RqPRmzHHsB3VvucivSkIAvJFDI5O3c=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966 h1:B0J02caTR6tpSJozBJyiAzT6CtBzjclw4pgm9gg8Ys0=
+gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -640,6 +652,8 @@ honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXe
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/api v0.0.0-20191004102255-dacd7df5a50b h1:38Nx0U83WjBqn1hUWxlgKc7mvH7WhyHfypxeW3zWwCQ=
 k8s.io/api v0.0.0-20191004102255-dacd7df5a50b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
+k8s.io/apiextensions-apiserver v0.0.0-20191004105443-a7d558db75c6 h1:4MLSmJeNPWjrmHsWnCNFTmqQx+pMiAXqkXLLCTY3SnM=
+k8s.io/apiextensions-apiserver v0.0.0-20191004105443-a7d558db75c6/go.mod h1:IxkesAMoaCRoLrPJdZNZUQp9NfZnzqaVzLhb2VEQzXE=
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a h1:lDydUqHrbL/1l5ZQrqD1RIlabhmX8aiZEtxVUb+30iU=
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v0.0.0-20191004102537-eb5b9a8cfde7 h1:WyPHgjjXvF4zVVwKGZKKiJGBUW45AuN44uSOuH8euuE=
@@ -649,12 +663,14 @@ k8s.io/code-generator v0.0.0-20181117043124-c2090bec4d9b/go.mod h1:MYiN+ZJZ9HkET
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a h1:QoHVuRquf80YZ+/bovwxoMO3Q/A3nt3yTgS0/0nejuk=
 k8s.io/gengo v0.0.0-20190327210449-e17681d19d3a/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf h1:EYm5AW/UUDbnmnI+gK0TJDVK9qPLhM+sRHYanNKw0EQ=
 k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKfj0lK8EeCP7K1iUG65v09OM0/WG5E=
 k8s.io/kubernetes v1.13.12 h1:PFEEOVYtKvQUGIUYkF7QqbuOgz4QJ5I4KOisgF4hf6o=
 k8s.io/kubernetes v1.13.12/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
+k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 knative.dev/caching v0.0.0-20190719140829-2032732871ff h1:PrlDvOGvCASqW5Fs3ZGes0ma3P5Wr8nuzlTX+EnqfUg=
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b h1:DTbaZGn06qcEoHuNyw3VmajapIUMuLSVjwFh6pNPews=
@@ -663,6 +679,8 @@ knative.dev/pkg v0.0.0-20190909195211-528ad1c1dd62 h1:0neKnC9hstF5Lewj6OaAJdXqk2
 knative.dev/pkg v0.0.0-20190909195211-528ad1c1dd62/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 pack.ag/amqp v0.11.0/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+sigs.k8s.io/controller-tools v0.2.4 h1:la1h46EzElvWefWLqfsXrnsO3lZjpkI0asTpX6h8PLA=
+sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/hack/generate-openapi.sh
+++ b/hack/generate-openapi.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# generate-openapi generates and patches the CRDs yamls
+(
+  # To support running this script from anywhere, we have to first cd into this directory
+  # so we can install the tools.
+  cd "$(dirname "${0}")"
+  command -v ${GOPATH}/bin/controller-gen || go install sigs.k8s.io/controller-tools/cmd/controller-gen
+)
+
+MANIFESTS="$1"
+APIS_PKG="$2"
+GROUPS_WITH_VERSIONS="$3"
+
+function codegen::join() { local IFS="$1"; shift; echo "$*"; }
+
+# enumerate group versions
+FQ_APIS=() # e.g. k8s.io/api/apps/v1
+for GVs in ${GROUPS_WITH_VERSIONS}; do
+  IFS=: read -r G Vs <<<"${GVs}"
+
+  # enumerate versions
+  for V in ${Vs//,/ }; do
+    FQ_APIS+=("${APIS_PKG}/${G}/${V}")
+  done
+done
+
+${GOPATH}/bin/controller-gen schemapatch:manifests="${MANIFESTS}" output:dir="${MANIFESTS}" paths="$(codegen::join , "${FQ_APIS[@]}")"

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -12,6 +12,7 @@ import (
 	_ "k8s.io/code-generator/cmd/informer-gen"
 	_ "k8s.io/code-generator/cmd/lister-gen"
 	_ "k8s.io/kube-openapi/cmd/openapi-gen"
+	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
 
 	_ "knative.dev/pkg/codegen/cmd/injection-gen"
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -42,5 +42,7 @@ bash ${REPO_ROOT_DIR}/hack/generate-knative.sh "injection" \
   "pipeline:v1alpha1,v1alpha2" \
   --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate/boilerplate.go.txt
 
+bash ${REPO_ROOT_DIR}/hack/generate-openapi.sh ./config github.com/tektoncd/pipeline/pkg/apis "pipeline:v1alpha1"
+
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -63,7 +63,7 @@ type TaskSpec struct {
 	Sidecars []corev1.Container `json:"sidecars,omitempty"`
 
 	// Workspaces are the volumes that this Task requires.
-	Workspaces []WorkspaceDeclaration
+	Workspaces []WorkspaceDeclaration `json:"workspaces,omitempty"`
 }
 
 // Step embeds the Container type, which allows it to include fields not

--- a/pkg/apis/pipeline/v1alpha2/param_types.go
+++ b/pkg/apis/pipeline/v1alpha2/param_types.go
@@ -39,6 +39,7 @@ type ParamSpec struct {
 	// Default is the value a parameter takes if no input value is supplied. If
 	// default is set, a Task may be executed without a supplied value for the
 	// parameter.
+	// +kubebuilder:validation:Type=string
 	// +optional
 	Default *ArrayOrString `json:"default,omitempty"`
 }
@@ -64,7 +65,8 @@ type ResourceParam struct {
 
 // Param declares an ArrayOrString to use for the parameter called name.
 type Param struct {
-	Name  string        `json:"name"`
+	Name string `json:"name"`
+	// +kubebuilder:validation:Type=string
 	Value ArrayOrString `json:"value"`
 }
 
@@ -87,7 +89,7 @@ var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray}
 // Used in JSON unmarshalling so that a single JSON field can accept
 // either an individual string or an array of strings.
 type ArrayOrString struct {
-	Type      ParamType // Represents the stored type of ArrayOrString.
+	Type      ParamType `json:"type"` // Represents the stored type of ArrayOrString.
 	StringVal string
 	ArrayVal  []string
 }

--- a/pkg/apis/pipeline/v1alpha2/task_types.go
+++ b/pkg/apis/pipeline/v1alpha2/task_types.go
@@ -87,7 +87,7 @@ type TaskSpec struct {
 // Step embeds the Container type, which allows it to include fields not
 // provided by Container.
 type Step struct {
-	corev1.Container
+	corev1.Container `json:"-"`
 
 	// Script is the contents of an executable file to execute.
 	//


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This uses `controller-gen` to generate validation schema for our CRDs.

There is a few issue to fix before considering this ready.
- [ ] `go install …` failed because of dependencies, … which is a bit a shame…
- [ ] the generated schema is invalid :angel: there is a few *specific* comments to put at the right places to fix that, looking into it.

This carry on #1179 :angel: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The CRD definition now include a validation OpenAPIV3Schema
```
