### PR TITLE
Issue 1880: Adds ability to disable certificate validation in pullrequest resource

### DIFF
--- a/cmd/pullrequest-init/main.go
+++ b/cmd/pullrequest-init/main.go
@@ -19,18 +19,18 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
-
 	"github.com/tektoncd/pipeline/pkg/pullrequest"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
+	"os"
 )
 
 var (
-	prURL    = flag.String("url", "", "The url of the pull request to initialize.")
-	path     = flag.String("path", "", "Path of directory under which PR will be copied")
-	mode     = flag.String("mode", "download", "Whether to operate in download or upload mode")
-	provider = flag.String("provider", "", "The SCM provider to use. Optional")
+	prURL         = flag.String("url", "", "The url of the pull request to initialize.")
+	path          = flag.String("path", "", "Path of directory under which PR will be copied")
+	mode          = flag.String("mode", "download", "Whether to operate in download or upload mode")
+	provider      = flag.String("provider", "", "The SCM provider to use. Optional")
+	skipTLSVerify = flag.Bool("insecure-skip-tls-verify", false, "Enable skipping TLS certificate verification in the git client. Defaults to false")
 )
 
 func main() {
@@ -45,7 +45,7 @@ func main() {
 	ctx := context.Background()
 
 	token := os.Getenv("AUTH_TOKEN")
-	client, err := pullrequest.NewSCMHandler(logger, *prURL, *provider, token)
+	client, err := pullrequest.NewSCMHandler(logger, *prURL, *provider, token, *skipTLSVerify)
 	if err != nil {
 		logger.Fatalf("error creating GitHub client: %v", err)
 	}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -439,6 +439,9 @@ Params that can be added are the following:
 1.  `url`: represents the location of the pull request to fetch.
 1.  `provider`: represents the SCM provider to use. This will be "guessed" based
     on the url if not set. Valid values are `github` or `gitlab` today.
+1.  `insecure-skip-tls-verify`: represents whether to skip verification of certificates
+    from the git server. Valid values are `"true"` or `"false"`, the default being
+    `"false"`.
 
 #### Statuses
 
@@ -456,6 +459,8 @@ URLs should be of the form: https://github.com/tektoncd/pipeline/pull/1
 
 The PullRequest resource works with self hosted or enterprise GitHub/GitLab
 instances. Simply provide the pull request URL and set the `provider` parameter.
+If you need to skip certificate validation set the `insecure-skip-tls-verify` 
+parameter to `"true"`.
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1

--- a/pkg/pullrequest/scm_test.go
+++ b/pkg/pullrequest/scm_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package pullrequest
 
 import (
+	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"go.uber.org/zap"
@@ -26,56 +28,62 @@ import (
 
 func TestNewSCMHandler(t *testing.T) {
 	tests := []struct {
-		name        string
-		raw         string
-		wantBaseURL string
-		wantRepo    string
-		wantNum     int
-		wantErr     bool
+		name          string
+		raw           string
+		skipTLSVerify bool
+		wantBaseURL   string
+		wantRepo      string
+		wantNum       int
+		wantErr       bool
 	}{
 		{
-			name:        "github",
-			raw:         "https://github.com/foo/bar/pull/1",
-			wantBaseURL: "https://api.github.com/",
-			wantRepo:    "foo/bar",
-			wantNum:     1,
-			wantErr:     false,
+			name:          "github",
+			raw:           "https://github.com/foo/bar/pull/1",
+			skipTLSVerify: false,
+			wantBaseURL:   "https://api.github.com/",
+			wantRepo:      "foo/bar",
+			wantNum:       1,
+			wantErr:       false,
 		},
 		{
-			name:        "custom github",
-			raw:         "https://github.tekton.dev/foo/baz/pull/2",
-			wantBaseURL: "https://github.tekton.dev/api/v3/",
-			wantRepo:    "foo/baz",
-			wantNum:     2,
-			wantErr:     false,
+			name:          "custom github",
+			raw:           "https://github.tekton.dev/foo/baz/pull/2",
+			skipTLSVerify: false,
+			wantBaseURL:   "https://github.tekton.dev/api/v3/",
+			wantRepo:      "foo/baz",
+			wantNum:       2,
+			wantErr:       false,
 		},
 		{
-			name:        "gitlab",
-			raw:         "https://gitlab.com/foo/bar/merge_requests/3",
-			wantBaseURL: "https://gitlab.com/",
-			wantRepo:    "foo/bar",
-			wantNum:     3,
-			wantErr:     false,
+			name:          "gitlab",
+			raw:           "https://gitlab.com/foo/bar/merge_requests/3",
+			skipTLSVerify: false,
+			wantBaseURL:   "https://gitlab.com/",
+			wantRepo:      "foo/bar",
+			wantNum:       3,
+			wantErr:       false,
 		},
 		{
-			name:        "gitlab multi-level",
-			raw:         "https://gitlab.com/foo/bar/baz/merge_requests/3",
-			wantBaseURL: "https://gitlab.com/",
-			wantRepo:    "foo/bar/baz",
-			wantNum:     3,
-			wantErr:     false,
+			name:          "gitlab multi-level",
+			raw:           "https://gitlab.com/foo/bar/baz/merge_requests/3",
+			skipTLSVerify: true,
+			wantBaseURL:   "https://gitlab.com/",
+			wantRepo:      "foo/bar/baz",
+			wantNum:       3,
+			wantErr:       false,
 		},
 		{
-			name:    "unsupported",
-			raw:     "https://unsupported.com/foo/baz/merge_requests/3",
-			wantErr: true,
+			name:          "unsupported",
+			raw:           "https://unsupported.com/foo/baz/merge_requests/3",
+			skipTLSVerify: true,
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			observer, _ := observer.New(zap.InfoLevel)
 			logger := zap.New(observer).Sugar()
-			got, err := NewSCMHandler(logger, tt.raw, "", "")
+			got, err := NewSCMHandler(logger, tt.raw, "", "", tt.skipTLSVerify)
 			if err != nil {
 				if !tt.wantErr {
 					t.Errorf("NewSCMHandler() error = %v, wantErr %v", err, tt.wantErr)
@@ -90,6 +98,14 @@ func TestNewSCMHandler(t *testing.T) {
 			}
 			if baseURL := got.client.BaseURL.String(); baseURL != tt.wantBaseURL {
 				t.Errorf("NewSCMHandler() [base url] = %v, want %v", baseURL, tt.wantBaseURL)
+			}
+			switch transport := got.client.Client.Transport.(type) {
+			case *http.Transport:
+				if transport.TLSClientConfig.InsecureSkipVerify != tt.skipTLSVerify {
+					t.Errorf("NewSCMHandler() [InsecureSkipVerify] = %v, want %v", strconv.FormatBool(transport.TLSClientConfig.InsecureSkipVerify), tt.skipTLSVerify)
+				}
+			default:
+				t.Errorf("NewSCMHandler() client.Client.Transport was not of type http.Transport")
 			}
 		})
 	}


### PR DESCRIPTION
# Changes

Fixes Issue #1880 by adding the ability to disable certificate validation in the client interacting with the git server performing actions related to the use of the pipeline resource of type pullrequest.

To disable, user specifies sslVerify parameter in their resource with value set to "false".  Value is true by default.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Users are now able to disable certificate validation in the client that is used to perform actions for the pull request pipeline resource.  To disable certificate validation, the user specifies the sslVerify parameter in their pipeline resource with the value set to "false".  Value is true by default.
```
