### PR TITLE
Revert "Don't rely on .status.podName to find Pod associated with a T…

### DIFF
--- a/pkg/reconciler/taskrun/cancel.go
+++ b/pkg/reconciler/taskrun/cancel.go
@@ -26,8 +26,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// cancelTaskRun marks the TaskRun as cancelled and deletes pods linked to it.
-func cancelTaskRun(tr *v1alpha1.TaskRun, clientset kubernetes.Interface) error {
+type logger interface {
+	Warn(args ...interface{})
+	Warnf(template string, args ...interface{})
+}
+
+// cancelTaskRun marks the TaskRun as cancelled and delete pods linked to it.
+func cancelTaskRun(tr *v1alpha1.TaskRun, clientSet kubernetes.Interface, logger logger) error {
+	logger.Warn("task run %q has been cancelled", tr.Name)
 	tr.Status.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionFalse,
@@ -35,10 +41,13 @@ func cancelTaskRun(tr *v1alpha1.TaskRun, clientset kubernetes.Interface) error {
 		Message: fmt.Sprintf("TaskRun %q was cancelled", tr.Name),
 	})
 
-	pod, err := getPod(tr, clientset)
-	if err != nil {
-		return err
+	if tr.Status.PodName == "" {
+		logger.Warnf("task run %q has no pod running yet", tr.Name)
+		return nil
 	}
 
-	return clientset.CoreV1().Pods(tr.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
+	if err := clientSet.CoreV1().Pods(tr.Namespace).Delete(tr.Status.PodName, &metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -85,8 +85,19 @@ var (
 	cloudEventTarget1 = "https://foo"
 	cloudEventTarget2 = "https://bar"
 
-	simpleStep  = tb.Step("foo", tb.StepName("simple-step"), tb.StepCommand("/mycmd"))
-	simpleTask  = tb.Task("test-task", "foo", tb.TaskSpec(simpleStep))
+	simpleStep        = tb.Step("foo", tb.StepName("simple-step"), tb.StepCommand("/mycmd"))
+	simpleTask        = tb.Task("test-task", "foo", tb.TaskSpec(simpleStep))
+	taskMultipleSteps = tb.Task("test-task-multi-steps", "foo", tb.TaskSpec(
+		tb.Step("foo", tb.StepName("z-step"),
+			tb.StepCommand("/mycmd"),
+		),
+		tb.Step("foo", tb.StepName("v-step"),
+			tb.StepCommand("/mycmd"),
+		),
+		tb.Step("foo", tb.StepName("x-step"),
+			tb.StepCommand("/mycmd"),
+		),
+	))
 	clustertask = tb.ClusterTask("test-cluster-task", tb.ClusterTaskSpec(simpleStep))
 
 	outputTask = tb.Task("test-output-task", "foo", tb.TaskSpec(
@@ -393,9 +404,9 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 				t.Fatalf("Reconcile didn't set pod name")
 			}
 
-			pod, err := getPod(tr, clients.Kube)
+			pod, err := clients.Kube.CoreV1().Pods(tr.Namespace).Get(tr.Status.PodName, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Failed to fetch Pod: %v", err)
+				t.Fatalf("Failed to fetch build pod: %v", err)
 			}
 
 			if d := cmp.Diff(tc.wantPod.ObjectMeta, pod.ObjectMeta, ignoreRandomPodNameSuffix); d != "" {
@@ -508,6 +519,7 @@ func TestReconcile(t *testing.T) {
 
 	taskRunWithPod := tb.TaskRun("test-taskrun-with-pod", "foo",
 		tb.TaskRunSpec(tb.TaskRunTaskRef(simpleTask.Name)),
+		tb.TaskRunStatus(tb.PodName("some-pod-abcdethat-no-longer-exists")),
 	)
 
 	taskruns := []*v1alpha1.TaskRun{
@@ -908,7 +920,7 @@ func TestReconcile(t *testing.T) {
 				t.Fatalf("Reconcile didn't set pod name")
 			}
 
-			pod, err := getPod(tr, clients.Kube)
+			pod, err := clients.Kube.CoreV1().Pods(tr.Namespace).Get(tr.Status.PodName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to fetch build pod: %v", err)
 			}
@@ -948,20 +960,99 @@ func TestReconcile_SetsStartTime(t *testing.T) {
 	}
 }
 
+func TestReconcile_SortTaskRunStatusSteps(t *testing.T) {
+	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskRef(taskMultipleSteps.Name)),
+		tb.TaskRunStatus(
+			tb.PodName("the-pod"),
+		),
+	)
+
+	// The order of the container statuses has been shuffled, not aligning with the order of the
+	// spec steps of the Task any more. After Reconcile is called, we should see the order of status
+	// steps in TaksRun has been converted to the same one as in spec steps of the Task.
+	d := test.Data{
+		TaskRuns: []*v1alpha1.TaskRun{taskRun},
+		Tasks:    []*v1alpha1.Task{taskMultipleSteps},
+		Pods: []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "foo",
+				Name:      "the-pod",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodSucceeded,
+				ContainerStatuses: []corev1.ContainerStatus{{
+					Name: "step-nop",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+				}, {
+					Name: "step-x-step",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+				}, {
+					Name: "step-v-step",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+				}, {
+					Name: "step-z-step",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+				}},
+			},
+		}},
+	}
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	if err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun)); err != nil {
+		t.Errorf("expected no error reconciling valid TaskRun but got %v", err)
+	}
+	verifyTaskRunStatusStep(t, taskRun)
+}
+
+func verifyTaskRunStatusStep(t *testing.T, taskRun *v1alpha1.TaskRun) {
+	actualStepOrder := []string{}
+	for _, state := range taskRun.Status.Steps {
+		actualStepOrder = append(actualStepOrder, state.Name)
+	}
+	expectedStepOrder := []string{}
+	for _, state := range taskMultipleSteps.Spec.Steps {
+		expectedStepOrder = append(expectedStepOrder, state.Name)
+	}
+	// Add a nop in the end. This may be removed in future.
+	expectedStepOrder = append(expectedStepOrder, "nop")
+	if d := cmp.Diff(expectedStepOrder, actualStepOrder); d != "" {
+		t.Errorf("The status steps in TaksRun doesn't match the spec steps in Task (-want, +got): %s", d)
+	}
+}
+
 func TestReconcile_DoesntChangeStartTime(t *testing.T) {
 	startTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
 	taskRun := tb.TaskRun("test-taskrun", "foo", tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name)),
-		tb.TaskRunStatus(tb.TaskRunStartTime(startTime)),
+		tb.TaskRunStatus(
+			tb.TaskRunStartTime(startTime),
+			tb.PodName("the-pod"),
+		),
 	)
 	d := test.Data{
 		TaskRuns: []*v1alpha1.TaskRun{taskRun},
 		Tasks:    []*v1alpha1.Task{simpleTask},
 		Pods: []*corev1.Pod{{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: taskRun.Namespace,
+				Namespace: "foo",
 				Name:      "the-pod",
-				Labels:    map[string]string{"tekton.dev/taskRun": taskRun.Name},
 			},
 		}},
 	}
