### PR TITLE
Remove linting from release pipelines 🧹

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -186,7 +186,6 @@ Install Task from plumbing too:
 
 ```bash
 # Apply the Tasks we are using from the catalog
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/lint.yaml
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/build.yaml
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/master/golang/tests.yaml
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/plumbing/master/tekton/resources/release/

--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -39,22 +39,7 @@ spec:
   - name: notification
     type: cloudEvent
   tasks:
-    - name: lint
-      taskRef:
-        name: golangci-lint
-      params:
-        - name: package
-          value: $(params.package)
-        - name: version
-          value: v1.24
-        - name: flags
-          value: "-v --timeout 10m"
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
     - name: unit-tests
-      runAfter: [lint]
       taskRef:
         name: golang-test
       params:
@@ -65,7 +50,6 @@ spec:
           - name: source
             resource: source-repo
     - name: build
-      runAfter: [lint]
       taskRef:
         name: golang-build
       params:

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -57,23 +57,7 @@ spec:
             resource: bucket
           - name: source-to-release
             resource: source-repo
-    - name: lint
-      runAfter: [precheck]
-      taskRef:
-        name: golangci-lint
-      params:
-        - name: package
-          value: $(params.package)
-        - name: flags
-          value: -v
-        - name: version
-          value: v1.24
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
     - name: unit-tests
-      runAfter: [lint]
       taskRef:
         name: golang-test
       params:
@@ -86,7 +70,7 @@ spec:
           - name: source
             resource: source-repo
     - name: build
-      runAfter: [lint]
+      runAfter: [precheck]
       taskRef:
         name: golang-build
       params:


### PR DESCRIPTION
# Changes
This might be a controversial choice but I think our release Pipelines
should only include Tasks that we expect to give us useful feedback
about the release.

Linting should never fail on a release Pipeline since any issues should
be caught in the PR and
tektoncd/plumbing#241 is making linting
flakey.

I also made it so build and unit test can run in parallel since neither depends
on the other.

I tested this by manually applying the pipelines and manually triggering
the nightly cron:

```
 k --context dogfood create job --from cronjob/nightly-cron-trigger-pipeline-nightly-release nightly-cron-trigger-pipeline-nightly-release-manual-03232020
```

@afrittoli @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).