### PR TITLE
PipelineTask Timeout e2e Test

### DIFF
--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -276,6 +276,13 @@ func PipelineTaskWorkspaceBinding(name, workspace string) PipelineTaskOp {
 	}
 }
 
+// PipelineTaskTimeout sets the timeout for the PipelineTask.
+func PipelineTaskTimeout(duration time.Duration) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.Timeout = &metav1.Duration{Duration: duration}
+	}
+}
+
 // PipelineRun creates a PipelineRun with default values.
 // Any number of PipelineRun modifier can be passed to transform it.
 func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -54,6 +54,7 @@ func TestPipeline(t *testing.T) {
 		),
 		tb.PipelineTask("never-gonna", "give-you-up",
 			tb.RunAfter("foo"),
+			tb.PipelineTaskTimeout(5*time.Second),
 		),
 		tb.PipelineTask("foo", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{TaskSpec: v1alpha2.TaskSpec{
 			Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -132,6 +133,7 @@ func TestPipeline(t *testing.T) {
 				Name:     "never-gonna",
 				TaskRef:  &v1alpha1.TaskRef{Name: "give-you-up"},
 				RunAfter: []string{"foo"},
+				Timeout:  &metav1.Duration{Duration: 5 * time.Second},
 			}, {
 				Name: "foo",
 				TaskSpec: &v1alpha1.TaskSpec{TaskSpec: v1alpha2.TaskSpec{

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -220,3 +220,146 @@ func TestTaskRunTimeout(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", "run-giraffe", err)
 	}
 }
+
+func TestPipelineTaskTimeout(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	t.Logf("Creating Tasks in namespace %s", namespace)
+	task1 := tb.Task("success", namespace, tb.TaskSpec(
+		tb.Step("ubuntu", tb.StepCommand("sleep"), tb.StepArgs("1s"))))
+
+	task2 := tb.Task("timeout", namespace, tb.TaskSpec(
+		tb.Step("ubuntu", tb.StepCommand("sleep"), tb.StepArgs("10s"))))
+
+	if _, err := c.TaskClient.Create(task1); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", task1.Name, err)
+	}
+	if _, err := c.TaskClient.Create(task2); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", task2.Name, err)
+	}
+
+	pipeline := tb.Pipeline("pipelinetasktimeout", namespace,
+		tb.PipelineSpec(
+			tb.PipelineTask("pipelinetask1", task1.Name, tb.PipelineTaskTimeout(10*time.Second)),
+			tb.PipelineTask("pipelinetask2", task2.Name, tb.PipelineTaskTimeout(5*time.Second)),
+		),
+	)
+
+	pipelineRun := tb.PipelineRun("prtasktimeout", namespace, tb.PipelineRunSpec(pipeline.Name))
+
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
+	}
+
+	t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+		c := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
+				return true, fmt.Errorf("pipelineRun %q already finished", pipelineRun.Name)
+			} else if c.Status == corev1.ConditionUnknown && (c.Reason == "Running" || c.Reason == "Pending") {
+				return true, nil
+			}
+		}
+		return false, nil
+	}, "PipelineRunRunning"); err != nil {
+		t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: fmt.Sprintf("tekton.dev/pipelineRun=%s", pipelineRun.Name)})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
+	}
+
+	t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRun.Name, namespace)
+	errChan := make(chan error, len(taskrunList.Items))
+	defer close(errChan)
+
+	for _, taskrunItem := range taskrunList.Items {
+		go func(name string) {
+			err := WaitForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
+				c := tr.Status.GetCondition(apis.ConditionSucceeded)
+				if c != nil {
+					if c.Status == corev1.ConditionTrue || c.Status == corev1.ConditionFalse {
+						return true, fmt.Errorf("taskRun %q already finished", name)
+					} else if c.Status == corev1.ConditionUnknown && (c.Reason == "Running" || c.Reason == "Pending") {
+						return true, nil
+					}
+				}
+				return false, nil
+			}, "TaskRunRunning")
+			errChan <- err
+		}(taskrunItem.Name)
+	}
+
+	for i := 1; i <= len(taskrunList.Items); i++ {
+		if <-errChan != nil {
+			t.Errorf("Error waiting for TaskRun %s to be running: %s", taskrunList.Items[i-1].Name, err)
+		}
+	}
+
+	if _, err := c.PipelineRunClient.Get(pipelineRun.Name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
+	}
+
+	t.Logf("Waiting for PipelineRun %s with PipelineTask timeout in namespace %s to fail", pipelineRun.Name, namespace)
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, func(pr *v1alpha1.PipelineRun) (bool, error) {
+		c := pr.Status.GetCondition(apis.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionFalse {
+				if c.Reason == resources.ReasonFailed {
+					return true, nil
+				}
+				return true, fmt.Errorf("pipelineRun %q completed with the wrong reason: %s", pipelineRun.Name, c.Reason)
+			} else if c.Status == corev1.ConditionTrue {
+				return true, fmt.Errorf("pipelineRun %q completed successfully, but should have been Failed", pipelineRun.Name)
+			}
+		}
+		return false, nil
+	}, "PipelineRunTimedOut"); err != nil {
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
+	}
+
+	t.Logf("Waiting for TaskRun from PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
+	var wg sync.WaitGroup
+	for _, taskrunItem := range taskrunList.Items {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			err := WaitForTaskRunState(c, name, func(tr *v1alpha1.TaskRun) (bool, error) {
+				cond := tr.Status.GetCondition(apis.ConditionSucceeded)
+				if cond != nil {
+					if tr.Spec.TaskRef.Name == task1.Name && cond.Status == corev1.ConditionTrue {
+						if cond.Reason == "Succeeded" {
+							return true, nil
+						}
+						return true, fmt.Errorf("taskRun %q completed with the wrong reason: %s", task1.Name, cond.Reason)
+					} else if tr.Spec.TaskRef.Name == task1.Name && cond.Status == corev1.ConditionFalse {
+						return true, fmt.Errorf("taskRun %q failed, but should have been Succeeded", name)
+					}
+
+					if tr.Spec.TaskRef.Name == task2.Name && cond.Status == corev1.ConditionFalse {
+						if cond.Reason == "TaskRunTimeout" {
+							return true, nil
+						}
+						return true, fmt.Errorf("taskRun %q completed with the wrong reason: %s", task2.Name, cond.Reason)
+					} else if tr.Spec.TaskRef.Name == task2.Name && cond.Status == corev1.ConditionTrue {
+						return true, fmt.Errorf("taskRun %q should have timed out", name)
+					}
+				}
+				return false, nil
+			}, "TaskRunTimeout")
+			if err != nil {
+				t.Errorf("Error waiting for TaskRun %s to timeout: %s", name, err)
+			}
+		}(taskrunItem.Name)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Closes #2073 

# Changes

Adding an e2e test in `timeout_test.go` for verifying a PipelineTask successfully times out a PipelineTask that violates its Timeout set.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
N/A
```
