### PR TITLE
Adds Basic Support for Star Array Notation

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -250,8 +250,8 @@ can be passed to the `Task` from a `TaskRun`.
 Input parameters in the form of `$(inputs.params.foo)` are replaced inside of
 the [`steps`](#steps) (see also [variable substitution](#variable-substitution)).
 
-The following `Task` declares an input parameter called 'flags', and uses it in
-the `steps.args` list.
+The following `Task` declares two input parameters named 'flags' (array) and 'someURL' (string), and uses them in
+the `steps.args` list. Array parameters like 'flags' can be expanded inside of an existing array by using star expansion syntax by adding `[*]` to the named parameter as we do below using `$(inputs.params.flags[*])`. 
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1
@@ -268,7 +268,7 @@ spec:
   steps:
     - name: build
       image: my-builder
-      args: ["build", "$(inputs.params.flags)", "url=$(inputs.params.someURL)"]
+      args: ["build", "$(inputs.params.flags[*])", "url=$(inputs.params.someURL)"]
 ```
 
 The following `TaskRun` supplies a dynamic number of strings within the `flags` parameter:
@@ -576,7 +576,7 @@ Param values from resources can also be accessed using [variable substitution](.
 
 ##### Variable Substitution with Parameters of Type `Array`
 
-Referenced parameters of type `array` will expand to insert the array elements in the reference string's spot.
+Referenced parameters of type `array` can be expanded using 'star-expansion' by adding `[*]` to the named parameter to insert the array elements in the reference string's spot.
 
 So, with the following parameter:
 
@@ -590,7 +590,7 @@ inputs:
           - "elements"
 ```
 
-then `command: ["first", "$(inputs.params.array-param)", "last"]` will become
+then `command: ["first", "$(inputs.params.array-param[*])", "last"]` will become
 `command: ["first", "some", "array", "elements", "last"]`
 
 Note that array parameters __*must*__ be referenced in a completely isolated string within a larger string array.
@@ -602,14 +602,14 @@ the string isn't isolated:
 ```yaml
  - name: build-step
       image: gcr.io/cloud-builders/some-image
-      args: ["build", "additionalArg $(inputs.params.build-args)"]
+      args: ["build", "additionalArg $(inputs.params.build-args[*])"]
 ```
 
 Similarly, referencing `build-args` in a non-array field is also invalid:
 
 ```yaml
  - name: build-step
-      image: "$(inputs.params.build-args)"
+      image: "$(inputs.params.build-args[*])"
       args: ["build", "args"]
 ```
 
@@ -618,7 +618,7 @@ A valid reference to the `build-args` parameter is isolated and in an eligible f
 ```yaml
  - name: build-step
       image: gcr.io/cloud-builders/some-image
-      args: ["build", "$(inputs.params.build-args)", "additonalArg"]
+      args: ["build", "$(inputs.params.build-args[*])", "additonalArg"]
 ```
 
 #### Variable Substitution with Workspaces

--- a/examples/pipelineruns/output-pipelinerun.yaml
+++ b/examples/pipelineruns/output-pipelinerun.yaml
@@ -53,7 +53,7 @@ spec:
   - name: read
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['$(inputs.params.args)']  # tests that new targetpath and previous task output is dumped
+    args: ['$(inputs.params.args[*])']  # tests that new targetpath and previous task output is dumped
 ---
 # The Output of the first Task (git resource) create-file is given as an `Input`
 # to the next `Task` check-stuff-file-exists using`from` clause.

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -174,6 +174,15 @@ func TestPipeline_Validate(t *testing.T) {
 		)),
 		failureExpected: false,
 	}, {
+		name: "valid star array parameter variables",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
+			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
+			tb.PipelineTask("bar", "bar-task",
+				tb.PipelineTaskParam("a-param", "$(baz[*])", "and", "$(foo-is-baz[*])")),
+		)),
+		failureExpected: false,
+	}, {
 		name: "pipeline parameter nested in task parameter",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
@@ -288,11 +297,27 @@ func TestPipeline_Validate(t *testing.T) {
 		)),
 		failureExpected: true,
 	}, {
+		name: "star array parameter used as string",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
+			tb.PipelineTask("bar", "bar-task",
+				tb.PipelineTaskParam("a-param", "$(params.baz[*])")),
+		)),
+		failureExpected: true,
+	}, {
 		name: "array parameter string template not isolated",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz)", "last")),
+		)),
+		failureExpected: true,
+	}, {
+		name: "star array parameter string template not isolated",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
+			tb.PipelineTask("bar", "bar-task",
+				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz[*])", "last")),
 		)),
 		failureExpected: true,
 	}, {

--- a/pkg/apis/pipeline/v1alpha2/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha2/pipeline_validation_test.go
@@ -255,7 +255,27 @@ func TestPipeline_Validate(t *testing.T) {
 					Name:    "bar",
 					TaskRef: &v1alpha2.TaskRef{Name: "bar-task"},
 					Params: []v1alpha2.Param{{
-						Name: "a-param", Value: v1alpha2.ArrayOrString{ArrayVal: []string{"$(baz)", "and", "$(foo-is-)"}},
+						Name: "a-param", Value: v1alpha2.ArrayOrString{ArrayVal: []string{"$(baz)", "and", "$(foo-is-baz)"}},
+					}},
+				}},
+			},
+		},
+		failureExpected: false,
+	}, {
+		name: "valid star array parameter variables",
+		p: &v1alpha2.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha2.PipelineSpec{
+				Params: []v1alpha2.ParamSpec{{
+					Name: "baz", Type: v1alpha2.ParamTypeArray, Default: &v1alpha2.ArrayOrString{Type: v1alpha2.ParamTypeArray, ArrayVal: []string{"some", "default"}},
+				}, {
+					Name: "foo-is-baz", Type: v1alpha2.ParamTypeArray,
+				}},
+				Tasks: []v1alpha2.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha2.TaskRef{Name: "bar-task"},
+					Params: []v1alpha2.Param{{
+						Name: "a-param", Value: v1alpha2.ArrayOrString{ArrayVal: []string{"$(baz[*])", "and", "$(foo-is-baz[*])"}},
 					}},
 				}},
 			},
