### PR TITLE
CI: Fix shell expansion when creating resources

### DIFF
--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -93,8 +93,9 @@ function create_resources() {
   local resource=$1
   echo ">> Creating resources ${resource}"
 
-  # Applying the resources, either *taskruns or * *pipelineruns
-  for file in $(find ${REPO_ROOT_DIR}/examples/${resource}s/ -name *.yaml -not -path "${REPO_ROOT_DIR}/examples/${resource}s/no-ci/*" | sort); do
+  # Applying the resources, either *taskruns or * *pipelineruns except those
+  # in the no-ci directory
+  for file in $(find ${REPO_ROOT_DIR}/examples/${resource}s/ -name '*.yaml' -not -path '*/no-ci/*' | sort); do
     perl -p -e 's/gcr.io\/christiewilson-catfactory/$ENV{KO_DOCKER_REPO}/g' ${file} | ko create -f - || return 1
   done
 }


### PR DESCRIPTION
Previously, `create_resource` function in test/e2e-common.sh would
fail to apply yaml files if the root directory (for some reason)
contained a yaml file as

```
  find ${REPO_ROOT_DIR}/examples/${resource}s/ -name *.yaml
```
will expand to `find ${REPO_ROOT_DIR}/examples/${resource}s/ -name <filenames...>.yaml
This is fixed by properly quoting to prevent shell expansion.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ 🙅‍♂ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ 🙅‍♂ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
