### PR TITLE
Fix ClusterTask Example

### DIFF
--- a/examples/taskruns/clustertask.yaml
+++ b/examples/taskruns/clustertask.yaml
@@ -5,7 +5,9 @@ metadata:
 spec:
   steps:
   - image: ubuntu
-    script: echo hello
+    script: |
+      #!/usr/bin/env bash
+      echo "Hello"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun


### PR DESCRIPTION
Using the clustertask example results in the following:

```
Error from server (BadRequest): error when creating "https://raw.githubusercontent.com/tektoncd/pipeline/master/examples/taskruns/clustertask.yaml": admission webhook "webhook.tekton.dev" denied the request: mutation failed: script must start with a shebang (#!): steps.script
error when retrieving current configuration of:
Resource: "tekton.dev/v1alpha1, Resource=taskruns", GroupVersionKind: "tekton.dev/v1alpha1, Kind=TaskRun"
Name: "", Namespace: "default"
Object: &{map["apiVersion":"tekton.dev/v1alpha1" "kind":"TaskRun" "metadata":map["annotations":map["kubectl.kubernetes.io/last-applied-configuration":""] "generateName":"clustertask-" "namespace":"default"] "spec":map["taskRef":map["kind":"ClusterTask" "name":"clustertask"]]]}
from server for: "https://raw.githubusercontent.com/tektoncd/pipeline/master/examples/taskruns/clustertask.yaml": resource name may not be empty
```

This pull request adds a shebang for the ClusterTask definition.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


# Release Notes

```
Add shebang for ClusterTask example
```
