### PR TITLE
Make default managed-by label configurable

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -41,3 +41,9 @@ data:
     # default-service-account contains the default service account name
     # to use for TaskRun and PipelineRun, if none is specified.
     default-service-account: "default"
+
+    # default-managed-by-label-value contains the default value given to the
+    # "app.kubernetes.io/managed-by" label applied to all Pods created for
+    # TaskRuns. If a user's requested TaskRun specifies another value for this
+    # label, the user's request supercedes.
+    default-managed-by-label-value: "tekton-pipelines"

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -26,30 +26,35 @@ import (
 
 const (
 	// ConfigName is the name of the configmap
-	DefaultsConfigName       = "config-defaults"
-	DefaultTimeoutMinutes    = 60
-	NoTimeoutDuration        = 0 * time.Minute
-	defaultTimeoutMinutesKey = "default-timeout-minutes"
-	defaultServiceAccountKey = "default-service-account"
+	DefaultsConfigName            = "config-defaults"
+	DefaultTimeoutMinutes         = 60
+	NoTimeoutDuration             = 0 * time.Minute
+	defaultTimeoutMinutesKey      = "default-timeout-minutes"
+	defaultServiceAccountKey      = "default-service-account"
+	defaultManagedByLabelValueKey = "default-managed-by-label-value"
+	DefaultManagedByLabelValue    = "tekton-pipelines"
 )
 
 // Defaults holds the default configurations
 // +k8s:deepcopy-gen=true
 type Defaults struct {
-	DefaultTimeoutMinutes int
-	DefaultServiceAccount string
+	DefaultTimeoutMinutes      int
+	DefaultServiceAccount      string
+	DefaultManagedByLabelValue string
 }
 
 // Equals returns true if two Configs are identical
 func (cfg *Defaults) Equals(other *Defaults) bool {
 	return other.DefaultTimeoutMinutes == cfg.DefaultTimeoutMinutes &&
-		other.DefaultServiceAccount == cfg.DefaultServiceAccount
+		other.DefaultServiceAccount == cfg.DefaultServiceAccount &&
+		other.DefaultManagedByLabelValue == cfg.DefaultManagedByLabelValue
 }
 
 // NewDefaultsFromMap returns a Config given a map corresponding to a ConfigMap
 func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 	tc := Defaults{
-		DefaultTimeoutMinutes: DefaultTimeoutMinutes,
+		DefaultTimeoutMinutes:      DefaultTimeoutMinutes,
+		DefaultManagedByLabelValue: DefaultManagedByLabelValue,
 	}
 	if defaultTimeoutMin, ok := cfgMap[defaultTimeoutMinutesKey]; ok {
 		timeout, err := strconv.ParseInt(defaultTimeoutMin, 10, 0)
@@ -61,6 +66,9 @@ func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 
 	if defaultServiceAccount, ok := cfgMap[defaultServiceAccountKey]; ok {
 		tc.DefaultServiceAccount = defaultServiceAccount
+	}
+	if defaultManagedByLabelValue, ok := cfgMap[defaultManagedByLabelValueKey]; ok {
+		tc.DefaultManagedByLabelValue = defaultManagedByLabelValue
 	}
 
 	return &tc, nil

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -25,8 +25,9 @@ import (
 
 func TestNewDefaultsFromConfigMap(t *testing.T) {
 	expectedConfig := &Defaults{
-		DefaultTimeoutMinutes: 50,
-		DefaultServiceAccount: "tekton",
+		DefaultTimeoutMinutes:      50,
+		DefaultServiceAccount:      "tekton",
+		DefaultManagedByLabelValue: "something-else",
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigName, expectedConfig)
 }
@@ -34,7 +35,8 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 func TestNewDefaultsFromEmptyConfigMap(t *testing.T) {
 	DefaultsConfigEmptyName := "config-defaults-empty"
 	expectedConfig := &Defaults{
-		DefaultTimeoutMinutes: 60,
+		DefaultTimeoutMinutes:      60,
+		DefaultManagedByLabelValue: "tekton-pipelines",
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigEmptyName, expectedConfig)
 }

--- a/pkg/apis/config/testdata/config-defaults.yaml
+++ b/pkg/apis/config/testdata/config-defaults.yaml
@@ -20,3 +20,4 @@ metadata:
 data:
   default-timeout-minutes: "50"
   default-service-account: "tekton"
+  default-managed-by-label-value: "something-else"

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -28,8 +28,20 @@ import (
 
 var _ apis.Defaultable = (*TaskRun)(nil)
 
+const managedByLabelKey = "app.kubernetes.io/managed-by"
+
 func (tr *TaskRun) SetDefaults(ctx context.Context) {
 	tr.Spec.SetDefaults(ctx)
+
+	// If the TaskRun doesn't have a managed-by label, apply the default
+	// specified in the config.
+	cfg := config.FromContextOrDefaults(ctx)
+	if tr.ObjectMeta.Labels == nil {
+		tr.ObjectMeta.Labels = map[string]string{}
+	}
+	if _, found := tr.ObjectMeta.Labels[managedByLabelKey]; !found {
+		tr.ObjectMeta.Labels[managedByLabelKey] = cfg.Defaults.DefaultManagedByLabelValue
+	}
 }
 
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -109,6 +109,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 		name: "empty no context",
 		in:   &v1alpha1.TaskRun{},
 		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
+			},
 			Spec: v1alpha1.TaskRunSpec{
 				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
@@ -121,6 +124,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 		},
 		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
+			},
 			Spec: v1alpha1.TaskRunSpec{
 				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
 				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
@@ -134,6 +140,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 		},
 		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
+			},
 			Spec: v1alpha1.TaskRunSpec{
 				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
 				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
@@ -148,6 +157,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 		},
 		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
+			},
 			Spec: v1alpha1.TaskRunSpec{
 				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
 				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
@@ -173,6 +185,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 			},
 		},
 		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
