### PR TITLE
Add authority for resource deployments.apps to tutorial-role

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -436,7 +436,7 @@ to do so, use the following command:
 ```bash
 kubectl create clusterrole tutorial-role \
                --verb=get,list,watch,create,update,patch,delete \
-               --resource=deployments
+               --resource=deployments,deployments.apps
 ```
 
 Now you need to assign this new role `tutorial-role` to your `ServiceAccount`,


### PR DESCRIPTION
# Changes

Closes #2031 
To create deployment.apps/leeroy-web in deploy-web task, add authority for resource deployments.apps to tutorial-role.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
