### PR TITLE
Check for LimitRange Minimum for TaskRun Container Requests

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tekton-pipelines-admin
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims"]
+    resources: ["pods", "pods/log", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims", "limitranges"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -20,6 +20,7 @@ Creation of a `PipelineRun` will trigger the creation of
 - [Cancelling a PipelineRun](#cancelling-a-pipelinerun)
 - [Examples](https://github.com/tektoncd/pipeline/tree/master/examples/pipelineruns)
 - [Logs](logs.md)
+- [LimitRange Name](#limitrange-name)
 
 ## Syntax
 
@@ -36,7 +37,6 @@ following fields:
     your `PipelineRun` resource object.
     - [`pipelineRef` or `pipelineSpec`](#specifiying-a-pipeline) - Specifies the [`Pipeline`](pipelines.md) you want to run.
 - Optional:
-
   - [`resources`](#resources) - Specifies which
     [`PipelineResources`](resources.md) to use for this `PipelineRun`.
   - [`serviceAccountName`](#service-account) - Specifies a `ServiceAccount` resource
@@ -51,6 +51,10 @@ following fields:
     follow the instruction [here](taskruns.md#Configuring-default-timeout) to configure the
     default timeout, the same way as `TaskRun`.
   - [`podTemplate`](#pod-template) - Specifies a [pod template](./podtemplates.md) that will be used as the basis for the `Task` pod.
+  - [`limitRangeName`](#limitrange-name) - Specifies the name of a LimitRange that exists in the namespace of the `PipelineRun`. This LimitRange's minimum 
+    for container resource requests will be used as part of requesting the appropriate amount of CPU, memory, and ephemeral storage for containers that are 
+    part of the `TaskRuns` of a `PipelineRun`. This property only needs to be specified if the `PipelineRun` is happening in a namespace with a LimitRange 
+    minimum specified for container resource requests.
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -371,6 +375,37 @@ metadata:
 spec:
   # […]
   status: "PipelineRunCancelled"
+```
+
+## LimitRange Name
+
+In order to request the minimum amount of resources needed to support the containers 
+for `steps` that are part of a `TaskRun`, Tekton only requests the maximum values for CPU, 
+memory, and ephemeral storage from the `steps` that are part of a TaskRun. Only the max 
+resource request values are needed since `steps` only execute one at a time in `TaskRun` pod. 
+All requests that are not the max values are set to zero as a result. 
+
+When a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) is present in a namespace 
+with a minimum set for container resource requests (i.e. CPU, memory, and ephemeral storage) where `PipelineRuns` 
+are attempting to run, the `limitRangeName` property must be specified to appropriately apply the LimitRange's 
+minimum values to containers that are part of a `TaskRun` associated with a `PipelineRun`. This property helps 
+prevent failures of `TaskRuns` not meeting the minimum requirements specified by a LimitRange for containers.
+
+In the example below, the LimitRange `limit-mem-cpu-per-container` will be applied to all `TaskRuns` associated 
+with the `PipelineRun`:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  creationTimestamp: null
+  generateName: deploy-pipeline-run-
+  namespace: default
+spec:
+  pipelineRef:
+    name: deploy-pipeline-hello
+  limitRangeName: "limit-mem-cpu-per-container"
+status: {}
 ```
 
 ---

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -26,6 +26,7 @@ A `TaskRun` runs until all `steps` have completed or until a failure occurs.
 - [Examples](#examples)
 - [Sidecars](#sidecars)
 - [Logs](logs.md)
+- [LimitRange Name](#limitrange-name)
 
 ---
 
@@ -60,6 +61,9 @@ following fields:
   - [`podTemplate`](#pod-template) - Specifies a [pod template](./podtemplates.md) that will be used as the basis for the `Task` pod.
   - [`workspaces`](#workspaces) - Specify the actual volumes to use for the
     [workspaces](tasks.md#workspaces) declared by a `Task`
+  - [`limitRangeName`](#limitrange-name) - Specifies the name of a LimitRange that exists in the namespace of the `TaskRun`. This LimitRange's minimum 
+    for container resource requests will be used as part of requesting the appropriate amount of CPU, memory, and ephemeral storage for containers that are 
+    part of a `TaskRun`. This property only needs to be specified if the `TaskRun` is happening in a namespace with a LimitRange minimum specified for container resource requests.
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -699,6 +703,40 @@ of how the step containers inside that pod exited. This issue only manifests
 with the `get pods` command. The Pod description will instead show a Status of
 Failed and the individual container statuses will correctly reflect how and why
 they exited.
+
+## LimitRange Name
+
+In order to request the minimum amount of resources needed to support the containers 
+for `steps` that are part of a `TaskRun`, Tekton only requests the maximum values for CPU, 
+memory, and ephemeral storage from the `steps` that are part of a TaskRun. Only the max 
+resource request values are needed since `steps` only execute one at a time in `TaskRun` pod. 
+All requests that are not the max values are set to zero as a result. 
+
+When a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) is present in a namespace 
+with a minimum set for container resource requests (i.e. CPU, memory, and ephemeral storage) where `TaskRuns` 
+are attempting to run, the `limitRangeName` property must be specified to appropriately apply the LimitRange's 
+minimum values to `steps` that are part of a `TaskRun`. This property helps prevent failures of `TaskRuns` not 
+meeting the minimum requirements specified by a LimitRange for containers.
+
+In the example below, the LimitRange `limit-mem-cpu-per-container` will be applied to all `steps` associated with 
+a `TaskRun` in namespace `default`:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: TaskRun
+metadata:
+  creationTimestamp: null
+  generateName: echo-hello-world-run-
+  namespace: default
+spec:
+  inputs: {}
+  outputs: {}
+  serviceAccountName: ""
+  taskRef:
+    name: echo-hello-world
+  timeout: 1h0m0s
+  limitRangeName: "limit-mem-cpu-per-container"
+```
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
@@ -40,6 +41,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/api v0.10.0
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -66,6 +66,12 @@ type PipelineRunSpec struct {
 	// with those declared in the pipeline.
 	// +optional
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
+	// Used to specify name of LimitRange that exists in namespace
+	// where PipelineRun will run so that the LimitRange's minimum for
+	// container requests can be used by containers of TaskRuns associated
+	// with PipelineRun
+	// +optional
+	LimitRangeName string `json:"limitRangeName"`
 }
 
 // PipelineRunSpecStatus defines the pipelinerun spec status the user can provide

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -49,14 +49,17 @@ type TaskRunSpec struct {
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
-
 	// PodTemplate holds pod specific configuration
 	// +optional
 	PodTemplate *PodTemplate `json:"podTemplate,omitempty"`
-
 	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
 	// +optional
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
+	// Used to specify name of LimitRange that exists in namespace
+	// where TaskRun will run so that the LimitRange's minimum for
+	// container requests can be used by containers of TaskRun
+	// +optional
+	LimitRangeName string `json:"limitRangeName"`
 }
 
 // TaskRunSpecStatus defines the taskrun spec status the user can provide

--- a/pkg/apis/pipeline/v1alpha2/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha2/taskrun_types.go
@@ -48,13 +48,16 @@ type TaskRunSpec struct {
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
-
 	// PodTemplate holds pod specific configuration
 	PodTemplate PodTemplate `json:"podTemplate,omitempty"`
-
 	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
 	// +optional
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
+	// Used to specify name of LimitRange that exists in namespace
+	// where TaskRun will run so that the LimitRange's minimum for
+	// container requests can be used by containers of TaskRun
+	// +optional
+	LimitRangeName string `json:"limitRangeName"`
 }
 
 // TaskRunSpecStatus defines the taskrun spec status the user can provide

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -562,6 +562,7 @@ func (c *Reconciler) createTaskRun(rprt *resources.ResolvedPipelineRunTask, pr *
 			ServiceAccountName: pr.GetServiceAccountName(rprt.PipelineTask.Name),
 			Timeout:            getTaskRunTimeout(pr),
 			PodTemplate:        pr.Spec.PodTemplate,
+			LimitRangeName:     pr.Spec.LimitRangeName,
 		}}
 
 	if rprt.ResolvedTaskResources.TaskName != "" {


### PR DESCRIPTION
Closes #1045
Closes #1920

# Changes

This pull request adds the ability to specify a LimitRange name as part of how a TaskRun handles container resource requests. Currently, pipelines/tasks do not work when a LimitRange minimum is specified because all container requests that do not have the max values are set to 0. Since these requests are 0, they fail to meet the minimum specified and the TaskRun fails.

In order to specify a LimitRange name, a LimitRangeName property has been added to TaskRun/PipelineRun specs. The LimitRange name is then used to get the LimitRange, which is passed to `resolveResourceRequests`. LimitRanges were added to the 200-clusterrole.yaml to allow LimitRanges to be accessed. 

Open to suggestions on more robust testing and can also include docs/examples if helpful.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Allow pipelines/tasks to work when LimitRange minimum is set by specifying a LimitRangeName as part of TaskRun/PipelineRun specs
```
