### PR TITLE
Remove messages about kodata in task logs

### DIFF
--- a/cmd/creds-init/main.go
+++ b/cmd/creds-init/main.go
@@ -17,18 +17,20 @@ package main
 
 import (
 	"flag"
+	"go.uber.org/zap"
 
 	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
 	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
-	"knative.dev/pkg/logging"
 )
 
 func main() {
 	flag.Parse()
 
+	prod, _ := zap.NewProduction()
+	logger := prod.Sugar()
+
 	// ignore atomic level because we are not watching this config for any updates
-	logger, _ := logging.NewLogger("", "creds-init")
 	defer func() {
 		_ = logger.Sync()
 	}()

--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -17,11 +17,11 @@ package main
 
 import (
 	"flag"
+	"go.uber.org/zap"
 
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/git"
 	"github.com/tektoncd/pipeline/pkg/termination"
-	"knative.dev/pkg/logging"
 )
 
 var (
@@ -42,8 +42,8 @@ func init() {
 
 func main() {
 	flag.Parse()
-
-	logger, _ := logging.NewLogger("", "git-init")
+	prod, _ := zap.NewProduction()
+	logger := prod.Sugar()
 	defer func() {
 		_ = logger.Sync()
 	}()

--- a/cmd/pullrequest-init/main.go
+++ b/cmd/pullrequest-init/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/pullrequest"
 	"go.uber.org/zap"
-	"knative.dev/pkg/logging"
 )
 
 var (
@@ -36,7 +35,8 @@ var (
 
 func main() {
 	flag.Parse()
-	logger, _ := logging.NewLogger("", "pullrequest-init")
+	prod, _ := zap.NewProduction()
+	logger := prod.Sugar()
 	logger = logger.With(
 		zap.String("resource_type", "pullrequest"),
 		zap.String("mode", *mode))

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
@@ -40,6 +41,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/api v0.10.0
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -18,6 +18,7 @@ package entrypoint
 
 import (
 	"fmt"
+	"go.uber.org/zap"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/pkg/termination"
 )
 
@@ -80,7 +80,8 @@ type PostWriter interface {
 // Go optionally waits for a file, runs the command, and writes a
 // post file.
 func (e Entrypointer) Go() error {
-	logger, _ := logging.NewLogger("", "entrypoint")
+	prod, _ := zap.NewProduction()
+	logger := prod.Sugar()
 	defer func() {
 		_ = logger.Sync()
 	}()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Change the loggers in entrypoint, creds-init, and pullrequest-init to use the default Zap sugared logger.
    
Previously, these loggers cluttered Task output with messages about being unable to fetch ko information.
    
This addresses #1145

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)  No functionality changed
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) N/A
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

