### PR TITLE
Indicate minimum cluster version is now 1.15 🚓

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,7 +91,7 @@ configuring Kubernetes resources.
 Docker for Desktop using an edge version has been proven to work for both
 developing and running Pipelines. The recommended configuration is:
 
--   Kubernetes version 1.11 or later
+-   Kubernetes version 1.15 or later
 -   4 vCPU nodes (`n1-standard-4`)
 -   Node autoscaling, up to 3 nodes
 -   API scopes for cloud-platform
@@ -113,7 +113,7 @@ kubectl config use-context docker-for-desktop` To setup a cluster with GKE:
     variable (e.g. `PROJECT_ID`).
 
 1.  Create a GKE cluster (with `--cluster-version=latest` but you can use any
-    version 1.11 or later):
+    version 1.15 or later):
 
     ```bash
     export PROJECT_ID=my-gcp-project
@@ -131,7 +131,7 @@ kubectl config use-context docker-for-desktop` To setup a cluster with GKE:
      --machine-type=n1-standard-4 \
      --image-type=cos \
      --num-nodes=1 \
-     --cluster-version=latest
+     --cluster-version=1.15
     ```
 
     Note that

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,7 +9,7 @@ Use this page to add the component to an existing Kubernetes cluster.
 
 ## Pre-requisites
 
-1. A Kubernetes cluster version 1.11 or later (_if you don't have an existing
+1. A Kubernetes cluster version 1.15 or later (_if you don't have an existing
    cluster_):
 
    ```bash
@@ -34,7 +34,7 @@ Use this page to add the component to an existing Kubernetes cluster.
 
 The versions of Tekton Pipelines available are:
 
-* [Officially released versions](https://github.com/tektoncd/pipeline/releases), e.g. `v0.6.0`
+* [Officially released versions](https://github.com/tektoncd/pipeline/releases), e.g. `v0.10.0`
 * [Nightly releases](../tekton/README.md#nightly-releases) are
   published every night to `gcr.io/tekton-nightly`
 * `HEAD` - To install the most recent, unreleased code in the repo see


### PR DESCRIPTION
# Changes

In https://github.com/tektoncd/pipeline/pull/1894 we bumped our k8s
dependencies such that a cluster must now be running at least 1.15.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