+			},
 			Spec: v1alpha1.TaskRunSpec{
 				TaskRef:            &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
@@ -192,6 +207,67 @@ func TestTaskRunDefaulting(t *testing.T) {
 			})
 			return s.ToContext(ctx)
 		},
+	}, {
+		name: "TaskRun managed-by set in config",
+		in: &v1alpha1.TaskRun{
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{Name: "foo"},
+			},
+		},
+		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "something-else"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.DefaultsConfigName,
+				},
+				Data: map[string]string{
+					"default-timeout-minutes":        "5",
+					"default-managed-by-label-value": "something-else",
+				},
+			})
+			return s.ToContext(ctx)
+		},
+	}, {
+		name: "TaskRun managed-by set in request and config (request wins)",
+		in: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "user-specified"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{Name: "foo"},
+			},
+		},
+		want: &v1alpha1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"app.kubernetes.io/managed-by": "user-specified"},
+			},
+			Spec: v1alpha1.TaskRunSpec{
+				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logtesting.TestLogger(t))
+			s.OnConfigChanged(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: config.DefaultsConfigName,
+				},
+				Data: map[string]string{
+					"default-timeout-minutes":        "5",
+					"default-managed-by-label-value": "something-else",
+				},
+			})
+			return s.ToContext(ctx)
+		},
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -201,9 +277,8 @@ func TestTaskRunDefaulting(t *testing.T) {
 				ctx = tc.wc(ctx)
 			}
 			got.SetDefaults(ctx)
