### PR TITLE
Fail step-script if param value is not applied

### DIFF
--- a/examples/taskruns/step-script.yaml
+++ b/examples/taskruns/step-script.yaml
@@ -76,7 +76,7 @@ spec:
         if v != 'param-value':
           print('Param values not applied')
           print('Got: ', v)
-          quit()
+          exit(1)
 
     # Test that args are allowed and passed to the script as expected.
     - name: args-allowed


### PR DESCRIPTION
Following up on #1925 -- correctly applying params in the example is great, but actually failing when they weren't applied would have helped this get discovered much sooner.

I blame Python, which I should never be allowed to write.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
