### PR TITLE
Fix Broken Link and Typo for LimitRange Docs

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -20,7 +20,7 @@ Creation of a `PipelineRun` will trigger the creation of
 - [Cancelling a PipelineRun](#cancelling-a-pipelinerun)
 - [Examples](https://github.com/tektoncd/pipeline/tree/master/examples/pipelineruns)
 - [Logs](logs.md)
-- [LimitRanges](#limitrange-name)
+- [LimitRanges](#limitranges)
 
 ## Syntax
 
@@ -378,7 +378,7 @@ spec:
 In order to request the minimum amount of resources needed to support the containers 
 for `steps` that are part of a `TaskRun`, Tekton only requests the maximum values for CPU, 
 memory, and ephemeral storage from the `steps` that are part of a TaskRun. Only the max 
-resource request values are needed since `steps` only execute one at a time in `TaskRun` pod. 
+resource request values are needed since `steps` only execute one at a time in a `TaskRun` pod. 
 All requests that are not the max values are set to zero as a result. 
 
 When a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) is present in a namespace 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -26,7 +26,7 @@ A `TaskRun` runs until all `steps` have completed or until a failure occurs.
 - [Examples](#examples)
 - [Sidecars](#sidecars)
 - [Logs](logs.md)
-- [LimitRanges](#limitrange-name)
+- [LimitRanges](#limitranges)
 
 ---
 
@@ -708,7 +708,7 @@ they exited.
 In order to request the minimum amount of resources needed to support the containers 
 for `steps` that are part of a `TaskRun`, Tekton only requests the maximum values for CPU, 
 memory, and ephemeral storage from the `steps` that are part of a TaskRun. Only the max 
-resource request values are needed since `steps` only execute one at a time in `TaskRun` pod. 
+resource request values are needed since `steps` only execute one at a time in a `TaskRun` pod. 
 All requests that are not the max values are set to zero as a result. 
 
 When a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) is present in a namespace 


### PR DESCRIPTION
This pull request fixes the links to the LimitRange documentation at the tops of TaskRuns/PipelineRuns docs. It also corrects a minor typo in the LimitRange sections of both docs. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
N/A
```
