### PR TITLE
Add LimitRangeName to v1alpha2.PipelineRun 🌷

### DIFF
--- a/pkg/apis/pipeline/v1alpha2/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha2/pipelinerun_types.go
@@ -155,6 +155,12 @@ type PipelineRunSpec struct {
 	// with those declared in the pipeline.
 	// +optional
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
+	// Used to specify name of LimitRange that exists in namespace
+	// where PipelineRun will run so that the LimitRange's minimum for
+	// container requests can be used by containers of TaskRuns associated
+	// with PipelineRun
+	// +optional
+	LimitRangeName string `json:"limitRangeName"`
 }
 
 // PipelineRunSpecStatus defines the pipelinerun spec status the user can provide


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It got added to `v1alpha1.PipelineRun` at the same time
`v1alpha2.PipelineRun` was created, so I missed it.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @chmouel @abayer 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
