### PR TITLE
Fix typo and some comments on uppercase variables in pkg/pod.

### DIFF
--- a/pkg/pod/resource_request.go
+++ b/pkg/pod/resource_request.go
@@ -41,7 +41,7 @@ func resolveResourceRequests(containers []corev1.Container) []corev1.Container {
 		}
 	}
 
-	// Set resource requests for all steps but the theh last container to
+	// Set resource requests for all steps but the last container to
 	// zero.
 	for i := range containers[:len(containers)-1] {
 		containers[i].Resources.Requests = allZeroQty()

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -29,30 +29,30 @@ import (
 )
 
 const (
-	// reasonCouldntGetTask indicates that the reason for the failure status is that the
+	// ReasonCouldntGetTask indicates that the reason for the failure status is that the
 	// Task couldn't be found
 	ReasonCouldntGetTask = "CouldntGetTask"
 
-	// reasonFailedResolution indicated that the reason for failure status is
+	// ReasonFailedResolution indicated that the reason for failure status is
 	// that references within the TaskRun could not be resolved
 	ReasonFailedResolution = "TaskRunResolutionFailed"
 
-	// reasonFailedValidation indicated that the reason for failure status is
+	// ReasonFailedValidation indicated that the reason for failure status is
 	// that taskrun failed runtime validation
 	ReasonFailedValidation = "TaskRunValidationFailed"
 
-	// reasonRunning indicates that the reason for the inprogress status is that the TaskRun
+	// ReasonRunning indicates that the reason for the inprogress status is that the TaskRun
 	// is just starting to be reconciled
 	ReasonRunning = "Running"
 
-	// reasonTimedOut indicates that the TaskRun has taken longer than its configured timeout
+	// ReasonTimedOut indicates that the TaskRun has taken longer than its configured timeout
 	ReasonTimedOut = "TaskRunTimeout"
 
-	// reasonExceededResourceQuota indicates that the TaskRun failed to create a pod due to
+	// ReasonExceededResourceQuota indicates that the TaskRun failed to create a pod due to
 	// a ResourceQuota in the namespace
 	ReasonExceededResourceQuota = "ExceededResourceQuota"
 
-	// reasonExceededNodeResources indicates that the TaskRun's pod has failed to start due
+	// ReasonExceededNodeResources indicates that the TaskRun's pod has failed to start due
 	// to resource constraints on the node
 	ReasonExceededNodeResources = "ExceededNodeResources"
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
