### PR TITLE
Update service port naming inline with istio naming conventions

### DIFF
--- a/config/400-controller-service.yaml
+++ b/config/400-controller-service.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   ports:
-  - name: metrics
+  - name: http-metrics
     port: 9090
     protocol: TCP
     targetPort: 9090

--- a/config/400-webhook-service.yaml
+++ b/config/400-webhook-service.yaml
@@ -21,7 +21,8 @@ metadata:
   namespace: tekton-pipelines
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     app: tekton-pipelines-webhook


### PR DESCRIPTION


https://istio.io/docs/ops/deployment/requirements/

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

To be on the safer side when deployed to a cluster with Istio deployed, we should follow service port naming convention as stated here -> https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Named service ports: Service ports must be named. The port name key/value pairs must have the following syntax: name: <protocol>[-<suffix>]. See Protocol Selection for more details.
https://istio.io/docs/ops/deployment/requirements/
```
