### PR TITLE
Correct the output of a "failed" taskrun

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -247,7 +247,15 @@ func areStepsComplete(pod *corev1.Pod) bool {
 	return stepsComplete
 }
 
+func sortContainerStatuses(podInstance *corev1.Pod) {
+	sort.Slice(podInstance.Status.ContainerStatuses[:], func(i, j int) bool {
+		return podInstance.Status.ContainerStatuses[i].State.Terminated.FinishedAt.Time.Before(podInstance.Status.ContainerStatuses[j].State.Terminated.FinishedAt.Time)
+	})
+
+}
+
 func getFailureMessage(pod *corev1.Pod) string {
+	sortContainerStatuses(pod)
 	// First, try to surface an error about the actual build step that failed.
 	for _, status := range pod.Status.ContainerStatuses {
 		term := status.State.Terminated

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -660,3 +660,45 @@ func TestSortTaskRunStepOrder(t *testing.T) {
 		t.Errorf("Unexpected step order (-want, +got): %s", d)
 	}
 }
+
+func TestSortContainerStatuses(t *testing.T) {
+	samplePod := corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "hello",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: time.Now()},
+						},
+					},
+				}, {
+					Name: "my",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: time.Now().Add(time.Second * 5)},
+						},
+					},
+				}, {
+					Name: "world",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							FinishedAt: metav1.Time{Time: time.Now().Add(time.Second * -5)},
+						},
+					},
+				},
+			},
+		},
+	}
+	sortContainerStatuses(&samplePod)
+	var gotNames []string
+	for _, status := range samplePod.Status.ContainerStatuses {
+		gotNames = append(gotNames, status.Name)
+	}
+
+	want := []string{"world", "hello", "my"}
+	if d := cmp.Diff(want, gotNames); d != "" {
+		t.Errorf("Unexpected step order (-want, +got): %s", d)
+	}
+
+}


### PR DESCRIPTION
Fix issue: #1905 
Sort the `pod.podstatus.containerStatuses` by `finishedAt`

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
