### PR TITLE
Add handling of working directory

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -28,3 +28,13 @@ data:
   # See https://github.com/tektoncd/pipeline/issues/2013 for more
   # info.
   disable-home-env-overwrite: "false"
+  # Setting this flag to "true" will prevent Tekton overriding your
+  # Task container's working directory.
+  #
+  # The default behaviour currently is for Tekton to override the
+  # working directory if not set by the user but this will change
+  # in an upcoming release.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/1836 for more
+  # info.
+  disable-working-directory-overwrite: "false"

--- a/docs/install.md
+++ b/docs/install.md
@@ -244,6 +244,25 @@ data:
   disable-home-env-overwrite: "true" # Tekton will not overwrite $HOME in Steps.
 ```
 
+- `disable-working-directory-overwrite` - Setting this flag to "true" will prevent Tekton
+from overwriting Step containers' working directory. The default
+value is "false" and so the default behaviour is for the working directory to be 
+overwritten by Tekton with `/workspace` if the working directory is not specified explicitly
+for the step container. This default is very likely to change in an upcoming
+release. For further reference see https://github.com/tektoncd/pipeline/issues/1836.
+
+Here is an example of the `feature-flags` ConfigMap with `disable-working-directory-overwrite`
+flipped on:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+data:
+  disable-working-directory-overwrite: "true" # Tekton will not overwrite the working directory in Steps.
+```
+
 ## Custom Releases
 
 The [release Task](./../tekton/README.md) can be used for creating a custom


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tekton currently overwrites the working directory in task containers if a specific working directory is not specified. This behaviour is problematic when an image explicitly sets a working directory and expects it to be set to that value upon running.

This PR introduces a feature-flags ConfigMap with a single flag - disable-working-directory-overwrite - that, when set to "true" will prevent Tekton from overriding the working directory in Task containers. This behaviour will be kept for one release which must include a deprecation warning that the behaviour will be changing soon. In the release after that the flag will be flipped so that the default behaviour becomes for Tekton to NOT override the working directory.

Contributes to issue #1836

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Tekton currently overwrites the working directory in Step containers if not explicitly specified by the user. This behaviour is problematic when an image explicitly sets the working directory and expects it to be set to that value upon running. You can now disable this behaviour in Tekton by using the feature-flags ConfigMap. See docs/install.md for further details on disabling this behaviour.
```
