### PR TITLE
Issue 1862: Gitlab status upload fails with missing commit error

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,7 @@ github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jenkins-x/go-scm v1.5.65 h1:ieH+0JSWENObn1SDWFj2K40iV5Eia4aTl6W6bDdLwI0=
 github.com/jenkins-x/go-scm v1.5.65/go.mod h1:MgGRkJScE/rJ30J/bXYqduN5sDPZqZFITJopsnZmTOw=
+github.com/jenkins-x/go-scm v1.5.66 h1:xKLQd5YGW+LAvR2xlN8IMaSzYOqW7g7s6WbbLsUuV24=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pkg/pullrequest/disk.go
+++ b/pkg/pullrequest/disk.go
@@ -169,6 +169,18 @@ func FromDisk(path string) (*Resource, error) {
 	var err error
 	var manifest Manifest
 
+	// If pr.json exists in output directory, preload r.PR
+	prPath := filepath.Join(path, "pr.json")
+	if _, err := os.Stat(prPath); err == nil {
+		b, err := ioutil.ReadFile(prPath)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(b, r.PR); err != nil {
+			return nil, err
+		}
+	}
+
 	commentsPath := filepath.Join(path, "comments")
 	r.Comments, manifest, err = commentsFromDisk(commentsPath)
 	if err != nil {
@@ -198,7 +210,9 @@ func FromDisk(path string) (*Resource, error) {
 		return nil, err
 	}
 
-	r.PR.Sha = r.PR.Head.Sha
+	if r.PR.Head.Sha != "" {
+		r.PR.Sha = r.PR.Head.Sha
+	}
 
 	return r, nil
 }

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -642,3 +642,52 @@ func TestLabelsFromDisk(t *testing.T) {
 		})
 	}
 }
+
+func TestFromDiskPRShaWithNullHeadAndBase(t *testing.T) {
+	d, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+
+	expectedSha := "1a2s3d4f5g6g6h7j8k9l"
+	// Write some refs
+	base := scm.PullRequestBranch{
+		Repo: scm.Repository{},
+		Ref:  "",
+		Sha:  "",
+	}
+	head := scm.PullRequestBranch{
+		Repo: scm.Repository{},
+		Ref:  "",
+		Sha:  "",
+	}
+	pr := scm.PullRequest{
+		Sha:  expectedSha,
+		Base: base,
+		Head: head,
+	}
+
+	writeFile := func(p string, v interface{}) {
+		b, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile(p, b, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFile(filepath.Join(d, "base.json"), &base)
+	writeFile(filepath.Join(d, "head.json"), &head)
+	writeFile(filepath.Join(d, "pr.json"), &pr)
+
+	rsrc, err := FromDisk(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rsrc.PR.Sha != expectedSha {
+		t.Errorf("FromDisk() returned sha `%s`, expected `%s`", rsrc.PR.Sha, expectedSha)
+	}
+
+}


### PR DESCRIPTION
# Changes

This PR adds the preloading of data into the resource.PullRequest
used in the FromDisk() method.  If the pr.json file has been copied
into the ouput directory, it is unmarshalled into the resource prior
to subsequent updates from other files on disk, avoiding overwiting
the r.PR.Sha with a null value from head.json (should that situation
occur).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fixes issue 1862: Gitlab status upload fails with missing commit error when using pipelineresource
of type pullrequest.
```
