### PR TITLE
Added conditional check tests

### DIFF
--- a/test/conditional_check_test.go
+++ b/test/conditional_check_test.go
@@ -1,0 +1,96 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	tb "github.com/tektoncd/pipeline/test/builder"
+	knativetest "knative.dev/pkg/test"
+)
+
+func TestPipelineRunConditionalCheck(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	condResource := tb.Condition("file-exists", namespace,
+		tb.ConditionSpec(
+			tb.ConditionParamSpec("path", v1alpha1.ParamTypeString),
+			tb.ConditionResource("workspace", v1alpha1.PipelineResourceTypeGit),
+			tb.ConditionSpecCheck("", "alpine"),
+			tb.ConditionSpecCheckScript("cat $(resources.workspace.path)/$(params.path)| grep \"Cloud Native\""),
+		),
+	)
+
+	if _, err := c.ConditionClient.Create(condResource); err != nil {
+		t.Fatalf("Failed to create simple repo PipelineResource: %s", err)
+	}
+
+	repoResource := tb.PipelineResource("pipeline-git", namespace, tb.PipelineResourceSpec(
+		v1alpha1.PipelineResourceTypeGit,
+		tb.PipelineResourceSpecParam("Url", "https://github.com/tektoncd/pipeline"),
+		tb.PipelineResourceSpecParam("Revision", "master"),
+	))
+	if _, err := c.PipelineResourceClient.Create(repoResource); err != nil {
+		t.Fatalf("Failed to create simple repo PipelineResource: %s", err)
+	}
+
+	conditionalTask := tb.Task("list-files", namespace, tb.TaskSpec(
+		tb.TaskInputs(
+			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
+		),
+		tb.Step("ubuntu", tb.StepName("run-ls"), tb.StepCommand("/bin/bash"), tb.StepArgs("-c", "ls -al $(inputs.resources.workspace.path)")),
+	))
+
+	if _, err := c.TaskClient.Create(conditionalTask); err != nil {
+		t.Fatalf("Failed to create echo Task: %s", err)
+	}
+
+	pipeline := tb.Pipeline("list-files-pipeline", namespace, tb.PipelineSpec(
+		tb.PipelineDeclaredResource("source-repo", "git"),
+		tb.PipelineParamSpec("path", v1alpha1.ParamTypeString, tb.ParamSpecDefault("README.md")),
+		tb.PipelineTask("list-files-1", "list-files",
+			tb.PipelineTaskCondition("file-exists",
+				tb.PipelineTaskConditionParam("path", "$(params.path)"),
+				tb.PipelineTaskConditionResource("workspace", "source-repo")),
+			tb.PipelineTaskInputResource("workspace", "source-repo"),
+		),
+	))
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create list-files-pipelin: %s", err)
+	}
+
+	pipelineRun := tb.PipelineRun("demo-condtional-pr", namespace, tb.PipelineRunSpec("list-files-pipeline",
+		tb.PipelineRunServiceAccountName("default"),
+		tb.PipelineRunResourceBinding("source-repo", tb.PipelineResourceBindingRef("pipeline-git")),
+	))
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create demo-condtional-pr PipelineRun: %s", err)
+	}
+
+	t.Logf("Waiting for Conditional pipeline to complete")
+	if err := WaitForPipelineRunState(c, "demo-condtional-pr", pipelineRunTimeout, PipelineRunSucceed("demo-condtional-pr"), "PipelineRunSuccess"); err != nil {
+		t.Fatalf("Error waiting for PipelineRun to finish: %s", err)
+	}
+
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Added condition check Test on pipeline Run resources
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
