### PR TITLE
Refine example for "pullrequest" resource

### DIFF
--- a/examples/taskruns/pullrequest.yaml
+++ b/examples/taskruns/pullrequest.yaml
@@ -1,33 +1,63 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: github-token
+type: Opaque
+data:
+  # Access token of github, don't forget base64 it
+  token: MWY3ZDIxMWM2MzdiYWM1MjA5OWU0MDcyNjlhNGVmNjEzMZE2NDkwYQ==
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
+  name: pullrequest
+spec:
+  type: pullRequest
+  params:
+    - name: url
+      # I just picked a random PR.
+      value: https://github.com/tektoncd/pipeline/pull/100
+  secrets:
+    - fieldName: authToken
+      secretName: github-token
+      secretKey: token
+---
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun
 metadata:
-  generateName: pullrequest-
+  name: pullrequest
 spec:
   inputs:
     resources:
     - name: pr
-      resourceSpec:
-        type: pullRequest
-        params:
-        - name: url
-          # I just picked a random PR. The first couple didn't have any interesting comments or labels.
-          value: https://github.com/tektoncd/pipeline/pull/100
+      resourceRef:
+        name: pullrequest
+  outputs:
+    resources:
+    - name: pr
+      resourceRef:
+        name: pullrequest
   taskSpec:
     inputs:
       resources:
       - name: pr
         type: pullRequest
+    outputs:
+      resources:
+      - name: pr
+        type: pullRequest
+        targetPath: /workspace/pr
     steps:
     - name: dump-workspace
       image: ubuntu
       script: find $(inputs.resources.pr.path)/* -type f | xargs tail -n +1
 
-    - name: ensure-approved
+    - name: ensure-approved-label-question
       image: ubuntu
       script: |
         if [ -f "$(inputs.resources.pr.path)/labels/approved" ]; then
           echo "PR is approved!"
         else
           echo "PR is not approved!"
-          exit 1
+          touch  "$(inputs.resources.pr.path)/labels/question"
         fi


### PR DESCRIPTION
I think we need a e2e(`pullrequest` is both input and output) example.

The example will
1. Download the `pr`
2. Check if the `pr` is approved
3. If not add label `question`
4. Uplaod the `pr`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
