### PR TITLE
Create pr when PR number is empty on output

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -477,6 +477,22 @@ spec:
       value: github
 ```
 
+### Creating a new PullRequest
+
+This resource can also create new PRs, you'll need to populate the following
+fields in the resource `pr.json` file:
+
+```json
+{
+  "title": "Shiny PR",
+  "head": "my-fork:new-feature-branch",
+  "base": "master",
+  "body:" "My Shiny new PR"
+}
+```
+
+Comments and labels will also be added to the newly created PR.
+
 ### Image Resource
 
 An `image` resource represents an image that lives in a remote repository. It is

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/imdario/mergo v0.3.8 // indirect
-	github.com/jenkins-x/go-scm v1.5.65
+	github.com/jenkins-x/go-scm v1.5.72
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/markbates/inflect v1.0.4 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,12 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/bigkevmcd/go-scm v0.0.0-20200122140456-4effdca1d2f5 h1:YoBjz3+xOBcvwleAqLKgGYvFNzwoN78X+glEAvX/3Aw=
+github.com/bigkevmcd/go-scm v0.0.0-20200122140456-4effdca1d2f5/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
+github.com/bigkevmcd/go-scm v0.0.0-20200122142159-0df85a345017 h1:Cx7UyMS512h2GVlE6Ioh3GJaRxizHZLxOUJO9/sGNmI=
+github.com/bigkevmcd/go-scm v0.0.0-20200122142159-0df85a345017/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
+github.com/bigkevmcd/go-scm v0.0.0-20200122142912-a6fb9d6535c5 h1:X2cRKhzs/lRwo7kHh9y9Hp+q4v/JLaQU+DlmPmRhtOs=
+github.com/bigkevmcd/go-scm v0.0.0-20200122142912-a6fb9d6535c5/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
@@ -301,6 +307,10 @@ github.com/jcmturner/gofork v0.0.0-20190328161633-dc7c13fece03/go.mod h1:MK8+TM0
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
 github.com/jenkins-x/go-scm v1.5.65 h1:ieH+0JSWENObn1SDWFj2K40iV5Eia4aTl6W6bDdLwI0=
 github.com/jenkins-x/go-scm v1.5.65/go.mod h1:MgGRkJScE/rJ30J/bXYqduN5sDPZqZFITJopsnZmTOw=
+github.com/jenkins-x/go-scm v1.5.71 h1:NWbwd9s5vrxnn0vCJIYhRsUYHY1OZa9WsMx+nTHyfP0=
+github.com/jenkins-x/go-scm v1.5.71/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
+github.com/jenkins-x/go-scm v1.5.72 h1:QA6VGYBzX9dSxKchHzZGIiwU6VL4xkfkhuWItCc4/g0=
+github.com/jenkins-x/go-scm v1.5.72/go.mod h1:PCT338UhP/pQ0IeEeMEf/hoLTYKcH7qjGEKd7jPkeYg=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -219,17 +219,8 @@ func TestFromDiskWithoutComments(t *testing.T) {
 		Sha:  "sha2",
 	}
 
-	writeFile := func(p string, v interface{}) {
-		b, err := json.Marshal(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := ioutil.WriteFile(p, b, 0700); err != nil {
-			t.Fatal(err)
-		}
-	}
-	writeFile(filepath.Join(d, "base.json"), &base)
-	writeFile(filepath.Join(d, "head.json"), &head)
+	writeFile(t, filepath.Join(d, "base.json"), &base)
+	writeFile(t, filepath.Join(d, "head.json"), &head)
 
 	rsrc, err := FromDisk(d)
 	if err != nil {
@@ -265,17 +256,8 @@ func TestFromDisk(t *testing.T) {
 		Sha:  "sha2",
 	}
 
-	writeFile := func(p string, v interface{}) {
-		b, err := json.Marshal(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := ioutil.WriteFile(p, b, 0700); err != nil {
-			t.Fatal(err)
-		}
-	}
-	writeFile(filepath.Join(d, "base.json"), &base)
-	writeFile(filepath.Join(d, "head.json"), &head)
+	writeFile(t, filepath.Join(d, "base.json"), &base)
+	writeFile(t, filepath.Join(d, "head.json"), &head)
 
 	// Write some statuses
 	statuses := []scm.Status{
@@ -295,7 +277,7 @@ func TestFromDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, s := range statuses {
-		writeFile(filepath.Join(d, "status", s.Label+".json"), &s)
+		writeFile(t, filepath.Join(d, "status", s.Label+".json"), &s)
 	}
 
 	// Write some labels
@@ -330,7 +312,7 @@ func TestFromDisk(t *testing.T) {
 	manifest := make([]string, 0, len(comments))
 	for _, c := range comments {
 		id := strconv.Itoa(c.ID)
-		writeFile(filepath.Join(d, "comments", id+".json"), &c)
+		writeFile(t, filepath.Join(d, "comments", id+".json"), &c)
 		manifest = append(manifest, id)
 	}
 	writeManifest(t, manifest, filepath.Join(d, "comments", manifestPath))
@@ -668,18 +650,9 @@ func TestFromDiskPRShaWithNullHeadAndBase(t *testing.T) {
 		Head: head,
 	}
 
-	writeFile := func(p string, v interface{}) {
-		b, err := json.Marshal(v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := ioutil.WriteFile(p, b, 0700); err != nil {
-			t.Fatal(err)
-		}
-	}
-	writeFile(filepath.Join(d, "base.json"), &base)
-	writeFile(filepath.Join(d, "head.json"), &head)
-	writeFile(filepath.Join(d, "pr.json"), &pr)
+	writeFile(t, filepath.Join(d, "base.json"), &base)
+	writeFile(t, filepath.Join(d, "head.json"), &head)
+	writeFile(t, filepath.Join(d, "pr.json"), &pr)
 
 	rsrc, err := FromDisk(d)
 	if err != nil {
@@ -690,4 +663,14 @@ func TestFromDiskPRShaWithNullHeadAndBase(t *testing.T) {
 		t.Errorf("FromDisk() returned sha `%s`, expected `%s`", rsrc.PR.Sha, expectedSha)
 	}
 
+}
+
+func writeFile(t *testing.T, p string, v interface{}) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(p, b, 0700); err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
# Changes

This changes the `pullrequest` resource to allow it to create PRs during the upload.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
