### PR TITLE
Correct the wrong MD format for document: podTemplates

### DIFF
--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -46,7 +46,8 @@ The current fields supported are:
   [priority class](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)
   to use when running the pod. Use this, for example, to selectively enable
   preemption on lower priority workloads.
-  - `schedulerName` the name of the [scheduler](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/)
+- `schedulerName` the name of the 
+  [scheduler](https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/)
   to use when dispatching the Pod. This can be used when workloads of specific types need specific schedulers,
   eg: If you are using volcano.sh for Machine Learning Workloads, you can pass the schedulerName and have Tasks be 
   dispatched by the volcano.sh scheduler.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Correct wrong List format of MD.
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
