### PR TITLE
Use correct name for embedded pipelines to prevent reconciler panic

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -283,7 +283,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 			Status: corev1.ConditionFalse,
 			Reason: ReasonFailedValidation,
 			Message: fmt.Sprintf("Pipeline %s can't be Run; it has an invalid spec: %s",
-				fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pr.Name), err),
+				fmt.Sprintf("%s/%s", pipelineMeta.Namespace, pipelineMeta.Name), err),
 		})
 		return nil
 	}
@@ -295,7 +295,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 			Status: corev1.ConditionFalse,
 			Reason: ReasonInvalidBindings,
 			Message: fmt.Sprintf("PipelineRun %s doesn't bind Pipeline %s's PipelineResources correctly: %s",
-				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), fmt.Sprintf("%s/%s", pr.Namespace, pr.Spec.PipelineRef.Name), err),
+				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), fmt.Sprintf("%s/%s", pr.Namespace, pipelineMeta.Name), err),
 		})
 		return nil
 	}
@@ -322,7 +322,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1alpha1.PipelineRun) er
 			Status: corev1.ConditionFalse,
 			Reason: ReasonParameterTypeMismatch,
 			Message: fmt.Sprintf("PipelineRun %s parameters have mismatching types with Pipeline %s's parameters: %s",
-				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), fmt.Sprintf("%s/%s", pr.Namespace, pr.Spec.PipelineRef.Name), err),
+				fmt.Sprintf("%s/%s", pr.Namespace, pr.Name), fmt.Sprintf("%s/%s", pr.Namespace, pipelineMeta.Name), err),
 		})
 		return nil
 	}

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -386,24 +386,37 @@ func PipelineRunNilTimeout(prs *v1alpha1.PipelineRunSpec) {
 	prs.Timeout = nil
 }
 
-// PipelineRunNodeSelector sets the Node selector to the PipelineSpec.
+// PipelineRunNodeSelector sets the Node selector to the PipelineRunSpec.
 func PipelineRunNodeSelector(values map[string]string) PipelineRunSpecOp {
 	return func(prs *v1alpha1.PipelineRunSpec) {
 		prs.PodTemplate.NodeSelector = values
 	}
 }
 
-// PipelineRunTolerations sets the Node selector to the PipelineSpec.
+// PipelineRunTolerations sets the Node selector to the PipelineRunSpec.
 func PipelineRunTolerations(values []corev1.Toleration) PipelineRunSpecOp {
 	return func(prs *v1alpha1.PipelineRunSpec) {
 		prs.PodTemplate.Tolerations = values
 	}
 }
 
-// PipelineRunAffinity sets the affinity to the PipelineSpec.
+// PipelineRunAffinity sets the affinity to the PipelineRunSpec.
 func PipelineRunAffinity(affinity *corev1.Affinity) PipelineRunSpecOp {
 	return func(prs *v1alpha1.PipelineRunSpec) {
 		prs.PodTemplate.Affinity = affinity
+	}
+}
+
+// PipelineRunPipelineSpec adds a PipelineSpec to the PipelineRunSpec.
+// Any number of PipelineSpec modifiers can be passed to transform it.
+func PipelineRunPipelineSpec(ops ...PipelineSpecOp) PipelineRunSpecOp {
+	return func(prs *v1alpha1.PipelineRunSpec) {
+		ps := &v1alpha1.PipelineSpec{}
+		prs.PipelineRef = nil
+		for _, op := range ops {
+			op(ps)
+		}
+		prs.PipelineSpec = ps
 	}
 }
 

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -264,6 +264,35 @@ func TestPipelineRunWithResourceSpec(t *testing.T) {
 	}
 }
 
+func TestPipelineRunWithPipelineSpec(t *testing.T) {
+	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineTask("a-task", "some-task")),
+		tb.PipelineRunServiceAccountName("sa"),
+	))
+
+	expectedPipelineRun := &v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+		},
+		Spec: v1alpha1.PipelineRunSpec{
+			PipelineRef: nil,
+			PipelineSpec: &v1alpha1.PipelineSpec{
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "a-task",
+					TaskRef: v1alpha1.TaskRef{Name: "some-task"},
+				}},
+			},
+			ServiceAccountName: "sa",
+			Timeout:            &metav1.Duration{Duration: 1 * time.Hour},
+		},
+	}
+
+	if diff := cmp.Diff(expectedPipelineRun, pipelineRun); diff != "" {
+		t.Fatalf("PipelineRun diff -want, +got: %s", diff)
+	}
+}
+
 func TestPipelineResource(t *testing.T) {
 	pipelineResource := tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),


### PR DESCRIPTION
# Changes

In a couple of places we were using `pr.Spec.PipelineRef.Name`.
pipelineRef is nil for embedded pipelineSpecs leading to reconciler
panics. Also added some test cases for that catches these scenarios.

Fixes #1785

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

