### PR TITLE
Make testcase of "retry" raise error rather than just log

### DIFF
--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -113,17 +113,14 @@ func TestTaskRunRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to list Pods: %v", err)
 	} else if len(pods.Items) != wantPods {
-		// TODO: Make this an error.
-		t.Logf("BUG: Found %d Pods, want %d", len(pods.Items), wantPods)
+		t.Errorf("BUG: Found %d Pods, want %d", len(pods.Items), wantPods)
 	}
 	for _, p := range pods.Items {
 		if _, found := podNames[p.Name]; !found {
-			// TODO: Make this an error.
-			t.Logf("BUG: TaskRunStatus.RetriesStatus did not report pod name %q", p.Name)
+			t.Errorf("BUG: TaskRunStatus.RetriesStatus did not report pod name %q", p.Name)
 		}
 		if p.Status.Phase != corev1.PodFailed {
-			// TODO: Make this an error.
-			t.Logf("BUG: Pod %q is not failed: %v", p.Name, p.Status.Phase)
+			t.Errorf("BUG: Pod %q is not failed: %v", p.Name, p.Status.Phase)
 		}
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Related issue #1976 , after the issue resolve, the related e2e test case should be enable.
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
