### PR TITLE
Add a description field to pipeline workspace declarations

### DIFF
--- a/pkg/apis/pipeline/v1alpha2/workspace_types.go
+++ b/pkg/apis/pipeline/v1alpha2/workspace_types.go
@@ -77,6 +77,11 @@ type WorkspaceBinding struct {
 type WorkspacePipelineDeclaration struct {
 	// Name is the name of a workspace to be provided by a PipelineRun.
 	Name string `json:"name"`
+	// Description is a human readable string describing how the workspace will be
+	// used in the Pipeline. It can be useful to include a bit of detail about which
+	// tasks are intended to have access to the data on the workspace.
+	// +optional
+	Description string `json:"description"`
 }
 
 // WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

A description field can help rationalize how a workspace will be used
across multiple tasks in a pipeline without forcing the user to read and
interpret the tasks themselves.

This PR adds an optional description field to pipeline workspace
declarations to help with this. I would personally like this support to help when writing
example pipelines for catalog tasks. e.g. https://github.com/tektoncd/catalog/pull/182/files#diff-eee548fe380dc59c94cc87563f0d454cR82

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)~~
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
You can now include a description as part of your pipeline's workspace declarations to help users figure out how their volumes will be used in the pipeline.
```
