### PR TITLE
Linking to conditions-doc insteadof self

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -375,7 +375,7 @@ tasks:
             resource: source-repo
 ```
 
-In this example, `my-condition` refers to a [Condition](#conditions) custom resource. The `build-push` 
+In this example, `my-condition` refers to a [Condition](./conditions.md) custom resource. The `build-push` 
 task will only be executed if the condition evaluates to true. 
 
 Resources in conditions can also use the [`from`](#from) field to indicate that they 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -375,7 +375,7 @@ tasks:
             resource: source-repo
 ```
 
-In this example, `my-condition` refers to a [Condition](./conditions.md) custom resource. The `build-push` 
+In this example, `my-condition` refers to a [Condition](conditions.md) custom resource. The `build-push` 
 task will only be executed if the condition evaluates to true. 
 
 Resources in conditions can also use the [`from`](#from) field to indicate that they 


### PR DESCRIPTION
# Changes
Changing link to the condition.md page since the internal links to the same paragraf was confusing.

