### PR TITLE
Update v1alpha2 PodTemplate pointer 🌷

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
-	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
@@ -41,7 +40,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
-	google.golang.org/api v0.10.0
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect

--- a/pkg/apis/pipeline/v1alpha2/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha2/taskrun_defaults.go
@@ -56,6 +56,11 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 		trs.ServiceAccountName = defaultSA
 	}
 
+	defaultPodTemplate := cfg.Defaults.DefaultPodTemplate
+	if trs.PodTemplate == nil {
+		trs.PodTemplate = defaultPodTemplate
+	}
+
 	// If this taskrun has an embedded task, apply the usual task defaults
 	if trs.TaskSpec != nil {
 		trs.TaskSpec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha2/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha2/taskrun_defaults_test.go
@@ -70,6 +70,29 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}, {
+		desc: "pod template is nil",
+		trs:  &v1alpha2.TaskRunSpec{},
+		want: &v1alpha2.TaskRunSpec{
+			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+		},
+	}, {
+		desc: "pod template is not nil",
+		trs: &v1alpha2.TaskRunSpec{
+			PodTemplate: &v1alpha2.PodTemplate{
+				NodeSelector: map[string]string{
+					"label": "value",
+				},
+			},
+		},
+		want: &v1alpha2.TaskRunSpec{
+			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			PodTemplate: &v1alpha2.PodTemplate{
+				NodeSelector: map[string]string{
+					"label": "value",
+				},
+			},
+		},
+	}, {
 		desc: "embedded taskSpec",
 		trs: &v1alpha2.TaskRunSpec{
 			TaskSpec: &v1alpha2.TaskSpec{

--- a/pkg/apis/pipeline/v1alpha2/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha2/taskrun_types.go
@@ -49,7 +49,7 @@ type TaskRunSpec struct {
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 	// PodTemplate holds pod specific configuration
-	PodTemplate PodTemplate `json:"podTemplate,omitempty"`
+	PodTemplate *PodTemplate `json:"podTemplate,omitempty"`
 	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
 	// +optional
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`

--- a/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha2/zz_generated.deepcopy.go
@@ -1330,7 +1330,11 @@ func (in *TaskRunSpec) DeepCopyInto(out *TaskRunSpec) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
-	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
+	if in.PodTemplate != nil {
+		in, out := &in.PodTemplate, &out.PodTemplate
+		*out = new(pod.Template)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Workspaces != nil {
 		in, out := &in.Workspaces, &out.Workspaces
 		*out = make([]WorkspaceBinding, len(*in))


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This recently changed in v1alpha1, the `PodTemplate` field is now a
pointer. Porting those changes to v1alpha2.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @bobcatfish @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
