### PR TITLE
Reduce arguments for substitution.ValidateVariable 📼

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -290,13 +290,13 @@ func validatePipelineVariables(tasks []PipelineTask, prefix string, paramNames m
 }
 
 func validatePipelineVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariable(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariable(name, value, prefix, "task parameter", "pipelinespec.params", vars)
 }
 
 func validatePipelineNoArrayReferenced(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableProhibited(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariableProhibited(name, value, prefix, "task parameter", "pipelinespec.params", vars)
 }
 
 func validatePipelineArraysIsolated(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableIsolated(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariableIsolated(name, value, prefix, "task parameter", "pipelinespec.params", vars)
 }

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -368,15 +368,15 @@ func validateVariables(steps []Step, prefix string, vars map[string]struct{}) *a
 }
 
 func validateTaskVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariable(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", vars)
+	return substitution.ValidateVariable(name, value, "(?:inputs|outputs)."+prefix, "step", "taskspec.steps", vars)
 }
 
 func validateTaskNoArrayReferenced(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableProhibited(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", arrayNames)
+	return substitution.ValidateVariableProhibited(name, value, "(?:inputs|outputs)."+prefix, "step", "taskspec.steps", arrayNames)
 }
 
 func validateTaskArraysIsolated(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableIsolated(name, value, prefix, "(?:inputs|outputs).", "step", "taskspec.steps", arrayNames)
+	return substitution.ValidateVariableIsolated(name, value, "(?:inputs|outputs)."+prefix, "step", "taskspec.steps", arrayNames)
 }
 
 func checkForDuplicates(resources []TaskResource, path string) *apis.FieldError {

--- a/pkg/apis/pipeline/v1alpha2/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha2/pipeline_validation.go
@@ -289,13 +289,13 @@ func validatePipelineVariables(tasks []PipelineTask, prefix string, paramNames m
 }
 
 func validatePipelineVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariable(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariable(name, value, prefix, "task parameter", "pipelinespec.params", vars)
 }
 
 func validatePipelineNoArrayReferenced(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableProhibited(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariableProhibited(name, value, prefix, "task parameter", "pipelinespec.params", vars)
 }
 
 func validatePipelineArraysIsolated(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableIsolated(name, value, prefix, "", "task parameter", "pipelinespec.params", vars)
+	return substitution.ValidateVariableIsolated(name, value, prefix, "task parameter", "pipelinespec.params", vars)
 }

--- a/pkg/apis/pipeline/v1alpha2/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha2/task_validation.go
@@ -318,13 +318,13 @@ func validateVariables(steps []Step, prefix string, vars map[string]struct{}) *a
 }
 
 func validateTaskVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariable(name, value, prefix, "", "step", "taskspec.steps", vars)
+	return substitution.ValidateVariable(name, value, prefix, "step", "taskspec.steps", vars)
 }
 
 func validateTaskNoArrayReferenced(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableProhibited(name, value, prefix, "", "step", "taskspec.steps", arrayNames)
+	return substitution.ValidateVariableProhibited(name, value, prefix, "step", "taskspec.steps", arrayNames)
 }
 
 func validateTaskArraysIsolated(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
-	return substitution.ValidateVariableIsolated(name, value, prefix, "", "step", "taskspec.steps", arrayNames)
+	return substitution.ValidateVariableIsolated(name, value, prefix, "step", "taskspec.steps", arrayNames)
 }

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -28,8 +28,8 @@ const parameterSubstitution = "[_a-zA-Z][_a-zA-Z0-9.-]*"
 
 const braceMatchingRegex = "(\\$(\\(%s.(?P<var>%s)\\)))"
 
-func ValidateVariable(name, value, prefix, contextPrefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
-	if vs, present := extractVariablesFromString(value, contextPrefix+prefix); present {
+func ValidateVariable(name, value, prefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
+	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
 			if _, ok := vars[v]; !ok {
 				return &apis.FieldError{
@@ -43,8 +43,8 @@ func ValidateVariable(name, value, prefix, contextPrefix, locationName, path str
 }
 
 // Verifies that variables matching the relevant string expressions do not reference any of the names present in vars.
-func ValidateVariableProhibited(name, value, prefix, contextPrefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
-	if vs, present := extractVariablesFromString(value, contextPrefix+prefix); present {
+func ValidateVariableProhibited(name, value, prefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
+	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
 			if _, ok := vars[v]; ok {
 				return &apis.FieldError{
@@ -58,9 +58,9 @@ func ValidateVariableProhibited(name, value, prefix, contextPrefix, locationName
 }
 
 // Verifies that variables matching the relevant string expressions are completely isolated if present.
-func ValidateVariableIsolated(name, value, prefix, contextPrefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
-	if vs, present := extractVariablesFromString(value, contextPrefix+prefix); present {
-		firstMatch, _ := extractExpressionFromString(value, contextPrefix+prefix)
+func ValidateVariableIsolated(name, value, prefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
+	if vs, present := extractVariablesFromString(value, prefix); present {
+		firstMatch, _ := extractExpressionFromString(value, prefix)
 		for _, v := range vs {
 			if _, ok := vars[v]; ok {
 				if len(value) != len(firstMatch) {

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -27,12 +27,11 @@ import (
 
 func TestValidateVariables(t *testing.T) {
 	type args struct {
-		input         string
-		prefix        string
-		contextPrefix string
-		locationName  string
-		path          string
-		vars          map[string]struct{}
+		input        string
+		prefix       string
+		locationName string
+		path         string
+		vars         map[string]struct{}
 	}
 	for _, tc := range []struct {
 		name          string
@@ -41,11 +40,10 @@ func TestValidateVariables(t *testing.T) {
 	}{{
 		name: "valid variable",
 		args: args{
-			input:         "--flag=$(inputs.params.baz)",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
+			input:        "--flag=$(inputs.params.baz)",
+			prefix:       "inputs.params",
+			locationName: "step",
+			path:         "taskspec.steps",
 			vars: map[string]struct{}{
 				"baz": {},
 			},
@@ -54,11 +52,10 @@ func TestValidateVariables(t *testing.T) {
 	}, {
 		name: "multiple variables",
 		args: args{
-			input:         "--flag=$(inputs.params.baz) $(input.params.foo)",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
+			input:        "--flag=$(inputs.params.baz) $(input.params.foo)",
+			prefix:       "inputs.params",
+			locationName: "step",
+			path:         "taskspec.steps",
 			vars: map[string]struct{}{
 				"baz": {},
 				"foo": {},
@@ -80,11 +77,10 @@ func TestValidateVariables(t *testing.T) {
 	}, {
 		name: "undefined variable",
 		args: args{
-			input:         "--flag=$(inputs.params.baz)",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
+			input:        "--flag=$(inputs.params.baz)",
+			prefix:       "inputs.params",
+			locationName: "step",
+			path:         "taskspec.steps",
 			vars: map[string]struct{}{
 				"foo": {},
 			},
@@ -96,11 +92,10 @@ func TestValidateVariables(t *testing.T) {
 	}, {
 		name: "undefined variable and defined variable",
 		args: args{
-			input:         "--flag=$(inputs.params.baz) $(input.params.foo)",
-			prefix:        "params",
-			contextPrefix: "inputs.",
-			locationName:  "step",
-			path:          "taskspec.steps",
+			input:        "--flag=$(inputs.params.baz) $(input.params.foo)",
+			prefix:       "inputs.params",
+			locationName: "step",
+			path:         "taskspec.steps",
 			vars: map[string]struct{}{
 				"foo": {},
 			},
@@ -111,7 +106,7 @@ func TestValidateVariables(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := substitution.ValidateVariable("somefield", tc.args.input, tc.args.prefix, tc.args.contextPrefix, tc.args.locationName, tc.args.path, tc.args.vars)
+			got := substitution.ValidateVariable("somefield", tc.args.input, tc.args.prefix, tc.args.locationName, tc.args.path, tc.args.vars)
 
 			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("ValidateVariable() error did not match expected error %s", d)


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I found contextPrefix and prefix quite confusing, and they are always
used together (concatenated `contextPrefix+prefix`). This simplifies
the function to only take one argument instead of two, called
`prefix`.

/kind cleanup

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