-			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				t.Errorf("SetDefaults (-want, +got) = %v",
-					cmp.Diff(got, tc.want, ignoreUnexportedResources))
+			if d := cmp.Diff(tc.want, got, ignoreUnexportedResources); d != "" {
+				t.Errorf("SetDefaults (-want, +got) = %v", d)
 			}
 		})
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -33,9 +33,7 @@ import (
 const (
 	homeDir = "/tekton/home"
 
-	taskRunLabelKey     = pipeline.GroupName + pipeline.TaskRunLabelKey
-	ManagedByLabelKey   = "app.kubernetes.io/managed-by"
-	ManagedByLabelValue = "tekton-pipelines"
+	taskRunLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
 )
 
 // These are effectively const, but Go doesn't have such an annotation.
@@ -237,7 +235,6 @@ func makeLabels(s *v1alpha1.TaskRun) map[string]string {
 	// has a managed-by label, it should override this default.
 
 	// Copy through the TaskRun's labels to the underlying Pod's.
-	labels[ManagedByLabelKey] = ManagedByLabelValue
 	for k, v := range s.ObjectMeta.Labels {
 		labels[k] = v
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -653,45 +653,21 @@ script-heredoc-randomly-generated-78c5n
 
 func TestMakeLabels(t *testing.T) {
 	taskRunName := "task-run-name"
-	for _, c := range []struct {
-		desc     string
-		trLabels map[string]string
-		want     map[string]string
-	}{{
-		desc: "taskrun labels pass through",
-		trLabels: map[string]string{
-			"foo":   "bar",
-			"hello": "world",
+	want := map[string]string{
+		taskRunLabelKey: taskRunName,
+		"foo":           "bar",
+		"hello":         "world",
+	}
+	got := makeLabels(&v1alpha1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: taskRunName,
+			Labels: map[string]string{
+				"foo":   "bar",
+				"hello": "world",
+			},
 		},
-		want: map[string]string{
-			taskRunLabelKey:   taskRunName,
-			ManagedByLabelKey: ManagedByLabelValue,
-			"foo":             "bar",
-			"hello":           "world",
-		},
-	}, {
-		desc: "taskrun managed-by overrides; taskrun label key doesn't",
-		trLabels: map[string]string{
-			"foo":             "bar",
-			taskRunLabelKey:   "override-me",
-			ManagedByLabelKey: "managed-by-something-else",
-		},
-		want: map[string]string{
-			taskRunLabelKey:   taskRunName,
-			ManagedByLabelKey: "managed-by-something-else",
-			"foo":             "bar",
-		},
-	}} {
-		t.Run(c.desc, func(t *testing.T) {
-			got := makeLabels(&v1alpha1.TaskRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   taskRunName,
-					Labels: c.trLabels,
-				},
-			})
-			if d := cmp.Diff(got, c.want); d != "" {
-				t.Errorf("Diff labels:\n%s", d)
-			}
-		})
+	})
+	if d := cmp.Diff(got, want); d != "" {
+		t.Errorf("Diff labels:\n%s", d)
 	}
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -258,8 +258,9 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 	defaultSAName := "pipelines"
 	defaultCfg := &config.Config{
 		Defaults: &config.Defaults{
-			DefaultServiceAccount: defaultSAName,
-			DefaultTimeoutMinutes: 60,
+			DefaultServiceAccount:      defaultSAName,
+			DefaultTimeoutMinutes:      60,
+			DefaultManagedByLabelValue: "tekton-pipelines",
 		},
 	}
 
@@ -274,7 +275,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-run-success"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -312,7 +313,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-with-sa"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-sa-run-success"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-sa-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -533,7 +534,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-run-success"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -570,7 +571,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-with-sa"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-sa-run-success"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-sa-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -608,7 +609,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-task-with-substitution"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-substitution"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-substitution",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -685,7 +686,7 @@ func TestReconcile(t *testing.T) {
 		wantPod: tb.Pod("test-taskrun-with-taskspec-pod-abcde", "foo",
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-taskspec"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-taskspec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -740,7 +741,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-cluster-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-cluster-task"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-cluster-task",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -776,7 +777,7 @@ func TestReconcile(t *testing.T) {
 		wantPod: tb.Pod("test-taskrun-with-resource-spec-pod-abcde", "foo",
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-resource-spec"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-resource-spec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
@@ -830,7 +831,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
 			tb.PodLabel(taskNameLabelKey, "test-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-pod"),
-			tb.PodLabel(podconvert.ManagedByLabelKey, podconvert.ManagedByLabelValue),
+			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-pod",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(


### PR DESCRIPTION
This adds a new value to config-defaults.yaml to specify the default
managed-by label value that should be used if the user doesn't specify.

This moves managed-by label setting from pkg/pod/pod.go, where its value
was a const, into taskrun_defaults.go, where the value comes from the
ConfigMap value.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
The default app.kubernetes.io/managed-by label value is configurable in a ConfigMap
```

/assign @sbwsg 