### PR TITLE
Enhance reconcile of taskrun to avoid extra pod creation

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -224,7 +224,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 				*metav1.NewControllerRef(taskRun, groupVersionKind),
 			},
 			Annotations: podAnnotations,
-			Labels:      makeLabels(taskRun),
+			Labels:      MakeLabels(taskRun),
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:                corev1.RestartPolicyNever,
@@ -247,7 +247,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 }
 
 // makeLabels constructs the labels we will propagate from TaskRuns to Pods.
-func makeLabels(s *v1alpha1.TaskRun) map[string]string {
+func MakeLabels(s *v1alpha1.TaskRun) map[string]string {
 	labels := make(map[string]string, len(s.ObjectMeta.Labels)+1)
 	// NB: Set this *before* passing through TaskRun labels. If the TaskRun
 	// has a managed-by label, it should override this default.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -736,7 +736,7 @@ func TestMakeLabels(t *testing.T) {
 		"foo":           "bar",
 		"hello":         "world",
 	}
-	got := makeLabels(&v1alpha1.TaskRun{
+	got := MakeLabels(&v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: taskRunName,
 			Labels: map[string]string{

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -180,7 +180,7 @@ func MakeTaskRunStatus(tr v1alpha1.TaskRun, pod *corev1.Pod, taskSpec v1alpha1.T
 }
 
 func updateCompletedTaskRun(trs *v1alpha1.TaskRunStatus, pod *corev1.Pod) {
-	if didTaskRunFail(pod) {
+	if DidTaskRunFail(pod) {
 		msg := getFailureMessage(pod)
 		trs.SetCondition(&apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -231,7 +231,8 @@ func updateIncompleteTaskRun(trs *v1alpha1.TaskRunStatus, pod *corev1.Pod) {
 	}
 }
 
-func didTaskRunFail(pod *corev1.Pod) bool {
+// DidTaskRunFail check the status of pod to decide if related taskrun is failed
+func DidTaskRunFail(pod *corev1.Pod) bool {
 	f := pod.Status.Phase == corev1.PodFailed
 	for _, s := range pod.Status.ContainerStatuses {
 		if isContainerStep(s.Name) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fix issue: #1976 


The root cause for the issue is:
The `reconsile` of `taskrun` hit error:
```
Failed to update taskRun status, the object has been modified; please apply your changes to the latest version and try again
```
it's a benign error, we should just ignore it, but current reconcile cannot, see the logic:
- Check if `taskrun.Status.Podname` is nil, if not, get the pod and move on, one follow-up step is add `READY` annotation to the pod to make pod run container one by one.
- If `taskrun.Status.Podname` is nil, create a new pod and move on.

The problem is: 
If hit `Failed to update taskRun status` error, the `taskrun` will stay in workqueue and reconcile again after increased delay, but the `Podname` is still nil (although it's not in real world, since the pod has been created), so a extra pod will be created. and the previous pod will stick in `Running` forever since no one add `READY` annotation. 


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
