### PR TITLE
Add Script Support to Sidecars

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -496,6 +496,16 @@ volumes:
     emptyDir: {}
 ```
 
+Sidecars can also run a script, like a Step:
+
+```yaml
+sidecars:
+  image: busybox
+  name: hello-sidecar
+  script: |
+    echo 'Hello from sidecar!'
+```
+
 Note: There is a known bug with Tekton's existing sidecar implementation.
 Tekton uses a specific image, called "nop", to stop sidecars. The "nop" image
 is configurable using a flag of the Tekton controller. If the configured "nop"

--- a/examples/taskruns/sidecar-ready-script.yaml
+++ b/examples/taskruns/sidecar-ready-script.yaml
@@ -16,8 +16,6 @@ spec:
     steps:
     - name: check-ready
       image: ubuntu
-      # The step will only succeed if the sidecar has written this file, which
-      # it does 5s after it starts, before it reports Ready.
       script: cat /shared/message
       volumeMounts:
       - name: shared

--- a/examples/taskruns/sidecar-ready-script.yaml
+++ b/examples/taskruns/sidecar-ready-script.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  generateName: sidecar-ready-
+spec:
+  taskSpec:
+    sidecars:
+    - name: slow-sidecar
+      image: ubuntu
+      script: |
+        echo "hello from sidecar" > /shared/message
+      volumeMounts:
+      - name: shared
+        mountPath: /shared
+
+    steps:
+    - name: check-ready
+      image: ubuntu
+      # The step will only succeed if the sidecar has written this file, which
+      # it does 5s after it starts, before it reports Ready.
+      script: cat /shared/message
+      volumeMounts:
+      - name: shared
+        mountPath: /shared
+
+    # Sidecars don't have /workspace mounted by default, so we have to define
+    # our own shared volume.
+    volumes:
+    - name: shared
+      emptyDir: {}

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -60,7 +60,7 @@ type TaskSpec struct {
 
 	// Sidecars are run alongside the Task's step containers. They begin before
 	// the steps start and end after the steps complete.
-	Sidecars []corev1.Container `json:"sidecars,omitempty"`
+	Sidecars []Sidecar `json:"sidecars,omitempty"`
 
 	// Workspaces are the volumes that this Task requires.
 	Workspaces []WorkspaceDeclaration `json:"workspaces,omitempty"`
@@ -69,6 +69,8 @@ type TaskSpec struct {
 // Step embeds the Container type, which allows it to include fields not
 // provided by Container.
 type Step = v1alpha2.Step
+
+type Sidecar = v1alpha2.Sidecar
 
 // +genclient
 // +genclient:noStatus

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -1640,7 +1640,7 @@ func (in *TaskSpec) DeepCopyInto(out *TaskSpec) {
 	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
-		*out = make([]v1.Container, len(*in))
+		*out = make([]v1alpha2.Step, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/apis/pipeline/v1alpha2/task_types.go
+++ b/pkg/apis/pipeline/v1alpha2/task_types.go
@@ -81,7 +81,7 @@ type TaskSpec struct {
 
 	// Sidecars are run alongside the Task's step containers. They begin before
 	// the steps start and end after the steps complete.
-	Sidecars []corev1.Container `json:"sidecars,omitempty"`
+	Sidecars []Sidecar `json:"sidecars,omitempty"`
 
 	// Workspaces are the volumes that this Task requires.
 	Workspaces []WorkspaceDeclaration
@@ -97,6 +97,9 @@ type Step struct {
 	// If Script is not empty, the Step cannot have an Command or Args.
 	Script string `json:"script,omitempty"`
 }
+
+// A sidecar has the same data structure as a Step, consisting of a Container, and optional Script.
+type Sidecar = Step
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // TaskList contains a list of Task

--- a/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
@@ -277,7 +277,7 @@ func (in *TaskSpec) DeepCopyInto(out *TaskSpec) {
 	}
 	if in.Sidecars != nil {
 		in, out := &in.Sidecars, &out.Sidecars
-		*out = make([]v1.Container, len(*in))
+		*out = make([]Step, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -93,7 +93,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 
 	// Convert any steps with Script to command+args.
 	// If any are found, append an init container to initialize scripts.
-	scriptsInit, stepContainers := convertScripts(images.ShellImage, steps)
+	scriptsInit, stepContainers, sidecarContainers := convertScripts(images.ShellImage, steps, taskSpec.Sidecars)
 	if scriptsInit != nil {
 		initContainers = append(initContainers, *scriptsInit)
 		volumes = append(volumes, scriptsVolume)
@@ -171,9 +171,10 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 		return nil, err
 	}
 
-	// Merge sidecar containers with step containers.
 	mergedPodContainers := stepContainers
-	for _, sc := range taskSpec.Sidecars {
+
+	// Merge sidecar containers with step containers.
+	for _, sc := range sidecarContainers {
 		sc.Name = names.SimpleNameGenerator.RestrictLength(fmt.Sprintf("%v%v", sidecarPrefix, sc.Name))
 		mergedPodContainers = append(mergedPodContainers, sc)
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -355,10 +355,14 @@ func TestMakePod(t *testing.T) {
 				Image:   "primary-image",
 				Command: []string{"cmd"}, // avoid entrypoint lookup.
 			}}},
-			Sidecars: []corev1.Container{{
-				Name:  "sc-name",
-				Image: "sidecar-image",
-			}},
+			Sidecars: []v1alpha1.Sidecar{
+				{
+					Container: corev1.Container{
+						Name:  "sc-name",
+						Image: "sidecar-image",
+					},
+				},
+			},
 		},
 		wantAnnotations: map[string]string{},
 		want: &corev1.PodSpec{
@@ -393,6 +397,76 @@ func TestMakePod(t *testing.T) {
 				},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
+		},
+	}, {
+		desc: "sidecar container with script",
+		ts: v1alpha1.TaskSpec{
+			Steps: []v1alpha1.Step{{Container: corev1.Container{
+				Name:    "primary-name",
+				Image:   "primary-image",
+				Command: []string{"cmd"}, // avoid entrypoint lookup.
+			}}},
+			Sidecars: []v1alpha1.Sidecar{
+				{
+					Container: corev1.Container{
+						Name:  "sc-name",
+						Image: "sidecar-image",
+					},
+					Script: "#!/bin/sh\necho hello from sidecar",
+				},
+			},
+		},
+		wantAnnotations: map[string]string{},
+		want: &corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{
+				{
+					Name:         "place-scripts",
+					Image:        "busybox",
+					Command:      []string{"sh"},
+					TTY:          true,
+					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
+					Args: []string{"-c", `tmpfile="/tekton/scripts/sidecar-script-0-9l9zj"
+touch ${tmpfile} && chmod +x ${tmpfile}
+cat > ${tmpfile} << 'sidecar-script-heredoc-randomly-generated-mz4c7'
+#!/bin/sh
+echo hello from sidecar
+sidecar-script-heredoc-randomly-generated-mz4c7
+`},
+				},
+				placeToolsInit,
+			},
+			Containers: []corev1.Container{{
+				Name:    "step-primary-name",
+				Image:   "primary-image",
+				Command: []string{"/tekton/tools/entrypoint"},
+				Args: []string{
+					"-wait_file",
+					"/tekton/downward/ready",
+					"-wait_file_content",
+					"-post_file",
+					"/tekton/tools/0",
+					"-termination_path",
+					"/tekton/termination",
+					"-entrypoint",
+					"cmd",
+					"--",
+				},
+				Env:                    implicitEnvVars,
+				VolumeMounts:           append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
+				WorkingDir:             pipeline.WorkspaceDir,
+				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
+				TerminationMessagePath: "/tekton/termination",
+			}, {
+				Name:  "sidecar-sc-name",
+				Image: "sidecar-image",
+				Resources: corev1.ResourceRequirements{
+					Requests: nil,
+				},
+				Command:      []string{"/tekton/scripts/sidecar-script-0-9l9zj"},
+				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
+			}},
+			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume),
 		},
 	}, {
 		desc: "resource request",

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -406,34 +406,32 @@ func TestMakePod(t *testing.T) {
 				Image:   "primary-image",
 				Command: []string{"cmd"}, // avoid entrypoint lookup.
 			}}},
-			Sidecars: []v1alpha1.Sidecar{
-				{
-					Container: corev1.Container{
-						Name:  "sc-name",
-						Image: "sidecar-image",
-					},
-					Script: "#!/bin/sh\necho hello from sidecar",
+			Sidecars: []v1alpha1.Sidecar{{
+				Container: corev1.Container{
+					Name:  "sc-name",
+					Image: "sidecar-image",
 				},
+				Script: "#!/bin/sh\necho hello from sidecar",
+			},
 			},
 		},
 		wantAnnotations: map[string]string{},
 		want: &corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{
-				{
-					Name:         "place-scripts",
-					Image:        "busybox",
-					Command:      []string{"sh"},
-					TTY:          true,
-					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
-					Args: []string{"-c", `tmpfile="/tekton/scripts/sidecar-script-0-9l9zj"
+			InitContainers: []corev1.Container{{
+				Name:         "place-scripts",
+				Image:        "busybox",
+				Command:      []string{"sh"},
+				TTY:          true,
+				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
+				Args: []string{"-c", `tmpfile="/tekton/scripts/sidecar-script-0-9l9zj"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'sidecar-script-heredoc-randomly-generated-mz4c7'
 #!/bin/sh
 echo hello from sidecar
 sidecar-script-heredoc-randomly-generated-mz4c7
 `},
-				},
+			},
 				placeToolsInit,
 			},
 			Containers: []corev1.Container{{

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -74,7 +74,7 @@ func convertScripts(shellImage string, steps []v1alpha1.Step, sidecars []v1alpha
 //
 // It iterates through the list of steps (or sidecars), generates the script file name and heredoc termination string,
 // adds an entry to the init container args, sets up the step container to run the script, and sets the volume mounts.
-func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, placeScripts *bool, format string) []corev1.Container {
+func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, placeScripts *bool, namePrefix string) []corev1.Container {
 	containers := []corev1.Container{}
 	for i, s := range steps {
 		if s.Script == "" {
@@ -99,7 +99,7 @@ func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, 
 
 		// Append to the place-scripts script to place the
 		// script file in a known location in the scripts volume.
-		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", format, i)))
+		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", namePrefix, i)))
 		// heredoc is the "here document" placeholder string
 		// used to cat script contents into the file. Typically
 		// this is the string "EOF" but if this value were
@@ -107,7 +107,7 @@ func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, 
 		// string "EOF" in their own scripts. Instead we
 		// randomly generate a string to (hopefully) prevent
 		// collisions.
-		heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", format))
+		heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", namePrefix))
 		initContainer.Args[1] += fmt.Sprintf(`tmpfile="%s"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << '%s'

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -45,12 +45,12 @@ var (
 	}
 )
 
-// convertScripts converts any steps that specify a Script field into a normal Container.
+// convertScripts converts any steps and sidecars that specify a Script field into a normal Container.
 //
 // It does this by prepending a container that writes specified Script bodies
 // to executable files in a shared volumeMount, then produces Containers that
 // simply run those executable files.
-func convertScripts(shellImage string, steps []v1alpha1.Step) (*corev1.Container, []corev1.Container) {
+func convertScripts(shellImage string, steps []v1alpha1.Step, sidecars []v1alpha1.Sidecar) (*corev1.Container, []corev1.Container, []corev1.Container) {
 	placeScripts := false
 	placeScriptsInit := corev1.Container{
 		Name:         "place-scripts",
@@ -61,7 +61,21 @@ func convertScripts(shellImage string, steps []v1alpha1.Step) (*corev1.Container
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 	}
 
-	var containers []corev1.Container
+	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, &placeScripts, "script")
+	sidecarContainers := convertListOfSteps(sidecars, &placeScriptsInit, &placeScripts, "sidecar-script")
+
+	if placeScripts {
+		return &placeScriptsInit, convertedStepContainers, sidecarContainers
+	}
+	return nil, convertedStepContainers, sidecarContainers
+}
+
+// convertListOfSteps does the heavy lifting for convertScripts.
+//
+// It iterates through the list of steps (or sidecars), generates the script file name and heredoc termination string,
+// adds an entry to the init container args, sets up the step container to run the script, and sets the volume mounts.
+func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, placeScripts *bool, format string) []corev1.Container {
+	containers := []corev1.Container{}
 	for i, s := range steps {
 		if s.Script == "" {
 			// Nothing to convert.
@@ -81,11 +95,11 @@ func convertScripts(shellImage string, steps []v1alpha1.Step) (*corev1.Container
 
 		// At least one step uses a script, so we should return a
 		// non-nil init container.
-		placeScripts = true
+		*placeScripts = true
 
 		// Append to the place-scripts script to place the
 		// script file in a known location in the scripts volume.
-		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("script-%d", i)))
+		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", format, i)))
 		// heredoc is the "here document" placeholder string
 		// used to cat script contents into the file. Typically
 		// this is the string "EOF" but if this value were
@@ -93,8 +107,8 @@ func convertScripts(shellImage string, steps []v1alpha1.Step) (*corev1.Container
 		// string "EOF" in their own scripts. Instead we
 		// randomly generate a string to (hopefully) prevent
 		// collisions.
-		heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("script-heredoc-randomly-generated")
-		placeScriptsInit.Args[1] += fmt.Sprintf(`tmpfile="%s"
+		heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", format))
+		initContainer.Args[1] += fmt.Sprintf(`tmpfile="%s"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << '%s'
 %s
@@ -110,9 +124,5 @@ cat > ${tmpfile} << '%s'
 		steps[i].VolumeMounts = append(steps[i].VolumeMounts, scriptsVolumeMount)
 		containers = append(containers, steps[i].Container)
 	}
-
-	if placeScripts {
-		return &placeScriptsInit, containers
-	}
-	return nil, containers
+	return containers
 }

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -128,7 +128,7 @@ func ApplyReplacements(spec *v1alpha1.TaskSpec, stringReplacements map[string]st
 	// Apply variable substitution to the sidecar definitions
 	sidecars := spec.Sidecars
 	for i := range sidecars {
-		v1alpha1.ApplyContainerReplacements(&sidecars[i], stringReplacements, arrayReplacements)
+		v1alpha1.ApplyContainerReplacements(&sidecars[i].Container, stringReplacements, arrayReplacements)
 	}
 
 	return spec

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -64,13 +64,15 @@ var (
 				},
 			}},
 		},
-		Sidecars: []corev1.Container{{
-			Name:  "foo",
-			Image: "$(inputs.params.myimage)",
-			Env: []corev1.EnvVar{{
+		Sidecars: []v1alpha1.Sidecar{{
+			Container: corev1.Container{
 				Name:  "foo",
-				Value: "$(inputs.params.FOO)",
-			}},
+				Image: "$(inputs.params.myimage)",
+				Env: []corev1.EnvVar{{
+					Name:  "foo",
+					Value: "$(inputs.params.FOO)",
+				}},
+			},
 		}},
 		StepTemplate: &corev1.Container{
 			Env: []corev1.EnvVar{{
@@ -527,8 +529,8 @@ func TestApplyParameters(t *testing.T) {
 		spec.Volumes[1].VolumeSource.Secret.SecretName = "world"
 		spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "world"
 
-		spec.Sidecars[0].Image = "bar"
-		spec.Sidecars[0].Env[0].Value = "world"
+		spec.Sidecars[0].Container.Image = "bar"
+		spec.Sidecars[0].Container.Env[0].Value = "world"
 	})
 	got := resources.ApplyParameters(simpleTaskSpec, tr, dp...)
 	if d := cmp.Diff(got, want); d != "" {

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -163,7 +163,7 @@ func Sidecar(name, image string, ops ...ContainerOp) TaskSpecOp {
 		for _, op := range ops {
 			op(&c)
 		}
-		spec.Sidecars = append(spec.Sidecars, c)
+		spec.Sidecars = append(spec.Sidecars, v1alpha1.Sidecar{Container: c})
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This makes a sidecar behave like a Step, and allows the ability to pass a script argument.

This enables #1856.

To implement this, I created a `Sidecar` type that was the same as `Step`.  

I then changed `convertScripts` to accept an image, a slice of steps, and a slice of sidecars, and return the init container, and two lists of containers: one for steps, and one for sidecars.  

I also refactored `convertScripts` to call a helper function, `convertListOfSteps`, that takes a list of steps to convert, a pointer to the init container to add to, a pointer to `placeScripts`, and a format string for writing out the heredoc and temp file names.  It returns the converted list of containers.  `convertListOfSteps` does most of the work that `convertScripts` does.  It might be a little ugly but it seemed better than putting everything in `convertScripts`.  __Unfortunately this doesn't translate very well to the Github PR viewer, but git diff works fine__

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add script support to sidecars
```