@@ -982,13 +1073,15 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 	withWrongRef := tb.TaskRun("taskrun-with-wrong-ref", "foo", tb.TaskRunSpec(
 		tb.TaskRunTaskRef("taskrun-with-wrong-ref", tb.TaskRefKind(v1alpha1.ClusterTaskKind)),
 	))
+	taskRuns := []*v1alpha1.TaskRun{noTaskRun, withWrongRef}
+	tasks := []*v1alpha1.Task{simpleTask}
 
 	d := test.Data{
-		TaskRuns: []*v1alpha1.TaskRun{noTaskRun, withWrongRef},
-		Tasks:    []*v1alpha1.Task{simpleTask},
+		TaskRuns: taskRuns,
+		Tasks:    tasks,
 	}
 
-	for _, tc := range []struct {
+	testcases := []struct {
 		name    string
 		taskRun *v1alpha1.TaskRun
 		reason  string
@@ -1000,7 +1093,9 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 		name:    "task run with no task",
 		taskRun: withWrongRef,
 		reason:  podconvert.ReasonFailedResolution,
-	}} {
+	}}
+
+	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			testAssets, cancel := getTaskRunController(t, d)
 			defer cancel()
@@ -1034,6 +1129,7 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 func TestReconcilePodFetchError(t *testing.T) {
 	taskRun := tb.TaskRun("test-taskrun-run-success", "foo",
 		tb.TaskRunSpec(tb.TaskRunTaskRef("test-task")),
+		tb.TaskRunStatus(tb.PodName("will-not-be-found")),
 	)
 	d := test.Data{
 		TaskRuns: []*v1alpha1.TaskRun{taskRun},
@@ -1042,14 +1138,15 @@ func TestReconcilePodFetchError(t *testing.T) {
 
 	testAssets, cancel := getTaskRunController(t, d)
 	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
 
-	// Induce an error fetching pods.
-	testAssets.Clients.Kube.PrependReactor("list", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+	clients.Kube.PrependReactor("get", "pods", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, errors.New("induce failure fetching pods")
 	})
 
-	if err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun)); err == nil {
-		t.Fatal("expected error when reconciling a Task for which we couldn't get the corresponding Pod but got nil")
+	if err := c.Reconciler.Reconcile(context.Background(), fmt.Sprintf("%s/%s", taskRun.Namespace, taskRun.Name)); err == nil {
+		t.Fatal("expected error when reconciling a Task for which we couldn't get the corresponding Build Pod but got nil")
 	}
 }
 
@@ -1083,7 +1180,11 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MakePod: %v", err)
 	}
