### PR TITLE
Allow disabling implicit HOME overwrite

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  # Setting this flag to "true" will prevent Tekton overriding your
+  # Task container's $HOME environment variable.
+  #
+  # The default behaviour currently is for Tekton to override the
+  # $HOME environment variable but this will change in an upcoming
+  # release.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2013 for more
+  # info.
+  disable-home-env-overwrite: "false"

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -147,11 +147,14 @@ If the image is a private registry, the service account should include an
 
 ## Builder namespace on containers
 
-The `/tekton/` namespace is reserved on containers for various system tools,
-such as the following:
+The `/tekton/` directory is reserved on containers for internal usage. Examples
+of how this directory is used:
 
-- The environment variable HOME is set to `/tekton/home`, used by the builder
-  tools and injected on into all of the step containers
+- Task Results are written to `/tekton/results`
+- Various tools like the entrypoint are placed in `/tekton/tools`
+- The termination log message is written to `/tekton/termination`
+- Sequencing step containers is done using both `/tekton/downward/ready`
+and numbered files in `/tekton/tools`
 
 ## Handling of injected sidecars
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -125,10 +125,10 @@ for more information_
 
 ### How are resources shared between tasks
 
-Pipelines need a way to share `PipelineResources` between tasks. The alternatives are a
-[Persistent volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/),
+Pipelines need a way to share `PipelineResources` between tasks. The options are a
+[Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/),
 an [S3 Bucket](https://aws.amazon.com/s3/)
-or a [GCS storage bucket](https://cloud.google.com/storage/)
+or a [GCS Bucket](https://cloud.google.com/storage/)
 
 The PVC option can be configured using a ConfigMap with the name
 `config-artifact-pvc` and the following attributes:
@@ -153,7 +153,7 @@ The GCS storage bucket or the S3 bucket can be configured using a ConfigMap with
 This is a limitation coming from using [gsutil](https://cloud.google.com/storage/docs/gsutil) with a boto configuration
 behind the scene to access the S3 bucket.
 
-An typical configuration to use an S3 bucket is available below :
+A typical configuration to use an S3 bucket is available below :
 
 ```yaml
 apiVersion: v1
@@ -218,6 +218,31 @@ data:
 
 *NOTE:* The `_example` key in the provided [config-defaults.yaml](./../config/config-defaults.yaml)
 file contains the keys that can be overriden and their default values.
+
+### Turning On or Off Features of the Pipelines Controller
+
+The ConfigMap `feature-flags` can be used to turn on or off specific features
+of the Pipelines Controller.
+
+Supported flags:
+
+- `disable-home-env-overwrite` - Setting this flag to "true" will prevent Tekton
+from overwriting Step containers' `$HOME` environment variable. The default
+value is "false" and so the default behaviour is for `$HOME` to be overwritten by
+Tekton with `/tekton/home`. This default is very likely to change in an upcoming
+release. For further reference see https://github.com/tektoncd/pipeline/issues/2013.
+
+Here is an example of the `feature-flags` ConfigMap with `disable-home-env-overwrite`
+flipped on:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+data:
+  disable-home-env-overwrite: "true" # Tekton will not overwrite $HOME in Steps.
+```
 
 ## Custom Releases
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -50,7 +50,7 @@ following fields:
   - [`serviceAccountName`](#service-account) - Specifies a `ServiceAccount` resource
     object that enables your build to run with the defined authentication
     information. When a `ServiceAccount` isn't specified, the `default-service-account`
-    specified in the configmap - config-defaults will be applied.
+    specified in the configmap `config-defaults` will be applied.
   - [`inputs`] - Specifies [input parameters](#input-parameters) and
     [input resources](#providing-resources)
   - [`outputs`] - Specifies [output resources](#providing-resources)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
 	github.com/cloudevents/sdk-go v1.0.0
@@ -44,6 +45,7 @@ require (
 	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20200214144324-88be01311a71 // indirect
+	google.golang.org/api v0.15.0
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/names"
+	"github.com/tektoncd/pipeline/pkg/system"
 	"github.com/tektoncd/pipeline/pkg/version"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +33,9 @@ import (
 
 const (
 	homeDir = "/tekton/home"
+
+	featureFlagConfigMapName     = "feature-flags"
+	featureFlagDisableHomeEnvKey = "disable-home-env-overwrite"
 
 	taskRunLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
 )
@@ -47,10 +51,6 @@ var (
 		Kind:    "TaskRun",
 	}
 	// These are injected into all of the source/step containers.
-	implicitEnvVars = []corev1.EnvVar{{
-		Name:  "HOME",
-		Value: homeDir,
-	}}
 	implicitVolumeMounts = []corev1.VolumeMount{{
 		Name:      "tekton-internal-workspace",
 		MountPath: pipeline.WorkspaceDir,
@@ -72,6 +72,15 @@ var (
 func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha1.TaskSpec, kubeclient kubernetes.Interface, entrypointCache EntrypointCache) (*corev1.Pod, error) {
 	var initContainers []corev1.Container
 	var volumes []corev1.Volume
+
+	implicitEnvVars := []corev1.EnvVar{}
+
+	if shouldOverrideHomeEnv(kubeclient) {
+		implicitEnvVars = append(implicitEnvVars, corev1.EnvVar{
+			Name:  "HOME",
+			Value: homeDir,
+		})
+	}
 
 	// Add our implicit volumes first, so they can be overridden by the user if they prefer.
 	volumes = append(volumes, implicitVolumes...)
@@ -287,4 +296,18 @@ func getLimitRangeMinimum(namespace string, kubeclient kubernetes.Interface) (co
 	}
 
 	return min, nil
+}
+
+// shouldOverrideHomeEnv returns a bool indicating whether a Pod should have its
+// $HOME environment variable overwritten with /tekton/home or if it should be
+// left unmodified. The default behaviour is to overwrite the $HOME variable
+// but this is planned to change in an upcoming release.
+//
+// For further reference see https://github.com/tektoncd/pipeline/issues/2013
+func shouldOverrideHomeEnv(kubeclient kubernetes.Interface) bool {
+	configMap, err := kubeclient.CoreV1().ConfigMaps(system.GetNamespace()).Get(featureFlagConfigMapName, metav1.GetOptions{})
+	if err == nil && configMap != nil && configMap.Data != nil && configMap.Data[featureFlagDisableHomeEnvKey] == "true" {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Tekton currently overwrites the $HOME variables in task containers. This behaviour is problematic when an image explicitly sets the HOME env var and expects it to be set to that value upon running.

This PR introduces a `feature-flags` ConfigMap with a single flag - `disable-home-env-overwrite` - that, when set to "true" will prevent Tekton from overriding the $HOME variable in Task containers.  This behaviour will be kept for one release which must include a deprecation warning that the behaviour will be changing soon. In the release after that the flag will be flipped so that the default behaviour becomes for Tekton to NOT override the $HOME variable.

Contributes to issues #2013 and #1836

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Tekton currently overwrites the $HOME variables in Step containers. This behaviour is problematic when an image explicitly sets the HOME env var and expects it to be set to that value upon running. You can now disable this behaviour in Tekton by using the feature-flags ConfigMap. See docs/install.md for further details on disabling this behaviour.
```