@@ -532,6 +552,24 @@ func TestPipeline_Validate(t *testing.T) {
 		},
 		failureExpected: true,
 	}, {
+		name: "star array parameter used as string",
+		p: &v1alpha2.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha2.PipelineSpec{
+				Params: []v1alpha2.ParamSpec{{
+					Name: "baz", Type: v1alpha2.ParamTypeString, Default: &v1alpha2.ArrayOrString{Type: v1alpha2.ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+				}},
+				Tasks: []v1alpha2.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha2.TaskRef{Name: "bar-task"},
+					Params: []v1alpha2.Param{{
+						Name: "a-param", Value: v1alpha2.ArrayOrString{Type: v1alpha2.ParamTypeString, StringVal: "$(params.baz[*])"},
+					}},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
 		name: "array parameter string template not isolated",
 		p: &v1alpha2.Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
@@ -544,6 +582,24 @@ func TestPipeline_Validate(t *testing.T) {
 					TaskRef: &v1alpha2.TaskRef{Name: "bar-task"},
 					Params: []v1alpha2.Param{{
 						Name: "a-param", Value: v1alpha2.ArrayOrString{Type: v1alpha2.ParamTypeArray, ArrayVal: []string{"value: $(params.baz)", "last"}},
+					}},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "star array parameter string template not isolated",
+		p: &v1alpha2.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha2.PipelineSpec{
+				Params: []v1alpha2.ParamSpec{{
+					Name: "baz", Type: v1alpha2.ParamTypeString, Default: &v1alpha2.ArrayOrString{Type: v1alpha2.ParamTypeArray, ArrayVal: []string{"anarray", "elements"}},
+				}},
+				Tasks: []v1alpha2.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha2.TaskRef{Name: "bar-task"},
+					Params: []v1alpha2.Param{{
+						Name: "a-param", Value: v1alpha2.ArrayOrString{Type: v1alpha2.ParamTypeArray, ArrayVal: []string{"value: $(params.baz[*])", "last"}},
 					}},
 				}},
 			},

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -24,13 +24,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-const parameterSubstitution = "[_a-zA-Z][_a-zA-Z0-9.-]*"
+const parameterSubstitution = `[_a-zA-Z][_a-zA-Z0-9.-]*(\[\*\])?`
 
 const braceMatchingRegex = "(\\$(\\(%s.(?P<var>%s)\\)))"
 
 func ValidateVariable(name, value, prefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
+			v = strings.TrimSuffix(v, "[*]")
 			if _, ok := vars[v]; !ok {
 				return &apis.FieldError{
 					Message: fmt.Sprintf("non-existent variable in %q for %s %s", value, locationName, name),
@@ -46,6 +47,7 @@ func ValidateVariable(name, value, prefix, locationName, path string, vars map[s
 func ValidateVariableProhibited(name, value, prefix, locationName, path string, vars map[string]struct{}) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
+			v = strings.TrimSuffix(v, "[*]")
 			if _, ok := vars[v]; ok {
 				return &apis.FieldError{
 					Message: fmt.Sprintf("variable type invalid in %q for %s %s", value, locationName, name),
@@ -62,6 +64,7 @@ func ValidateVariableIsolated(name, value, prefix, locationName, path string, va
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		firstMatch, _ := extractExpressionFromString(value, prefix)
 		for _, v := range vs {
+			v = strings.TrimSuffix(v, "[*]")
 			if _, ok := vars[v]; ok {
 				if len(value) != len(firstMatch) {
 					return &apis.FieldError{
@@ -130,6 +133,12 @@ func ApplyArrayReplacements(in string, stringReplacements map[string]string, arr
 		// If the input string matches a replacement's key (without padding characters), return the corresponding array.
 		// Note that the webhook should prevent all instances where this could evaluate to false.
 		if (strings.Count(in, stringToReplace) == 1) && len(in) == len(stringToReplace) {
+			return v
+		}
+
+		// same replace logic for star array expressions
+		starStringtoReplace := fmt.Sprintf("$(%s[*])", k)
+		if (strings.Count(in, starStringtoReplace) == 1) && len(in) == len(starStringtoReplace) {
 			return v
 		}
 	}

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -218,6 +218,14 @@ func TestApplyArrayReplacements(t *testing.T) {
 			arrayReplacements:  map[string][]string{"ace": {"replacement", "a"}, "match": {"1", "2"}},
 		},
 		expectedOutput: []string{"1", "2"},
+	}, {
+		name: "array star replacement",
+		args: args{
+			input:              "$(match[*])",
+			stringReplacements: map[string]string{"string": "word", "lacement": "lacements"},
+			arrayReplacements:  map[string][]string{"ace": {"replacement", "a"}, "match": {"1", "2"}},
+		},
+		expectedOutput: []string{"1", "2"},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOutput := substitution.ApplyArrayReplacements(tc.args.input, tc.args.stringReplacements, tc.args.arrayReplacements)


### PR DESCRIPTION
# Changes
When referring to an array reference that we want to expand inside an existing array we should use star syntax.
For example: ["a", "b", "$(params.myArray[*])", "d"] to avoid confusion when in the future we want to add the array itself as an array element.

Basic support changes are in substitution.go
All other changes are for unit tests

Fixes #2041
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

