### PR TITLE
leave max container request values at original index

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -119,7 +119,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 	initContainers = append(initContainers, entrypointInit)
 	volumes = append(volumes, toolsVolume, downwardVolume)
 
-	// Zero out non-max resource requests, move max resource requests to the last step.
+	// Zero out non-max resource requests.
 	stepContainers = resolveResourceRequests(stepContainers)
 
 	// Add implicit env vars.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -436,10 +436,16 @@ func TestMakePod(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				Env:                    implicitEnvVars,
-				VolumeMounts:           append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
-				WorkingDir:             pipeline.WorkspaceDir,
-				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
+				Env:          implicitEnvVars,
+				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
+				WorkingDir:   pipeline.WorkspaceDir,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("8"),
+						corev1.ResourceMemory:           zeroQty,
+						corev1.ResourceEphemeralStorage: zeroQty,
+					},
+				},
 				TerminationMessagePath: "/tekton/termination",
 			}, {
 				Name:    "step-unnamed-1",
@@ -461,7 +467,7 @@ func TestMakePod(t *testing.T) {
 				WorkingDir:   pipeline.WorkspaceDir,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("8"),
+						corev1.ResourceCPU:              zeroQty,
 						corev1.ResourceMemory:           resource.MustParse("100Gi"),
 						corev1.ResourceEphemeralStorage: zeroQty,
 					},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cherry pick of #1937

---

#1655 refactored how container resource requests are handled as part of a TaskRun. As part of that pr, all max request values for steps associated with a TaskRun were placed in the last container. 

The problem with this approach is that the last container can have a limit set that does not take into account whether another container has a higher request value. 

To avoid this, this pull request leaves the request values at the original indices where they are found so they work appropriately with the limits set. This was the way this was originally implemented prior to #1655.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Leave max container requests at original indices to account for container limits
```
