### PR TITLE
Ensure taskRef (optional param) is non nil before setting defaults 

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
@@ -30,8 +30,10 @@ func (p *Pipeline) SetDefaults(ctx context.Context) {
 
 func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for _, pt := range ps.Tasks {
-		if pt.TaskRef.Kind == "" {
-			pt.TaskRef.Kind = NamespacedTaskKind
+		if pt.TaskRef != nil {
+			if pt.TaskRef.Kind == "" {
+				pt.TaskRef.Kind = NamespacedTaskKind
+			}
 		}
 	}
 	for i := range ps.Params {

--- a/pkg/apis/pipeline/v1alpha2/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1alpha2/pipeline_defaults.go
@@ -30,8 +30,10 @@ func (p *Pipeline) SetDefaults(ctx context.Context) {
 
 func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for _, pt := range ps.Tasks {
-		if pt.TaskRef.Kind == "" {
-			pt.TaskRef.Kind = NamespacedTaskKind
+		if pt.TaskRef != nil {
+			if pt.TaskRef.Kind == "" {
+				pt.TaskRef.Kind = NamespacedTaskKind
+			}
 		}
 	}
 	for i := range ps.Params {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
