### PR TITLE
Increase PipelineTask Timeout by 10s in e2e Test

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -244,7 +244,7 @@ func TestPipelineTaskTimeout(t *testing.T) {
 
 	pipeline := tb.Pipeline("pipelinetasktimeout", namespace,
 		tb.PipelineSpec(
-			tb.PipelineTask("pipelinetask1", task1.Name, tb.PipelineTaskTimeout(10*time.Second)),
+			tb.PipelineTask("pipelinetask1", task1.Name, tb.PipelineTaskTimeout(20*time.Second)),
 			tb.PipelineTask("pipelinetask2", task2.Name, tb.PipelineTaskTimeout(5*time.Second)),
 		),
 	)


### PR DESCRIPTION
There has been some flaky behavior with the PipelineTaskTimeout test in `timeout_test.go`. This appears to be due to the fact that the first PipelineTask can some times go over its 10 second timeout. 

See more information from [integration test logs](https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/2098/pull-tekton-pipeline-integration-tests/1232289580770660354/) that revealed this issue.

This pull request increases the Timeout for the test by 10 seconds to have the PipelineTask timeout after 20 seconds. The point of the first PipelineTask is to not violate its Timeout, so the goal is for it to succeed.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
N/A
```
