### PR TITLE
An example in the taskrun doc is not runnable

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -372,19 +372,6 @@ creating `read-repo-run`. Task `read-task` has git input resource and TaskRun
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1
-kind: TaskRun
-metadata:
-  name: read-repo-run
-spec:
-  taskRef:
-    name: read-task
-  inputs:
-    resources:
-      - name: workspace
-        resourceRef:
-          name: go-example-git
----
-apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
   name: go-example-git
@@ -406,10 +393,20 @@ spec:
   steps:
     - name: readme
       image: ubuntu
-      command:
-        - /bin/bash
-      args:
-        - "cat README.md"
+      script: cat workspace/README.md
+---
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  name: read-repo-run
+spec:
+  taskRef:
+    name: read-task
+  inputs:
+    resources:
+      - name: workspace
+        resourceRef:
+          name: go-example-git
 ```
 
 ### Example with embedded specs


### PR DESCRIPTION
This commit fixes #1855 - an example in the taskrun doc is not runnable.

Two changes were required to make this example in docs/taskruns.md
runnable:

1. "cat README.md" needed to be updated to "cat workspace/README.md"
because the git resource is checked out to /workspace/workspace

2. The TaskRun needed to be moved from above the resource and task
declarations to be the last resource in the document.

As an added bonus I've updated the example to use the script field
instead of `bash -c $(args)`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)