### PR TITLE
Use named field in test tables 🌮

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -229,25 +229,25 @@ func TestPipelineRunGetServiceAccountName(t *testing.T) {
 		saNames map[string]string
 	}{
 		{
-			"default SA",
-			tb.PipelineRun("pr", "ns",
+			name: "default SA",
+			pr: tb.PipelineRun("pr", "ns",
 				tb.PipelineRunSpec("prs",
 					tb.PipelineRunServiceAccountName("defaultSA"),
 					tb.PipelineRunServiceAccountNameTask("taskName", "taskSA"))),
-			map[string]string{
+			saNames: map[string]string{
 				"unknown":  "defaultSA",
 				"taskName": "taskSA",
 			},
 		},
 		{
-			"mixed default SA",
-			tb.PipelineRun("defaultSA", "defaultSA",
+			name: "mixed default SA",
+			pr: tb.PipelineRun("defaultSA", "defaultSA",
 				tb.PipelineRunSpec("defaultSA",
 					tb.PipelineRunServiceAccountName("defaultSA"),
 					tb.PipelineRunServiceAccountNameTask("task1", "task1SA"),
 					tb.PipelineRunServiceAccountNameTask("task2", "task2SA"),
 				)),
-			map[string]string{
+			saNames: map[string]string{
 				"unknown": "defaultSA",
 				"task1":   "task1SA",
 				"task2":   "task2SA",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It makes it a bit more readable and "safe" to change.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
