### PR TITLE
feat(TaskRunSpec) : Add SchedulerName to TaskRunSpec

### DIFF
--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -46,6 +46,10 @@ The current fields supported are:
   [priority class](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
   to use when running the pod. Use this, for example, to selectively enable
   preemption on lower priority workloads.
+  - `schedulerName` the name of the [scheduler](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/)
+  to use when dispatching the Pod. This can be used when workloads of specific types need specific schedulers,
+  eg: If you are using volcano.sh for Machine Learning Workloads, you can pass the schedulerName and have Tasks be 
+  dispatched by the volcano.sh scheduler.
 
 
 A pod template can be specified for `TaskRun` or `PipelineRun` resources.

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -192,7 +192,8 @@ allows to customize some Pod specific field per `Task` execution, aka `TaskRun`.
 
 In the following example, the Task is defined with a `volumeMount`
 (`my-cache`), that is provided by the TaskRun, using a
-PersistenceVolumeClaim. The Pod will also run as a non-root user.
+PersistenceVolumeClaim. The SchedulerName has also been provided to define which scheduler should be used to
+dispatch the Pod. The Pod will also run as a non-root user.
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1
@@ -219,6 +220,7 @@ spec:
   taskRef:
     name: mytask
   podTemplate:
+    schedulerName: volcano
     securityContext:
       runAsNonRoot: true
     volumes:

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -90,6 +90,9 @@ type Template struct {
 	// default.
 	// +optional
 	PriorityClassName *string `json:"priorityClassName,omitempty" protobuf:"bytes,7,opt,name=priorityClassName"`
+	// SchedulerName specifies the scheduler to be used to dispatch the Pod
+	// +optional
+	SchedulerName string `json:"schedulerName"`
 }
 
 func (tpl *Template) Equals(other *Template) bool {

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -238,6 +238,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 			SecurityContext:              podTemplate.SecurityContext,
 			RuntimeClassName:             podTemplate.RuntimeClassName,
 			AutomountServiceAccountToken: podTemplate.AutomountServiceAccountToken,
+			SchedulerName:                podTemplate.SchedulerName,
 			DNSPolicy:                    dnsPolicy,
 			DNSConfig:                    podTemplate.DNSConfig,
 			EnableServiceLinks:           podTemplate.EnableServiceLinks,

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -676,14 +676,20 @@ script-heredoc-randomly-generated-78c5n
 	}, {
 		desc: "using another scheduler",
 		ts: v1alpha1.TaskSpec{
-			Steps: []v1alpha1.Step{{Container: corev1.Container{
-				Name:    "schedule-me",
-				Image:   "image",
-				Command: []string{"cmd"}, // avoid entrypoint lookup.
-			}}},
+			TaskSpec: v1alpha2.TaskSpec{
+				Steps: []v1alpha1.Step{
+					{
+						Container: corev1.Container{
+							Name:    "schedule-me",
+							Image:   "image",
+							Command: []string{"cmd"}, // avoid entrypoint lookup.
+						},
+					},
+				},
+			},
 		},
 		trs: v1alpha1.TaskRunSpec{
-			PodTemplate: v1alpha1.PodTemplate{
+			PodTemplate: &v1alpha1.PodTemplate{
 				SchedulerName: "there-scheduler",
 			},
 		},
@@ -702,14 +708,17 @@ script-heredoc-randomly-generated-78c5n
 					"-wait_file_content",
 					"-post_file",
 					"/tekton/tools/0",
+					"-termination_path",
+					"/tekton/termination",
 					"-entrypoint",
 					"cmd",
 					"--",
 				},
-				Env:          implicitEnvVars,
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
-				WorkingDir:   pipeline.WorkspaceDir,
-				Resources:    corev1.ResourceRequirements{Requests: allZeroQty()},
+				Env:                    implicitEnvVars,
+				VolumeMounts:           append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
+				WorkingDir:             pipeline.WorkspaceDir,
+				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
+				TerminationMessagePath: "/tekton/termination",
 			}},
 		},
 	}} {


### PR DESCRIPTION
# Changes
Set scheduler in TaskRunSpec to execute Tasks with specific schedulers.
fixes https://github.com/tektoncd/pipeline/issues/1739

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


- API changes
`SchedulerName` added to TaskRunSpec
- Any changes in behavior
`SchedulerName` set in `TaskRunSpec` recorded by `Pod` so that the `Pod` is dispatched by the mentioned schduler.

```
