### PR TITLE
Deduplicate and sort termination message items

### DIFF
--- a/pkg/termination/parse_test.go
+++ b/pkg/termination/parse_test.go
@@ -39,6 +39,32 @@ func TestParseMessage(t *testing.T) {
 		desc: "empty message",
 		msg:  "",
 		want: nil,
+	}, {
+		desc: "duplicate keys",
+		msg: `[
+		{"key":"foo","value":"first"},
+		{"key":"foo","value":"middle"},
+		{"key":"foo","value":"last"}]`,
+		want: []v1alpha1.PipelineResourceResult{{
+			Key:   "foo",
+			Value: "last",
+		}},
+	}, {
+		desc: "sorted by key",
+		msg: `[
+		{"key":"zzz","value":"last"},
+		{"key":"ddd","value":"middle"},
+		{"key":"aaa","value":"first"}]`,
+		want: []v1alpha1.PipelineResourceResult{{
+			Key:   "aaa",
+			Value: "first",
+		}, {
+			Key:   "ddd",
+			Value: "middle",
+		}, {
+			Key:   "zzz",
+			Value: "last",
+		}},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got, err := ParseMessage(c.msg)


### PR DESCRIPTION
If a user or resource writes to /tekton/termination to append an output
result, later ones should win.

Also sort the deduplicated results for reproducibility.

cc @othomann 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._