### PR TITLE
update example step-script.yaml to be valid

### DIFF
--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -10,9 +10,6 @@ spec:
         default: param-value
 
     steps:
-    - name: noshebang
-      image: ubuntu
-      script: echo "no shebang"
     - name: bash
       image: ubuntu
       env:
@@ -77,13 +74,3 @@ spec:
           print('Param values not applied')
           print('Got: ', v)
           quit()
-
-    # Test that args are allowed and passed to the script as expected.
-    - name: args-allowed
-      image: ubuntu
-      args: ['hello', 'world']
-      script: |
-        #!/usr/bin/env bash
-        [[ $# == 2 ]]
-        [[ $1 == "hello" ]]
-        [[ $2 == "world" ]]


### PR DESCRIPTION
# Changes
The shebang script and args seem to not be valid anymore:
```
Error from server (BadRequest): error when creating "taskrun.yaml": admission webhook "webhook.tekton.dev" denied the request: mutation failed: script must start with a shebang (#!): steps.script
```
```
Error from server (BadRequest): error when creating "taskrun.yaml": admission webhook "webhook.tekton.dev" denied the request: mutation failed: script cannot be used with args or command: steps.script
```
