### PR TITLE
Avoid a panic when sorting container statuses

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -257,7 +257,14 @@ func areStepsComplete(pod *corev1.Pod) bool {
 
 func sortContainerStatuses(podInstance *corev1.Pod) {
 	sort.Slice(podInstance.Status.ContainerStatuses, func(i, j int) bool {
-		return podInstance.Status.ContainerStatuses[i].State.Terminated.FinishedAt.Time.Before(podInstance.Status.ContainerStatuses[j].State.Terminated.FinishedAt.Time)
+		var ifinish, jfinish time.Time
+		if term := podInstance.Status.ContainerStatuses[i].State.Terminated; term != nil {
+			ifinish = term.FinishedAt.Time
+		}
+		if term := podInstance.Status.ContainerStatuses[j].State.Terminated; term != nil {
+			jfinish = term.FinishedAt.Time
+		}
+		return ifinish.Before(jfinish)
 	})
 
 }

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -699,11 +699,9 @@ func TestSortContainerStatuses(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "my",
+					Name:  "my",
 					State: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							FinishedAt: metav1.Time{Time: time.Now().Add(time.Second * 5)},
-						},
+						// No Terminated status, terminated == 0 (and no panic)
 					},
 				}, {
 					Name: "world",
@@ -722,7 +720,7 @@ func TestSortContainerStatuses(t *testing.T) {
 		gotNames = append(gotNames, status.Name)
 	}
 
-	want := []string{"world", "hello", "my"}
+	want := []string{"my", "world", "hello"}
 	if d := cmp.Diff(want, gotNames); d != "" {
 		t.Errorf("Unexpected step order (-want, +got): %s", d)
 	}


### PR DESCRIPTION
If a step fails, subsequent steps might not have a terminated time yet,
which led to a panic and crashloop backoff in the controller.

The only place where `sortContainerStatuses` is used is when deriving the failure message (the first `Message` of any terminated step, i.e., where `Terminated != nil`, so sorting these to the beginning of the list has no practical effect.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/assign @sbwsg 