### PR TITLE
Improve e2e test flakyness

### DIFF
--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -62,6 +62,12 @@ func TestDAGPipelineRun(t *testing.T) {
 		t.Fatalf("Failed to create echo Task: %s", err)
 	}
 
+	// Make sure the Pipeline has been created (wait for it)
+	if err := WaitForTaskCreated(c, "echo-task", "TaskCreated"); err != nil {
+		t.Errorf("Error waiting for Task echo-task to be created: %s", err)
+		t.Fatal("Pipeline execution failed, Task echo-task has not been created")
+	}
+
 	// Create the repo PipelineResource (doesn't really matter which repo we use)
 	repoResource := tb.PipelineResource("repo", namespace, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
@@ -105,6 +111,13 @@ func TestDAGPipelineRun(t *testing.T) {
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create dag-pipeline: %s", err)
 	}
+
+	// Make sure the Pipeline has been created (wait for it)
+	if err := WaitForPipelineCreated(c, "dag-pipeline", "PipelineCreated"); err != nil {
+		t.Errorf("Error waiting for Pipeline dag-pipeline to be created: %s", err)
+		t.Fatal("Pipeline execution failed, Pipeline dag-pipeline has not been created")
+	}
+
 	pipelineRun := tb.PipelineRun("dag-pipeline-run", namespace, tb.PipelineRunSpec("dag-pipeline",
 		tb.PipelineRunResourceBinding("repo", tb.PipelineResourceBindingRef("repo")),
 	))

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -29,7 +29,7 @@ import (
 	knativetest "knative.dev/pkg/test"
 )
 
-// TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
+// TestDuplicatePodTaskRun creates 5 builds and checks that each of them has only one build pod.
 func TestDuplicatePodTaskRun(t *testing.T) {
 	c, namespace := setup(t)
 	t.Parallel()
@@ -38,7 +38,7 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 25; i++ {
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		taskrunName := fmt.Sprintf("duplicate-pod-taskrun-%d", i)
 		t.Logf("Creating taskrun %q.", taskrunName)

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -65,6 +65,12 @@ func TestGitPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
 			}
 
+			// Make sure the Pipeline has been created (wait for it)
+			if err := WaitForPipelineCreated(c, gitTestPipelineName, "PipelineCreated"); err != nil {
+				t.Errorf("Error waiting for Pipeline %s to be created: %s", gitTestPipelineName, err)
+				t.Fatalf("Pipeline execution failed, Pipeline %s has not been created", gitTestPipelineName)
+			}
+
 			t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
 			if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -86,6 +86,12 @@ func TestSidecarTaskSupport(t *testing.T) {
 				t.Errorf("Failed to create Task %q: %v", sidecarTaskName, err)
 			}
 
+			// Make sure the Task has been created (wait for it)
+			if err := WaitForTaskCreated(clients, sidecarTaskName, "TaskCreated"); err != nil {
+				t.Errorf("Error waiting for Task %s to be created: %s", sidecarTaskName, err)
+				t.Fatalf("Task execution failed, Task %s has not been created", sidecarTaskName)
+			}
+
 			t.Logf("Creating TaskRun %q", sidecarTaskRunName)
 			if _, err := clients.TaskRunClient.Create(taskRun); err != nil {
 				t.Errorf("Failed to create TaskRun %q: %v", sidecarTaskRunName, err)

--- a/test/wait.go
+++ b/test/wait.go
@@ -68,6 +68,36 @@ type TaskRunStateFn func(r *v1alpha1.TaskRun) (bool, error)
 // PipelineRunStateFn is a condition function on TaskRun used polling functions
 type PipelineRunStateFn func(pr *v1alpha1.PipelineRun) (bool, error)
 
+// WaitForPipelineCreated wait until a pipeline has been created
+func WaitForPipelineCreated(c *clients, name, desc string) error {
+	metricName := fmt.Sprintf("WaitForPipelineCreated/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
+	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+		pc, err := c.PipelineClient.Get(name, metav1.GetOptions{})
+		if pc.GetName() == name {
+			return true, err
+		}
+		return false, nil
+	})
+}
+
+// WaitForTaskCreated wait until a task has been created
+func WaitForTaskCreated(c *clients, name, desc string) error {
+	metricName := fmt.Sprintf("WaitForTaskCreated/%s/%s", name, desc)
+	_, span := trace.StartSpan(context.Background(), metricName)
+	defer span.End()
+
+	return wait.PollImmediate(interval, timeout, func() (bool, error) {
+		tc, err := c.TaskClient.Get(name, metav1.GetOptions{})
+		if tc.GetName() == name {
+			return true, err
+		}
+		return false, err
+	})
+}
+
 // WaitForTaskRunState polls the status of the TaskRun called name from client every
 // interval until inState returns `true` indicating it is done, returns an
 // error or timeout. desc will be used to name the metric that is emitted to

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -37,6 +37,46 @@ var (
 	failure = apis.Condition{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}
 )
 
+func TestWaitForTaskCreated(t *testing.T) {
+	tname := "bananas"
+	task := tb.Task(tname, waitNamespace,
+		tb.TaskSpec(
+			tb.Step("foo", "busybox",
+				tb.StepCommand("/bin/sh"),
+				tb.StepArgs("-c", "sleep 10"),
+			),
+		),
+	)
+
+	d := Data{
+		Tasks: []*v1alpha1.Task{task},
+	}
+	c, cancel := fakeClients(t, d)
+	defer cancel()
+	err := WaitForTaskCreated(c, tname, "TaskCreated")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWaitForPipelineCreated(t *testing.T) {
+	pname := "raspberries"
+	pipeline := tb.Pipeline(pname, waitNamespace,
+		tb.PipelineSpec(
+			tb.PipelineTask("foo", "banana"),
+		),
+	)
+	d := Data{
+		Pipelines: []*v1alpha1.Pipeline{pipeline},
+	}
+	c, cancel := fakeClients(t, d)
+	defer cancel()
+	err := WaitForPipelineCreated(c, pname, "PipelineCreated")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestWaitForTaskRunStateSucceed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{


### PR DESCRIPTION
When we run a lot of e2e tests with reasonably sized VMs we are getting some
OOMKilled pods or some race between the task/pipeline to the runs.

For the OOMKilled we reduce the number of tasks runs concurently from 25 to 5,
as I am not sure what are the advantages of using a greater number and this ease
up the nodes.

For the race we are waiting that the objects gets created before running
the *Runs objects so the TaskRun doesn't get created after the Task (or
Pipeline).

Fixes #1820
Fixes #1819
Fixes #1815


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [👍] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ 🤷‍♂ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [👍] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

# Release Notes
