### PR TITLE
Use vendor-ed version of plumbing instead of go get 🦸

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -16,8 +16,7 @@
 
 # Helper functions for E2E tests.
 
-go get -d github.com/tektoncd/plumbing
-source $(go list -m -f '{{.Dir}}' github.com/tektoncd/plumbing)/scripts/e2e-tests.sh
+source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 
 function teardown() {
     subheader "Tearing down Tekton Pipelines"

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -26,8 +26,7 @@
 export DISABLE_MD_LINTING=1
 export DISABLE_MD_LINK_CHECK=1
 
-go get -d github.com/tektoncd/plumbing
-source $(go list -m -f '{{.Dir}}' github.com/tektoncd/plumbing)/scripts/presubmit-tests.sh
+source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
 
 function post_build_tests() {
   header "running golangci-lint"


### PR DESCRIPTION

# Changes

Using `go get -d` updates continuously the plumbing dependency,
without really updating the vendor folder, which means it becomes
inconsistency.

This is a follow-up of #1763.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
