### PR TITLE
Group pipeline_validation_test together 😁

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -36,18 +36,6 @@ func TestPipeline_Validate(t *testing.T) {
 		)),
 		failureExpected: false,
 	}, {
-		name: "valid resource declarations and usage",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskInputResource("some-workspace", "great-resource"),
-				tb.PipelineTaskOutputResource("some-image", "wonderful-resource")),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("wow-image", "wonderful-resource", tb.From("bar"))),
-		)),
-		failureExpected: false,
-	}, {
 		name: "period in name",
 		p: tb.Pipeline("pipe.line", "namespace", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
@@ -84,27 +72,7 @@ func TestPipeline_Validate(t *testing.T) {
 			tb.PipelineTask("foo", "_foo-task"),
 		)),
 		failureExpected: true,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Validate(context.Background())
-			if (!tt.failureExpected) && (err != nil) {
-				t.Errorf("Pipeline.Validate() returned error: %v", err)
-			}
-
-			if tt.failureExpected && (err == nil) {
-				t.Error("Pipeline.Validate() did not return error, wanted error")
-			}
-		})
-	}
-}
-
-func TestPipelineSpec_Validate(t *testing.T) {
-	tests := []struct {
-		name            string
-		p               *v1alpha1.Pipeline
-		failureExpected bool
-	}{{
+	}, {
 		name: "no duplicate tasks",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
@@ -172,13 +140,6 @@ func TestPipelineSpec_Validate(t *testing.T) {
 				tb.PipelineTaskParam("a-param", "$(input.workspace.$(baz))")),
 		)),
 		failureExpected: false,
-	}, {
-		name: "duplicate tasks",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
-			tb.PipelineTask("foo", "foo-task"),
-			tb.PipelineTask("foo", "foo-task"),
-		)),
-		failureExpected: true,
 	}, {
 		name: "from is on first task",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
@@ -260,24 +221,21 @@ func TestPipelineSpec_Validate(t *testing.T) {
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", "invalidtype", tb.ParamSpecDefault("some", "default")),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(baz)", "and", "$(foo-is-baz)")),
+			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "array parameter mismatching default type",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("astring")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "arrayelement", "$(baz)")),
+			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "string parameter mismatching default type",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "arrayelement", "$(baz)")),
+			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
@@ -306,13 +264,13 @@ func TestPipelineSpec_Validate(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.p.Spec.Validate(context.Background())
+			err := tt.p.Validate(context.Background())
 			if (!tt.failureExpected) && (err != nil) {
-				t.Errorf("PipelineSpec.Validate() returned error: %v", err)
+				t.Errorf("Pipeline.Validate() returned error: %v", err)
 			}
 
 			if tt.failureExpected && (err == nil) {
-				t.Error("PipelineSpec.Validate() did not return error, wanted error")
+				t.Error("Pipeline.Validate() did not return error, wanted error")
 			}
 		})
 	}


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`TestPipelineSpec_Validate` and `TestPipeline_Validate` do test the
exact same thing, so grouping them in one (`TestPipeline_Validate`)
and remove duplicates.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
