### PR TITLE
Update the dind sidecar example to use a recent dind image

### DIFF
--- a/examples/taskruns/dind-sidecar.yaml
+++ b/examples/taskruns/dind-sidecar.yaml
@@ -7,6 +7,10 @@ spec:
     steps:
     - image: docker
       name: client
+      env:
+      # Connect to the sidecar over TCP without TLS.
+      - name: DOCKER_HOST
+        value: tcp://localhost:2375
       script: |
           #!/usr/bin/env sh
           # Run a Docker container.
@@ -28,12 +32,14 @@ spec:
         name: dind-socket
 
     sidecars:
-    # 18.09-dind seems to be the latest version of the image that works with
-    # this example. The next released image, 19.03-dind doesn't work.
-    - image: docker:18.09-dind
+    - image: docker:dind
       name: server
       securityContext:
         privileged: true
+      env:
+      # This disables TLS for TCP connections between the sidecar and client step.
+      - name: DOCKER_TLS_CERTDIR
+        value: ''
       volumeMounts:
       - mountPath: /var/run/
         name: dind-socket


### PR DESCRIPTION
Some time after 18.09, Docker stopped communicating with its daemon
using the socket, and instead uses TCP. This example now uses TCP
accordingly, without TLS.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

Fixes #1929 