### PR TITLE
TaskRun reconcile and  timeout found,  updateTaskRunStatusForTimeout delete pod optimization

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -511,17 +511,14 @@ func (c *Reconciler) updateTaskRunStatusForTimeout(tr *v1alpha1.TaskRun) error {
 	//
 	// If there's no such Pod, there's nothing to delete.
 	pod, err := getPod(tr, c.KubeClientSet)
-	switch {
-	case err == nil:
-		// Nothing to delete.
-	case err != nil:
+	if err != nil {
 		return err
-	default:
-		c.Logger.Infof("TaskRun %q has timed out, deleting pod", tr.Name)
-		if err := c.KubeClientSet.CoreV1().Pods(tr.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
-			c.Logger.Errorf("Failed to terminate pod: %v", err)
-			return err
-		}
+	}
+
+	c.Logger.Infof("TaskRun %q has timed out, deleting pod", tr.Name)
+	if err := c.KubeClientSet.CoreV1().Pods(tr.Namespace).Delete(pod.Name, &metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		c.Logger.Errorf("Failed to terminate pod: %v", err)
+		return err
 	}
 
 	timeout := tr.Spec.Timeout.Duration


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
TaskRun reconcile and  timeout found,  `updateTaskRunStatusForTimeout` delete pod optimization.

The former nil check(through switch/case) logic in `pkg/reconciler/taskrun/taskrun.go ->
 updateTaskRunStatusForTimeout` of getPod result is confusing, and the default block is unreachable, so the deleting pod related is not executed. Modify to simple condition check and fix the problem.

@ImJasonH  could you please help to check?


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

