### PR TITLE
Use vendor folder to speed up CI 🥄

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/prometheus/procfs v0.0.5 // indirect
 	github.com/rogpeppe/go-internal v1.3.2 // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20191102174205-af46314aec7b // indirect
-	github.com/tektoncd/plumbing v0.0.0-20191216083742-847dcf196de9
+	github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2
 	github.com/vdemeester/k8s-pkg-credentialprovider v1.13.12-1 // indirect
 	go.opencensus.io v0.22.1
 	go.uber.org/zap v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/tektoncd/plumbing v0.0.0-20191216083742-847dcf196de9 h1:Iu6stVfs72OBV0c3srVX0oogjhLu+stqlvKHT41+pTI=
-github.com/tektoncd/plumbing v0.0.0-20191216083742-847dcf196de9/go.mod h1:QZHgU07PRBTRF6N57w4+ApRu8OgfYLFNqCDlfEZaD9Y=
+github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2 h1:BksmpUwtap3THXJ8Z4KGcotsvpRdFQKySjDHgtc22lA=
+github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2/go.mod h1:QZHgU07PRBTRF6N57w4+ApRu8OgfYLFNqCDlfEZaD9Y=
 github.com/tektoncd/plumbing/pipelinerun-logs v0.0.0-20191206114338-712d544c2c21/go.mod h1:S62EUWtqmejjJgUMOGB1CCCHRp6C706laH06BoALkzU=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -111,6 +111,8 @@ spec:
       value: /workspace/go
     - name: GO111MODULE
       value: "off"
+    - name: GOFLAGS
+      value: "-mod=vendor"
     - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
       value: /secret/release.json
     script: |

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -76,6 +76,8 @@ spec:
       params:
         - name: package
           value: $(params.package)
+        - name: flags
+          value: -v -mod=vendor
       resources:
         inputs:
           - name: source
@@ -88,7 +90,7 @@ spec:
         - name: package
           value: $(params.package)
         - name: flags
-          value: -ldflags "-X github.com/tektoncd/pipeline/pkg/version.PipelineVersion=$(params.versionTag)"
+          value: -mod=vendor -ldflags "-X github.com/tektoncd/pipeline/pkg/version.PipelineVersion=$(params.versionTag)"
       resources:
         inputs:
           - name: source

--- a/vendor/github.com/tektoncd/plumbing/gcp.md
+++ b/vendor/github.com/tektoncd/plumbing/gcp.md
@@ -8,9 +8,11 @@ have access to.
   [`tekton-releases`](http://console.cloud.google.com/home/dashboard?project=tekton-releases)
 - The GKE cluster that [`Prow`](prow/README.md), `Tekton`, and [`boskos`](boskos/README.md) run in is called
   [`prow`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/prow?project=tekton-releases)
+- The GKE cluster that is used for nightly releases and other dogfooding is called
+  [`dogfooding`](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfooding?project=tekton-releases)
 - The GCP project
   [`tekton-nightly`](http://console.cloud.google.com/home/dashboard?project=tekton-nightly)
-  is used for nightly releases
+  is used to hold nightly release artifacts
 
 This project and cluster are used for:
 

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -333,7 +333,7 @@ function update_licenses() {
   local dst=$1
   shift
   if [ -f "${REPO_ROOT_DIR}/go.mod" ]; then
-    run_go_tool github.com/google/go-licenses go-licenses save ./... --save_path=${dst} --force
+    go-licenses save ./... --save_path=${dst} --force
     # Hack to make sure directories retain write permissions after save. This
     # can happen if the directory being copied is a Go module.
     # See https://github.com/google/go-licenses/issues/11
@@ -347,10 +347,8 @@ function update_licenses() {
 # Parameters: $1...$n - directories and files to inspect.
 function check_licenses() {
   if [ -f "${REPO_ROOT_DIR}/go.mod" ]; then
-    run_go_tool github.com/google/go-licenses go-licenses check ./...
+    go-licenses check ./...
   else
-    # Fetch the google/licenseclassifier for its license db
-    go get -u github.com/google/licenseclassifier
     # Check that we don't have any forbidden licenses in our images.
     run_go_tool ./vendor/github.com/knative/test-infra/tools/dep-collector dep-collector -check $@
   fi

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,7 +271,7 @@ github.com/shurcooL/graphql/internal/jsonutil
 github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
-# github.com/tektoncd/plumbing v0.0.0-20191216083742-847dcf196de9
+# github.com/tektoncd/plumbing v0.0.0-20200217163359-cd0db6e567d2
 github.com/tektoncd/plumbing
 github.com/tektoncd/plumbing/scripts
 # github.com/vdemeester/k8s-pkg-credentialprovider v1.13.12-1


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
We still are using the `vendor` folder, so the CI should use this to
build instead of trying to download the world.

- It will speed up the CI
- It will make sure we can build and test with what's in `vendor`

This also updates release Task(s) and Pipeline(s) to use the `vendor` folder.

/hold
- <del>Depends on tektoncd/plumbing#232</del>
- <del>Depends on tektoncd/plumbing#239</del>
- <del>Needs the nightly test-runner image to be built</lel>

/cc @afrittoli 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
