### PR TITLE
Don't assume $0 is the script source

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/library.sh
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/library.sh
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 cd ${REPO_ROOT_DIR}
 

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/library.sh
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 readonly TMP_DIFFROOT="$(mktemp -d ${REPO_ROOT_DIR}/tmpdiffroot.XXXXXX)"
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -16,7 +16,7 @@
 
 # Helper functions for E2E tests.
 
-source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
 
 function teardown() {
     subheader "Tearing down Tekton Pipelines"

--- a/test/e2e-tests-upgrade.sh
+++ b/test/e2e-tests-upgrade.sh
@@ -24,7 +24,7 @@
 # Scenario 2: install the previous release, create the pipelines and tasks, upgrade
 # to the current release, and validate whether the Tekton pipeline works.
 
-source $(dirname $0)/e2e-common.sh
+source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 PREVIOUS_PIPELINE_VERSION=v0.5.2
 
 # Script entry point.

--- a/test/e2e-tests-yaml.sh
+++ b/test/e2e-tests-yaml.sh
@@ -18,7 +18,7 @@
 # and deploy Tekton Pipelines to it for running integration tests.
 
 go get -d github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher
-source $(dirname $0)/e2e-common.sh
+source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Script entry point.
 

--- a/test/e2e-tests-yaml.sh
+++ b/test/e2e-tests-yaml.sh
@@ -17,7 +17,6 @@
 # This script calls out to scripts in tektoncd/plumbing to setup a cluster
 # and deploy Tekton Pipelines to it for running integration tests.
 
-go get -d github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher
 source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Script entry point.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,7 +17,7 @@
 # This script calls out to scripts in tektoncd/plumbing to setup a cluster
 # and deploy Tekton Pipelines to it for running integration tests.
 
-source $(dirname $0)/e2e-common.sh
+source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Script entry point.
 

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -26,7 +26,7 @@
 export DISABLE_MD_LINTING=1
 export DISABLE_MD_LINK_CHECK=1
 
-source $(dirname $0)/../vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/presubmit-tests.sh
 
 function post_build_tests() {
   header "running golangci-lint"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Don't assume $0 is the script source

Part of our 'downstream' CI we reuse the `test/e2e-common.sh` functions.

We have a script that source the test/e2e-common.sh and run with the downstream
specifics functions.

$0 in the e2e-common assume the script is run from `test/e2e-tests.sh` when our
script which source test/e2e-tests.sh is something else somewhere else.

Let use git to safely detect the toplevel of the directory from where we can
source the vendor directory.

Remove latest go get from there too


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [🤷🏼‍♂️] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [🤷🏼‍♂️] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [👍] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
## Reviewer Notes


# Release Notes


