### PR TITLE
Add script mode for Conditions

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -34,10 +34,9 @@ following fields:
 ### Check
 
 The `check` field is required. You define a single check to define the body of a `Condition`. The 
-check must specify a container image that adheres to the [container contract](./container-contract.md). 
-The container image runs till completion. The container must exit successfully i.e. with an exit code 0 
-for the condition evaluation to be successful. All other exit codes are considered to be a condition check
-failure.
+check must specify a [`Step`](./tasks.md#steps). The container image runs till completion. The container 
+must exit successfully i.e. with an exit code 0 for the condition evaluation to be successful. All other 
+exit codes are considered to be a condition check failure.
 
 ### Parameters
 

--- a/examples/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml
+++ b/examples/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml
@@ -11,8 +11,7 @@ spec:
       optional: true
   check:
     image: alpine
-    command: ["/bin/sh"]
-    args: ['-c', 'test ! -f $(resources.optional-workspace.path)/$(params.path)']
+    script: 'test ! -f $(resources.optional-workspace.path)/$(params.path)'
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -39,9 +38,7 @@ spec:
   steps:
     - name: run-ls
       image: ubuntu
-      script: |
-        #!/usr/bin/env bash
-        ls -al $(inputs.resources.optional-workspace.path)
+      script: 'ls -al $(inputs.resources.optional-workspace.path)'
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline

--- a/examples/pipelineruns/conditional-pipelinerun.yaml
+++ b/examples/pipelineruns/conditional-pipelinerun.yaml
@@ -10,8 +10,7 @@ spec:
       type: git
   check:
     image: alpine
-    command: ["/bin/sh"]
-    args: ['-c', 'test -f $(resources.workspace.path)/$(params.path)']
+    script: 'test -f $(resources.workspace.path)/$(params.path)'
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
@@ -37,8 +36,7 @@ spec:
   steps:
     - name: run-ls
       image: ubuntu
-      command: ["/bin/bash"]
-      args: ['-c', 'ls -al $(inputs.resources.workspace.path)']
+      script: 'ls -al $(inputs.resources.workspace.path)'
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Pipeline

--- a/pkg/apis/pipeline/v1alpha1/condition_types.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types.go
@@ -71,7 +71,7 @@ type ConditionCheckStatusFields struct {
 // ConditionSpec defines the desired state of the Condition
 type ConditionSpec struct {
 	// Check declares container whose exit code determines where a condition is true or false
-	Check corev1.Container `json:"check,omitempty"`
+	Check Step `json:"check,omitempty"`
 
 	// Params is an optional set of parameters which must be supplied by the user when a Condition
 	// is evaluated

--- a/pkg/apis/pipeline/v1alpha1/condition_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation.go
@@ -38,8 +38,8 @@ func (cs *ConditionSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
 
-	if cs.Check.Image == "" {
-		return apis.ErrMissingField("Check.Image")
+	if err := validateSteps([]Step{cs.Check}).ViaField("Check"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
@@ -61,6 +61,17 @@ func TestCondition_Invalidate(t *testing.T) {
 			Message: "missing field(s)",
 			Paths:   []string{"Spec.Check.Image"},
 		},
+	}, {
+		name: "condition with script and command",
+		cond: tb.Condition("cond", "foo",
+			tb.ConditionSpec(
+				tb.ConditionSpecCheck("cname", "image", tb.Command("exit 0")),
+				tb.ConditionSpecCheckScript("echo foo"),
+			)),
+		expectedError: apis.FieldError{
+			Message: "step 0 script cannot be used with command",
+			Paths:   []string{"Spec.Check.script"},
+		},
 	}}
 
 	for _, tc := range tcs {

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -96,7 +96,7 @@ func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() (*v1alpha1.TaskSpec, er
 	}
 
 	t := &v1alpha1.TaskSpec{
-		Steps: []v1alpha1.Step{{Container: rcc.Condition.Spec.Check}},
+		Steps: []v1alpha1.Step{rcc.Condition.Spec.Check},
 	}
 
 	t.Inputs = &v1alpha1.Inputs{

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -128,7 +128,7 @@ var condition = v1alpha1.Condition{
 		Name: "always-true",
 	},
 	Spec: v1alpha1.ConditionSpec{
-		Check: corev1.Container{},
+		Check: v1alpha1.Step{},
 	},
 }
 

--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -67,7 +67,13 @@ func ConditionSpecCheck(name, image string, ops ...ContainerOp) ConditionSpecOp 
 		for _, op := range ops {
 			op(c)
 		}
-		spec.Check = *c
+		spec.Check.Container = *c
+	}
+}
+
+func ConditionSpecCheckScript(script string) ConditionSpecOp {
+	return func(spec *v1alpha1.ConditionSpec) {
+		spec.Check.Script = script
 	}
 }
 

--- a/test/builder/condition_test.go
+++ b/test/builder/condition_test.go
@@ -44,9 +44,11 @@ func TestCondition(t *testing.T) {
 			Namespace: "foo",
 		},
 		Spec: v1alpha1.ConditionSpec{
-			Check: corev1.Container{
-				Image:   "ubuntu",
-				Command: []string{"exit 0"},
+			Check: v1alpha1.Step{
+				Container: corev1.Container{
+					Image:   "ubuntu",
+					Command: []string{"exit 0"},
+				},
 			},
 			Params: []v1alpha1.ParamSpec{{
 				Name:        "param-1",
@@ -69,4 +71,32 @@ func TestCondition(t *testing.T) {
 	if d := cmp.Diff(expected, condition); d != "" {
 		t.Fatalf("Condition diff -want, +got: %v", d)
 	}
+}
+
+func TestConditionWithScript(t *testing.T) {
+	condition := tb.Condition("cond-name", "foo",
+		tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu"),
+			tb.ConditionSpecCheckScript("ls /tmp"),
+		),
+	)
+
+	expected := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cond-name",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.ConditionSpec{
+			Check: v1alpha1.Step{
+				Container: corev1.Container{
+					Image: "ubuntu",
+				},
+				Script: "ls /tmp",
+			},
+		},
+	}
+
+	if d := cmp.Diff(expected, condition); d != "" {
+		t.Fatalf("Condition diff -want, +got: %v", d)
+	}
+
 }


### PR DESCRIPTION
# Changes
Allows to use simplified way of creating shell script, same as for Tasks.
Fixes #1694

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add script mode for Conditions
```