-
+	taskRun.Status = v1alpha1.TaskRunStatus{
+		TaskRunStatusFields: v1alpha1.TaskRunStatusFields{
+			PodName: pod.Name,
+		},
+	}
 	d := test.Data{
 		TaskRuns: []*v1alpha1.TaskRun{taskRun},
 		Tasks:    []*v1alpha1.Task{simpleTask},
@@ -1143,24 +1244,14 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 		Reason:  "Build succeeded",
 		Message: "Build succeeded",
 	}
-	taskRun := &v1alpha1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-taskrun-run-success",
-			Namespace: "the-namespace",
-		},
-		Status: v1alpha1.TaskRunStatus{Status: duckv1beta1.Status{
-			Conditions: []apis.Condition{*taskSt},
-		}},
-	}
+	taskRun := tb.TaskRun("test-taskrun-run-success", "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name),
+	), tb.TaskRunStatus(tb.StatusCondition(*taskSt)))
 	d := test.Data{
-		TaskRuns: []*v1alpha1.TaskRun{taskRun},
-		Pods: []*corev1.Pod{{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "the-pod",
-				Namespace: taskRun.Namespace,
-				Labels:    map[string]string{"tekton.dev/taskRun": taskRun.Name},
-			},
-		}},
+		TaskRuns: []*v1alpha1.TaskRun{
+			taskRun,
+		},
+		Tasks: []*v1alpha1.Task{simpleTask},
 	}
 
 	testAssets, cancel := getTaskRunController(t, d)
@@ -1176,75 +1267,110 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 		t.Fatalf("Expected completed TaskRun %s to exist but instead got error when getting it: %v", taskRun.Name, err)
 	}
 	if d := cmp.Diff(taskSt, newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
+		t.Fatalf("Did not get expected conditon (-want, +got): %v", d)
+	}
+}
+
+func TestReconcileOnCancelledTaskRun(t *testing.T) {
+	taskRun := tb.TaskRun("test-taskrun-run-cancelled", "foo", tb.TaskRunSpec(
+		tb.TaskRunTaskRef(simpleTask.Name),
+		tb.TaskRunCancelled,
+	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
+		Type:   apis.ConditionSucceeded,
+		Status: corev1.ConditionUnknown,
+	})))
+	d := test.Data{
+		TaskRuns: []*v1alpha1.TaskRun{taskRun},
+		Tasks:    []*v1alpha1.Task{simpleTask},
+	}
+
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if err := c.Reconciler.Reconcile(context.Background(), fmt.Sprintf("%s/%s", taskRun.Namespace, taskRun.Name)); err != nil {
+		t.Fatalf("Unexpected error when reconciling completed TaskRun : %v", err)
+	}
+	newTr, err := clients.Pipeline.TektonV1alpha1().TaskRuns(taskRun.Namespace).Get(taskRun.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Expected completed TaskRun %s to exist but instead got error when getting it: %v", taskRun.Name, err)
+	}
+
+	expectedStatus := &apis.Condition{
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionFalse,
+		Reason:  "TaskRunCancelled",
+		Message: `TaskRun "test-taskrun-run-cancelled" was cancelled`,
+	}
+	if d := cmp.Diff(expectedStatus, newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition (-want, +got): %v", d)
 	}
 }
 
 func TestReconcileTimeouts(t *testing.T) {
-	for _, tc := range []struct {
+	type testCase struct {
 		taskRun        *v1alpha1.TaskRun
 		expectedStatus *apis.Condition
-	}{{
-		taskRun: tb.TaskRun("test-taskrun-timeout", "foo",
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef(simpleTask.Name),
-				tb.TaskRunTimeout(10*time.Second),
-			),
-			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionUnknown}),
-				tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
+	}
 
-		expectedStatus: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  "TaskRunTimeout",
-			Message: `TaskRun "test-taskrun-timeout" failed to finish within "10s"`,
-		},
-	}, {
-		taskRun: tb.TaskRun("test-taskrun-default-timeout-60-minutes", "foo",
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef(simpleTask.Name),
-			),
-			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionUnknown}),
-				tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
+	testcases := []testCase{
+		{
+			taskRun: tb.TaskRun("test-taskrun-timeout", "foo",
+				tb.TaskRunSpec(
+					tb.TaskRunTaskRef(simpleTask.Name),
+					tb.TaskRunTimeout(10*time.Second),
+				),
+				tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown}),
+					tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
 
-		expectedStatus: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  "TaskRunTimeout",
-			Message: `TaskRun "test-taskrun-default-timeout-60-minutes" failed to finish within "1h0m0s"`,
-		},
-	}, {
-		taskRun: tb.TaskRun("test-taskrun-nil-timeout-default-60-minutes", "foo",
-			tb.TaskRunSpec(
-				tb.TaskRunTaskRef(simpleTask.Name),
-				tb.TaskRunNilTimeout,
-			),
-			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
-				Type:   apis.ConditionSucceeded,
-				Status: corev1.ConditionUnknown}),
-				tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
+			expectedStatus: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  "TaskRunTimeout",
+				Message: `TaskRun "test-taskrun-timeout" failed to finish within "10s"`,
+			},
+		}, {
+			taskRun: tb.TaskRun("test-taskrun-default-timeout-60-minutes", "foo",
+				tb.TaskRunSpec(
+					tb.TaskRunTaskRef(simpleTask.Name),
+				),
+				tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown}),
+					tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
 
