### PR TITLE
Propagate Condition labels to the TaskRun/Pod

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -10,6 +10,7 @@ This document defines `Conditions` and their capabilities.
   - [Check](#check)
   - [Parameters](#parameters)
   - [Resources](#resources)
+- [Labels](#labels)
 - [Examples](#examples)
 
 ## Syntax
@@ -70,6 +71,10 @@ provide the Condition container step with data or context that is needed to perf
 Resources in Conditions work similar to the way they work in `Tasks` i.e. they can be accessed using
 [variable substitution](./resources.md#variable-substitution) and the `targetPath` field can be used
 to [control where the resource is mounted](./resources.md#controlling-where-resources-are-mounted)
+
+## Labels
+
+[Labels](labels.md) defined as part of the `Condition` metadata will be automatically propagated to the `Pod`.
 
 ## Examples
 

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -27,6 +27,9 @@ propagated from the referenced `Task` (if one exists, see the
 [Specifying a `Task`](taskruns.md#specifying-a-task) section of the `TaskRun`
 documentation) to the corresponding `TaskRun` and then to the `Pod`.
 
+For `Conditions`, labels are propagated automatically to the corresponding `TaskRuns`
+and then to `Pods`.
+
 ## Automatically Added Labels
 
 The following labels are added to resources automatically:

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -653,6 +653,10 @@ func (c *Reconciler) makeConditionCheckContainer(rprt *resources.ResolvedPipelin
 	labels := getTaskrunLabels(pr, rprt.PipelineTask.Name)
 	labels[pipeline.GroupName+pipeline.ConditionCheckKey] = rcc.ConditionCheckName
 
+	for key, value := range rcc.Condition.ObjectMeta.Labels {
+		labels[key] = value
+	}
+
 	taskSpec, err := rcc.ConditionToTaskSpec()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get TaskSpec from Condition: %w", err)

--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -44,6 +44,17 @@ func Condition(name, namespace string, ops ...ConditionOp) *v1alpha1.Condition {
 	return condition
 }
 
+func ConditionLabels(labels map[string]string) ConditionOp {
+	return func(Condition *v1alpha1.Condition) {
+		if Condition.ObjectMeta.Labels == nil {
+			Condition.ObjectMeta.Labels = map[string]string{}
+		}
+		for key, value := range labels {
+			Condition.ObjectMeta.Labels[key] = value
+		}
+	}
+}
+
 // ConditionSpec creates a ConditionSpec with default values.
 // Any number of ConditionSpec modifiers can be passed to transform it.
 func ConditionSpec(ops ...ConditionSpecOp) ConditionOp {

--- a/test/builder/condition_test.go
+++ b/test/builder/condition_test.go
@@ -29,6 +29,11 @@ import (
 
 func TestCondition(t *testing.T) {
 	condition := tb.Condition("cond-name", "foo",
+		tb.ConditionLabels(
+			map[string]string{
+				"label-1": "label-value-1",
+				"label-2": "label-value-2",
+			}),
 		tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu", tb.Command("exit 0")),
 			tb.ConditionParamSpec("param-1", v1alpha1.ParamTypeString,
 				tb.ParamSpecDefault("default"),
@@ -42,6 +47,10 @@ func TestCondition(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cond-name",
 			Namespace: "foo",
+			Labels: map[string]string{
+				"label-1": "label-value-1",
+				"label-2": "label-value-2",
+			},
 		},
 		Spec: v1alpha1.ConditionSpec{
 			Check: corev1.Container{

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -480,6 +480,17 @@ func BlockOwnerDeletion(o *metav1.OwnerReference) {
 	o.BlockOwnerDeletion = &trueB
 }
 
+func TaskRunLabels(labels map[string]string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		if tr.ObjectMeta.Labels == nil {
+			tr.ObjectMeta.Labels = map[string]string{}
+		}
+		for key, value := range labels {
+			tr.ObjectMeta.Labels[key] = value
+		}
+	}
+}
+
 func TaskRunLabel(key, value string) TaskRunOp {
 	return func(tr *v1alpha1.TaskRun) {
 		if tr.ObjectMeta.Labels == nil {

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -162,11 +162,13 @@ func TestClusterTask(t *testing.T) {
 
 func TestTaskRunWithTaskRef(t *testing.T) {
 	var trueB = true
+
 	taskRun := tb.TaskRun("test-taskrun", "foo",
 		tb.TaskRunOwnerReference("PipelineRun", "test",
 			tb.OwnerReferenceAPIVersion("a1"),
 			tb.Controller, tb.BlockOwnerDeletion,
 		),
+		tb.TaskRunLabels(map[string]string{"label-2": "label-value-2", "label-3": "label-value-3"}),
 		tb.TaskRunLabel("label", "label-value"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task-output",
@@ -211,7 +213,11 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 				Controller:         &trueB,
 				BlockOwnerDeletion: &trueB,
 			}},
-			Labels:      map[string]string{"label": "label-value"},
+			Labels: map[string]string{
+				"label":   "label-value",
+				"label-2": "label-value-2",
+				"label-3": "label-value-3",
+			},
 			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.TaskRunSpec{


### PR DESCRIPTION
# Changes

Labels on Conditions will automatically propagate to the created TaskRun (and indirectly to the underlying Pod).  This is similar to (and leveraging) the default behavior that [propagates TaskRun labels to the Pod](https://github.com/tektoncd/pipeline/blob/5a9e8ba6f525d5a568c9360db8413efb8f4d0ee1/pkg/pod/pod.go#L204) automatically.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Labels on Conditions will automatically propagate to the created TaskRun (and indirectly to the underlying Pod).
```
