### PR TITLE
Remove comment about Condition being WIP

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -2,8 +2,6 @@
 
 This document defines `Conditions` and their capabilities.
 
-*NOTE*: This feature is currently a WIP being tracked in [#1137](https://github.com/tektoncd/pipeline/issues/1137)
-
 ---
 
 - [Syntax](#syntax)

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -12,6 +12,7 @@ This document defines `Pipelines` and their capabilities.
     - [From](#from)
     - [RunAfter](#runAfter)
     - [Retries](#retries)
+    - [Conditions](#conditions)
 - [Ordering](#ordering)
 - [Examples](#examples)
 


### PR DESCRIPTION
# Changes

The WIP comment was originally added (I think) when just the condition
types existed but not the implementation. Now that there is an
implementation, we can remove it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
