### PR TITLE
Use `tekton` instead of all as categories 🎿

### DIFF
--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -21,7 +21,7 @@ spec:
     kind: ClusterTask
     plural: clustertasks
     categories:
-    - all
+    - tekton
     - tekton-pipelines
   scope: Cluster
   # Opt into the status subresource so metadata.generation

--- a/config/300-condition.yaml
+++ b/config/300-condition.yaml
@@ -21,7 +21,7 @@ spec:
     kind: Condition
     plural: conditions
     categories:
-      - all
+      - tekton
       - tekton-pipelines
   scope: Namespaced
   # Opt into the status subresource so metadata.generation

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -21,7 +21,7 @@ spec:
     kind: Pipeline
     plural: pipelines
     categories:
-    - all
+    - tekton
     - tekton-pipelines
   scope: Namespaced
   # Opt into the status subresource so metadata.generation

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -21,7 +21,7 @@ spec:
     kind: PipelineRun
     plural: pipelineruns
     categories:
-    - all
+    - tekton
     - tekton-pipelines
     shortNames:
     - pr

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -21,7 +21,7 @@ spec:
     kind: PipelineResource
     plural: pipelineresources
     categories:
-    - all
+    - tekton
     - tekton-pipelines
   scope: Namespaced
   # Opt into the status subresource so metadata.generation

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -21,7 +21,7 @@ spec:
     kind: Task
     plural: tasks
     categories:
-    - all
+    - tekton
     - tekton-pipelines
   scope: Namespaced
   # Opt into the status subresource so metadata.generation

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -21,7 +21,7 @@ spec:
     kind: TaskRun
     plural: taskruns
     categories:
-    - all
+    - tekton
     - tekton-pipelines
     shortNames:
     - tr


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This means Tekton struct won't show in `kubectl get all` but in
`kubectl get tekton` (or `kubectl get tekton-pipelines`) 😉.

If we do this for other tektoncd project (like [`tektoncd/triggers`](https://github.com/tektoncd/triggers)), it would be nice :angel: (we would be able to list all tekton related resource at once, not polluting or being polluted by `all`). And each tekton components can define their own (like `tekton-pipelines` here, `tekton-triggers` for triggers, …)

Fix #1246

/cc @sbwsg @dibyom @bobcatfish @ImJasonH 
/ping @siamaksade 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Remove the category `all` for our CRD and have a `tekton` categorie that is shared with other tektoncd projects
```
