### PR TITLE
Add tekton.dev/release annotation to the webhook 🏋

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-pipelines
     app.kubernetes.io/component: controller
+    tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -23,6 +23,7 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-pipelines
     app.kubernetes.io/component: webhook-controller
+    tekton.dev/release: "devel"
 spec:
   replicas: 1
   selector:
@@ -32,6 +33,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        tekton.dev/release: "devel"
       labels:
         app: tekton-pipelines-webhook
         app.kubernetes.io/name: tekton-pipelines

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -141,6 +141,7 @@ spec:
 
       # Rewrite "devel" to inputs.params.versionTag
       sed -i 's/devel/$(inputs.params.versionTag)/g' /workspace/go/src/github.com/tektoncd/pipeline/config/controller.yaml
+      sed -i 's/devel/$(inputs.params.versionTag)/g' /workspace/go/src/github.com/tektoncd/pipeline/config/webhook.yaml
 
       # Publish images and create release.yaml
       ko resolve --preserve-import-paths -t $(inputs.params.versionTag) -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > /workspace/output/bucket/latest/release.yaml


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We currently only add this annotation to the controller. Let's also
add it to the webhook. We are also adding it to the deployment
itself (as a label).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @ImJasonH @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Annotate the webhook in addition to the controller with the tetkon release (tekton.dev/release)
```
