### PR TITLE
Correcting Comment Typos and Updating cancelPipelineRun Error Message

### DIFF
--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// cancelPipelineRun makrs the PipelineRun as cancelled and any resolved taskrun too.
+// cancelPipelineRun marks the PipelineRun as cancelled and any resolved TaskRun(s) too.
 func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.ResolvedPipelineRunTask, clientSet clientset.Interface) error {
 	pr.Status.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
@@ -54,7 +54,7 @@ func cancelPipelineRun(pr *v1alpha1.PipelineRun, pipelineState []*resources.Reso
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("error cancelled PipelineRun's TaskRun(s): %s", strings.Join(errs, "\n"))
+		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, strings.Join(errs, "\n"))
 	}
 	return nil
 }

--- a/pkg/reconciler/taskrun/cancel.go
+++ b/pkg/reconciler/taskrun/cancel.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// cancelTaskRun marks the TaskRun as cancelled and delete pods linked to it.
+// cancelTaskRun marks the TaskRun as cancelled and deletes pods linked to it.
 func cancelTaskRun(tr *v1alpha1.TaskRun, clientset kubernetes.Interface) error {
 	tr.Status.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,


### PR DESCRIPTION
This pull request changes the error message for cancelling a pipelinerun's taskruns. There can potentially be multiple errors so the message should reflect that. I also changed the message itself to be a little more easy to interpret.

Also correcting minor typos for comments.

As a side note, I find it somewhat of an odd behavior that a completed taskrun as part of a pipelinerun would be marked as cancelled if it already completed. It might be worth further discussing if that's the right approach if I am interpreting this behavior correctly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
More descriptive error from cancelling a TaskRun associated with a cancelled PipelineRun
```
