### PR TITLE
Allow keeping namespaces after running tests for investigation

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -185,6 +185,10 @@ Tests importing [`github.com/tektoncd/pipeline/test`](#adding-integration-tests)
 recognize the
 [flags added by `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags).
 
+Tests are run in a new random namespace prefixed with the word `arendelle-`.
+Unless you set the `TEST_KEEP_NAMESPACES` environment variable they will get
+automatically cleaned up after running the test.
+
 ### Running specific test cases
 
 To run all the test cases with their names starting with the same letters, e.g.

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -97,9 +97,11 @@ func tearDown(t *testing.T, cs *clients, namespace string) {
 		}
 	}
 
-	t.Logf("Deleting namespace %s", namespace)
-	if err := cs.KubeClient.Kube.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
-		t.Errorf("Failed to delete namespace %s: %s", namespace, err)
+	if os.Getenv("TEST_KEEP_NAMESPACES") != "" {
+		t.Logf("Deleting namespace %s", namespace)
+		if err := cs.KubeClient.Kube.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
+			t.Errorf("Failed to delete namespace %s: %s", namespace, err)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When we have a failure, the tearDown function would delete the randomly created 'arendelle'
namespace with no way to investigate.

Add an environment variable `TEST_KEEP_NAMESPACES` to disable the namespace
deletion. This could be useful for successful run too, for further investigation
if needed.


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [NA] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [NA] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

NA

# Release Notes

NA