### PR TITLE
Update dind-sidecar example

### DIFF
--- a/examples/taskruns/dind-sidecar.yaml
+++ b/examples/taskruns/dind-sidecar.yaml
@@ -5,34 +5,39 @@ metadata:
 spec:
   taskSpec:
     steps:
-      - image: docker
-        name: client
-        workingDir: /workspace
-        script: |
-            #!/usr/bin/env sh
-            cat > Dockerfile << EOF
-            FROM ubuntu
-            RUN apt-get update
-            ENTRYPOINT ["echo", "hello"]
-            EOF
-            docker build -t hello . && docker run hello
-            docker images
-        volumeMounts:
-          - mountPath: /var/run/
-            name: dind-socket
+    - image: docker
+      name: client
+      script: |
+          #!/usr/bin/env sh
+          # Run a Docker container.
+          docker run busybox echo hello
+
+          # Write a Dockerfile and `docker build` it.
+          cat > Dockerfile << EOF
+          FROM ubuntu
+          RUN apt-get update
+          ENTRYPOINT ["echo", "hello"]
+          EOF
+          docker build -t hello . && docker run hello
+          docker images
+
+          # ...then run it!
+          docker run hello
+      volumeMounts:
+      - mountPath: /var/run/
+        name: dind-socket
+
     sidecars:
-      - image: docker:18.05-dind
-        name: server
-        securityContext:
-          privileged: true
-        volumeMounts:
-          - mountPath: /var/lib/docker
-            name: dind-storage
-          - mountPath: /var/run/
-            name: dind-socket
+    # 18.09-dind seems to be the latest version of the image that works with
+    # this example. The next released image, 19.03-dind doesn't work.
+    - image: docker:18.09-dind
+      name: server
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /var/run/
+        name: dind-socket
 
     volumes:
-      - name: dind-storage
-        emptyDir: {}
-      - name: dind-socket
-        emptyDir: {}
+    - name: dind-socket
+      emptyDir: {}


### PR DESCRIPTION
- YAML format to reduce unnecessary indentation
- upgrade to `18.09-dind`, which is the latest version that seems to work (https://github.com/tektoncd/pipeline/issues/1929)
- demonstrate running images in addition to building them
- remove unnecessary `dind-storage` volume

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
