### PR TITLE
Adding substitution for result path variable

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -275,3 +275,5 @@ status:
     value: |
       1579722445
 ```
+
+Instead of hardcoding the path to the result file, the user can also use a variable. So `/tekton/results/current-date-unix-timestamp` can be replaced with: `$(results.current-date-unix-timestamp.path)`. This is more flexible if the path to result files ever changes.

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -18,9 +18,11 @@ package resources
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/tektoncd/pipeline/pkg/workspace"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 )
@@ -92,6 +94,17 @@ func ApplyWorkspaces(spec *v1alpha1.TaskSpec, w []v1alpha1.WorkspaceDeclaration,
 	v := workspace.GetVolumes(wb)
 	for name, vv := range v {
 		stringReplacements[fmt.Sprintf("workspaces.%s.volume", name)] = vv.Name
+	}
+	return ApplyReplacements(spec, stringReplacements, map[string][]string{})
+}
+
+// ApplyTaskResults applies the substitution from values in results which are referenced in spec as subitems
+// of the replacementStr.
+func ApplyTaskResults(spec *v1alpha1.TaskSpec) *v1alpha1.TaskSpec {
+	stringReplacements := map[string]string{}
+
+	for _, result := range spec.Results {
+		stringReplacements[fmt.Sprintf("results.%s.path", result.Name)] = filepath.Join(pipeline.DefaultResultPath, result.Name)
 	}
 	return ApplyReplacements(spec, stringReplacements, map[string][]string{})
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -513,6 +513,9 @@ func (c *Reconciler) createPod(tr *v1alpha1.TaskRun, rtr *resources.ResolvedTask
 	// Apply workspace resource substitution
 	ts = resources.ApplyWorkspaces(ts, ts.Workspaces, tr.Spec.Workspaces)
 
+	// Apply task result substitution
+	ts = resources.ApplyTaskResults(ts)
+
 	ts, err = workspace.Apply(*ts, tr.Spec.Workspaces)
 	if err != nil {
 		c.Logger.Errorf("Failed to create a pod for taskrun: %s due to workspace error %v", tr.Name, err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Adding variable substitution for task results variable

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Users can refer to the task result file by using the variable $(results.<result name>.path)
```
