### PR TITLE
Add Secret volume source support to workspaces

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -279,6 +279,24 @@ workspaces:
     name: my-configmap
 ```
 
+A Secret can also be used as a workspace with the following caveats:
+
+1. Secret volume sources are always mounted as read-only inside a task's
+containers - tasks cannot write content to them and a step may error out
+and fail the task if a write is attempted.
+2. The Secret you want to use as a workspace must already exist prior
+to the TaskRun being submitted.
+
+To use a [`secret`](https://kubernetes.io/docs/concepts/storage/volumes/#secret)
+as a `workspace`:
+
+```yaml
+workspaces:
+- name: myworkspace
+  secret:
+    secretName: my-secret
+```
+
 _For a complete example see [workspace.yaml](../examples/taskruns/workspace.yaml)._
 
 ## Status

--- a/examples/taskruns/workspace.yaml
+++ b/examples/taskruns/workspace.yaml
@@ -17,6 +17,16 @@ metadata:
 data:
   message: hello world
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+type: Opaque
+stringData:
+  username: user
+data:
+  message: aGVsbG8gc2VjcmV0
+---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun
 metadata:
@@ -39,6 +49,9 @@ spec:
         items:
           - key: message
             path: my-message.txt
+    - name: custom5
+      secret:
+        secretName: my-secret
   taskSpec:
     steps:
     - name: write
@@ -62,6 +75,13 @@ spec:
     - name: readconfigmap
       image: ubuntu
       script: cat $(workspaces.custom4.path)/my-message.txt | grep "hello world"
+    - name: readsecret
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        cat $(workspaces.custom5.path)/username | grep "user"
+        cat $(workspaces.custom5.path)/message | grep "hello secret"
     workspaces:
     - name: custom
     - name: custom2
@@ -69,3 +89,5 @@ spec:
     - name: custom3
     - name: custom4
       mountPath: /baz/bar/quux
+    - name: custom5
+      mountPath: /my/secret/volume

--- a/pkg/apis/pipeline/v1alpha1/workspace_types.go
+++ b/pkg/apis/pipeline/v1alpha1/workspace_types.go
@@ -24,5 +24,4 @@ import (
 type WorkspaceDeclaration = v1alpha2.WorkspaceDeclaration
 
 // WorkspaceBinding maps a Task's declared workspace to a Volume.
-// Currently we only support PersistentVolumeClaims, EmptyDir and ConfigMap.
 type WorkspaceBinding = v1alpha2.WorkspaceBinding

--- a/pkg/apis/pipeline/v1alpha1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/workspace_validation_test.go
@@ -51,6 +51,14 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Valid secret",
+		binding: &WorkspaceBinding{
+			Name: "beth",
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "my-secret",
+			},
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := tc.binding.Validate(context.Background()); err != nil {
@@ -78,6 +86,30 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Provided both emptydir and configmap",
+		binding: &WorkspaceBinding{
+			Name:     "beth",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "foo-configmap",
+				},
+			},
+		},
+	}, {
+		name: "Provided both configmap and secret",
+		binding: &WorkspaceBinding{
+			Name: "beth",
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "my-configmap",
+				},
+			},
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "my-secret",
+			},
+		},
+	}, {
 		name: "Provided neither pvc nor emptydir",
 		binding: &WorkspaceBinding{
 			Name: "beth",
@@ -93,6 +125,12 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 		binding: &WorkspaceBinding{
 			Name:      "beth",
 			ConfigMap: &corev1.ConfigMapVolumeSource{},
+		},
+	}, {
+		name: "Provide secret without a secretName",
+		binding: &WorkspaceBinding{
+			Name:   "beth",
+			Secret: &corev1.SecretVolumeSource{},
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha2/workspace_types.go
+++ b/pkg/apis/pipeline/v1alpha2/workspace_types.go
@@ -48,7 +48,6 @@ func (w *WorkspaceDeclaration) GetMountPath() string {
 }
 
 // WorkspaceBinding maps a Task's declared workspace to a Volume.
-// Currently we only support PersistentVolumeClaims and EmptyDir.
 type WorkspaceBinding struct {
 	// Name is the name of the workspace populated by the volume.
 	Name string `json:"name"`
@@ -68,4 +67,7 @@ type WorkspaceBinding struct {
 	// ConfigMap represents a configMap that should populate this workspace.
 	// +optional
 	ConfigMap *corev1.ConfigMapVolumeSource `json:"configMap,omitempty"`
+	// Secret represents a secret that should populate this workspace.
+	// +optional
+	Secret *corev1.SecretVolumeSource `json:"secret,omitempty"`
 }

--- a/pkg/apis/pipeline/v1alpha2/workspace_validation.go
+++ b/pkg/apis/pipeline/v1alpha2/workspace_validation.go
@@ -29,6 +29,7 @@ var allVolumeSourceFields []string = []string{
 	"workspace.persistentvolumeclaim",
 	"workspace.emptydir",
 	"workspace.configmap",
+	"workspace.secret",
 }
 
 // Validate looks at the Volume provided in wb and makes sure that it is valid.
@@ -59,6 +60,11 @@ func (b *WorkspaceBinding) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrMissingField("workspace.configmap.name")
 	}
 
+	// For a Secret to work, you must provide the name of the Secret to use.
+	if b.Secret != nil && b.Secret.SecretName == "" {
+		return apis.ErrMissingField("workspace.secret.secretName")
+	}
+
 	return nil
 }
 
@@ -73,6 +79,9 @@ func (b *WorkspaceBinding) numSources() int {
 		n++
 	}
 	if b.ConfigMap != nil {
+		n++
+	}
+	if b.Secret != nil {
 		n++
 	}
 	return n

--- a/pkg/apis/pipeline/v1alpha2/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha2/workspace_validation_test.go
@@ -51,6 +51,14 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Valid secret",
+		binding: &WorkspaceBinding{
+			Name: "beth",
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "my-secret",
+			},
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := tc.binding.Validate(context.Background()); err != nil {
@@ -93,6 +101,12 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 		binding: &WorkspaceBinding{
 			Name:      "beth",
 			ConfigMap: &corev1.ConfigMapVolumeSource{},
+		},
+	}, {
+		name: "Provide secret without a secretName",
+		binding: &WorkspaceBinding{
+			Name:   "beth",
+			Secret: &corev1.SecretVolumeSource{},
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
@@ -318,6 +318,11 @@ func (in *WorkspaceBinding) DeepCopyInto(out *WorkspaceBinding) {
 		*out = new(v1.ConfigMapVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Secret != nil {
+		in, out := &in.Secret, &out.Secret
+		*out = new(v1.SecretVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -86,6 +86,33 @@ func TestGetVolumes(t *testing.T) {
 			},
 		},
 	}, {
+		name: "binding a single workspace with secret",
+		workspaces: []v1alpha1.WorkspaceBinding{{
+			Name: "custom",
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "foobarsecret",
+				Items: []corev1.KeyToPath{{
+					Key:  "foobar",
+					Path: "foobar.txt",
+				}},
+			},
+			SubPath: "/foo/bar/baz",
+		}},
+		expectedVolumes: map[string]corev1.Volume{
+			"custom": {
+				Name: "ws-78c5n",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "foobarsecret",
+						Items: []corev1.KeyToPath{{
+							Key:  "foobar",
+							Path: "foobar.txt",
+						}},
+					},
+				},
+			},
+		},
+	}, {
 		name:            "0 workspace bindings",
 		workspaces:      []v1alpha1.WorkspaceBinding{},
 		expectedVolumes: map[string]corev1.Volume{},
@@ -105,7 +132,7 @@ func TestGetVolumes(t *testing.T) {
 		}},
 		expectedVolumes: map[string]corev1.Volume{
 			"custom": {
-				Name: "ws-78c5n",
+				Name: "ws-6nl7g",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -113,7 +140,7 @@ func TestGetVolumes(t *testing.T) {
 				},
 			},
 			"even-more-custom": {
-				Name: "ws-6nl7g",
+				Name: "ws-j2tds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "myotherpvc",
@@ -138,7 +165,7 @@ func TestGetVolumes(t *testing.T) {
 		}},
 		expectedVolumes: map[string]corev1.Volume{
 			"custom": {
-				Name: "ws-j2tds",
+				Name: "ws-vr6ds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -147,7 +174,7 @@ func TestGetVolumes(t *testing.T) {
 			},
 			"custom2": {
 				// Since it is the same PVC source, it can't be added twice with two different names
-				Name: "ws-j2tds",
+				Name: "ws-vr6ds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #1438

The final of the original feature requests related to workspaces
was to include support for Secrets as the source of a volume mounted
into Task containers.

This PR introduces support for Secrets as workspaces in a TaskRun
definition.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Secrets can now be used for the contents of task workspaces. Users can now more easily declare and expose a secret as a volume for tasks to use in their step containers.
```