### PR TITLE
add SidecarState to test builder

### DIFF
--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -69,8 +69,11 @@ type TaskRunOutputsOp func(*v1alpha1.TaskRunOutputs)
 // ResolvedTaskResourcesOp is an operation which modify a ResolvedTaskResources struct.
 type ResolvedTaskResourcesOp func(*resources.ResolvedTaskResources)
 
-// StepStateOp is an operation which modify a StepStep struct.
+// StepStateOp is an operation which modifies a StepState struct.
 type StepStateOp func(*v1alpha1.StepState)
+
+// SidecarStateOp is an operation which modifies a SidecarState struct.
+type SidecarStateOp func(*v1alpha1.SidecarState)
 
 // VolumeOp is an operation which modify a Volume struct.
 type VolumeOp func(*corev1.Volume)
@@ -349,6 +352,17 @@ func StepState(ops ...StepStateOp) TaskRunStatusOp {
 	}
 }
 
+// SidecarState adds a SidecarState to the TaskRunStatus.
+func SidecarState(ops ...SidecarStateOp) TaskRunStatusOp {
+	return func(s *v1alpha1.TaskRunStatus) {
+		state := &v1alpha1.SidecarState{}
+		for _, op := range ops {
+			op(state)
+		}
+		s.Sidecars = append(s.Sidecars, *state)
+	}
+}
+
 // TaskRunStartTime sets the start time to the TaskRunStatus.
 func TaskRunStartTime(startTime time.Time) TaskRunStatusOp {
 	return func(s *v1alpha1.TaskRunStatus) {
@@ -466,6 +480,20 @@ func SetStepStateWaiting(waiting corev1.ContainerStateWaiting) StepStateOp {
 		s.ContainerState = corev1.ContainerState{
 			Waiting: &waiting,
 		}
+	}
+}
+
+// SetSidecarStateName sets Name of Sidecar for SidecarState.
+func SetSidecarStateName(name string) SidecarStateOp {
+	return func(s *v1alpha1.SidecarState) {
+		s.Name = name
+	}
+}
+
+// SetSidecarStateImageID sets ImageID of Sidecar for SidecarState.
+func SetSidecarStateImageID(imageID string) SidecarStateOp {
+	return func(s *v1alpha1.SidecarState) {
+		s.ImageID = imageID
 	}
 }
 

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -202,6 +202,10 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 			tb.PodName("my-pod-name"),
 			tb.StatusCondition(apis.Condition{Type: apis.ConditionSucceeded}),
 			tb.StepState(tb.StateTerminated(127)),
+			tb.SidecarState(
+				tb.SetSidecarStateName("sidecar"),
+				tb.SetSidecarStateImageID("ImageID"),
+			),
 		),
 	)
 	expectedTaskRun := &v1alpha1.TaskRun{
@@ -281,7 +285,8 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded}},
 			},
 			TaskRunStatusFields: v1alpha1.TaskRunStatusFields{
-				PodName: "my-pod-name",
+				PodName:  "my-pod-name",
+				Sidecars: []v1alpha2.SidecarState{{Name: "sidecar", ImageID: "ImageID"}},
 				Steps: []v1alpha1.StepState{{ContainerState: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{ExitCode: 127},
 				}}},


### PR DESCRIPTION
Closes #2078 

# Changes

Adding a type of `SidecarStateOp` and `SidecarState` function to help with aspects of unit testing around Sidecars.

Also added `SetSidecarStateName` and `SetSidecarStateImageID` setter functions to set properties of a SidecarState with unit testing.

Will follow up with setting the ContainerState for Sidecars when #2074 is resolved.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Adding SidecarState, SetSidecarStateName, and SetSidecarStateImageID to test builder to aid with unit testing involving Sidecars
```
