### PR TITLE
Correct "outputs.resources.%s.path"

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/resource_paths.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_paths.go
@@ -31,6 +31,9 @@ func OutputResourcePath(r ResourceDeclaration) string {
 
 func path(root string, r ResourceDeclaration) string {
 	if r.TargetPath != "" {
+		if filepath.IsAbs(r.TargetPath) {
+			return r.TargetPath
+		}
 		return filepath.Join("/workspace", r.TargetPath)
 	}
 	return filepath.Join(root, r.Name)


### PR DESCRIPTION
Fix issue #1642 
If the `targetpath` is AP, `outputs.resources.%s.path` is exactly the `targetpath`, or it should be: `/workspace/` + `targetpath`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
