### PR TITLE
Refactoring to use a lightweight image

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -230,10 +230,10 @@ func TestPipelineTaskTimeout(t *testing.T) {
 
 	t.Logf("Creating Tasks in namespace %s", namespace)
 	task1 := tb.Task("success", namespace, tb.TaskSpec(
-		tb.Step("ubuntu", tb.StepCommand("sleep"), tb.StepArgs("1s"))))
+		tb.Step("busybox", tb.StepCommand("sleep"), tb.StepArgs("1s"))))
 
 	task2 := tb.Task("timeout", namespace, tb.TaskSpec(
-		tb.Step("ubuntu", tb.StepCommand("sleep"), tb.StepArgs("10s"))))
+		tb.Step("busybox", tb.StepCommand("sleep"), tb.StepArgs("10s"))))
 
 	if _, err := c.TaskClient.Create(task1); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", task1.Name, err)


### PR DESCRIPTION
This will change the image used in testtask
from ubuntu to busybox as it is lightweight
and downloadable fast on every run

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```


```
