### PR TITLE
Rename some test to be closer to golang naming convention 💅

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -40,7 +40,7 @@ var images = pipeline.Images{
 	ImageDigestExporterImage: "override-with-imagedigest-exporter-image:latest",
 }
 
-func Test_Invalid_BuildGCSResource(t *testing.T) {
+func TestBuildGCSResource_Invalid(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		pipelineResource *v1alpha1.PipelineResource
@@ -100,7 +100,7 @@ func Test_Invalid_BuildGCSResource(t *testing.T) {
 	}
 }
 
-func Test_Valid_NewBuildGCSResource(t *testing.T) {
+func TestNewBuildGCSResource_Valid(t *testing.T) {
 	pr := tb.PipelineResource("build-gcs-resource", "default", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
@@ -125,7 +125,7 @@ func Test_Valid_NewBuildGCSResource(t *testing.T) {
 	}
 }
 
-func Test_BuildGCSGetReplacements(t *testing.T) {
+func TestBuildGCS_GetReplacements(t *testing.T) {
 	r := &v1alpha1.BuildGCSResource{
 		Name:     "gcs-resource",
 		Location: "gs://fake-bucket",
@@ -141,7 +141,7 @@ func Test_BuildGCSGetReplacements(t *testing.T) {
 	}
 }
 
-func Test_BuildGCSGetInputSteps(t *testing.T) {
+func TestBuildGCS_GetInputSteps(t *testing.T) {
 	for _, at := range []v1alpha1.GCSArtifactType{
 		v1alpha1.GCSArchive,
 		v1alpha1.GCSZipArchive,

--- a/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go
@@ -25,7 +25,7 @@ import (
 	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
-func Test_NewCloudEventResource_Invalid(t *testing.T) {
+func TestNewCloudEventResource_Invalid(t *testing.T) {
 	testcases := []struct {
 		name             string
 		pipelineResource *v1alpha1.PipelineResource
@@ -52,7 +52,7 @@ func Test_NewCloudEventResource_Invalid(t *testing.T) {
 	}
 }
 
-func Test_NewCloudEventResource_Valid(t *testing.T) {
+func TestNewCloudEventResource_Valid(t *testing.T) {
 	pr := tb.PipelineResource("cloud-event-resource-uri", "default", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCloudEvent,
 		tb.PipelineResourceSpecParam("TargetURI", "http://fake-sink"),
@@ -72,7 +72,7 @@ func Test_NewCloudEventResource_Valid(t *testing.T) {
 	}
 }
 
-func Test_CloudEventGetReplacements(t *testing.T) {
+func TestCloudEvent_GetReplacements(t *testing.T) {
 	r := &v1alpha1.CloudEventResource{
 		Name:      "cloud-event-resource",
 		TargetURI: "http://fake-uri",
@@ -88,7 +88,7 @@ func Test_CloudEventGetReplacements(t *testing.T) {
 	}
 }
 
-func Test_CloudEventInputContainerSpec(t *testing.T) {
+func TestCloudEvent_InputContainerSpec(t *testing.T) {
 	r := &v1alpha1.CloudEventResource{
 		Name:      "cloud-event-resource",
 		TargetURI: "http://fake-uri",
@@ -103,7 +103,7 @@ func Test_CloudEventInputContainerSpec(t *testing.T) {
 	}
 }
 
-func Test_CloudEventOutputContainerSpec(t *testing.T) {
+func TestCloudEvent_OutputContainerSpec(t *testing.T) {
 	r := &v1alpha1.CloudEventResource{
 		Name:      "cloud-event-resource",
 		TargetURI: "http://fake-uri",

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -134,7 +134,7 @@ func TestNewClusterResource(t *testing.T) {
 	}
 }
 
-func Test_ClusterResource_GetInputTaskModifier(t *testing.T) {
+func TestClusterResource_GetInputTaskModifier(t *testing.T) {
 	names.TestingSeed()
 	clusterResource := &v1alpha1.ClusterResource{
 		Name: "test-cluster-resource",

--- a/pkg/apis/pipeline/v1alpha1/git_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource_test.go
@@ -26,13 +26,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Test_Invalid_NewGitResource(t *testing.T) {
+func TestNewGitResource_Invalid(t *testing.T) {
 	if _, err := v1alpha1.NewGitResource("override-with-git:latest", tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGCS))); err == nil {
 		t.Error("Expected error creating Git resource")
 	}
 }
 
-func Test_Valid_NewGitResource(t *testing.T) {
+func TestNewGitResource_Valid(t *testing.T) {
 	for _, tc := range []struct {
 		desc             string
 		pipelineResource *v1alpha1.PipelineResource
@@ -181,7 +181,7 @@ func Test_Valid_NewGitResource(t *testing.T) {
 	}
 }
 
-func Test_GitResource_Replacements(t *testing.T) {
+func TestGitResource_Replacements(t *testing.T) {
 	r := &v1alpha1.GitResource{
 		Name:      "git-resource",
 		Type:      v1alpha1.PipelineResourceTypeGit,
@@ -207,7 +207,7 @@ func Test_GitResource_Replacements(t *testing.T) {
 	}
 }
 
-func Test_GitResource_GetDownloadTaskModifier(t *testing.T) {
+func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 	names.TestingSeed()
 
 	for _, tc := range []struct {

--- a/pkg/apis/pipeline/v1alpha1/image_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource_test.go
@@ -25,7 +25,7 @@ import (
 	tb "github.com/tektoncd/pipeline/test/builder"
 )
 
-func Test_Invalid_NewImageResource(t *testing.T) {
+func TestNewImageResource_Invalid(t *testing.T) {
 	r := tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
 
 	_, err := v1alpha1.NewImageResource(r)
@@ -34,7 +34,7 @@ func Test_Invalid_NewImageResource(t *testing.T) {
 	}
 }
 
-func Test_Valid_NewImageResource(t *testing.T) {
+func TestNewImageResource_Valid(t *testing.T) {
 	want := &v1alpha1.ImageResource{
 		Name:   "image-resource",
 		Type:   v1alpha1.PipelineResourceTypeImage,
@@ -62,7 +62,7 @@ func Test_Valid_NewImageResource(t *testing.T) {
 	}
 }
 
-func Test_ImageResource_Replacements(t *testing.T) {
+func TestImageResource_Replacements(t *testing.T) {
 	ir := &v1alpha1.ImageResource{
 		Name:   "image-resource",
 		Type:   v1alpha1.PipelineResourceTypeImage,

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -66,7 +66,7 @@ func TestTaskRun_Validate(t *testing.T) {
 	}
 }
 
-func Test_TaskRun_Workspaces_Invalid(t *testing.T) {
+func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 	tests := []struct {
 		name    string
 		tr      *v1alpha1.TaskRun

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -419,7 +419,7 @@ func readAndUnmarshal(t *testing.T, p string, v interface{}) {
 	}
 }
 
-func Test_labelsToDisk(t *testing.T) {
+func TestLabelsToDisk(t *testing.T) {
 	type args struct {
 		labels []*scm.Label
 	}
@@ -487,7 +487,7 @@ func Test_labelsToDisk(t *testing.T) {
 	}
 }
 
-func Test_statusToDisk(t *testing.T) {
+func TestStatusToDisk(t *testing.T) {
 	type args struct {
 		statuses []*scm.Status
 	}
@@ -566,7 +566,7 @@ func writeManifest(t *testing.T, items []string, path string) {
 	}
 }
 
-func Test_labelsFromDisk(t *testing.T) {
+func TestLabelsFromDisk(t *testing.T) {
 	type args struct {
 		fileNames []string
 	}

--- a/pkg/pullrequest/scm_test.go
+++ b/pkg/pullrequest/scm_test.go
@@ -95,7 +95,7 @@ func TestNewSCMHandler(t *testing.T) {
 	}
 }
 
-func Test_guessProvider(t *testing.T) {
+func TestGuessProvider(t *testing.T) {
 	tests := []struct {
 		name    string
 		url     string

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -25,7 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func Test_EmitEvent(t *testing.T) {
+func TestEmitEvent(t *testing.T) {
 	testcases := []struct {
 		name        string
 		before      *apis.Condition

--- a/pkg/reconciler/taskrun/resources/volume_test.go
+++ b/pkg/reconciler/taskrun/resources/volume_test.go
@@ -24,7 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Test_PVC_Volume(t *testing.T) {
+func TestGetPVCVolume(t *testing.T) {
 	expectedVolume := corev1.Volume{
 		Name: "test-pvc",
 		VolumeSource: corev1.VolumeSource{

--- a/pkg/system/names_test.go
+++ b/pkg/system/names_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func Test_GetNamespace(t *testing.T) {
+func TestGetNamespace(t *testing.T) {
 	testcases := []struct {
 		envVar       string
 		expectEnvVar string


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Usually it is `TestF()` and `TestF_Case()` for a function `F()`.

This is completely *nits* but… I don't like seeing `Test_Foo_Bar()` when looking at tests :sweat_smile:.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
