### PR TITLE
feat: creds-init, add ability to filter secrets for a specific GitHub…

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -175,6 +175,32 @@ generated containing the credentials configured in the `Secret`, and these
 credentials are then used to authenticate when retrieving any
 `PipelineResources`.
 
+## GitHub Apps
+
+[GitHub Apps](https://developer.github.com/apps/about-apps/) are the preferred way for automated operations say from
+within a pipeline to interact with GitHub, rather than managing a 'bot' user and personal access token.
+
+A GitHub App is installed into a GitHub Organisation or users account, an API is then called to retrieve a token that can
+then be used to authenticate Git requests.  This means we now have many tokens, one for each Organisation.  For Tekton
+to mount the correct Kubernetes secret for a given Organisation we need to annotate each secret with the owner that
+matches the Organisation, so we can filter out other secrets during the `creds-init` pipeline step.
+
+   ```yaml
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: basic-user-pass
+     annotations:
+       tekton.dev/git-0: https://github.com
+       tekton.dev/githubapp-owner: <github organisation>
+   type: kubernetes.io/basic-auth
+   stringData:
+     username: <username>
+     password: <password>
+   ```
+
+__NOTE__ GitHub Apps issue a short lived token which needs to be continually refreshed.
+
 ## Basic authentication (Docker)
 
 1. Define a `Secret` containing the username and password that the build should

--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -36,7 +36,7 @@ import (
 //
 // If it finds secrets, it also returns a set of Volumes to attach to the Pod
 // to provide those secrets to this initialization.
-func credsInit(credsImage string, serviceAccountName, namespace string, kubeclient kubernetes.Interface, volumeMounts []corev1.VolumeMount, implicitEnvVars []corev1.EnvVar) (*corev1.Container, []corev1.Volume, error) {
+func credsInit(credsImage string, serviceAccountName, namespace, owner string, kubeclient kubernetes.Interface, volumeMounts []corev1.VolumeMount, implicitEnvVars []corev1.EnvVar) (*corev1.Container, []corev1.Volume, error) {
 	if serviceAccountName == "" {
 		serviceAccountName = "default"
 	}
@@ -55,7 +55,10 @@ func credsInit(credsImage string, serviceAccountName, namespace string, kubeclie
 		if err != nil {
 			return nil, nil, err
 		}
-
+		// if there's a github app annotation on the secret let's match that to the github org this pipeline is for
+		if owner != "" && secret.Annotations[gitHubAppAnnotationKey] != "" && secret.Annotations[gitHubAppAnnotationKey] != owner {
+			continue
+		}
 		matched := false
 		for _, b := range builders {
 			if sa := b.MatchingAnnotations(secret); len(sa) > 0 {

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -34,6 +34,9 @@ const (
 	homeDir = "/tekton/home"
 
 	taskRunLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
+
+	gitHubAppAnnotationKey = "tekton.dev/githubapp-owner"
+	ownerLabelKey          = "owner"
 )
 
 // These are effectively const, but Go doesn't have such an annotation.
@@ -77,7 +80,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 	volumes = append(volumes, implicitVolumes...)
 
 	// Inititalize any credentials found in annotated Secrets.
-	if credsInitContainer, secretsVolumes, err := credsInit(images.CredsImage, taskRun.Spec.ServiceAccountName, taskRun.Namespace, kubeclient, implicitVolumeMounts, implicitEnvVars); err != nil {
+	if credsInitContainer, secretsVolumes, err := credsInit(images.CredsImage, taskRun.Spec.ServiceAccountName, taskRun.Namespace, taskRun.Labels[ownerLabelKey], kubeclient, implicitVolumeMounts, implicitEnvVars); err != nil {
 		return nil, err
 	} else if credsInitContainer != nil {
 		initContainers = append(initContainers, *credsInitContainer)


### PR DESCRIPTION
… organisation when using GitHub Apps

fixes #1886

# Changes

Adds ability to filter secrets for a specific GitHub organisation when using GitHub Apps.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
- Fixes #1886
- Filter multiple git secrets when using GitHub Apps
```
