### PR TITLE
Create a additional release.notags.yaml with only digests 💫

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -57,6 +57,14 @@ To add the Tekton Pipelines component to an existing cluster:
    _(Previous versions will be available at `previous/$VERSION_NUMBER`, e.g.
    https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.2.0/release.yaml.)_
 
+   If the container runtime your kubernetes system is does not support
+   `image-reference:tag@digest` (like `cri-o`, used in OpenShift 4.x),
+   you can use the `release.notags.yaml` instead.
+
+   ```bash
+   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.notags.yaml
+   ```
+
 1. Run the
    [`kubectl get`](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#get)
    command to monitor the Tekton Pipelines components until all of the

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -144,6 +144,10 @@ spec:
 
       # Publish images and create release.yaml
       ko resolve --preserve-import-paths -t $(inputs.params.versionTag) -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > /workspace/output/bucket/latest/release.yaml
+      # Publish images and create release.notags.yaml
+      # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
+      # This is currently the case for `cri-o` (and most likely others)
+      ko resolve --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > /workspace/output/bucket/latest/release.notags.yaml
     volumeMounts:
       - name: gcp-secret
         mountPath: /secret
@@ -157,6 +161,7 @@ spec:
 
       mkdir -p /workspace/output/bucket/previous/$(inputs.params.versionTag)/
       cp /workspace/output/bucket/latest/release.yaml /workspace/output/bucket/previous/$(inputs.params.versionTag)/release.yaml
+      cp /workspace/output/bucket/latest/release.notags.yaml /workspace/output/bucket/previous/$(inputs.params.versionTag)/release.notags.yaml
 
   - name: tag-images
     image: google/cloud-sdk


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Some container runtime do not support image reference with both tag
and digest (see https://github.com/cri-o/cri-o/pull/3060). This
change the release process by adding one more release yaml that
doesn't have both tag and digest, only digest (like initially).

/cc @a-roberts 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add a `release.notags.yaml` release file that contains only digests.
```
