### PR TITLE
[cherry-pick v0.10.x] Avoid a panic when sorting container statuses

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -257,7 +257,14 @@ func areStepsComplete(pod *corev1.Pod) bool {
 
 func sortContainerStatuses(podInstance *corev1.Pod) {
 	sort.Slice(podInstance.Status.ContainerStatuses, func(i, j int) bool {
-		return podInstance.Status.ContainerStatuses[i].State.Terminated.FinishedAt.Time.Before(podInstance.Status.ContainerStatuses[j].State.Terminated.FinishedAt.Time)
+		var ifinish, jfinish time.Time
+		if term := podInstance.Status.ContainerStatuses[i].State.Terminated; term != nil {
+			ifinish = term.FinishedAt.Time
+		}
+		if term := podInstance.Status.ContainerStatuses[j].State.Terminated; term != nil {
+			jfinish = term.FinishedAt.Time
+		}
+		return ifinish.Before(jfinish)
 	})
 
 }

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -699,11 +699,9 @@ func TestSortContainerStatuses(t *testing.T) {
 						},
 					},
 				}, {
-					Name: "my",
+					Name:  "my",
 					State: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{
-							FinishedAt: metav1.Time{Time: time.Now().Add(time.Second * 5)},
-						},
+						// No Terminated status, terminated == 0 (and no panic)
 					},
 				}, {
 					Name: "world",
@@ -722,7 +720,7 @@ func TestSortContainerStatuses(t *testing.T) {
 		gotNames = append(gotNames, status.Name)
 	}
 
-	want := []string{"world", "hello", "my"}
+	want := []string{"my", "world", "hello"}
 	if d := cmp.Diff(want, gotNames); d != "" {
 		t.Errorf("Unexpected step order (-want, +got): %s", d)
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If a step fails, subsequent steps might not have a terminated time yet,
which led to a panic and crashloop backoff in the controller.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
