### PR TITLE
test/builder: namespace is optional

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/build_gcs_resource_test.go
@@ -46,28 +46,28 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "no location params",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-location-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-location-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("NotLocation", "doesntmatter"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
 		)),
 	}, {
 		name: "location param with empty value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-location-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-location-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", ""),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
 		)),
 	}, {
 		name: "no artifactType params",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-artifactType-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-artifactType-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
 		)),
 	}, {
 		name: "artifactType param with empty value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-artifactType-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-artifactType-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -75,7 +75,7 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 		)),
 	}, {
 		name: "artifactType param with invalid value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -83,7 +83,7 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 		)),
 	}, {
 		name: "artifactType param with secrets value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param-and-secrets", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param-and-secrets", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -101,7 +101,7 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 }
 
 func TestNewBuildGCSResource_Valid(t *testing.T) {
-	pr := tb.PipelineResource("build-gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("build-gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 		tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -181,7 +181,7 @@ func TestBuildGCS_GetInputSteps(t *testing.T) {
 }
 
 func TestBuildGCS_InvalidArtifactType(t *testing.T) {
-	pr := tb.PipelineResource("build-gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("build-gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 		tb.PipelineResourceSpecParam("type", "build-gcs"),

--- a/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cloud_event_resource_test.go
@@ -31,12 +31,12 @@ func TestNewCloudEventResource_Invalid(t *testing.T) {
 		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "create resource with no parameter",
-		pipelineResource: tb.PipelineResource("cloud-event-resource-no-uri", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("cloud-event-resource-no-uri", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCloudEvent,
 		)),
 	}, {
 		name: "create resource with invalid type",
-		pipelineResource: tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("git-resource", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("URL", "git://fake/repo"),
 			tb.PipelineResourceSpecParam("Revision", "fake_rev"),
@@ -53,7 +53,7 @@ func TestNewCloudEventResource_Invalid(t *testing.T) {
 }
 
 func TestNewCloudEventResource_Valid(t *testing.T) {
-	pr := tb.PipelineResource("cloud-event-resource-uri", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("cloud-event-resource-uri", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCloudEvent,
 		tb.PipelineResourceSpecParam("TargetURI", "http://fake-sink"),
 	))

--- a/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_resource_test.go
@@ -33,7 +33,7 @@ func TestNewClusterResource(t *testing.T) {
 		want     *v1alpha1.ClusterResource
 	}{{
 		desc: "basic cluster resource",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
@@ -49,7 +49,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "resource with password instead of token",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
@@ -67,7 +67,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "set insecure flag to true when there is no cert",
-		resource: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("token", "my-token"),
@@ -82,7 +82,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "basic cluster resource with namespace",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
@@ -100,7 +100,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "basic resource with secrets",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecSecretParam("cadata", "secret1", "cadatakey"),

--- a/pkg/apis/pipeline/v1alpha1/condition_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestConditionCheck_IsDone(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,
@@ -41,7 +41,7 @@ func TestConditionCheck_IsDone(t *testing.T) {
 }
 
 func TestConditionCheck_IsSuccessful(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionTrue,

--- a/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCondition_Validate(t *testing.T) {
-	c := tb.Condition("condname", "foo",
+	c := tb.Condition("condname",
 		tb.ConditionSpec(
 			tb.ConditionSpecCheck("cname", "ubuntu"),
 			tb.ConditionParamSpec("paramname", v1alpha1.ParamTypeString),
@@ -47,14 +47,14 @@ func TestCondition_Invalidate(t *testing.T) {
 		expectedError apis.FieldError
 	}{{
 		name: "invalid meta",
-		cond: tb.Condition("invalid.,name", ""),
+		cond: tb.Condition("invalid.,name"),
 		expectedError: apis.FieldError{
 			Message: "Invalid resource name: special character . must not be present",
 			Paths:   []string{"metadata.name"},
 		},
 	}, {
 		name: "no image",
-		cond: tb.Condition("cond", "foo", tb.ConditionSpec(
+		cond: tb.Condition("cond", tb.ConditionSpec(
 			tb.ConditionSpecCheck("", ""),
 		)),
 		expectedError: apis.FieldError{
@@ -63,7 +63,7 @@ func TestCondition_Invalidate(t *testing.T) {
 		},
 	}, {
 		name: "condition with script and command",
-		cond: tb.Condition("cond", "foo",
+		cond: tb.Condition("cond",
 			tb.ConditionSpec(
 				tb.ConditionSpecCheck("cname", "image", tb.Command("exit 0")),
 				tb.ConditionSpecCheckScript("echo foo"),

--- a/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/gcs_resource_test.go
@@ -32,12 +32,12 @@ func TestInvalidNewStorageResource(t *testing.T) {
 		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "wrong-resource-type",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit),
 		),
 	}, {
 		name: "unimplemented type",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 				tb.PipelineResourceSpecParam("type", "non-existent-type"),
@@ -45,14 +45,14 @@ func TestInvalidNewStorageResource(t *testing.T) {
 		),
 	}, {
 		name: "no type",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 			),
 		),
 	}, {
 		name: "no location params",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("NotLocation", "doesntmatter"),
 				tb.PipelineResourceSpecParam("type", "gcs"),
@@ -60,7 +60,7 @@ func TestInvalidNewStorageResource(t *testing.T) {
 		),
 	}, {
 		name: "location param with empty value",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("Location", ""),
 				tb.PipelineResourceSpecParam("type", "gcs"),
@@ -77,7 +77,7 @@ func TestInvalidNewStorageResource(t *testing.T) {
 }
 
 func TestValidNewGCSResource(t *testing.T) {
-	pr := tb.PipelineResource("gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 		tb.PipelineResourceSpecParam("type", "gcs"),
@@ -124,7 +124,7 @@ func TestGCSGetReplacements(t *testing.T) {
 }
 
 func TestGetParams(t *testing.T) {
-	pr := tb.PipelineResource("gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gcs://some-bucket.zip"),
 		tb.PipelineResourceSpecParam("type", "gcs"),

--- a/pkg/apis/pipeline/v1alpha1/git_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/git_resource_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestNewGitResource_Invalid(t *testing.T) {
-	if _, err := v1alpha1.NewGitResource("override-with-git:latest", tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGCS))); err == nil {
+	if _, err := v1alpha1.NewGitResource("override-with-git:latest", tb.PipelineResource("git-resource", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGCS))); err == nil {
 		t.Error("Expected error creating Git resource")
 	}
 }
@@ -39,7 +39,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		want             *v1alpha1.GitResource
 	}{{
 		desc: "With Revision",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -57,7 +57,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without Revision",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 			),
@@ -74,7 +74,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With Submodules",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -92,7 +92,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without Submodules",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -111,7 +111,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With positive depth",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -130,7 +130,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With zero depth",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -149,7 +149,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without SSLVerify",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),

--- a/pkg/apis/pipeline/v1alpha1/image_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/image_resource_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestNewImageResource_Invalid(t *testing.T) {
-	r := tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
+	r := tb.PipelineResource("git-resource", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
 
 	_, err := v1alpha1.NewImageResource(r)
 	if err == nil {
@@ -44,7 +44,6 @@ func TestNewImageResource_Valid(t *testing.T) {
 
 	r := tb.PipelineResource(
 		"image-resource",
-		"default",
 		tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeImage,
 			tb.PipelineResourceSpecParam("URL", "https://test.com/test/test"),

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -32,57 +32,57 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected bool
 	}{{
 		name: "valid metadata",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: false,
 	}, {
 		name: "period in name",
-		p: tb.Pipeline("pipe.line", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipe.line", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline name too long",
-		p: tb.Pipeline("asdf123456789012345678901234567890123456789012345678901234567890", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("asdf123456789012345678901234567890123456789012345678901234567890", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid (duplicate tasks)",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec empty task name",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid task name",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("_foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid taskref name",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "_foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec missing tasfref and taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("", ""),
 			tb.PipelineTask("", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{})),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec with taskref and taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{
 				Steps: []v1alpha1.Step{{Container: corev1.Container{
 					Name:  "foo",
@@ -93,13 +93,13 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{})),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec valid taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{
 				Steps: []v1alpha1.Step{{Container: corev1.Container{
 					Name:  "foo",
@@ -110,7 +110,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "no duplicate tasks",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 			tb.PipelineTask("bar", "bar-task"),
 		)),
@@ -118,7 +118,7 @@ func TestPipeline_Validate(t *testing.T) {
 	}, {
 		// Adding this case because `task.Resources` is a pointer, explicitly making sure this is handled
 		name: "task without resources",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task"),
 			tb.PipelineTask("foo", "foo-task",
@@ -127,7 +127,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid resource declarations and usage",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task",
@@ -143,7 +143,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid condition only resource",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskCondition("some-condition",
@@ -152,7 +152,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeString),
 			tb.PipelineTask("bar", "bar-task",
@@ -161,7 +161,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid array parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("bar", "bar-task",
@@ -170,7 +170,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "pipeline parameter nested in task parameter",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "$(input.workspace.$(baz))")),
@@ -178,7 +178,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "from is on first task",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "great-resource", tb.From("bar"))),
@@ -186,7 +186,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "from task doesnt exist",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("baz", "baz-task"),
 			tb.PipelineTask("foo", "foo-task",
@@ -195,7 +195,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "output resources missing from declaration",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "great-resource"),
@@ -204,7 +204,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "input resources missing from declaration",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "missing-resource"),
@@ -213,7 +213,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "invalid condition only resource",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskCondition("some-condition",
 					tb.PipelineTaskConditionResource("some-workspace", "missing-resource"))),
@@ -221,7 +221,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "invalid from in condition",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskCondition("some-condition",
@@ -230,7 +230,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "from resource isn't output by task",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task",
@@ -241,20 +241,20 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "not defined parameter variable",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskParam("a-param", "$(params.does-not-exist)")))),
 		failureExpected: true,
 	}, {
 		name: "not defined parameter variable with defined",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("foo", v1alpha1.ParamTypeString, tb.ParamSpecDefault("something")),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskParam("a-param", "$(params.foo) and $(params.does-not-exist)")))),
 		failureExpected: true,
 	}, {
 		name: "invalid parameter type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", "invalidtype", tb.ParamSpecDefault("some", "default")),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("bar", "bar-task"),
@@ -262,21 +262,21 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "array parameter mismatching default type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("astring")),
 			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "string parameter mismatching default type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "array parameter used as string",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "$(params.baz)")),
@@ -284,7 +284,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "array parameter string template not isolated",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz)", "last")),
@@ -292,7 +292,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "invalid dependency graph between the tasks",
-		p: tb.Pipeline("foo", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("foo", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo", tb.RunAfter("bar")),
 			tb.PipelineTask("bar", "bar", tb.RunAfter("foo")),
 		)),

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -131,7 +131,7 @@ func TestPipelineRunIsCancelled(t *testing.T) {
 }
 
 func TestPipelineRunKey(t *testing.T) {
-	pr := tb.PipelineRun("prunname", "testns")
+	pr := tb.PipelineRun("prunname")
 	expectedKey := fmt.Sprintf("PipelineRun/%p", pr)
 	if pr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, pr.GetRunKey())
@@ -206,7 +206,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(t.Name(), func(t *testing.T) {
-			pr := tb.PipelineRun("pr", "foo",
+			pr := tb.PipelineRun("pr",
 				tb.PipelineRunSpec("test-pipeline",
 					tb.PipelineRunTimeout(tc.timeout),
 				),
@@ -230,7 +230,7 @@ func TestPipelineRunGetServiceAccountName(t *testing.T) {
 	}{
 		{
 			"default SA",
-			tb.PipelineRun("pr", "ns",
+			tb.PipelineRun("pr",
 				tb.PipelineRunSpec("prs",
 					tb.PipelineRunServiceAccountName("defaultSA"),
 					tb.PipelineRunServiceAccountNameTask("taskName", "taskSA"))),
@@ -241,7 +241,7 @@ func TestPipelineRunGetServiceAccountName(t *testing.T) {
 		},
 		{
 			"mixed default SA",
-			tb.PipelineRun("defaultSA", "defaultSA",
+			tb.PipelineRun("defaultSA",
 				tb.PipelineRunSpec("defaultSA",
 					tb.PipelineRunServiceAccountName("defaultSA"),
 					tb.PipelineRunServiceAccountNameTask("task1", "task1SA"),

--- a/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pull_request_resource_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestPullRequest_NewResource(t *testing.T) {
 	url := "https://github.com/tektoncd/pipeline/pulls/1"
-	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("foo", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypePullRequest,
 		tb.PipelineResourceSpecParam("url", url),
 		tb.PipelineResourceSpecParam("provider", "github"),
@@ -54,7 +54,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 }
 
 func TestPullRequest_NewResource_error(t *testing.T) {
-	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
+	pr := tb.PipelineResource("foo", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
 	if _, err := v1alpha1.NewPullRequestResource("override-with-pr:latest", pr); err == nil {
 		t.Error("NewPullRequestResource() want error, got nil")
 	}

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -31,11 +31,10 @@ import (
 )
 
 func TestTaskRun_GetBuildPodRef(t *testing.T) {
-	tr := tb.TaskRun("taskrunname", "testns")
+	tr := tb.TaskRun("taskrunname")
 	if d := cmp.Diff(tr.GetBuildPodRef(), corev1.ObjectReference{
 		APIVersion: "v1",
 		Kind:       "Pod",
-		Namespace:  "testns",
 		Name:       "taskrunname",
 	}); d != "" {
 		t.Fatalf("taskrun build pod ref mismatch: %s", d)
@@ -49,11 +48,11 @@ func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 		expectedPVCName string
 	}{{
 		name:            "invalid owner reference",
-		tr:              tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
+		tr:              tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
 		expectedPVCName: "",
 	}, {
 		name:            "valid pipelinerun owner",
-		tr:              tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
+		tr:              tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
 		expectedPVCName: "testpr-pvc",
 	}, {
 		name:            "nil taskrun",
@@ -75,11 +74,11 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 		want bool
 	}{{
 		name: "invalid owner reference",
-		tr:   tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
+		tr:   tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
 		want: false,
 	}, {
 		name: "valid pipelinerun owner",
-		tr:   tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
+		tr:   tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
 		want: true,
 	}}
 	for _, tt := range tests {
@@ -92,7 +91,7 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 }
 
 func TestTaskRunIsDone(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,
@@ -104,7 +103,7 @@ func TestTaskRunIsDone(t *testing.T) {
 }
 
 func TestTaskRunIsCancelled(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunSpec(
+	tr := tb.TaskRun("", tb.TaskRunSpec(
 		tb.TaskRunSpecStatus(v1alpha1.TaskRunSpecStatusCancelled)),
 	)
 	if !tr.IsCancelled() {
@@ -113,7 +112,7 @@ func TestTaskRunIsCancelled(t *testing.T) {
 }
 
 func TestTaskRunKey(t *testing.T) {
-	tr := tb.TaskRun("taskrunname", "")
+	tr := tb.TaskRun("taskrunname")
 	expectedKey := fmt.Sprintf("TaskRun/%p", tr)
 	if tr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, tr.GetRunKey())
@@ -148,7 +147,7 @@ func TestTaskRunHasStarted(t *testing.T) {
 	}}
 	for _, tc := range params {
 		t.Run(tc.name, func(t *testing.T) {
-			tr := tb.TaskRun("taskrunname", "testns")
+			tr := tb.TaskRun("taskrunname")
 			tr.Status = tc.trStatus
 			if tr.HasStarted() != tc.expectedValue {
 				t.Fatalf("Expected taskrun HasStarted() to return %t but got %t", tc.expectedValue, tr.HasStarted())
@@ -166,7 +165,7 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 		expetectedPipelineRun string
 	}{{
 		name: "yes",
-		tr: tb.TaskRun("taskrunname", "testns",
+		tr: tb.TaskRun("taskrunname",
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "pipeline"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "pipelinerun"),
 		),
@@ -175,7 +174,7 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 		expetectedPipelineRun: "pipelinerun",
 	}, {
 		name:          "no",
-		tr:            tb.TaskRun("taskrunname", "testns"),
+		tr:            tb.TaskRun("taskrunname"),
 		expectedValue: false,
 	}}
 

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -37,11 +37,11 @@ func TestTaskRun_Invalid(t *testing.T) {
 		want *apis.FieldError
 	}{{
 		name: "invalid taskspec",
-		task: tb.TaskRun("taskmetaname", "default"),
+		task: tb.TaskRun("taskmetaname"),
 		want: apis.ErrMissingField("spec"),
 	}, {
 		name: "invalid taskrun metadata",
-		task: tb.TaskRun("task.name", "default"),
+		task: tb.TaskRun("task.name"),
 		want: &apis.FieldError{
 			Message: "Invalid resource name: special character . must not be present",
 			Paths:   []string{"metadata.name"},
@@ -58,7 +58,7 @@ func TestTaskRun_Invalid(t *testing.T) {
 }
 
 func TestTaskRun_Validate(t *testing.T) {
-	tr := tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+	tr := tb.TaskRun("taskname", tb.TaskRunSpec(
 		tb.TaskRunTaskRef("taskrefname"),
 	))
 	if err := tr.Validate(context.Background()); err != nil {
@@ -73,7 +73,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 		wantErr *apis.FieldError
 	}{{
 		name: "make sure WorkspaceBinding validation invoked",
-		tr: tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+		tr: tb.TaskRun("taskname", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task"),
 			// When using PVC it's required that you provide a volume name
 			tb.TaskRunWorkspacePVC("workspace", "", ""),
@@ -81,7 +81,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 		wantErr: apis.ErrMissingField("workspace.persistentvolumeclaim.claimname"),
 	}, {
 		name: "bind same workspace twice",
-		tr: tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+		tr: tb.TaskRun("taskname", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task"),
 			tb.TaskRunWorkspaceEmptyDir("workspace", ""),
 			tb.TaskRunWorkspaceEmptyDir("workspace", ""),

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -37,35 +37,35 @@ func TestCancelPipelineRun(t *testing.T) {
 		taskRuns      []*v1alpha1.TaskRun
 	}{{
 		name: "no-resolved-taskrun",
-		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunCancelled,
 			),
 		),
 	}, {
 		name: "1-of-resolved-taskrun",
-		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunCancelled,
 			),
 		),
 		pipelineState: []*resources.ResolvedPipelineRunTask{
-			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
+			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", tb.TaskRunNamespace("foo"))},
 			{TaskRunName: "t2"},
 		},
-		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo")},
+		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", tb.TaskRunNamespace("foo"))},
 	}, {
 		name: "resolved-taskruns",
-		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunCancelled,
 			),
 		),
 		pipelineState: []*resources.ResolvedPipelineRunTask{
-			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
-			{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", "foo")},
+			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", tb.TaskRunNamespace("foo"))},
+			{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", tb.TaskRunNamespace("foo"))},
 		},
-		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo"), tb.TaskRun("t2", "foo")},
+		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", tb.TaskRunNamespace("foo")), tb.TaskRun("t2", tb.TaskRunNamespace("foo"))},
 	}}
 	for _, tc := range testCases {
 		tc := tc

--- a/pkg/reconciler/pipelinerun/metrics_test.go
+++ b/pkg/reconciler/pipelinerun/metrics_test.go
@@ -51,7 +51,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 		expectedCount    int64
 	}{{
 		name: "for_succeeded_pipeline",
-		taskRun: tb.PipelineRun("pipelinerun-1", "ns",
+		taskRun: tb.PipelineRun("pipelinerun-1", tb.PipelineRunNamespace("ns"),
 			tb.PipelineRunSpec("pipeline-1"),
 			tb.PipelineRunStatus(
 				tb.PipelineRunStartTime(startTime),
@@ -71,7 +71,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 		expectedCount:    1,
 	}, {
 		name: "for_failed_pipeline",
-		taskRun: tb.PipelineRun("pipelinerun-1", "ns",
+		taskRun: tb.PipelineRun("pipelinerun-1", tb.PipelineRunNamespace("ns"),
 			tb.PipelineRunSpec("pipeline-1"),
 			tb.PipelineRunStatus(
 				tb.PipelineRunStartTime(startTime),
@@ -128,7 +128,7 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 func addPipelineRun(informer alpha1.PipelineRunInformer, run, pipeline, ns string, status corev1.ConditionStatus, t *testing.T) {
 	t.Helper()
 
-	err := informer.Informer().GetIndexer().Add(tb.PipelineRun(run, ns,
+	err := informer.Informer().GetIndexer().Add(tb.PipelineRun(run, tb.PipelineRunNamespace(ns),
 		tb.PipelineRunSpec(pipeline),
 		tb.PipelineRunStatus(
 			tb.PipelineRunStatusCondition(apis.Condition{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -85,7 +85,7 @@ func TestReconcile(t *testing.T) {
 	names.TestingSeed()
 
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("test-pipeline-run-success", "foo",
+		tb.PipelineRun("test-pipeline-run-success", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunServiceAccountName("test-sa"),
 				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
@@ -106,7 +106,7 @@ func TestReconcile(t *testing.T) {
 	moreFunParam := tb.PipelineTaskParam("bar", "$(params.bar)")
 	templatedParam := tb.PipelineTaskParam("templatedparam", "$(inputs.workspace.$(params.rev-param))")
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline("test-pipeline", "foo",
+		tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineDeclaredResource("best-image", "image"),
@@ -144,7 +144,7 @@ func TestReconcile(t *testing.T) {
 		),
 	}
 	ts := []*v1alpha1.Task{
-		tb.Task("unit-test-task", "foo", tb.TaskSpec(
+		tb.Task("unit-test-task", tb.TaskNamespace("foo"), tb.TaskSpec(
 			tb.TaskInputs(
 				tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
 				tb.InputsParamSpec("foo", v1alpha1.ParamTypeString), tb.InputsParamSpec("bar", v1alpha1.ParamTypeString), tb.InputsParamSpec("templatedparam", v1alpha1.ParamTypeString),
@@ -154,7 +154,7 @@ func TestReconcile(t *testing.T) {
 				tb.OutputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
 			),
 		)),
-		tb.Task("unit-test-followup-task", "foo", tb.TaskSpec(
+		tb.Task("unit-test-followup-task", tb.TaskNamespace("foo"), tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
 		)),
 	}
@@ -174,7 +174,7 @@ func TestReconcile(t *testing.T) {
 		)),
 	}
 	rs := []*v1alpha1.PipelineResource{
-		tb.PipelineResource("some-repo", "foo", tb.PipelineResourceSpec(
+		tb.PipelineResource("some-repo", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("url", "https://github.com/kristoff/reindeer"),
 		)),
@@ -216,7 +216,7 @@ func TestReconcile(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject()
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-1-mz4c7", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-1-mz4c7", tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-success",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -288,12 +288,12 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 	names.TestingSeed()
 
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("test-pipeline-run-success", "foo",
+		tb.PipelineRun("test-pipeline-run-success", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline"),
 		),
 	}
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline("test-pipeline", "foo",
+		tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineTask("unit-test-task-spec", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{
 					Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -335,7 +335,7 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject()
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-task-spec-9l9zj", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-task-spec-9l9zj", tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-success",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -367,51 +367,51 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 
 func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 	ts := []*v1alpha1.Task{
-		tb.Task("a-task-that-exists", "foo"),
-		tb.Task("a-task-that-needs-params", "foo", tb.TaskSpec(
+		tb.Task("a-task-that-exists", tb.TaskNamespace("foo")),
+		tb.Task("a-task-that-needs-params", tb.TaskNamespace("foo"), tb.TaskSpec(
 			tb.TaskInputs(tb.InputsParamSpec("some-param", v1alpha1.ParamTypeString)))),
-		tb.Task("a-task-that-needs-array-params", "foo", tb.TaskSpec(
+		tb.Task("a-task-that-needs-array-params", tb.TaskNamespace("foo"), tb.TaskSpec(
 			tb.TaskInputs(tb.InputsParamSpec("some-param", v1alpha1.ParamTypeArray)))),
-		tb.Task("a-task-that-needs-a-resource", "ns", tb.TaskSpec(
+		tb.Task("a-task-that-needs-a-resource", tb.TaskNamespace("foo"), tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", "git")),
 		)),
 	}
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline("pipeline-missing-tasks", "foo", tb.PipelineSpec(
+		tb.Pipeline("pipeline-missing-tasks", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineTask("myspecialtask", "sometask"),
 		)),
-		tb.Pipeline("a-pipeline-without-params", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-pipeline-without-params", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineTask("some-task", "a-task-that-needs-params"))),
-		tb.Pipeline("a-fine-pipeline", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-fine-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineDeclaredResource("a-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("some-task", "a-task-that-exists",
 				tb.PipelineTaskInputResource("needed-resource", "a-resource")))),
-		tb.Pipeline("a-pipeline-that-should-be-caught-by-admission-control", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-pipeline-that-should-be-caught-by-admission-control", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineTask("some-task", "a-task-that-exists",
 				tb.PipelineTaskInputResource("needed-resource", "a-resource")))),
-		tb.Pipeline("a-pipeline-with-array-params", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-pipeline-with-array-params", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineParamSpec("some-param", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("some-task", "a-task-that-needs-array-params"))),
-		tb.Pipeline("a-pipeline-with-missing-conditions", "foo", tb.PipelineSpec(tb.PipelineTask("some-task", "a-task-that-exists", tb.PipelineTaskCondition("condition-does-not-exist")))),
+		tb.Pipeline("a-pipeline-with-missing-conditions", tb.PipelineNamespace("foo"), tb.PipelineSpec(tb.PipelineTask("some-task", "a-task-that-exists", tb.PipelineTaskCondition("condition-does-not-exist")))),
 	}
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("invalid-pipeline", "foo", tb.PipelineRunSpec("pipeline-not-exist")),
-		tb.PipelineRun("pipelinerun-missing-tasks", "foo", tb.PipelineRunSpec("pipeline-missing-tasks")),
-		tb.PipelineRun("pipeline-params-dont-exist", "foo", tb.PipelineRunSpec("a-pipeline-without-params")),
-		tb.PipelineRun("pipeline-resources-not-bound", "foo", tb.PipelineRunSpec("a-fine-pipeline")),
-		tb.PipelineRun("pipeline-resources-dont-exist", "foo", tb.PipelineRunSpec("a-fine-pipeline",
+		tb.PipelineRun("invalid-pipeline", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("pipeline-not-exist")),
+		tb.PipelineRun("pipelinerun-missing-tasks", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("pipeline-missing-tasks")),
+		tb.PipelineRun("pipeline-params-dont-exist", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-without-params")),
+		tb.PipelineRun("pipeline-resources-not-bound", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-fine-pipeline")),
+		tb.PipelineRun("pipeline-resources-dont-exist", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-fine-pipeline",
 			tb.PipelineRunResourceBinding("a-resource", tb.PipelineResourceBindingRef("missing-resource")))),
-		tb.PipelineRun("pipeline-resources-not-declared", "foo", tb.PipelineRunSpec("a-pipeline-that-should-be-caught-by-admission-control")),
-		tb.PipelineRun("pipeline-mismatching-param-type", "foo", tb.PipelineRunSpec("a-pipeline-with-array-params", tb.PipelineRunParam("some-param", "stringval"))),
-		tb.PipelineRun("pipeline-conditions-missing", "foo", tb.PipelineRunSpec("a-pipeline-with-missing-conditions")),
-		tb.PipelineRun("embedded-pipeline-resources-not-bound", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineRun("pipeline-resources-not-declared", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-that-should-be-caught-by-admission-control")),
+		tb.PipelineRun("pipeline-mismatching-param-type", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-with-array-params", tb.PipelineRunParam("some-param", "stringval"))),
+		tb.PipelineRun("pipeline-conditions-missing", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-with-missing-conditions")),
+		tb.PipelineRun("embedded-pipeline-resources-not-bound", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 			tb.PipelineTask("some-task", "a-task-that-needs-a-resource"),
 			tb.PipelineDeclaredResource("workspace", "git"),
 		))),
-		tb.PipelineRun("embedded-pipeline-invalid", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineRun("embedded-pipeline-invalid", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 			tb.PipelineTask("bad-t@$k", "b@d-t@$k"),
 		))),
-		tb.PipelineRun("embedded-pipeline-mismatching-param-type", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineRun("embedded-pipeline-mismatching-param-type", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 			tb.PipelineParamSpec("some-param", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("some-task", "a-task-that-needs-array-params")),
 			tb.PipelineRunParam("some-param", "stringval"),
@@ -559,15 +559,15 @@ func TestReconcile_InvalidPipelineRunNames(t *testing.T) {
 }
 
 func TestUpdateTaskRunsState(t *testing.T) {
-	pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+	pr := tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("test-pipeline"))
 	pipelineTask := v1alpha1.PipelineTask{
 		Name:    "unit-test-1",
 		TaskRef: &v1alpha1.TaskRef{Name: "unit-test-task"},
 	}
-	task := tb.Task("unit-test-task", "foo", tb.TaskSpec(
+	task := tb.Task("unit-test-task", tb.TaskNamespace("foo"), tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
 	))
-	taskrun := tb.TaskRun("test-pipeline-run-success-unit-test-1", "foo", tb.TaskRunSpec(
+	taskrun := tb.TaskRun("test-pipeline-run-success-unit-test-1", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef("unit-test-task"),
 		tb.TaskRunServiceAccountName("test-sa"),
 	), tb.TaskRunStatus(
@@ -617,8 +617,8 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 	successConditionCheckName := "success-condition"
 	failingConditionCheckName := "fail-condition"
 
-	successCondition := tb.Condition("cond-1", "foo")
-	failingCondition := tb.Condition("cond-2", "foo")
+	successCondition := tb.Condition("cond-1", tb.ConditionNamespace("foo"))
+	failingCondition := tb.Condition("cond-2", tb.ConditionNamespace("foo"))
 
 	pipelineTask := v1alpha1.PipelineTask{
 		TaskRef: &v1alpha1.TaskRef{Name: "unit-test-task"},
@@ -629,20 +629,22 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 		}},
 	}
 
-	successConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(successConditionCheckName, "foo", tb.TaskRunStatus(
-		tb.StatusCondition(apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionTrue,
-		}),
-		tb.StepState(tb.StateTerminated(0)),
-	)))
-	failingConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(failingConditionCheckName, "foo", tb.TaskRunStatus(
-		tb.StatusCondition(apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionFalse,
-		}),
-		tb.StepState(tb.StateTerminated(127)),
-	)))
+	successConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(successConditionCheckName, tb.TaskRunNamespace("foo"),
+		tb.TaskRunStatus(
+			tb.StatusCondition(apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+			}),
+			tb.StepState(tb.StateTerminated(0)),
+		)))
+	failingConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(failingConditionCheckName, tb.TaskRunNamespace("foo"),
+		tb.TaskRunStatus(
+			tb.StatusCondition(apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+			}),
+			tb.StepState(tb.StateTerminated(127)),
+		)))
 
 	successConditionCheckStatus := &v1alpha1.PipelineRunConditionCheckStatus{
 		ConditionName: successCondition.Name,
@@ -728,7 +730,7 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+			pr := tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("test-pipeline"))
 
 			state := []*resources.ResolvedPipelineRunTask{{
 				PipelineTask:            &pipelineTask,
@@ -749,7 +751,7 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 
 func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 	taskRunName := "test-pipeline-run-completed-hello-world"
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa")),
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -763,11 +765,11 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 			}),
 		),
 	)}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world")))}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun(taskRunName, "foo",
+		tb.TaskRun(taskRunName, tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-completed"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -840,17 +842,17 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 }
 
 func TestReconcileOnCancelledPipelineRun(t *testing.T) {
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunCancelled,
 		),
 	)}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("test-pipeline-run-cancelled-hello-world", "foo",
+		tb.TaskRun("test-pipeline-run-cancelled-hello-world", tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-cancelled"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -894,10 +896,10 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 }
 
 func TestReconcileWithTimeout(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunTimeout(12*time.Hour),
@@ -905,7 +907,7 @@ func TestReconcileWithTimeout(t *testing.T) {
 		tb.PipelineRunStatus(
 			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -951,15 +953,15 @@ func TestReconcileWithTimeout(t *testing.T) {
 }
 
 func TestReconcileWithoutPVC(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 		tb.PipelineTask("hello-world-2", "hello-world"),
 	))}
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline")),
 	}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -999,15 +1001,15 @@ func TestReconcileWithoutPVC(t *testing.T) {
 }
 
 func TestReconcileCancelledPipelineRun(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world", tb.Retries(1)),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunCancelled,
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1050,17 +1052,17 @@ func TestReconcilePropagateLabels(t *testing.T) {
 	names.TestingSeed()
 	taskName := "hello-world-1"
 
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask(taskName, "hello-world"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-labels", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-labels", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunLabel("PipelineRunLabel", "PipelineRunValue"),
 		tb.PipelineRunLabel("tekton.dev/pipeline", "WillNotBeUsed"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1068,7 +1070,7 @@ func TestReconcilePropagateLabels(t *testing.T) {
 		Tasks:        ts,
 	}
 
-	expected := tb.TaskRun("test-pipeline-run-with-labels-hello-world-1-9l9zj", "foo",
+	expected := tb.TaskRun("test-pipeline-run-with-labels-hello-world-1-9l9zj", tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-labels",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1113,18 +1115,18 @@ func TestReconcilePropagateLabels(t *testing.T) {
 func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-0", "hello-world-task"),
 		tb.PipelineTask("hello-world-1", "hello-world-task"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa-0"),
 			tb.PipelineRunServiceAccountNameTask("hello-world-1", "test-sa-1"),
 		),
 	)}
 	ts := []*v1alpha1.Task{
-		tb.Task("hello-world-task", "foo"),
+		tb.Task("hello-world-task", tb.TaskNamespace("foo")),
 	}
 
 	d := test.Data{
@@ -1152,7 +1154,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 	taskRunNames := []string{"test-pipeline-run-different-service-accs-hello-world-0-9l9zj", "test-pipeline-run-different-service-accs-hello-world-1-mz4c7"}
 
 	expectedTaskRuns := []*v1alpha1.TaskRun{
-		tb.TaskRun(taskRunNames[0], "foo",
+		tb.TaskRun(taskRunNames[0], tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 				tb.Controller, tb.BlockOwnerDeletion,
@@ -1165,7 +1167,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 			tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 			tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-0"),
 		),
-		tb.TaskRun(taskRunNames[1], "foo",
+		tb.TaskRun(taskRunNames[1], tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 				tb.Controller, tb.BlockOwnerDeletion,
@@ -1215,10 +1217,10 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 	for _, tc := range tcs {
 
 		t.Run(tc.name, func(t *testing.T) {
-			ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline-retry", "foo", tb.PipelineSpec(
+			ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline-retry", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 				tb.PipelineTask("hello-world-1", "hello-world", tb.Retries(tc.retries)),
 			))}
-			prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-retry-run-with-timeout", "foo",
+			prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-retry-run-with-timeout", tb.PipelineRunNamespace("foo"),
 				tb.PipelineRunSpec("test-pipeline-retry",
 					tb.PipelineRunServiceAccountName("test-sa"),
 					tb.PipelineRunTimeout(12*time.Hour),
@@ -1228,10 +1230,10 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 			)}
 
 			ts := []*v1alpha1.Task{
-				tb.Task("hello-world", "foo"),
+				tb.Task("hello-world", tb.TaskNamespace("foo")),
 			}
 			trs := []*v1alpha1.TaskRun{
-				tb.TaskRun("hello-world-1", "foo",
+				tb.TaskRun("hello-world-1", tb.TaskRunNamespace("foo"),
 					tb.TaskRunStatus(
 						tb.PodName("my-pod-name"),
 						tb.StatusCondition(apis.Condition{
@@ -1294,16 +1296,16 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 func TestReconcilePropagateAnnotations(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-annotations", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-annotations", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1332,7 +1334,7 @@ func TestReconcilePropagateAnnotations(t *testing.T) {
 	if actual == nil {
 		t.Errorf("Expected a TaskRun to be created, but it wasn't.")
 	}
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-annotations-hello-world-1-9l9zj", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-annotations-hello-world-1-9l9zj", tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-annotations",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1363,28 +1365,28 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected *metav1.Duration
 	}{{
 		name: "nil timeout duration",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunNilTimeout),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
 		expected: &metav1.Duration{Duration: 60 * time.Minute},
 	}, {
 		name: "timeout specified in pr",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(20*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
 	}, {
 		name: "0 timeout duration",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(0*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
 		expected: &metav1.Duration{Duration: 0 * time.Minute},
 	}, {
 		name: "taskrun being created after timeout expired",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(1*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now().Add(-2*time.Minute)))),
 		expected: &metav1.Duration{Duration: 1 * time.Second},
@@ -1403,7 +1405,7 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 	names.TestingSeed()
 	prName := "test-pipeline-run"
 	conditions := []*v1alpha1.Condition{
-		tb.Condition("cond-1", "foo",
+		tb.Condition("cond-1", tb.ConditionNamespace("foo"),
 			tb.ConditionLabels(
 				map[string]string{
 					"label-1": "value-1",
@@ -1412,7 +1414,7 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 			tb.ConditionSpec(
 				tb.ConditionSpecCheck("", "foo", tb.Args("bar")),
 			)),
-		tb.Condition("cond-2", "foo",
+		tb.Condition("cond-2", tb.ConditionNamespace("foo"),
 			tb.ConditionLabels(
 				map[string]string{
 					"label-3": "value-3",
@@ -1422,18 +1424,18 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 				tb.ConditionSpecCheck("", "foo", tb.Args("bar")),
 			)),
 	}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world",
 			tb.PipelineTaskCondition("cond-1"),
 			tb.PipelineTaskCondition("cond-2")),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(prName, "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(prName, tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1483,7 +1485,7 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 func TestReconcileWithFailingConditionChecks(t *testing.T) {
 	names.TestingSeed()
 	conditions := []*v1alpha1.Condition{
-		tb.Condition("always-false", "foo", tb.ConditionSpec(
+		tb.Condition("always-false", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 			tb.ConditionSpecCheck("", "foo", tb.Args("bar")),
 		)),
 	}
@@ -1495,13 +1497,13 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		ConditionName: "always-false",
 		Status:        &v1alpha1.ConditionCheckStatus{},
 	}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("task-1", "hello-world"),
 		tb.PipelineTask("task-2", "hello-world", tb.PipelineTaskCondition("always-false")),
 		tb.PipelineTask("task-3", "hello-world", tb.RunAfter("task-1")),
 	))}
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-conditions", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-conditions", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
@@ -1521,9 +1523,9 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		})),
 	)}
 
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun(pipelineRunName+"task-1", "foo",
+		tb.TaskRun(pipelineRunName+"task-1", tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -1534,7 +1536,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 			}),
 			),
 		),
-		tb.TaskRun(conditionCheckName, "foo",
+		tb.TaskRun(conditionCheckName, tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -1576,7 +1578,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 	if actual == nil {
 		t.Errorf("Expected a ConditionCheck TaskRun to be created, but it wasn't.")
 	}
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-conditions-task-3-9l9zj", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-conditions-task-3-9l9zj", tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-conditions",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1597,7 +1599,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 }
 
 func makeExpectedTr(condName, ccName string, labels map[string]string) *v1alpha1.TaskRun {
-	return tb.TaskRun(ccName, "foo",
+	return tb.TaskRun(ccName, tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -33,7 +33,7 @@ func TestApplyParameters(t *testing.T) {
 		expected *v1alpha1.Pipeline
 	}{{
 		name: "single parameter",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -42,10 +42,10 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-second-param", "$(params.second-param)"),
 					tb.PipelineTaskParam("first-task-third-param", "static value"),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("second-param", "second-value"))),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -56,7 +56,7 @@ func TestApplyParameters(t *testing.T) {
 				))),
 	}, {
 		name: "pipeline parameter nested inside task parameter",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
@@ -64,9 +64,9 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-first-param", "$(input.workspace.$(params.first-param))"),
 					tb.PipelineTaskParam("first-task-second-param", "$(input.workspace.$(params.second-param))"),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline")),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
@@ -76,7 +76,7 @@ func TestApplyParameters(t *testing.T) {
 				))),
 	}, {
 		name: "parameters in task condition",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -86,10 +86,10 @@ func TestApplyParameters(t *testing.T) {
 						tb.PipelineTaskConditionParam("cond-second-param", "$(params.second-param)"),
 					),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("second-param", "second-value"))),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -101,7 +101,7 @@ func TestApplyParameters(t *testing.T) {
 				))),
 	}, {
 		name: "array parameter",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeArray, tb.ParamSpecDefault(
 					"default", "array", "value")),
@@ -113,11 +113,11 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-third-param", "static value"),
 					tb.PipelineTaskParam("first-task-fourth-param", "first", "$(params.fourth-param)"),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("second-param", "second-value", "array"),
 				tb.PipelineRunParam("fourth-param", "fourth-value", "array"))),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeArray, tb.ParamSpecDefault(
 					"default", "array", "value")),

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
@@ -29,7 +29,7 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-var c = tb.Condition("conditionname", "foo")
+var c = tb.Condition("conditionname", tb.ConditionNamespace("foo"))
 
 var notStartedState = TaskConditionCheckState{{
 	ConditionCheckName: "foo",
@@ -191,7 +191,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		want              v1alpha1.TaskSpec
 	}{{
 		name: "user-provided-container-name",
-		cond: tb.Condition("name", "foo", tb.ConditionSpec(
+		cond: tb.Condition("name", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 			tb.ConditionSpecCheck("foo", "ubuntu"),
 		)),
 		want: v1alpha1.TaskSpec{
@@ -203,7 +203,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		},
 	}, {
 		name: "default-container-name",
-		cond: tb.Condition("bar", "foo", tb.ConditionSpec(
+		cond: tb.Condition("bar", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 			tb.ConditionSpecCheck("", "ubuntu"),
 		)),
 		want: v1alpha1.TaskSpec{
@@ -215,7 +215,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		},
 	}, {
 		name: "with-input-params",
-		cond: tb.Condition("bar", "foo", tb.ConditionSpec(
+		cond: tb.Condition("bar", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 			tb.ConditionSpecCheck("$(params.name)", "$(params.img)",
 				tb.WorkingDir("$(params.not.replaced)")),
 			tb.ConditionParamSpec("name", v1alpha1.ParamTypeString),
@@ -239,13 +239,13 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		},
 	}, {
 		name: "with-resources",
-		cond: tb.Condition("bar", "foo", tb.ConditionSpec(
+		cond: tb.Condition("bar", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 			tb.ConditionSpecCheck("name", "ubuntu",
 				tb.Args("$(resources.git-resource.revision)")),
 			tb.ConditionResource("git-resource", v1alpha1.PipelineResourceTypeGit),
 		)),
 		resolvedResources: map[string]*v1alpha1.PipelineResource{
-			"git-resource": tb.PipelineResource("git-resource", "foo",
+			"git-resource": tb.PipelineResource("git-resource", tb.PipelineResourceNamespace("foo"),
 				tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 					tb.PipelineResourceSpecParam("revision", "master"),
 				)),
@@ -284,7 +284,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 func TestResolvedConditionCheck_ToTaskResourceBindings(t *testing.T) {
 	rcc := ResolvedConditionCheck{
 		ResolvedResources: map[string]*v1alpha1.PipelineResource{
-			"git-resource": tb.PipelineResource("some-repo", "foo"),
+			"git-resource": tb.PipelineResource("some-repo", tb.PipelineResourceNamespace("foo")),
 		},
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1018,7 +1018,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pr := tb.PipelineRun("somepipelinerun", "foo")
+			pr := tb.PipelineRun("somepipelinerun", tb.PipelineRunNamespace("foo"))
 			dag, err := DagFromState(tc.state)
 			if err != nil {
 				t.Fatalf("Unexpected error while buildig DAG for state %v: %v", tc.state, err)
@@ -1032,7 +1032,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings(t *testing.T) {
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunNamespace("namespace"), tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 		tb.PipelineRunResourceBinding("image-resource", tb.PipelineResourceBindingResourceSpec(
 			&v1alpha1.PipelineResourceSpec{
@@ -1044,7 +1044,7 @@ func TestGetResourcesFromBindings(t *testing.T) {
 			}),
 		),
 	))
-	r := tb.PipelineResource("sweet-resource", "namespace")
+	r := tb.PipelineResource("sweet-resource", tb.PipelineResourceNamespace("namespace"))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
 		if name != "sweet-resource" {
 			return nil, fmt.Errorf("request for unexpected resource %s", name)
@@ -1079,7 +1079,7 @@ func TestGetResourcesFromBindings_Missing(t *testing.T) {
 	//	tb.PipelineDeclaredResource("git-resource", "git"),
 	//	tb.PipelineDeclaredResource("image-resource", "image"),
 	//))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunNamespace("namespace"), tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
@@ -1092,7 +1092,7 @@ func TestGetResourcesFromBindings_Missing(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings_ErrorGettingResource(t *testing.T) {
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunNamespace("namespace"), tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
@@ -1107,7 +1107,7 @@ func TestGetResourcesFromBindings_ErrorGettingResource(t *testing.T) {
 func TestResolvePipelineRun(t *testing.T) {
 	names.TestingSeed()
 
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineTask("mytask1", "task",
 			tb.PipelineTaskInputResource("input1", "git-resource"),
@@ -1290,14 +1290,14 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 		p    *v1alpha1.Pipeline
 	}{{
 		name: "input doesnt exist",
-		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 			tb.PipelineTask("mytask1", "task",
 				tb.PipelineTaskInputResource("input1", "git-resource"),
 			),
 		)),
 	}, {
 		name: "output doesnt exist",
-		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 			tb.PipelineTask("mytask1", "task",
 				tb.PipelineTaskOutputResource("input1", "git-resource"),
 			),
@@ -1330,7 +1330,7 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 	names.TestingSeed()
 
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineTask("mytask-with-a-really-long-name-to-trigger-truncation", "task",
 			tb.PipelineTaskInputResource("input1", "git-resource"),
@@ -1692,11 +1692,11 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 func TestResolvedConditionCheck_WithResources(t *testing.T) {
 	names.TestingSeed()
 
-	condition := tb.Condition("always-true", "foo", tb.ConditionSpec(
+	condition := tb.Condition("always-true", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 		tb.ConditionResource("workspace", v1alpha1.PipelineResourceTypeGit),
 	))
 
-	gitResource := tb.PipelineResource("some-repo", "foo", tb.PipelineResourceSpec(
+	gitResource := tb.PipelineResource("some-repo", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit))
 
 	ptc := v1alpha1.PipelineTaskCondition{
@@ -1772,10 +1772,10 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 }
 
 func TestValidateResourceBindings(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunNamespace("namespace"), tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	err := ValidateResourceBindings(&p.Spec, pr)
@@ -1785,11 +1785,11 @@ func TestValidateResourceBindings(t *testing.T) {
 }
 
 func TestValidateResourceBindings_Missing(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineDeclaredResource("image-resource", "image"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunNamespace("namespace"), tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	err := ValidateResourceBindings(&p.Spec, pr)
@@ -1799,10 +1799,10 @@ func TestValidateResourceBindings_Missing(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings_Extra(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineNamespace("namespace"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunNamespace("namespace"), tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 		tb.PipelineRunResourceBinding("image-resource", tb.PipelineResourceBindingRef("sweet-resource2")),
 	))

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -31,11 +31,11 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		errorExpected bool
 	}{{
 		name: "proper param types",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineNamespace(namespace), tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace, tb.PipelineRunSpec(
+		pr: tb.PipelineRun("a-pipelinerun", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(
 			"test-pipeline",
 			tb.PipelineRunParam("correct-type-1", "somestring"),
 			tb.PipelineRunParam("mismatching-type", "astring"),
@@ -43,16 +43,16 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		errorExpected: false,
 	}, {
 		name:          "no params to get wrong",
-		p:             tb.Pipeline("a-pipeline", namespace),
-		pr:            tb.PipelineRun("a-pipelinerun", namespace),
+		p:             tb.Pipeline("a-pipeline", tb.PipelineNamespace(namespace)),
+		pr:            tb.PipelineRun("a-pipelinerun", tb.PipelineRunNamespace(namespace)),
 		errorExpected: false,
 	}, {
 		name: "string-array mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineNamespace(namespace), tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun", tb.PipelineRunNamespace(namespace),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "an", "array"),
@@ -60,11 +60,11 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		errorExpected: true,
 	}, {
 		name: "array-string mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineNamespace(namespace), tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeArray),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun", tb.PipelineRunNamespace(namespace),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "astring"),
@@ -92,22 +92,22 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 		pr   *v1alpha1.PipelineRun
 	}{{
 		name: "string-array mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineNamespace(namespace), tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun", tb.PipelineRunNamespace(namespace),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "an", "array"),
 				tb.PipelineRunParam("correct-type-2", "another", "array"))),
 	}, {
 		name: "array-string mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineNamespace(namespace), tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeArray),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun", tb.PipelineRunNamespace(namespace),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "astring"),

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -38,7 +38,7 @@ import (
 // Test case for providing recorder in the option
 func TestRecorderOptions(t *testing.T) {
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa")),
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -47,10 +47,10 @@ func TestRecorderOptions(t *testing.T) {
 			Message: "All Tasks have completed executing",
 		})),
 	)}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hellow-world"),
 	))}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world")}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,

--- a/pkg/reconciler/taskrun/metrics_test.go
+++ b/pkg/reconciler/taskrun/metrics_test.go
@@ -59,7 +59,7 @@ func TestRecordTaskrunDurationCount(t *testing.T) {
 		expectedCount    int64
 	}{{
 		desc: "for_succeeded_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -81,7 +81,7 @@ func TestRecordTaskrunDurationCount(t *testing.T) {
 		expectedCount:    1,
 	}, {
 		desc: "for_failed_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -130,7 +130,7 @@ func TestRecordPipelinerunTaskrunDurationCount(t *testing.T) {
 		expectedCount    int64
 	}{{
 		desc: "for_succeeded_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "pipeline-1"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "pipelinerun-1"),
 			tb.TaskRunSpec(
@@ -156,7 +156,7 @@ func TestRecordPipelinerunTaskrunDurationCount(t *testing.T) {
 		expectedCount:    1,
 	}, {
 		desc: "for_failed_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "pipeline-1"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "pipelinerun-1"),
 			tb.TaskRunSpec(
@@ -237,7 +237,7 @@ func TestRecordPodLatency(t *testing.T) {
 					LastTransitionTime: metav1.Time{Time: creationTime.Add(4 * time.Second)},
 				}),
 			)),
-		taskRun: tb.TaskRun("test-taskrun", "foo",
+		taskRun: tb.TaskRun("test-taskrun",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -254,7 +254,7 @@ func TestRecordPodLatency(t *testing.T) {
 		pod: tb.Pod("test-taskrun-pod-123456", "foo",
 			tb.PodCreationTimestamp(creationTime),
 		),
-		taskRun: tb.TaskRun("test-taskrun", "foo",
+		taskRun: tb.TaskRun("test-taskrun",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -284,7 +284,7 @@ func TestRecordPodLatency(t *testing.T) {
 }
 
 func addTaskruns(informer alpha1.TaskRunInformer, taskrun, task, ns string, status corev1.ConditionStatus, t *testing.T) {
-	if err := informer.Informer().GetIndexer().Add(tb.TaskRun(taskrun, ns,
+	if err := informer.Informer().GetIndexer().Add(tb.TaskRun(taskrun,
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(task),
 		),

--- a/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller_test.go
@@ -79,7 +79,7 @@ func TestSendCloudEvents(t *testing.T) {
 		wantTaskRun *v1alpha1.TaskRun
 	}{{
 		name: "testWithMultipleMixedCloudEvents",
-		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
 			tb.TaskRunSelfLink("/task/1234"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
@@ -93,7 +93,7 @@ func TestSendCloudEvents(t *testing.T) {
 				tb.TaskRunCloudEvent("http//attemptedsucceeded", "", 1, v1alpha1.CloudEventConditionSent),
 			),
 		),
-		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
@@ -132,7 +132,7 @@ func TestSendCloudEventsErrors(t *testing.T) {
 		wantTaskRun *v1alpha1.TaskRun
 	}{{
 		name: "testWithMultipleMixedCloudEvents",
-		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
 			tb.TaskRunSelfLink("/task/1234"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
@@ -142,7 +142,7 @@ func TestSendCloudEventsErrors(t *testing.T) {
 				tb.TaskRunCloudEvent("http//sink2", "", 0, v1alpha1.CloudEventConditionUnknown),
 			),
 		),
-		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
@@ -179,7 +179,7 @@ func TestInitializeCloudEvents(t *testing.T) {
 		wantTaskRun       *v1alpha1.TaskRun
 	}{{
 		name: "testWithMultipleMixedResources",
-		taskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources", "foo",
+		taskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources",
 			tb.TaskRunSelfLink("/task/1234"), tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 				tb.TaskRunOutputs(
@@ -190,21 +190,21 @@ func TestInitializeCloudEvents(t *testing.T) {
 			),
 		),
 		pipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("ce1", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("ce1", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeCloudEvent,
 				tb.PipelineResourceSpecParam("TargetURI", "http://foosink"),
 			)),
-			tb.PipelineResource("ce2", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("ce2", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeCloudEvent,
 				tb.PipelineResourceSpecParam("TargetURI", "http://barsink"),
 			)),
-			tb.PipelineResource("git", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("git", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "http://git.fake"),
 				tb.PipelineResourceSpecParam("Revision", "abcd"),
 			)),
 		},
-		wantTaskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
@@ -215,7 +215,7 @@ func TestInitializeCloudEvents(t *testing.T) {
 		),
 	}, {
 		name: "testWithNoCloudEventResources",
-		taskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources", "foo",
+		taskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources",
 			tb.TaskRunSelfLink("/task/1234"), tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 				tb.TaskRunOutputs(
@@ -224,13 +224,13 @@ func TestInitializeCloudEvents(t *testing.T) {
 			),
 		),
 		pipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("git", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("git", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "http://git.fake"),
 				tb.PipelineResourceSpecParam("Revision", "abcd"),
 			)),
 		},
-		wantTaskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources",
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -86,10 +86,10 @@ var (
 	cloudEventTarget2 = "https://bar"
 
 	simpleStep  = tb.Step("simple-step", "foo", tb.StepCommand("/mycmd"))
-	simpleTask  = tb.Task("test-task", "foo", tb.TaskSpec(simpleStep))
+	simpleTask  = tb.Task("test-task", tb.TaskNamespace("foo"), tb.TaskSpec(simpleStep))
 	clustertask = tb.ClusterTask("test-cluster-task", tb.ClusterTaskSpec(simpleStep))
 
-	outputTask = tb.Task("test-output-task", "foo", tb.TaskSpec(
+	outputTask = tb.Task("test-output-task", tb.TaskNamespace("foo"), tb.TaskSpec(
 		simpleStep, tb.TaskInputs(
 			tb.InputsResource(gitResource.Name, v1alpha1.PipelineResourceTypeGit),
 			tb.InputsResource(anotherGitResource.Name, v1alpha1.PipelineResourceTypeGit),
@@ -97,9 +97,9 @@ var (
 		tb.TaskOutputs(tb.OutputsResource(gitResource.Name, v1alpha1.PipelineResourceTypeGit)),
 	))
 
-	saTask = tb.Task("test-with-sa", "foo", tb.TaskSpec(tb.Step("sa-step", "foo", tb.StepCommand("/mycmd"))))
+	saTask = tb.Task("test-with-sa", tb.TaskNamespace("foo"), tb.TaskSpec(tb.Step("sa-step", "foo", tb.StepCommand("/mycmd"))))
 
-	templatedTask = tb.Task("test-task-with-substitution", "foo", tb.TaskSpec(
+	templatedTask = tb.Task("test-task-with-substitution", tb.TaskNamespace("foo"), tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
 			tb.InputsParamSpec("myarg", v1alpha1.ParamTypeString), tb.InputsParamSpec("myarghasdefault", v1alpha1.ParamTypeString, tb.ParamSpecDefault("dont see me")),
@@ -125,26 +125,26 @@ var (
 		})),
 	))
 
-	twoOutputsTask = tb.Task("test-two-output-task", "foo", tb.TaskSpec(
+	twoOutputsTask = tb.Task("test-two-output-task", tb.TaskNamespace("foo"), tb.TaskSpec(
 		simpleStep, tb.TaskOutputs(
 			tb.OutputsResource(cloudEventResource.Name, v1alpha1.PipelineResourceTypeCloudEvent),
 			tb.OutputsResource(anotherCloudEventResource.Name, v1alpha1.PipelineResourceTypeCloudEvent),
 		),
 	))
 
-	gitResource = tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
+	gitResource = tb.PipelineResource("git-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
-	anotherGitResource = tb.PipelineResource("another-git-resource", "foo", tb.PipelineResourceSpec(
+	anotherGitResource = tb.PipelineResource("another-git-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foobar.git"),
 	))
-	imageResource = tb.PipelineResource("image-resource", "foo", tb.PipelineResourceSpec(
+	imageResource = tb.PipelineResource("image-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage, tb.PipelineResourceSpecParam("URL", "gcr.io/kristoff/sven"),
 	))
-	cloudEventResource = tb.PipelineResource("cloud-event-resource", "foo", tb.PipelineResourceSpec(
+	cloudEventResource = tb.PipelineResource("cloud-event-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCloudEvent, tb.PipelineResourceSpecParam("TargetURI", cloudEventTarget1),
 	))
-	anotherCloudEventResource = tb.PipelineResource("another-cloud-event-resource", "foo", tb.PipelineResourceSpec(
+	anotherCloudEventResource = tb.PipelineResource("another-cloud-event-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCloudEvent, tb.PipelineResourceSpecParam("TargetURI", cloudEventTarget2),
 	))
 
@@ -242,10 +242,10 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 }
 
 func TestReconcile_ExplicitDefaultSA(t *testing.T) {
-	taskRunSuccess := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(
+	taskRunSuccess := tb.TaskRun("test-taskrun-run-success", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 	))
-	taskRunWithSaSuccess := tb.TaskRun("test-taskrun-with-sa-run-success", "foo", tb.TaskRunSpec(
+	taskRunWithSaSuccess := tb.TaskRun("test-taskrun-with-sa-run-success", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(saTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunServiceAccountName("test-sa"),
 	))
@@ -413,13 +413,13 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
-	taskRunSuccess := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(
+	taskRunSuccess := tb.TaskRun("test-taskrun-run-success", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 	))
-	taskRunWithSaSuccess := tb.TaskRun("test-taskrun-with-sa-run-success", "foo", tb.TaskRunSpec(
+	taskRunWithSaSuccess := tb.TaskRun("test-taskrun-with-sa-run-success", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(saTask.Name, tb.TaskRefAPIVersion("a1")), tb.TaskRunServiceAccountName("test-sa"),
 	))
-	taskRunSubstitution := tb.TaskRun("test-taskrun-substitution", "foo", tb.TaskRunSpec(
+	taskRunSubstitution := tb.TaskRun("test-taskrun-substitution", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(templatedTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
@@ -429,7 +429,7 @@ func TestReconcile(t *testing.T) {
 		),
 		tb.TaskRunOutputs(tb.TaskRunOutputsResource("myimage", tb.TaskResourceBindingRef("image-resource"))),
 	))
-	taskRunInputOutput := tb.TaskRun("test-taskrun-input-output", "foo",
+	taskRunInputOutput := tb.TaskRun("test-taskrun-input-output", tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(outputTask.Name),
@@ -451,7 +451,7 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	)
-	taskRunWithTaskSpec := tb.TaskRun("test-taskrun-with-taskspec", "foo", tb.TaskRunSpec(
+	taskRunWithTaskSpec := tb.TaskRun("test-taskrun-with-taskspec", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
 			tb.TaskRunInputsResource("workspace", tb.TaskResourceBindingRef(gitResource.Name)),
@@ -467,7 +467,7 @@ func TestReconcile(t *testing.T) {
 		),
 	))
 
-	taskRunWithResourceSpecAndTaskSpec := tb.TaskRun("test-taskrun-with-resource-spec", "foo", tb.TaskRunSpec(
+	taskRunWithResourceSpecAndTaskSpec := tb.TaskRun("test-taskrun-with-resource-spec", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunInputs(
 			tb.TaskRunInputsResource("workspace", tb.TaskResourceBindingResourceSpec(&v1alpha1.PipelineResourceSpec{
 				Type: v1alpha1.PipelineResourceTypeGit,
@@ -487,11 +487,11 @@ func TestReconcile(t *testing.T) {
 		),
 	))
 
-	taskRunWithClusterTask := tb.TaskRun("test-taskrun-with-cluster-task", "foo",
+	taskRunWithClusterTask := tb.TaskRun("test-taskrun-with-cluster-task", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSpec(tb.TaskRunTaskRef(clustertask.Name, tb.TaskRefKind(v1alpha1.ClusterTaskKind))),
 	)
 
-	taskRunWithLabels := tb.TaskRun("test-taskrun-with-labels", "foo",
+	taskRunWithLabels := tb.TaskRun("test-taskrun-with-labels", tb.TaskRunNamespace("foo"),
 		tb.TaskRunLabel("TaskRunLabel", "TaskRunValue"),
 		tb.TaskRunLabel(taskRunNameLabelKey, "WillNotBeUsed"),
 		tb.TaskRunSpec(
@@ -499,14 +499,14 @@ func TestReconcile(t *testing.T) {
 		),
 	)
 
-	taskRunWithAnnotations := tb.TaskRun("test-taskrun-with-annotations", "foo",
+	taskRunWithAnnotations := tb.TaskRun("test-taskrun-with-annotations", tb.TaskRunNamespace("foo"),
 		tb.TaskRunAnnotation("TaskRunAnnotation", "TaskRunValue"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name),
 		),
 	)
 
-	taskRunWithPod := tb.TaskRun("test-taskrun-with-pod", "foo",
+	taskRunWithPod := tb.TaskRun("test-taskrun-with-pod", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSpec(tb.TaskRunTaskRef(simpleTask.Name)),
 	)
 
@@ -929,7 +929,7 @@ func TestReconcile(t *testing.T) {
 }
 
 func TestReconcile_SetsStartTime(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
+	taskRun := tb.TaskRun("test-taskrun", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name),
 	))
 	d := test.Data{
@@ -950,7 +950,7 @@ func TestReconcile_SetsStartTime(t *testing.T) {
 
 func TestReconcile_DoesntChangeStartTime(t *testing.T) {
 	startTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
-	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
+	taskRun := tb.TaskRun("test-taskrun", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name)),
 		tb.TaskRunStatus(tb.TaskRunStartTime(startTime)),
 	)
@@ -978,8 +978,8 @@ func TestReconcile_DoesntChangeStartTime(t *testing.T) {
 }
 
 func TestReconcileInvalidTaskRuns(t *testing.T) {
-	noTaskRun := tb.TaskRun("notaskrun", "foo", tb.TaskRunSpec(tb.TaskRunTaskRef("notask")))
-	withWrongRef := tb.TaskRun("taskrun-with-wrong-ref", "foo", tb.TaskRunSpec(
+	noTaskRun := tb.TaskRun("notaskrun", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(tb.TaskRunTaskRef("notask")))
+	withWrongRef := tb.TaskRun("taskrun-with-wrong-ref", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef("taskrun-with-wrong-ref", tb.TaskRefKind(v1alpha1.ClusterTaskKind)),
 	))
 
@@ -1032,7 +1032,7 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 }
 
 func TestReconcilePodFetchError(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun-run-success", "foo",
+	taskRun := tb.TaskRun("test-taskrun-run-success", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSpec(tb.TaskRunTaskRef("test-task")),
 	)
 	d := test.Data{
@@ -1077,7 +1077,7 @@ func makePod(taskRun *v1alpha1.TaskRun, task *v1alpha1.Task) (*corev1.Pod, error
 }
 
 func TestReconcilePodUpdateStatus(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(tb.TaskRunTaskRef("test-task")))
+	taskRun := tb.TaskRun("test-taskrun-run-success", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(tb.TaskRunTaskRef("test-task")))
 
 	pod, err := makePod(taskRun, simpleTask)
 	if err != nil {
@@ -1185,7 +1185,7 @@ func TestReconcileTimeouts(t *testing.T) {
 		taskRun        *v1alpha1.TaskRun
 		expectedStatus *apis.Condition
 	}{{
-		taskRun: tb.TaskRun("test-taskrun-timeout", "foo",
+		taskRun: tb.TaskRun("test-taskrun-timeout", tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef(simpleTask.Name),
 				tb.TaskRunTimeout(10*time.Second),
@@ -1202,7 +1202,7 @@ func TestReconcileTimeouts(t *testing.T) {
 			Message: `TaskRun "test-taskrun-timeout" failed to finish within "10s"`,
 		},
 	}, {
-		taskRun: tb.TaskRun("test-taskrun-default-timeout-60-minutes", "foo",
+		taskRun: tb.TaskRun("test-taskrun-default-timeout-60-minutes", tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef(simpleTask.Name),
 			),
@@ -1218,7 +1218,7 @@ func TestReconcileTimeouts(t *testing.T) {
 			Message: `TaskRun "test-taskrun-default-timeout-60-minutes" failed to finish within "1h0m0s"`,
 		},
 	}, {
-		taskRun: tb.TaskRun("test-taskrun-nil-timeout-default-60-minutes", "foo",
+		taskRun: tb.TaskRun("test-taskrun-nil-timeout-default-60-minutes", tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef(simpleTask.Name),
 				tb.TaskRunNilTimeout,
@@ -1266,7 +1266,7 @@ func TestReconcileTimeouts(t *testing.T) {
 }
 
 func TestHandlePodCreationError(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun-pod-creation-failed", "foo", tb.TaskRunSpec(
+	taskRun := tb.TaskRun("test-taskrun-pod-creation-failed", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name),
 	), tb.TaskRunStatus(
 		tb.TaskRunStartTime(time.Now()),
@@ -1326,11 +1326,11 @@ func TestHandlePodCreationError(t *testing.T) {
 }
 
 func TestReconcileCloudEvents(t *testing.T) {
-	taskRunWithNoCEResources := tb.TaskRun("test-taskrun-no-ce-resources", "foo",
+	taskRunWithNoCEResources := tb.TaskRun("test-taskrun-no-ce-resources", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		))
-	taskRunWithTwoCEResourcesNoInit := tb.TaskRun("test-taskrun-two-ce-resources-no-init", "foo",
+	taskRunWithTwoCEResourcesNoInit := tb.TaskRun("test-taskrun-two-ce-resources-no-init", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(twoOutputsTask.Name),
 			tb.TaskRunOutputs(
@@ -1339,7 +1339,7 @@ func TestReconcileCloudEvents(t *testing.T) {
 			),
 		),
 	)
-	taskRunWithTwoCEResourcesInit := tb.TaskRun("test-taskrun-two-ce-resources-init", "foo",
+	taskRunWithTwoCEResourcesInit := tb.TaskRun("test-taskrun-two-ce-resources-init", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(twoOutputsTask.Name),
 			tb.TaskRunOutputs(
@@ -1352,7 +1352,7 @@ func TestReconcileCloudEvents(t *testing.T) {
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 0, v1alpha1.CloudEventConditionUnknown),
 		),
 	)
-	taskRunWithCESucceded := tb.TaskRun("test-taskrun-ce-succeeded", "foo",
+	taskRunWithCESucceded := tb.TaskRun("test-taskrun-ce-succeeded", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSelfLink("/task/1234"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(twoOutputsTask.Name),
@@ -1370,7 +1370,7 @@ func TestReconcileCloudEvents(t *testing.T) {
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 0, v1alpha1.CloudEventConditionUnknown),
 		),
 	)
-	taskRunWithCEFailed := tb.TaskRun("test-taskrun-ce-failed", "foo",
+	taskRunWithCEFailed := tb.TaskRun("test-taskrun-ce-failed", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSelfLink("/task/1234"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(twoOutputsTask.Name),
@@ -1388,7 +1388,7 @@ func TestReconcileCloudEvents(t *testing.T) {
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 0, v1alpha1.CloudEventConditionUnknown),
 		),
 	)
-	taskRunWithCESuccededOneAttempt := tb.TaskRun("test-taskrun-ce-succeeded-one-attempt", "foo",
+	taskRunWithCESuccededOneAttempt := tb.TaskRun("test-taskrun-ce-succeeded-one-attempt", tb.TaskRunNamespace("foo"),
 		tb.TaskRunSelfLink("/task/1234"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(twoOutputsTask.Name),
@@ -1442,35 +1442,35 @@ func TestReconcileCloudEvents(t *testing.T) {
 	}, {
 		name:    "ce-resources-no-init",
 		taskRun: taskRunWithTwoCEResourcesNoInit,
-		wantCloudEvents: tb.TaskRun("want", "foo", tb.TaskRunStatus(
+		wantCloudEvents: tb.TaskRun("want", tb.TaskRunNamespace("foo"), tb.TaskRunStatus(
 			tb.TaskRunCloudEvent(cloudEventTarget1, "", 0, v1alpha1.CloudEventConditionUnknown),
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 0, v1alpha1.CloudEventConditionUnknown),
 		)).Status.CloudEvents,
 	}, {
 		name:    "ce-resources-init",
 		taskRun: taskRunWithTwoCEResourcesInit,
-		wantCloudEvents: tb.TaskRun("want2", "foo", tb.TaskRunStatus(
+		wantCloudEvents: tb.TaskRun("want2", tb.TaskRunNamespace("foo"), tb.TaskRunStatus(
 			tb.TaskRunCloudEvent(cloudEventTarget1, "", 0, v1alpha1.CloudEventConditionUnknown),
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 0, v1alpha1.CloudEventConditionUnknown),
 		)).Status.CloudEvents,
 	}, {
 		name:    "ce-resources-init-task-successful",
 		taskRun: taskRunWithCESucceded,
-		wantCloudEvents: tb.TaskRun("want3", "foo", tb.TaskRunStatus(
+		wantCloudEvents: tb.TaskRun("want3", tb.TaskRunNamespace("foo"), tb.TaskRunStatus(
 			tb.TaskRunCloudEvent(cloudEventTarget1, "", 1, v1alpha1.CloudEventConditionSent),
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 1, v1alpha1.CloudEventConditionSent),
 		)).Status.CloudEvents,
 	}, {
 		name:    "ce-resources-init-task-failed",
 		taskRun: taskRunWithCEFailed,
-		wantCloudEvents: tb.TaskRun("want4", "foo", tb.TaskRunStatus(
+		wantCloudEvents: tb.TaskRun("want4", tb.TaskRunNamespace("foo"), tb.TaskRunStatus(
 			tb.TaskRunCloudEvent(cloudEventTarget1, "", 1, v1alpha1.CloudEventConditionSent),
 			tb.TaskRunCloudEvent(cloudEventTarget2, "", 1, v1alpha1.CloudEventConditionSent),
 		)).Status.CloudEvents,
 	}, {
 		name:    "ce-resources-init-task-successful-one-attempt",
 		taskRun: taskRunWithCESuccededOneAttempt,
-		wantCloudEvents: tb.TaskRun("want5", "foo", tb.TaskRunStatus(
+		wantCloudEvents: tb.TaskRun("want5", tb.TaskRunNamespace("foo"), tb.TaskRunStatus(
 			tb.TaskRunCloudEvent(cloudEventTarget1, "", 1, v1alpha1.CloudEventConditionUnknown),
 			tb.TaskRunCloudEvent(cloudEventTarget2, "fakemessage", 1, v1alpha1.CloudEventConditionSent),
 		)).Status.CloudEvents,

--- a/pkg/reconciler/taskrun/timeout_check_test.go
+++ b/pkg/reconciler/taskrun/timeout_check_test.go
@@ -35,19 +35,19 @@ func TestCheckTimeout(t *testing.T) {
 		expectedStatus bool
 	}{{
 		name: "TaskRun not started",
-		taskRun: tb.TaskRun("test-taskrun-not-started", "foo", tb.TaskRunSpec(
+		taskRun: tb.TaskRun("test-taskrun-not-started", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name),
 		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(zeroTime))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun no timeout",
-		taskRun: tb.TaskRun("test-taskrun-no-timeout", "foo", tb.TaskRunSpec(
+		taskRun: tb.TaskRun("test-taskrun-no-timeout", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(0),
 		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Hour)))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun timed out",
-		taskRun: tb.TaskRun("test-taskrun-timeout", "foo", tb.TaskRunSpec(
+		taskRun: tb.TaskRun("test-taskrun-timeout", tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name), tb.TaskRunTimeout(10*time.Second),
 		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
 		expectedStatus: true,

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -38,18 +38,18 @@ func TestValidateResolvedTaskResources_ValidResources(t *testing.T) {
 				tb.OutputsResource("optional-resource-to-provide", v1alpha1.PipelineResourceTypeImage, tb.ResourceOptional(true)),
 			),
 		),
-		tb.ResolvedTaskResourcesInputs("resource-to-build", tb.PipelineResource("example-resource", "foo",
+		tb.ResolvedTaskResourcesInputs("resource-to-build", tb.PipelineResource("example-resource", tb.PipelineResourceNamespace("foo"),
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("foo", "bar"),
 			))),
-		tb.ResolvedTaskResourcesInputs("optional-resource-to-build", tb.PipelineResource("example-resource", "foo",
+		tb.ResolvedTaskResourcesInputs("optional-resource-to-build", tb.PipelineResource("example-resource", tb.PipelineResourceNamespace("foo"),
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("foo", "bar"),
 			))),
-		tb.ResolvedTaskResourcesOutputs("resource-to-provide", tb.PipelineResource("example-image", "bar",
+		tb.ResolvedTaskResourcesOutputs("resource-to-provide", tb.PipelineResource("example-image", tb.PipelineResourceNamespace("bar"),
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage)),
 		),
-		tb.ResolvedTaskResourcesOutputs("optional-resource-to-provide", tb.PipelineResource("example-image", "bar",
+		tb.ResolvedTaskResourcesOutputs("optional-resource-to-provide", tb.PipelineResource("example-image", tb.PipelineResourceNamespace("bar"),
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage)),
 		))
 	if err := taskrun.ValidateResolvedTaskResources([]v1alpha1.Param{}, rtr); err != nil {
@@ -113,7 +113,7 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 }
 
 func TestValidateResolvedTaskResources_InvalidResources(t *testing.T) {
-	r := tb.PipelineResource("git-test-resource", "foo", tb.PipelineResourceSpec(
+	r := tb.PipelineResource("git-test-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("foo", "bar"),
 	))

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -37,12 +37,12 @@ import (
 
 var (
 	testNs     = "foo"
-	simpleStep = tb.Step("simple-step", testNs, tb.StepCommand("/mycmd"))
-	simpleTask = tb.Task("test-task", testNs, tb.TaskSpec(simpleStep))
+	simpleStep = tb.Step("simple-step", "step-image", tb.StepCommand("/mycmd"))
+	simpleTask = tb.Task("test-task", tb.TaskSpec(simpleStep))
 )
 
 func TestTaskRunCheckTimeouts(t *testing.T) {
-	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", testNs, tb.TaskRunSpec(
+	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(1*time.Second),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -51,7 +51,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
 	))
 
-	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+	taskRunRunning := tb.TaskRun("test-taskrun-running", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -60,7 +60,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now()),
 	))
 
-	taskRunRunningNilTimeout := tb.TaskRun("test-taskrun-running-nil-timeout", testNs, tb.TaskRunSpec(
+	taskRunRunningNilTimeout := tb.TaskRun("test-taskrun-running-nil-timeout", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunNilTimeout,
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -69,7 +69,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now()),
 	))
 
-	taskRunDone := tb.TaskRun("test-taskrun-completed", testNs, tb.TaskRunSpec(
+	taskRunDone := tb.TaskRun("test-taskrun-completed", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -77,7 +77,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		Status: corev1.ConditionTrue}),
 	))
 
-	taskRunCancelled := tb.TaskRun("test-taskrun-run-cancelled", testNs, tb.TaskRunSpec(
+	taskRunCancelled := tb.TaskRun("test-taskrun-run-cancelled", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name),
 		tb.TaskRunCancelled,
 		tb.TaskRunTimeout(1*time.Second),
@@ -158,10 +158,10 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 }
 
 func TestPipelinRunCheckTimeouts(t *testing.T) {
-	simplePipeline := tb.Pipeline("test-pipeline", testNs, tb.PipelineSpec(
+	simplePipeline := tb.Pipeline("test-pipeline", tb.PipelineNamespace(testNs), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))
-	prTimeout := tb.PipelineRun("test-pipeline-run-with-timeout", testNs,
+	prTimeout := tb.PipelineRun("test-pipeline-run-with-timeout", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunTimeout(1*time.Second),
@@ -169,9 +169,9 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 		tb.PipelineRunStatus(
 			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
 	)
-	ts := tb.Task("hello-world", testNs)
+	ts := tb.Task("hello-world")
 
-	prRunning := tb.PipelineRun("test-pipeline-running", testNs,
+	prRunning := tb.PipelineRun("test-pipeline-running", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 		),
@@ -181,7 +181,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			tb.PipelineRunStartTime(time.Now()),
 		),
 	)
-	prRunningNilTimeout := tb.PipelineRun("test-pipeline-running-nil-timeout", testNs,
+	prRunningNilTimeout := tb.PipelineRun("test-pipeline-running-nil-timeout", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunNilTimeout,
 		),
@@ -191,7 +191,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			tb.PipelineRunStartTime(time.Now()),
 		),
 	)
-	prDone := tb.PipelineRun("test-pipeline-done", testNs,
+	prDone := tb.PipelineRun("test-pipeline-done", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 		),
@@ -200,7 +200,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			Status: corev1.ConditionTrue}),
 		),
 	)
-	prCancelled := tb.PipelineRun("test-pipeline-cancel", testNs,
+	prCancelled := tb.PipelineRun("test-pipeline-cancel", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunCancelled,
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
@@ -283,7 +283,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 
 // TestWithNoFunc does not set taskrun/pipelinerun function and verifies that code does not panic
 func TestWithNoFunc(t *testing.T) {
-	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+	taskRunRunning := tb.TaskRun("test-taskrun-running", tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(2*time.Second),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -321,7 +321,7 @@ func TestWithNoFunc(t *testing.T) {
 // TestSetTaskRunTimer checks that the SetTaskRunTimer method correctly calls the TaskRun
 // callback after a set amount of time.
 func TestSetTaskRunTimer(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun-arbitrary-timer", testNs, tb.TaskRunSpec(
+	taskRun := tb.TaskRun("test-taskrun-arbitrary-timer", tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(2*time.Second),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -66,7 +66,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	defer deleteBucketSecret(c, t, namespace)
 
 	t.Logf("Creating GCS bucket %s", bucketName)
-	createbuckettask := tb.Task("createbuckettask", namespace, tb.TaskSpec(
+	createbuckettask := tb.Task("createbuckettask", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskVolume("bucket-secret-volume", tb.VolumeSource(corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: bucketSecretName,
@@ -86,7 +86,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 		t.Fatalf("Failed to create Task `%s`: %s", "createbuckettask", err)
 	}
 
-	createbuckettaskrun := tb.TaskRun("createbuckettaskrun", namespace,
+	createbuckettaskrun := tb.TaskRun("createbuckettaskrun", tb.TaskRunNamespace(namespace),
 		tb.TaskRunSpec(tb.TaskRunTaskRef("createbuckettask")))
 
 	t.Logf("Creating TaskRun %s", "createbuckettaskrun")
@@ -118,7 +118,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	defer resetConfigMap(t, c, systemNamespace, artifacts.GetBucketConfigName(), originalConfigMapData)
 
 	t.Logf("Creating Git PipelineResource %s", helloworldResourceName)
-	helloworldResource := tb.PipelineResource(helloworldResourceName, namespace, tb.PipelineResourceSpec(
+	helloworldResource := tb.PipelineResource(helloworldResourceName, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/pivotal-nader-ziada/gohelloworld"),
 		tb.PipelineResourceSpecParam("Revision", "master"),
@@ -129,7 +129,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Task %s", addFileTaskName)
-	addFileTask := tb.Task(addFileTaskName, namespace, tb.TaskSpec(
+	addFileTask := tb.Task(addFileTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource(helloworldResourceName, v1alpha1.PipelineResourceTypeGit)),
 		tb.TaskOutputs(tb.OutputsResource(helloworldResourceName, v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("addfile", "ubuntu", tb.StepCommand("/bin/bash"),
@@ -143,7 +143,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Task %s", runFileTaskName)
-	readFileTask := tb.Task(runFileTaskName, namespace, tb.TaskSpec(
+	readFileTask := tb.Task(runFileTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource(helloworldResourceName, v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("runfile", "ubuntu", tb.StepCommand("/workspace/helloworld/newfile")),
 	))
@@ -152,7 +152,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Pipeline %s", bucketTestPipelineName)
-	bucketTestPipeline := tb.Pipeline(bucketTestPipelineName, namespace, tb.PipelineSpec(
+	bucketTestPipeline := tb.Pipeline(bucketTestPipelineName, tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("source-repo", "git"),
 		tb.PipelineTask("addfile", addFileTaskName,
 			tb.PipelineTaskInputResource("helloworldgit", "source-repo"),
@@ -167,7 +167,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating PipelineRun %s", bucketTestPipelineRunName)
-	bucketTestPipelineRun := tb.PipelineRun(bucketTestPipelineRunName, namespace, tb.PipelineRunSpec(
+	bucketTestPipelineRun := tb.PipelineRun(bucketTestPipelineRunName, tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(
 		bucketTestPipelineName,
 		tb.PipelineRunResourceBinding("source-repo", tb.PipelineResourceBindingRef(helloworldResourceName)),
 	))
@@ -232,7 +232,7 @@ func resetConfigMap(t *testing.T, c *clients, namespace, configName string, valu
 }
 
 func runTaskToDeleteBucket(c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
-	deletelbuckettask := tb.Task("deletelbuckettask", namespace, tb.TaskSpec(
+	deletelbuckettask := tb.Task("deletelbuckettask", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskVolume("bucket-secret-volume", tb.VolumeSource(corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: bucketSecretName,
@@ -252,7 +252,7 @@ func runTaskToDeleteBucket(c *clients, t *testing.T, namespace, bucketName, buck
 		t.Fatalf("Failed to create Task `%s`: %s", "deletelbuckettask", err)
 	}
 
-	deletelbuckettaskrun := tb.TaskRun("deletelbuckettaskrun", namespace,
+	deletelbuckettaskrun := tb.TaskRun("deletelbuckettaskrun", tb.TaskRunNamespace(namespace),
 		tb.TaskRunSpec(tb.TaskRunTaskRef("deletelbuckettask")))
 
 	t.Logf("Creating TaskRun %s", "deletelbuckettaskrun")

--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -31,17 +31,23 @@ type ConditionSpecOp func(spec *v1alpha1.ConditionSpec)
 
 // Condition creates a Condition with default values.
 // Any number of Condition modifiers can be passed to transform it.
-func Condition(name, namespace string, ops ...ConditionOp) *v1alpha1.Condition {
+func Condition(name string, ops ...ConditionOp) *v1alpha1.Condition {
 	condition := &v1alpha1.Condition{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 	}
 	for _, op := range ops {
 		op(condition)
 	}
 	return condition
+}
+
+// ConditionNamespace sets the Namespace of the Condition
+func ConditionNamespace(namespace string) ConditionOp {
+	return func(condition *v1alpha1.Condition) {
+		condition.Namespace = namespace
+	}
 }
 
 func ConditionLabels(labels map[string]string) ConditionOp {

--- a/test/builder/condition_test.go
+++ b/test/builder/condition_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestCondition(t *testing.T) {
-	condition := tb.Condition("cond-name", "foo",
+	condition := tb.Condition("cond-name", tb.ConditionNamespace("foo"),
 		tb.ConditionLabels(
 			map[string]string{
 				"label-1": "label-value-1",
@@ -83,7 +83,7 @@ func TestCondition(t *testing.T) {
 }
 
 func TestConditionWithScript(t *testing.T) {
-	condition := tb.Condition("cond-name", "foo",
+	condition := tb.Condition("cond-name",
 		tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu"),
 			tb.ConditionSpecCheckScript("ls /tmp"),
 		),
@@ -91,8 +91,7 @@ func TestConditionWithScript(t *testing.T) {
 
 	expected := &v1alpha1.Condition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "cond-name",
-			Namespace: "foo",
+			Name: "cond-name",
 		},
 		Spec: v1alpha1.ConditionSpec{
 			Check: v1alpha1.Step{

--- a/test/builder/examples_test.go
+++ b/test/builder/examples_test.go
@@ -31,12 +31,12 @@ func ExampleTask() {
 	// You can declare re-usable modifiers
 	myStep := tb.Step("my-step", "myimage")
 	// … and use them in a Task definition
-	myTask := tb.Task("my-task", "namespace", tb.TaskSpec(
+	myTask := tb.Task("my-task", tb.TaskSpec(
 		tb.Step("simple-step", "myotherimage", tb.StepCommand("/mycmd")),
 		myStep,
 	))
 	// … and another one.
-	myOtherTask := tb.Task("my-other-task", "namespace",
+	myOtherTask := tb.Task("my-other-task",
 		tb.TaskSpec(myStep,
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
 		),
@@ -71,11 +71,11 @@ func ExampleClusterTask() {
 
 func ExampleTaskRun() {
 	// A simple definition, with a Task reference
-	myTaskRun := tb.TaskRun("my-taskrun", "namespace", tb.TaskRunSpec(
+	myTaskRun := tb.TaskRun("my-taskrun", tb.TaskRunSpec(
 		tb.TaskRunTaskRef("my-task"),
 	))
 	// … or a more complex one with inline TaskSpec
-	myTaskRunWithSpec := tb.TaskRun("my-taskrun-with-spec", "namespace", tb.TaskRunSpec(
+	myTaskRunWithSpec := tb.TaskRun("my-taskrun-with-spec", tb.TaskRunSpec(
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
 			tb.TaskRunInputsResource("workspace", tb.TaskResourceBindingRef("git-resource")),
@@ -106,7 +106,7 @@ func ExampleTaskRun() {
 }
 
 func ExamplePipeline() {
-	pipeline := tb.Pipeline("tomatoes", "namespace",
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace("namespace"),
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
 	expectedPipeline := &v1alpha1.Pipeline{
@@ -119,7 +119,7 @@ func ExamplePipeline() {
 }
 
 func ExamplePipelineRun() {
-	pipelineRun := tb.PipelineRun("pear", "namespace",
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("namespace"),
 		tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccountName("inexistent")),
 	)
 	expectedPipelineRun := &v1alpha1.PipelineRun{
@@ -132,10 +132,10 @@ func ExamplePipelineRun() {
 }
 
 func ExamplePipelineResource() {
-	gitResource := tb.PipelineResource("git-resource", "namespace", tb.PipelineResourceSpec(
+	gitResource := tb.PipelineResource("git-resource", tb.PipelineResourceNamespace("namespace"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
-	imageResource := tb.PipelineResource("image-resource", "namespace", tb.PipelineResourceSpec(
+	imageResource := tb.PipelineResource("image-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage, tb.PipelineResourceSpecParam("URL", "gcr.io/kristoff/sven"),
 	))
 	expectedGitResource := v1alpha1.PipelineResource{

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -61,11 +61,10 @@ type PipelineTaskConditionOp func(condition *v1alpha1.PipelineTaskCondition)
 
 // Pipeline creates a Pipeline with default values.
 // Any number of Pipeline modifier can be passed to transform it.
-func Pipeline(name, namespace string, ops ...PipelineOp) *v1alpha1.Pipeline {
+func Pipeline(name string, ops ...PipelineOp) *v1alpha1.Pipeline {
 	p := &v1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 	}
 
@@ -74,6 +73,13 @@ func Pipeline(name, namespace string, ops ...PipelineOp) *v1alpha1.Pipeline {
 	}
 
 	return p
+}
+
+// PipelineNamespace sets the namespace of the pipeline
+func PipelineNamespace(namespace string) PipelineOp {
+	return func(p *v1alpha1.Pipeline) {
+		p.Namespace = namespace
+	}
 }
 
 // PipelineSpec sets the PipelineSpec to the Pipeline.
@@ -269,11 +275,10 @@ func PipelineTaskConditionResource(name, resource string, from ...string) Pipeli
 
 // PipelineRun creates a PipelineRun with default values.
 // Any number of PipelineRun modifier can be passed to transform it.
-func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
+func PipelineRun(name string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
 	pr := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 		Spec: v1alpha1.PipelineRunSpec{},
 	}
@@ -283,6 +288,13 @@ func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.Pipelin
 	}
 
 	return pr
+}
+
+// PipelineRunNamespace sets the namespace of  the PipelineRun.
+func PipelineRunNamespace(namespace string) PipelineRunOp {
+	return func(pr *v1alpha1.PipelineRun) {
+		pr.Namespace = namespace
+	}
 }
 
 // PipelineRunSpec sets the PipelineRunSpec, references Pipeline with specified name, to the PipelineRun.
@@ -473,17 +485,23 @@ func PipelineRunTaskRunsStatus(taskRunName string, status *v1alpha1.PipelineRunT
 
 // PipelineResource creates a PipelineResource with default values.
 // Any number of PipelineResource modifier can be passed to transform it.
-func PipelineResource(name, namespace string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {
+func PipelineResource(name string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {
 	resource := &v1alpha1.PipelineResource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name: name,
 		},
 	}
 	for _, op := range ops {
 		op(resource)
 	}
 	return resource
+}
+
+// PipelineResourceNamespace sets the namespace of the PipelineResource.
+func PipelineResourceNamespace(namespace string) PipelineResourceOp {
+	return func(pr *v1alpha1.PipelineResource) {
+		pr.Namespace = namespace
+	}
 }
 
 // PipelineResourceSpec set the PipelineResourceSpec, with specified type, to the PipelineResource.

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -33,7 +33,7 @@ import (
 func TestPipeline(t *testing.T) {
 	creationTime := time.Now()
 
-	pipeline := tb.Pipeline("tomatoes", "foo", tb.PipelineSpec(
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("my-only-git-resource", "git"),
 		tb.PipelineDeclaredResource("my-only-image-resource", "image"),
 		tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value"), tb.ParamSpecDescription("default description")),
@@ -145,7 +145,7 @@ func TestPipelineRun(t *testing.T) {
 	startTime := time.Now()
 	completedTime := startTime.Add(5 * time.Minute)
 
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
 		tb.PipelineRunParam("first-param-string", "first-value"),
 		tb.PipelineRunParam("second-param-array", "some", "array"),
@@ -162,8 +162,7 @@ func TestPipelineRun(t *testing.T) {
 	), tb.PipelineRunLabel("label-key", "label-value"))
 	expectedPipelineRun := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pear",
-			Namespace: "foo",
+			Name: "pear",
 			Labels: map[string]string{
 				"label-key": "label-value",
 			},
@@ -209,7 +208,7 @@ func TestPipelineRunWithResourceSpec(t *testing.T) {
 	startTime := time.Now()
 	completedTime := startTime.Add(5 * time.Minute)
 
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
 		tb.PipelineRunParam("first-param-string", "first-value"),
 		tb.PipelineRunParam("second-param-array", "some", "array"),
@@ -281,15 +280,14 @@ func TestPipelineRunWithResourceSpec(t *testing.T) {
 }
 
 func TestPipelineRunWithPipelineSpec(t *testing.T) {
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 		tb.PipelineTask("a-task", "some-task")),
 		tb.PipelineRunServiceAccountName("sa"),
 	))
 
 	expectedPipelineRun := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "pear",
-			Namespace: "foo",
+			Name: "pear",
 		},
 		Spec: v1alpha1.PipelineRunSpec{
 			PipelineRef: nil,
@@ -310,7 +308,7 @@ func TestPipelineRunWithPipelineSpec(t *testing.T) {
 }
 
 func TestPipelineResource(t *testing.T) {
-	pipelineResource := tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
+	pipelineResource := tb.PipelineResource("git-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
 	expectedPipelineResource := &v1alpha1.PipelineResource{

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -81,11 +81,10 @@ var (
 
 // Task creates a Task with default values.
 // Any number of Task modifier can be passed to transform it.
-func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
+func Task(name string, ops ...TaskOp) *v1alpha1.Task {
 	t := &v1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 	}
 
@@ -94,6 +93,13 @@ func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
 	}
 
 	return t
+}
+
+// TaskNamespace sets the Namespace of the Task
+func TaskNamespace(namespace string) TaskOp {
+	return func(t *v1alpha1.Task) {
+		t.Namespace = namespace
+	}
 }
 
 // ClusterTask creates a ClusterTask with default values.
@@ -292,10 +298,9 @@ func InputsParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) Inp
 
 // TaskRun creates a TaskRun with default values.
 // Any number of TaskRun modifier can be passed to transform it.
-func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
+func TaskRun(name string, ops ...TaskRunOp) *v1alpha1.TaskRun {
 	tr := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
 			Name:        name,
 			Annotations: map[string]string{},
 		},
@@ -308,7 +313,14 @@ func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
 	return tr
 }
 
-// TaskRunStatus sets the TaskRunStatus to tshe TaskRun
+// TaskRunNamespace sets the Namespace of the TaskRun
+func TaskRunNamespace(namespace string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		tr.Namespace = namespace
+	}
+}
+
+// TaskRunStatus sets the TaskRunStatus to the TaskRun
 func TaskRunStatus(ops ...TaskRunStatusOp) TaskRunOp {
 	return func(tr *v1alpha1.TaskRun) {
 		status := &tr.Status

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -32,16 +32,16 @@ import (
 )
 
 var (
-	gitResource = tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
+	gitResource = tb.PipelineResource("git-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
-	anotherGitResource = tb.PipelineResource("another-git-resource", "foo", tb.PipelineResourceSpec(
+	anotherGitResource = tb.PipelineResource("another-git-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foobar.git"),
 	))
 )
 
 func TestTask(t *testing.T) {
-	task := tb.Task("test-task", "foo", tb.TaskSpec(
+	task := tb.Task("test-task", tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceTargetPath("/foo/bar")),
 			tb.InputsResource("optional_workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true)),
@@ -65,7 +65,7 @@ func TestTask(t *testing.T) {
 		tb.TaskWorkspace("bread", "kind of bread", "/bread/path", false),
 	))
 	expectedTask := &v1alpha1.Task{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-task", Namespace: "foo"},
+		ObjectMeta: metav1.ObjectMeta{Name: "test-task"},
 		Spec: v1alpha1.TaskSpec{
 			Steps: []v1alpha1.Step{{Container: corev1.Container{
 				Name:    "mycontainer",
@@ -163,7 +163,7 @@ func TestClusterTask(t *testing.T) {
 func TestTaskRunWithTaskRef(t *testing.T) {
 	var trueB = true
 
-	taskRun := tb.TaskRun("test-taskrun", "foo",
+	taskRun := tb.TaskRun("test-taskrun",
 		tb.TaskRunOwnerReference("PipelineRun", "test",
 			tb.OwnerReferenceAPIVersion("a1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -205,7 +205,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 	)
 	expectedTaskRun := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-taskrun", Namespace: "foo",
+			Name: "test-taskrun",
 			OwnerReferences: []metav1.OwnerReference{{
 				Name:               "test",
 				Kind:               "PipelineRun",
@@ -293,7 +293,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 }
 
 func TestTaskRunWithTaskSpec(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
+	taskRun := tb.TaskRun("test-taskrun", tb.TaskRunSpec(
 		tb.TaskRunTaskSpec(
 			tb.Step("step", "image", tb.StepCommand("/mycmd")),
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true))),
@@ -304,7 +304,7 @@ func TestTaskRunWithTaskSpec(t *testing.T) {
 	))
 	expectedTaskRun := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-taskrun", Namespace: "foo",
+			Name:        "test-taskrun",
 			Annotations: map[string]string{},
 		},
 		Spec: v1alpha1.TaskRunSpec{
@@ -339,8 +339,8 @@ func TestResolvedTaskResources(t *testing.T) {
 		tb.ResolvedTaskResourcesTaskSpec(
 			tb.Step("step", "image", tb.StepCommand("/mycmd")),
 		),
-		tb.ResolvedTaskResourcesInputs("foo", tb.PipelineResource("bar", "baz")),
-		tb.ResolvedTaskResourcesOutputs("qux", tb.PipelineResource("quux", "quuz")),
+		tb.ResolvedTaskResourcesInputs("foo", tb.PipelineResource("bar", tb.PipelineResourceNamespace("baz"))),
+		tb.ResolvedTaskResourcesOutputs("qux", tb.PipelineResource("quux", tb.PipelineResourceNamespace("quuz"))),
 	)
 	expectedResolvedTaskResources := &resources.ResolvedTaskResources{
 		TaskSpec: &v1alpha1.TaskSpec{

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -68,7 +68,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			defer tearDown(t, c, namespace)
 
 			t.Logf("Creating Task in namespace %s", namespace)
-			task := tb.Task("banana", namespace, tb.TaskSpec(
+			task := tb.Task("banana", tb.TaskNamespace(namespace), tb.TaskSpec(
 				tb.Step("foo", "ubuntu", tb.StepCommand("/bin/bash"), tb.StepArgs("-c", "sleep 5000")),
 			))
 			if _, err := c.TaskClient.Create(task); err != nil {
@@ -76,14 +76,14 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 
 			t.Logf("Creating Pipeline in namespace %s", namespace)
-			pipeline := tb.Pipeline("tomatoes", namespace,
+			pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace(namespace),
 				tb.PipelineSpec(pipelineTask),
 			)
 			if _, err := c.PipelineClient.Create(pipeline); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
 			}
 
-			pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
+			pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(pipeline.Name))
 
 			t.Logf("Creating PipelineRun in namespace %s", namespace)
 			if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -73,7 +73,7 @@ func TestClusterResource(t *testing.T) {
 }
 
 func getClusterResource(namespace, name, sname string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(name, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCluster,
 		tb.PipelineResourceSpecParam("Name", "helloworld-cluster"),
 		tb.PipelineResourceSpecParam("Url", "https://1.1.1.1"),
@@ -98,7 +98,7 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 }
 
 func getClusterResourceTask(namespace, name, configName string) *v1alpha1.Task {
-	return tb.Task(name, namespace, tb.TaskSpec(
+	return tb.Task(name, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("target-cluster", v1alpha1.PipelineResourceTypeCluster)),
 		tb.TaskVolume("config-vol", tb.VolumeSource(corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -121,7 +121,7 @@ func getClusterResourceTask(namespace, name, configName string) *v1alpha1.Task {
 }
 
 func getClusterResourceTaskRun(namespace, name, taskName, resName string) *v1alpha1.TaskRun {
-	return tb.TaskRun(name, namespace, tb.TaskRunSpec(
+	return tb.TaskRun(name, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(taskName),
 		tb.TaskRunInputs(tb.TaskRunInputsResource("target-cluster", tb.TaskResourceBindingRef(resName))),
 	))

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -49,7 +49,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	// Create the Task that echoes text
-	echoTask := tb.Task("echo-task", namespace, tb.TaskSpec(
+	echoTask := tb.Task("echo-task", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("repo", v1alpha1.PipelineResourceTypeGit),
 			tb.InputsParamSpec("text", v1alpha1.ParamTypeString, tb.ParamSpecDescription("The text that should be echoed")),
@@ -63,7 +63,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	}
 
 	// Create the repo PipelineResource (doesn't really matter which repo we use)
-	repoResource := tb.PipelineResource("repo", namespace, tb.PipelineResourceSpec(
+	repoResource := tb.PipelineResource("repo", tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/githubtraining/example-basic"),
 	))
@@ -73,7 +73,7 @@ func TestDAGPipelineRun(t *testing.T) {
 
 	// Intentionally declaring Tasks in a mixed up order to ensure the order
 	// of execution isn't at all dependent on the order they are declared in
-	pipeline := tb.Pipeline("dag-pipeline", namespace, tb.PipelineSpec(
+	pipeline := tb.Pipeline("dag-pipeline", tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("repo", "git"),
 		tb.PipelineTask("pipeline-task-3", "echo-task",
 			tb.PipelineTaskInputResource("repo", "repo", tb.From("pipeline-task-2-parallel-1", "pipeline-task-2-parallel-2")),
@@ -105,7 +105,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create dag-pipeline: %s", err)
 	}
-	pipelineRun := tb.PipelineRun("dag-pipeline-run", namespace, tb.PipelineRunSpec("dag-pipeline",
+	pipelineRun := tb.PipelineRun("dag-pipeline-run", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec("dag-pipeline",
 		tb.PipelineRunResourceBinding("repo", tb.PipelineResourceBindingRef("repo")),
 	))
 	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {

--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -43,7 +43,7 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 		taskrunName := fmt.Sprintf("duplicate-pod-taskrun-%d", i)
 		t.Logf("Creating taskrun %q.", taskrunName)
 
-		taskrun := tb.TaskRun(taskrunName, namespace, tb.TaskRunSpec(
+		taskrun := tb.TaskRun(taskrunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 			tb.TaskRunTaskSpec(tb.Step("echo", "busybox",
 				tb.StepCommand("/bin/echo"),
 				tb.StepArgs("simple"),

--- a/test/embed_test.go
+++ b/test/embed_test.go
@@ -62,7 +62,7 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 }
 
 func getEmbeddedTask(namespace string, args []string) *v1alpha1.Task {
-	return tb.Task(embedTaskName, namespace,
+	return tb.Task(embedTaskName, tb.TaskNamespace(namespace),
 		tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("docs", v1alpha1.PipelineResourceTypeGit)),
 			tb.Step("read", "ubuntu",
@@ -81,7 +81,7 @@ func getEmbeddedTaskRun(namespace string) *v1alpha1.TaskRun {
 			Value: "https://github.com/knative/docs",
 		}},
 	}
-	return tb.TaskRun(embedTaskRunName, namespace,
+	return tb.TaskRun(embedTaskRunName, tb.TaskRunNamespace(namespace),
 		tb.TaskRunSpec(
 			tb.TaskRunInputs(
 				tb.TaskRunInputsResource("docs", tb.TaskResourceBindingResourceSpec(testSpec)),

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -42,14 +42,14 @@ func TestEntrypointRunningStepsInOrder(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task(epTaskName, namespace, tb.TaskSpec(
+	task := tb.Task(epTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("step1", "ubuntu", tb.StepArgs("-c", "sleep 3 && touch foo")),
 		tb.Step("step2", "ubuntu", tb.StepArgs("-c", "ls", "foo")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun(epTaskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(epTaskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(epTaskName), tb.TaskRunServiceAccountName("default"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -147,7 +147,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 }
 
 func getGitPipelineResource(namespace, revision string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(gitSourceResourceName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(gitSourceResourceName, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/tektoncd/pipeline"),
 		tb.PipelineResourceSpecParam("Revision", revision),
@@ -155,14 +155,14 @@ func getGitPipelineResource(namespace, revision string) *v1alpha1.PipelineResour
 }
 
 func getGitCheckTask(namespace string) *v1alpha1.Task {
-	return tb.Task(gitTestTaskName, namespace, tb.TaskSpec(
+	return tb.Task(gitTestTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("git", "alpine/git", tb.StepArgs("--git-dir=/workspace/gitsource/.git", "show")),
 	))
 }
 
 func getGitCheckPipeline(namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(gitTestPipelineName, namespace, tb.PipelineSpec(
+	return tb.Pipeline(gitTestPipelineName, tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-repo", "git"),
 		tb.PipelineTask("git-check", gitTestTaskName,
 			tb.PipelineTaskInputResource("gitsource", "git-repo"),
@@ -171,7 +171,7 @@ func getGitCheckPipeline(namespace string) *v1alpha1.Pipeline {
 }
 
 func getGitCheckPipelineRun(namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(gitTestPipelineRunName, namespace, tb.PipelineRunSpec(
+	return tb.PipelineRun(gitTestPipelineRunName, tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(
 		gitTestPipelineName,
 		tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef(gitSourceResourceName)),
 	))

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -138,7 +138,7 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 }
 
 func getGoHelloworldGitResource(namespace string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(sourceResourceName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(sourceResourceName, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("url", "https://github.com/tektoncd/pipeline"),
 	))
@@ -147,14 +147,14 @@ func getGoHelloworldGitResource(namespace string) *v1alpha1.PipelineResource {
 func getHelmImageResource(namespace, dockerRepo string) *v1alpha1.PipelineResource {
 	imageName := fmt.Sprintf("%s/%s", dockerRepo, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(sourceImageName))
 
-	return tb.PipelineResource(sourceImageName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(sourceImageName, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage,
 		tb.PipelineResourceSpecParam("url", imageName),
 	))
 }
 
 func getCreateImageTask(namespace string) *v1alpha1.Task {
-	return tb.Task(createImageTaskName, namespace, tb.TaskSpec(
+	return tb.Task(createImageTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit)),
 		tb.TaskOutputs(tb.OutputsResource("builtimage", v1alpha1.PipelineResourceTypeImage)),
 		tb.Step("kaniko", "gcr.io/kaniko-project/executor:v0.15.0", tb.StepArgs(
@@ -166,7 +166,7 @@ func getCreateImageTask(namespace string) *v1alpha1.Task {
 }
 
 func getHelmDeployTask(namespace string) *v1alpha1.Task {
-	return tb.Task(helmDeployTaskName, namespace, tb.TaskSpec(
+	return tb.Task(helmDeployTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit),
 			tb.InputsResource("image", v1alpha1.PipelineResourceTypeImage),
@@ -186,7 +186,7 @@ func getHelmDeployTask(namespace string) *v1alpha1.Task {
 }
 
 func getHelmDeployPipeline(namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(helmDeployPipelineName, namespace, tb.PipelineSpec(
+	return tb.Pipeline(helmDeployPipelineName, tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-repo", "git"),
 		tb.PipelineDeclaredResource("the-image", "image"),
 		tb.PipelineParamSpec("chartname", v1alpha1.ParamTypeString),
@@ -204,7 +204,7 @@ func getHelmDeployPipeline(namespace string) *v1alpha1.Pipeline {
 }
 
 func getHelmDeployPipelineRun(namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(helmDeployPipelineRunName, namespace, tb.PipelineRunSpec(
+	return tb.PipelineRun(helmDeployPipelineRunName, tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(
 		helmDeployPipelineName,
 		tb.PipelineRunParam("chartname", "gohelloworld"),
 		tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef(sourceResourceName)),
@@ -304,14 +304,14 @@ func helmCleanup(c *clients, t *testing.T, namespace string) {
 
 func removeAllHelmReleases(c *clients, t *testing.T, namespace string) {
 	helmRemoveAllTaskName := "helm-remove-all-task"
-	helmRemoveAllTask := tb.Task(helmRemoveAllTaskName, namespace, tb.TaskSpec(
+	helmRemoveAllTask := tb.Task(helmRemoveAllTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("helm-remove-all", "alpine/helm:2.14.0", tb.StepCommand("/bin/sh"),
 			tb.StepArgs("-c", "helm ls --short --all | xargs -n1 helm del --purge"),
 		),
 	))
 
 	helmRemoveAllTaskRunName := "helm-remove-all-taskrun"
-	helmRemoveAllTaskRun := tb.TaskRun(helmRemoveAllTaskRunName, namespace, tb.TaskRunSpec(
+	helmRemoveAllTaskRun := tb.TaskRun(helmRemoveAllTaskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(helmRemoveAllTaskName),
 	))
 
@@ -333,12 +333,12 @@ func removeAllHelmReleases(c *clients, t *testing.T, namespace string) {
 
 func removeHelmFromCluster(c *clients, t *testing.T, namespace string) {
 	helmResetTaskName := "helm-reset-task"
-	helmResetTask := tb.Task(helmResetTaskName, namespace, tb.TaskSpec(
+	helmResetTask := tb.Task(helmResetTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("helm-reset", "alpine/helm:2.14.0", tb.StepArgs("reset", "--force")),
 	))
 
 	helmResetTaskRunName := "helm-reset-taskrun"
-	helmResetTaskRun := tb.TaskRun(helmResetTaskRunName, namespace, tb.TaskRunSpec(
+	helmResetTaskRun := tb.TaskRun(helmResetTaskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(helmResetTaskName),
 	))
 

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -123,7 +123,7 @@ func TestKanikoTaskRun(t *testing.T) {
 }
 
 func getGitResource(namespace string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(kanikoGitResourceName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(kanikoGitResourceName, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/GoogleContainerTools/kaniko"),
 		tb.PipelineResourceSpecParam("Revision", revision),
@@ -131,7 +131,7 @@ func getGitResource(namespace string) *v1alpha1.PipelineResource {
 }
 
 func getImageResource(namespace, repo string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(kanikoImageResourceName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(kanikoImageResourceName, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage,
 		tb.PipelineResourceSpecParam("url", repo),
 	))
@@ -160,11 +160,11 @@ func getTask(repo, namespace string) *v1alpha1.Task {
 	sidecar := tb.Sidecar("registry", "registry")
 	taskSpecOps = append(taskSpecOps, sidecar)
 
-	return tb.Task(kanikoTaskName, namespace, tb.TaskSpec(taskSpecOps...))
+	return tb.Task(kanikoTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(taskSpecOps...))
 }
 
 func getTaskRun(namespace string) *v1alpha1.TaskRun {
-	return tb.TaskRun(kanikoTaskRunName, namespace, tb.TaskRunSpec(
+	return tb.TaskRun(kanikoTaskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(kanikoTaskName),
 		tb.TaskRunTimeout(2*time.Minute),
 		tb.TaskRunInputs(tb.TaskRunInputsResource("gitsource", tb.TaskResourceBindingRef(kanikoGitResourceName))),

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -94,7 +94,7 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to create SA `%s`: %s", getName(saName, index), err)
 			}
 
-			task := tb.Task(getName(taskName, index), namespace, tb.TaskSpec(
+			task := tb.Task(getName(taskName, index), tb.TaskNamespace(namespace), tb.TaskSpec(
 				tb.TaskInputs(tb.InputsParamSpec("path", v1alpha1.ParamTypeString),
 					tb.InputsParamSpec("dest", v1alpha1.ParamTypeString)),
 				// Reference build: https://github.com/knative/build/tree/master/test/docker-basic
@@ -124,7 +124,7 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to create Condition `%s`: %s", cond1Name, err)
 			}
 
-			task := tb.Task(getName(taskName, index), namespace, tb.TaskSpec(
+			task := tb.Task(getName(taskName, index), tb.TaskNamespace(namespace), tb.TaskSpec(
 				tb.Step("echo-hello", "ubuntu",
 					tb.StepCommand("/bin/bash"),
 					tb.StepArgs("-c", "echo hello, world"),
@@ -229,7 +229,7 @@ func TestPipelineRun(t *testing.T) {
 }
 
 func getHelloWorldPipelineWithSingularTask(suffix int, namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
+	return tb.Pipeline(getName(pipelineName, suffix), tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineParamSpec("path", v1alpha1.ParamTypeString),
 		tb.PipelineParamSpec("dest", v1alpha1.ParamTypeString),
 		tb.PipelineTask(task1Name, getName(taskName, suffix),
@@ -242,7 +242,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 	inWorkspaceResource := tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)
 	outWorkspaceResource := tb.OutputsResource("workspace", v1alpha1.PipelineResourceTypeGit)
 	return []*v1alpha1.Task{
-		tb.Task("create-file", namespace, tb.TaskSpec(
+		tb.Task("create-file", tb.TaskNamespace(namespace), tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit,
 				tb.ResourceTargetPath("brandnewspace"),
 			)),
@@ -254,7 +254,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo other > $(outputs.resources.workspace.path)/other"),
 			),
 		)),
-		tb.Task("check-create-files-exists", namespace, tb.TaskSpec(
+		tb.Task("check-create-files-exists", tb.TaskNamespace(namespace), tb.TaskSpec(
 			tb.TaskInputs(inWorkspaceResource),
 			tb.TaskOutputs(outWorkspaceResource),
 			tb.Step("read-from-task-0", "ubuntu", tb.StepCommand("/bin/bash"),
@@ -264,7 +264,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo something > $(outputs.resources.workspace.path)/something"),
 			),
 		)),
-		tb.Task("check-create-files-exists-2", namespace, tb.TaskSpec(
+		tb.Task("check-create-files-exists-2", tb.TaskNamespace(namespace), tb.TaskSpec(
 			tb.TaskInputs(inWorkspaceResource),
 			tb.TaskOutputs(outWorkspaceResource),
 			tb.Step("read-from-task-0", "ubuntu", tb.StepCommand("/bin/bash"),
@@ -274,7 +274,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo else > $(outputs.resources.workspace.path)/else"),
 			),
 		)),
-		tb.Task("read-files", namespace, tb.TaskSpec(
+		tb.Task("read-files", tb.TaskNamespace(namespace), tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit,
 				tb.ResourceTargetPath("readingspace"),
 			)),
@@ -291,7 +291,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 func getFanInFanOutPipeline(suffix int, namespace string) *v1alpha1.Pipeline {
 	outGitResource := tb.PipelineTaskOutputResource("workspace", "git-repo")
 
-	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
+	return tb.Pipeline(getName(pipelineName, suffix), tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-repo", "git"),
 		tb.PipelineTask("create-file-kritis", "create-file",
 			tb.PipelineTaskInputResource("workspace", "git-repo"),
@@ -313,7 +313,7 @@ func getFanInFanOutPipeline(suffix int, namespace string) *v1alpha1.Pipeline {
 
 func getFanInFanOutGitResources(namespace string) []*v1alpha1.PipelineResource {
 	return []*v1alpha1.PipelineResource{
-		tb.PipelineResource("kritis-resource-git", namespace, tb.PipelineResourceSpec(
+		tb.PipelineResource("kritis-resource-git", tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("Url", "https://github.com/grafeas/kritis"),
 			tb.PipelineResourceSpecParam("Revision", "master"),
@@ -333,7 +333,7 @@ func getPipelineRunServiceAccount(suffix int, namespace string) *corev1.ServiceA
 	}
 }
 func getFanInFanOutPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(getName(pipelineRunName, suffix), namespace,
+	return tb.PipelineRun(getName(pipelineRunName, suffix), tb.PipelineRunNamespace(namespace),
 		tb.PipelineRunSpec(getName(pipelineName, suffix),
 			tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("kritis-resource-git")),
 		))
@@ -369,7 +369,7 @@ func getPipelineRunSecret(suffix int, namespace string) *corev1.Secret {
 }
 
 func getHelloWorldPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(getName(pipelineRunName, suffix), namespace,
+	return tb.PipelineRun(getName(pipelineRunName, suffix), tb.PipelineRunNamespace(namespace),
 		tb.PipelineRunLabel("hello-world-key", "hello-world-value"),
 		tb.PipelineRunSpec(getName(pipelineName, suffix),
 			tb.PipelineRunParam("path", "docker://gcr.io/build-crd-testing/secret-sauce"),
@@ -539,19 +539,19 @@ func assertAnnotationsMatch(t *testing.T, expectedAnnotations, actualAnnotations
 }
 
 func getPipelineWithFailingCondition(suffix int, namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
+	return tb.Pipeline(getName(pipelineName, suffix), tb.PipelineNamespace(namespace), tb.PipelineSpec(
 		tb.PipelineTask(task1Name, getName(taskName, suffix), tb.PipelineTaskCondition(cond1Name)),
 		tb.PipelineTask("task2", getName(taskName, suffix), tb.RunAfter(task1Name)),
 	))
 }
 
 func getFailingCondition(namespace string) *v1alpha1.Condition {
-	return tb.Condition(cond1Name, namespace, tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
+	return tb.Condition(cond1Name, tb.ConditionNamespace(namespace), tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
 		tb.Command("/bin/bash"), tb.Args("exit 1"))))
 }
 
 func getConditionalPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(getName(pipelineRunName, suffix), namespace,
+	return tb.PipelineRun(getName(pipelineRunName, suffix), tb.PipelineRunNamespace(namespace),
 		tb.PipelineRunLabel("hello-world-key", "hello-world-value"),
 		tb.PipelineRunSpec(getName(pipelineName, suffix)),
 	)

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -60,7 +60,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			sidecarTaskName := fmt.Sprintf("%s-%d", sidecarTaskName, i)
 			sidecarTaskRunName := fmt.Sprintf("%s-%d", sidecarTaskRunName, i)
-			task := tb.Task(sidecarTaskName, namespace,
+			task := tb.Task(sidecarTaskName, tb.TaskNamespace(namespace),
 				tb.TaskSpec(
 					tb.Step(
 						primaryContainerName,
@@ -75,7 +75,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 				),
 			)
 
-			taskRun := tb.TaskRun(sidecarTaskRunName, namespace,
+			taskRun := tb.TaskRun(sidecarTaskRunName, tb.TaskRunNamespace(namespace),
 				tb.TaskRunSpec(tb.TaskRunTaskRef(sidecarTaskName),
 					tb.TaskRunTimeout(1*time.Minute),
 				),

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -36,13 +36,13 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task("banana", namespace, tb.TaskSpec(
+	task := tb.Task("banana", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("foo", "busybox", tb.StepCommand("ls", "-la")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun("apple", namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun("apple", tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef("banana"), tb.TaskRunServiceAccountName("inexistent"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
@@ -54,10 +54,10 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	pipeline := tb.Pipeline("tomatoes", namespace,
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace(namespace),
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("inexistent"),
 	))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -41,7 +41,7 @@ func TestTaskRunFailure(t *testing.T) {
 	taskRunName := "failing-taskrun"
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task("failing-task", namespace, tb.TaskSpec(
+	task := tb.Task("failing-task", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("hello", "busybox",
 			tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "echo hello"),
 		),
@@ -55,7 +55,7 @@ func TestTaskRunFailure(t *testing.T) {
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(taskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef("failing-task"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
@@ -118,7 +118,7 @@ func TestTaskRunStatus(t *testing.T) {
 
 	fqImageName := "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task("status-task", namespace, tb.TaskSpec(
+	task := tb.Task("status-task", tb.TaskNamespace(namespace), tb.TaskSpec(
 		// This was the digest of the latest tag as of 8/12/2019
 		tb.Step("hello", "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
 			tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "echo hello"),
@@ -127,7 +127,7 @@ func TestTaskRunStatus(t *testing.T) {
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(taskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef("status-task"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -44,16 +44,16 @@ func TestPipelineRunTimeout(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
-	task := tb.Task("banana", namespace, tb.TaskSpec(
+	task := tb.Task("banana", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("foo", "busybox", tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "sleep 10"))))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", "banana", err)
 	}
 
-	pipeline := tb.Pipeline("tomatoes", namespace,
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace(namespace),
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name,
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(pipeline.Name,
 		tb.PipelineRunTimeout(5*time.Second),
 	))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
@@ -165,9 +165,9 @@ func TestPipelineRunTimeout(t *testing.T) {
 
 	// Verify that we can create a second Pipeline using the same Task without a Pipeline-level timeout that will not
 	// time out
-	secondPipeline := tb.Pipeline("peppers", namespace,
+	secondPipeline := tb.Pipeline("peppers", tb.PipelineNamespace(namespace),
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")))
-	secondPipelineRun := tb.PipelineRun("kiwi", namespace, tb.PipelineRunSpec("peppers"))
+	secondPipelineRun := tb.PipelineRun("kiwi", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec("peppers"))
 	if _, err := c.PipelineClient.Create(secondPipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", secondPipeline.Name, err)
 	}
@@ -190,17 +190,17 @@ func TestPipelineRunFailedAndRetry(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
-	task := tb.Task("banana", namespace, tb.TaskSpec(
+	task := tb.Task("banana", tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("foo", "busybox", tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "exit 1")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", "banana", err)
 	}
 
-	pipeline := tb.Pipeline("tomatoes", namespace,
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace(namespace),
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana", tb.Retries(numberOfRetries))),
 	)
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace(namespace), tb.PipelineRunSpec(pipeline.Name))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
@@ -242,11 +242,11 @@ func TestTaskRunTimeout(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(tb.Task("giraffe", namespace,
+	if _, err := c.TaskClient.Create(tb.Task("giraffe", tb.TaskNamespace(namespace),
 		tb.TaskSpec(tb.Step("amazing-busybox", "busybox", tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "sleep 3000"))))); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", "giraffe", err)
 	}
-	if _, err := c.TaskRunClient.Create(tb.TaskRun("run-giraffe", namespace, tb.TaskRunSpec(tb.TaskRunTaskRef("giraffe"),
+	if _, err := c.TaskRunClient.Create(tb.TaskRun("run-giraffe", tb.TaskRunNamespace(namespace), tb.TaskRunSpec(tb.TaskRunTaskRef("giraffe"),
 		// Do not reduce this timeout. Taskrun e2e test is also verifying
 		// if reconcile is triggered from timeout handler and not by pod informers
 		tb.TaskRunTimeout(30*time.Second)))); err != nil {

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -40,7 +40,7 @@ var (
 func TestWaitForTaskRunStateSucceed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{
-			tb.TaskRun("foo", waitNamespace, tb.TaskRunStatus(
+			tb.TaskRun("foo", tb.TaskRunNamespace(waitNamespace), tb.TaskRunStatus(
 				tb.StatusCondition(success),
 			)),
 		},
@@ -55,7 +55,7 @@ func TestWaitForTaskRunStateSucceed(t *testing.T) {
 func TestWaitForTaskRunStateFailed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{
-			tb.TaskRun("foo", waitNamespace, tb.TaskRunStatus(
+			tb.TaskRun("foo", tb.TaskRunNamespace(waitNamespace), tb.TaskRunStatus(
 				tb.StatusCondition(failure),
 			)),
 		},
@@ -71,7 +71,7 @@ func TestWaitForTaskRunStateFailed(t *testing.T) {
 func TestWaitForPipelineRunStateSucceed(t *testing.T) {
 	d := Data{
 		PipelineRuns: []*v1alpha1.PipelineRun{
-			tb.PipelineRun("bar", waitNamespace, tb.PipelineRunStatus(
+			tb.PipelineRun("bar", tb.PipelineRunNamespace(waitNamespace), tb.PipelineRunStatus(
 				tb.PipelineRunStatusCondition(success),
 			)),
 		},
@@ -87,7 +87,7 @@ func TestWaitForPipelineRunStateSucceed(t *testing.T) {
 func TestWaitForPipelineRunStateFailed(t *testing.T) {
 	d := Data{
 		PipelineRuns: []*v1alpha1.PipelineRun{
-			tb.PipelineRun("bar", waitNamespace, tb.PipelineRunStatus(
+			tb.PipelineRun("bar", tb.PipelineRunNamespace(waitNamespace), tb.PipelineRunStatus(
 				tb.PipelineRunStatusCondition(failure),
 			)),
 		},

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -40,7 +40,7 @@ func TestWorkingDirCreated(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(wdTaskName, namespace, tb.TaskSpec(
+	task := tb.Task(wdTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("step1", "ubuntu", tb.StepWorkingDir("/workspace/HELLOMOTO"), tb.StepArgs("-c", "echo YES")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
@@ -48,7 +48,7 @@ func TestWorkingDirCreated(t *testing.T) {
 	}
 
 	t.Logf("Creating TaskRun  namespace %s", namespace)
-	taskRun := tb.TaskRun(wdTaskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(wdTaskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(wdTaskName), tb.TaskRunServiceAccountName("default"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
@@ -94,7 +94,7 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(wdTaskName, namespace, tb.TaskSpec(
+	task := tb.Task(wdTaskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("step1", "ubuntu", tb.StepWorkingDir("/HELLOMOTO"), tb.StepArgs("-c", "echo YES")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
@@ -102,7 +102,7 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 	}
 
 	t.Logf("Creating TaskRun  namespace %s", namespace)
-	taskRun := tb.TaskRun(wdTaskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(wdTaskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(wdTaskName), tb.TaskRunServiceAccountName("default"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -37,7 +37,7 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(taskName, namespace, tb.TaskSpec(
+	task := tb.Task(taskName, tb.TaskNamespace(namespace), tb.TaskSpec(
 		tb.Step("attempt-write", "alpine", tb.StepScript("echo foo > /workspace/test/file")),
 		tb.TaskWorkspace("test", "test workspace", "/workspace/test", true),
 	))
@@ -45,7 +45,7 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(taskRunName, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(taskName), tb.TaskRunServiceAccountName("default"),
 		tb.TaskRunWorkspaceEmptyDir("test", ""),
 	))


### PR DESCRIPTION
# Changes

Allow the namespace of most of the test resources to be optional.
They can be provided as a XXXOp argument to the resource, e.g.,
tb.Task("my-task", tb.Namespace("my-namespace"))

Fixes #1824

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
