### PR TITLE
Port Workspace in pipeline support to v1alpha2 🎋

### DIFF
--- a/pkg/apis/pipeline/v1alpha2/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha2/pipeline_types.go
@@ -73,6 +73,10 @@ type PipelineSpec struct {
 	// Params declares a list of input parameters that must be supplied when
 	// this Pipeline is run.
 	Params []ParamSpec `json:"params,omitempty"`
+	// Workspaces declares a set of named workspaces that are expected to be
+	// provided by a PipelineRun.
+	// +optional
+	Workspaces []WorkspacePipelineDeclaration `json:"workspaces,omitempty"`
 }
 
 // PipelineTask defines a task in a Pipeline, passing inputs from both
@@ -111,6 +115,11 @@ type PipelineTask struct {
 	// Parameters declares parameters passed to this task.
 	// +optional
 	Params []Param `json:"params,omitempty"`
+
+	// Workspaces maps workspaces from the pipeline spec to the workspaces
+	// declared in the Task.
+	// +optional
+	Workspaces []WorkspacePipelineTaskBinding `json:"workspaces,omitempty"`
 }
 
 func (pt PipelineTask) HashKey() string {

--- a/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
@@ -322,6 +322,11 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Workspaces != nil {
+		in, out := &in.Workspaces, &out.Workspaces
+		*out = make([]WorkspacePipelineDeclaration, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -387,6 +392,11 @@ func (in *PipelineTask) DeepCopyInto(out *PipelineTask) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.Workspaces != nil {
+		in, out := &in.Workspaces, &out.Workspaces
+		*out = make([]WorkspacePipelineTaskBinding, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This port changes from #1866 to v1alpha2

/cc @sbwsg @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