-		expectedStatus: &apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  "TaskRunTimeout",
-			Message: `TaskRun "test-taskrun-nil-timeout-default-60-minutes" failed to finish within "1h0m0s"`,
-		},
-	}} {
+			expectedStatus: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  "TaskRunTimeout",
+				Message: `TaskRun "test-taskrun-default-timeout-60-minutes" failed to finish within "1h0m0s"`,
+			},
+		}, {
+			taskRun: tb.TaskRun("test-taskrun-nil-timeout-default-60-minutes", "foo",
+				tb.TaskRunSpec(
+					tb.TaskRunTaskRef(simpleTask.Name),
+					tb.TaskRunNilTimeout,
+				),
+				tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown}),
+					tb.TaskRunStartTime(time.Now().Add(-61*time.Minute)))),
+
+			expectedStatus: &apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  "TaskRunTimeout",
+				Message: `TaskRun "test-taskrun-nil-timeout-default-60-minutes" failed to finish within "1h0m0s"`,
+			},
+		}}
+
+	for _, tc := range testcases {
 		d := test.Data{
 			TaskRuns: []*v1alpha1.TaskRun{tc.taskRun},
 			Tasks:    []*v1alpha1.Task{simpleTask},
-			Pods: []*corev1.Pod{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "the-pod",
-					Namespace: tc.taskRun.Namespace,
-					Labels:    map[string]string{"tekton.dev/taskRun": tc.taskRun.Name},
-				},
-			}},
 		}
 		testAssets, cancel := getTaskRunController(t, d)
 		defer cancel()
@@ -1290,7 +1416,7 @@ func TestHandlePodCreationError(t *testing.T) {
 	// Prevent backoff timer from starting
 	c.timeoutHandler.SetTaskRunCallbackFunc(nil)
 
-	for _, tc := range []struct {
+	testcases := []struct {
 		description    string
 		err            error
 		expectedType   apis.ConditionType
@@ -1308,7 +1434,8 @@ func TestHandlePodCreationError(t *testing.T) {
 		expectedType:   apis.ConditionSucceeded,
 		expectedStatus: corev1.ConditionFalse,
 		expectedReason: podconvert.ReasonCouldntGetTask,
-	}} {
+	}}
+	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
 			c.handlePodCreationError(taskRun, tc.err)
 			foundCondition := false
@@ -1326,6 +1453,7 @@ func TestHandlePodCreationError(t *testing.T) {
 }
 
 func TestReconcileCloudEvents(t *testing.T) {
+
 	taskRunWithNoCEResources := tb.TaskRun("test-taskrun-no-ce-resources", "foo",
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
@@ -1411,25 +1539,12 @@ func TestReconcileCloudEvents(t *testing.T) {
 		taskRunWithTwoCEResourcesInit, taskRunWithCESucceded, taskRunWithCEFailed,
 		taskRunWithCESuccededOneAttempt,
 	}
-	var pods []*corev1.Pod
-	for _, tr := range taskruns {
-		pods = append(pods, &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "pod-for-" + tr.Name,
-				Namespace: tr.Namespace,
-				Labels: map[string]string{
-					"tekton.dev/taskRun": tr.Name,
-				},
-			},
-		})
-	}
 
 	d := test.Data{
 		TaskRuns:          taskruns,
 		Tasks:             []*v1alpha1.Task{simpleTask, twoOutputsTask},
 		ClusterTasks:      []*v1alpha1.ClusterTask{},
 		PipelineResources: []*v1alpha1.PipelineResource{cloudEventResource, anotherCloudEventResource},
-		Pods:              pods,
 	}
 	for _, tc := range []struct {
 		name            string


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

…askRun"

This reverts commit 0f20c3539f25ede46dfe58b83924e28db1fd783e.

Fixes  #1944

/cc @ImJasonH @steveodonovan @afrittoli 
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Revert "Don't rely on .status.podName to find Pod associated with a TaskRun" as it breaks `retries`..
```
