### PR TITLE
Add additional useful fields to the pod template

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -220,6 +220,24 @@ allows to customize some Pod specific field per `Task` execution, aka
 - `runtimeClassName`: the name of a
   [runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
   to use to run the pod.
+- `automountServiceAccountToken`: whether the token for the service account
+  being used by the pod should be automatically provided inside containers at a
+  predefined path. Defaults to `true`.
+- `dnsPolicy`: the
+  [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
+  for the pod, one of `ClusterFirst`, `Default`, or `None`. Defaults to
+  `ClusterFirst`. Note that `ClusterFirstWithHostNet` is not supported by Tekton
+  as Tekton pods cannot run with host networking.
+- `dnsConfig`:
+  [additional DNS configuration](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config)
+  for the pod, such as nameservers and search domains.
+- `enableServiceLinks`: whether services in the same namespace as the pod will
+  be exposed as environment variables to the pod, similar to Docker service
+  links. Defaults to `true`.
+- `priorityClassName`: the name of the
+  [priority class](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
+  to use when running the pod. Use this, for example, to selectively enable
+  preemption on lower priority workloads.
 
 In the following example, the `Task` is defined with a `volumeMount`
 (`my-cache`), that is provided by the `PipelineRun`, using a

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -192,6 +192,24 @@ allows to customize some Pod specific field per `Task` execution, aka
 - `runtimeClassName`: the name of a
   [runtime class](https://kubernetes.io/docs/concepts/containers/runtime-class/)
   to use to run the pod.
+- `automountServiceAccountToken`: whether the token for the service account
+  being used by the pod should be automatically provided inside containers at a
+  predefined path. Defaults to `true`.
+- `dnsPolicy`: the
+  [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
+  for the pod, one of `ClusterFirst`, `Default`, or `None`. Defaults to
+  `ClusterFirst`. Note that `ClusterFirstWithHostNet` is not supported by Tekton
+  as Tekton pods cannot run with host networking.
+- `dnsConfig`:
+  [additional DNS configuration](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config)
+  for the pod, such as nameservers and search domains.
+- `enableServiceLinks`: whether services in the same namespace as the pod will
+  be exposed as environment variables to the pod, similar to Docker service
+  links. Defaults to `true`.
+- `priorityClassName`: the name of the
+  [priority class](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
+  to use when running the pod. Use this, for example, to selectively enable
+  preemption on lower priority workloads.
 
 In the following example, the Task is defined with a `volumeMount`
 (`my-cache`), that is provided by the TaskRun, using a

--- a/pkg/apis/pipeline/v1alpha1/pod.go
+++ b/pkg/apis/pipeline/v1alpha1/pod.go
@@ -55,4 +55,36 @@ type PodTemplate struct {
 	// This is a beta feature as of Kubernetes v1.14.
 	// +optional
 	RuntimeClassName *string `json:"runtimeClassName,omitempty" protobuf:"bytes,2,opt,name=runtimeClassName"`
+
+	// AutomountServiceAccountToken indicates whether pods running as this
+	// service account should have an API token automatically mounted.
+	// +optional
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty" protobuf:"varint,3,opt,name=automountServiceAccountToken"`
+
+	// Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are
+	// 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig
+	// will be merged with the policy selected with DNSPolicy.
+	// +optional
+	DNSPolicy *corev1.DNSPolicy `json:"dnsPolicy,omitempty" protobuf:"bytes,4,opt,name=dnsPolicy,casttype=k8s.io/api/core/v1.DNSPolicy"`
+
+	// Specifies the DNS parameters of a pod.
+	// Parameters specified here will be merged to the generated DNS
+	// configuration based on DNSPolicy.
+	// +optional
+	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty" protobuf:"bytes,5,opt,name=dnsConfig"`
+
+	// EnableServiceLinks indicates whether information about services should be injected into pod's
+	// environment variables, matching the syntax of Docker links.
+	// Optional: Defaults to true.
+	// +optional
+	EnableServiceLinks *bool `json:"enableServiceLinks,omitempty" protobuf:"varint,6,opt,name=enableServiceLinks"`
+
+	// If specified, indicates the pod's priority. "system-node-critical" and
+	// "system-cluster-critical" are two special keywords which indicate the
+	// highest priorities with the former being the highest priority. Any other
+	// name must be defined by creating a PriorityClass object with that name.
+	// If not specified, the pod priority will be default or zero if there is no
+	// default.
+	// +optional
+	PriorityClassName *string `json:"priorityClassName,omitempty" protobuf:"bytes,7,opt,name=priorityClassName"`
 }

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1282,6 +1282,31 @@ func (in *PodTemplate) DeepCopyInto(out *PodTemplate) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.AutomountServiceAccountToken != nil {
+		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
+		*out = new(bool)
+		**out = **in
+	}
+	if in.DNSPolicy != nil {
+		in, out := &in.DNSPolicy, &out.DNSPolicy
+		*out = new(v1.DNSPolicy)
+		**out = **in
+	}
+	if in.DNSConfig != nil {
+		in, out := &in.DNSConfig, &out.DNSConfig
+		*out = new(v1.PodDNSConfig)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.EnableServiceLinks != nil {
+		in, out := &in.EnableServiceLinks, &out.EnableServiceLinks
+		*out = new(bool)
+		**out = **in
+	}
+	if in.PriorityClassName != nil {
+		in, out := &in.PriorityClassName, &out.PriorityClassName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -176,6 +176,16 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 		mergedPodContainers = append(mergedPodContainers, sc)
 	}
 
+	var dnsPolicy corev1.DNSPolicy
+	if taskRun.Spec.PodTemplate.DNSPolicy != nil {
+		dnsPolicy = *taskRun.Spec.PodTemplate.DNSPolicy
+	}
+
+	var priorityClassName string
+	if taskRun.Spec.PodTemplate.PriorityClassName != nil {
+		priorityClassName = *taskRun.Spec.PodTemplate.PriorityClassName
+	}
+
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			// We execute the build's pod in the same namespace as where the build was
@@ -194,16 +204,21 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 			Labels:      makeLabels(taskRun),
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:      corev1.RestartPolicyNever,
-			InitContainers:     initContainers,
-			Containers:         mergedPodContainers,
-			ServiceAccountName: taskRun.Spec.ServiceAccountName,
-			Volumes:            volumes,
-			NodeSelector:       taskRun.Spec.PodTemplate.NodeSelector,
-			Tolerations:        taskRun.Spec.PodTemplate.Tolerations,
-			Affinity:           taskRun.Spec.PodTemplate.Affinity,
-			SecurityContext:    taskRun.Spec.PodTemplate.SecurityContext,
-			RuntimeClassName:   taskRun.Spec.PodTemplate.RuntimeClassName,
+			RestartPolicy:                corev1.RestartPolicyNever,
+			InitContainers:               initContainers,
+			Containers:                   mergedPodContainers,
+			ServiceAccountName:           taskRun.Spec.ServiceAccountName,
+			Volumes:                      volumes,
+			NodeSelector:                 taskRun.Spec.PodTemplate.NodeSelector,
+			Tolerations:                  taskRun.Spec.PodTemplate.Tolerations,
+			Affinity:                     taskRun.Spec.PodTemplate.Affinity,
+			SecurityContext:              taskRun.Spec.PodTemplate.SecurityContext,
+			RuntimeClassName:             taskRun.Spec.PodTemplate.RuntimeClassName,
+			AutomountServiceAccountToken: taskRun.Spec.PodTemplate.AutomountServiceAccountToken,
+			DNSPolicy:                    dnsPolicy,
+			DNSConfig:                    taskRun.Spec.PodTemplate.DNSConfig,
+			EnableServiceLinks:           taskRun.Spec.PodTemplate.EnableServiceLinks,
+			PriorityClassName:            priorityClassName,
 		},
 	}, nil
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -60,6 +60,10 @@ func TestMakePod(t *testing.T) {
 	}
 
 	runtimeClassName := "gvisor"
+	automountServiceAccountToken := false
+	dnsPolicy := corev1.DNSNone
+	enableServiceLinks := false
+	priorityClassName := "system-cluster-critical"
 
 	for _, c := range []struct {
 		desc            string
@@ -167,7 +171,15 @@ func TestMakePod(t *testing.T) {
 						{Name: "net.ipv4.tcp_syncookies", Value: "1"},
 					},
 				},
-				RuntimeClassName: &runtimeClassName,
+				RuntimeClassName:             &runtimeClassName,
+				AutomountServiceAccountToken: &automountServiceAccountToken,
+				DNSPolicy:                    &dnsPolicy,
+				DNSConfig: &corev1.PodDNSConfig{
+					Nameservers: []string{"8.8.8.8"},
+					Searches:    []string{"tekton.local"},
+				},
+				EnableServiceLinks: &enableServiceLinks,
+				PriorityClassName:  &priorityClassName,
 			},
 		},
 		want: &corev1.PodSpec{
@@ -198,7 +210,15 @@ func TestMakePod(t *testing.T) {
 					{Name: "net.ipv4.tcp_syncookies", Value: "1"},
 				},
 			},
-			RuntimeClassName: &runtimeClassName,
+			RuntimeClassName:             &runtimeClassName,
+			AutomountServiceAccountToken: &automountServiceAccountToken,
+			DNSPolicy:                    dnsPolicy,
+			DNSConfig: &corev1.PodDNSConfig{
+				Nameservers: []string{"8.8.8.8"},
+				Searches:    []string{"tekton.local"},
+			},
+			EnableServiceLinks: &enableServiceLinks,
+			PriorityClassName:  priorityClassName,
 		},
 	}, {
 		desc: "very long step name",


### PR DESCRIPTION
# Changes

This change adds the fields `automountServiceAccountToken`, `dnsPolicy`, `dnsConfig`, `enableServiceLinks`, and `priorityClassName` to the pod template and propagates them directly to the underlying pod spec.

The `automountServiceAccountToken` and `enableServiceLinks` fields provide an extra degree of security for untrusted workloads and prevent potential environment variable conflicts with libraries used in pods.

The `dnsPolicy` and `dnsConfig` fields allow operators to override the DNS configuration for a task. As an example, an operator might want to prevent the CI pods from falling back to the node resolver, instead preferring a recursive resolver that is not tainted by local network configuration.

The `priorityClassName` is useful, for example, for allowing low-priority tasks to be preempted by the Kubernetes scheduler if needed.

Resolves #1775.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

* Support the `automountServiceAccountToken`, `dnsPolicy`, `dnsConfig`, and `enableServiceLinks` fields in pod templates