### PR TITLE
Use "ConditionRef + index" rather than "ConditionRef" to register "Condition" in state of "Pipelinerun"

### DIFF
--- a/examples/v1alpha1/pipelineruns/conditional-pipelinerun-with-same-condition-refer.yaml
+++ b/examples/v1alpha1/pipelineruns/conditional-pipelinerun-with-same-condition-refer.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: is-equal
+spec:
+  params:
+  - name: left
+    type: string
+  - name: right
+    type: string
+  check:
+    image: alpine
+    script: |
+      #!/bin/sh
+      if [ $(params.left) = $(params.right) ]; then
+        echo "$(params.left) == $(params.right)"
+        exit 0
+      else
+        echo "$(params.left) != $(params.right)"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: condition-pipeline
+spec:
+  params:
+  - name: one
+    type: string
+  - name: two
+    type: string
+  tasks:
+  - name: process
+    conditions:
+    - conditionRef: is-equal
+      params:
+        - name: left
+          value: "1"
+        - name: right
+          value: $(params.one)
+    - conditionRef: is-equal
+      params:
+        - name: left
+          value: "1"
+        - name: right
+          value: $(params.two)
+    taskRef:
+      kind: Task
+      name: run
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: run
+spec:
+  steps:
+    - name: echo
+      image: ubuntu
+      script: 'echo hello'
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: condition-pipelinerun
+spec:
+  params:
+  - name: one
+    value: "1"
+  - name: two
+    value: "2"
+  pipelineRef:
+    name: condition-pipeline

--- a/examples/v1beta1/pipelineruns/conditional-pipelinerun-with-same-condition-refer.yaml
+++ b/examples/v1beta1/pipelineruns/conditional-pipelinerun-with-same-condition-refer.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: is-equal
+spec:
+  params:
+  - name: left
+    type: string
+  - name: right
+    type: string
+  check:
+    image: alpine
+    script: |
+      #!/bin/sh
+      if [ $(params.left) = $(params.right) ]; then
+        echo "$(params.left) == $(params.right)"
+        exit 0
+      else
+        echo "$(params.left) != $(params.right)"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: condition-pipeline
+spec:
+  params:
+  - name: one
+    type: string
+  - name: two
+    type: string
+  tasks:
+  - name: process
+    conditions:
+    - conditionRef: is-equal
+      params:
+        - name: left
+          value: "1"
+        - name: right
+          value: $(params.one)
+    - conditionRef: is-equal
+      params:
+        - name: left
+          value: "1"
+        - name: right
+          value: $(params.two)
+    taskRef:
+      kind: Task
+      name: run
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run
+spec:
+  steps:
+    - name: echo
+      image: ubuntu
+      script: 'echo hello'
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: condition-pipelinerun
+spec:
+  params:
+  - name: one
+    value: "1"
+  - name: two
+    value: "2"
+  pipelineRef:
+    name: condition-pipeline

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -518,7 +518,7 @@ func getTaskRunsStatus(pr *v1alpha1.PipelineRun, state []*resources.ResolvedPipe
 			cStatus := make(map[string]*v1alpha1.PipelineRunConditionCheckStatus)
 			for _, c := range rprt.ResolvedConditionChecks {
 				cStatus[c.ConditionCheckName] = &v1alpha1.PipelineRunConditionCheckStatus{
-					ConditionName: c.Condition.Name,
+					ConditionName: c.ConditionRegisterName,
 				}
 				if c.ConditionCheck != nil {
 					cStatus[c.ConditionCheckName].Status = c.NewConditionCheckStatus()

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -644,8 +644,21 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 		tb.StepState(tb.StateTerminated(127)),
 	)))
 
+	successrcc := resources.ResolvedConditionCheck{
+		ConditionRegisterName: successCondition.Name + "-0",
+		ConditionCheckName:    successConditionCheckName,
+		Condition:             successCondition,
+		ConditionCheck:        successConditionCheck,
+	}
+	failingrcc := resources.ResolvedConditionCheck{
+		ConditionRegisterName: failingCondition.Name + "-0",
+		ConditionCheckName:    failingConditionCheckName,
+		Condition:             failingCondition,
+		ConditionCheck:        failingConditionCheck,
+	}
+
 	successConditionCheckStatus := &v1alpha1.PipelineRunConditionCheckStatus{
-		ConditionName: successCondition.Name,
+		ConditionName: successrcc.ConditionRegisterName,
 		Status: &v1alpha1.ConditionCheckStatus{
 			ConditionCheckStatusFields: v1alpha1.ConditionCheckStatusFields{
 				Check: corev1.ContainerState{
@@ -658,7 +671,7 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 		},
 	}
 	failingConditionCheckStatus := &v1alpha1.PipelineRunConditionCheckStatus{
-		ConditionName: failingCondition.Name,
+		ConditionName: failingrcc.ConditionRegisterName,
 		Status: &v1alpha1.ConditionCheckStatus{
 			ConditionCheckStatusFields: v1alpha1.ConditionCheckStatusFields{
 				Check: corev1.ContainerState{
@@ -669,17 +682,6 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}},
 			},
 		},
-	}
-
-	successrcc := resources.ResolvedConditionCheck{
-		ConditionCheckName: successConditionCheckName,
-		Condition:          successCondition,
-		ConditionCheck:     successConditionCheck,
-	}
-	failingrcc := resources.ResolvedConditionCheck{
-		ConditionCheckName: failingConditionCheckName,
-		Condition:          failingCondition,
-		ConditionCheck:     failingConditionCheck,
 	}
 
 	failedTaskRunStatus := v1alpha1.TaskRunStatus{
@@ -1504,8 +1506,8 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 	}
 	ccNameBase := prName + "-hello-world-1-9l9zj"
 	ccNames := map[string]string{
-		"cond-1": ccNameBase + "-cond-1-mz4c7",
-		"cond-2": ccNameBase + "-cond-2-mssqb",
+		"cond-1": ccNameBase + "-cond-1-0-mz4c7",
+		"cond-2": ccNameBase + "-cond-2-1-mssqb",
 	}
 	expectedConditionChecks := make([]*v1alpha1.TaskRun, len(conditions))
 	for index, condition := range conditions {
@@ -1537,7 +1539,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 
 	conditionCheckName := pipelineRunName + "task-2-always-false-xxxyyy"
 	prccs[conditionCheckName] = &v1alpha1.PipelineRunConditionCheckStatus{
-		ConditionName: "always-false",
+		ConditionName: "always-false-0",
 		Status:        &v1alpha1.ConditionCheckStatus{},
 	}
 	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -41,6 +41,7 @@ type GetCondition func(string) (*v1alpha1.Condition, error)
 // exists. ConditionCheck can be nil to represent there being no ConditionCheck (i.e the condition
 // has not been evaluated).
 type ResolvedConditionCheck struct {
+	ConditionRegisterName string
 	PipelineTaskCondition *v1alpha1.PipelineTaskCondition
 	ConditionCheckName    string
 	Condition             *v1alpha1.Condition

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1554,7 +1554,7 @@ func TestResolveConditionChecks(t *testing.T) {
 			name: "conditionCheck exists",
 			getTaskRun: func(name string) (*v1alpha1.TaskRun, error) {
 				switch name {
-				case "pipelinerun-mytask1-9l9zj-always-true-mz4c7":
+				case "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7":
 					return cc, nil
 				case "pipelinerun-mytask1-9l9zj":
 					return &trs[0], nil
@@ -1563,7 +1563,8 @@ func TestResolveConditionChecks(t *testing.T) {
 				}
 			},
 			expectedConditionCheck: TaskConditionCheckState{{
-				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-mz4c7",
+				ConditionRegisterName: "always-true-0",
+				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7",
 				Condition:             &condition,
 				ConditionCheck:        v1alpha1.NewConditionCheck(cc),
 				PipelineTaskCondition: &ptc,
@@ -1573,7 +1574,7 @@ func TestResolveConditionChecks(t *testing.T) {
 		{
 			name: "conditionCheck doesn't exist",
 			getTaskRun: func(name string) (*v1alpha1.TaskRun, error) {
-				if name == "pipelinerun-mytask1-mssqb-always-true-78c5n" {
+				if name == "pipelinerun-mytask1-mssqb-always-true-0-78c5n" {
 					return nil, nil
 				} else if name == "pipelinerun-mytask1-mssqb" {
 					return &trs[0], nil
@@ -1581,7 +1582,8 @@ func TestResolveConditionChecks(t *testing.T) {
 				return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
 			},
 			expectedConditionCheck: TaskConditionCheckState{{
-				ConditionCheckName:    "pipelinerun-mytask1-mssqb-always-true-78c5n",
+				ConditionRegisterName: "always-true-0",
+				ConditionCheckName:    "pipelinerun-mytask1-mssqb-always-true-0-78c5n",
 				Condition:             &condition,
 				PipelineTaskCondition: &ptc,
 				ResolvedResources:     providedResources,
@@ -1655,23 +1657,25 @@ func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 			name: "conditionCheck exists",
 			getTaskRun: func(name string) (*v1alpha1.TaskRun, error) {
 				switch name {
-				case "pipelinerun-mytask1-9l9zj-always-true-mz4c7":
+				case "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7":
 					return cc1, nil
 				case "pipelinerun-mytask1-9l9zj":
 					return &trs[0], nil
-				case "pipelinerun-mytask1-9l9zj-always-true-mssqb":
+				case "pipelinerun-mytask1-9l9zj-always-true-1-mssqb":
 					return cc2, nil
 				}
 				return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
 			},
 			expectedConditionCheck: TaskConditionCheckState{{
-				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-mz4c7",
+				ConditionRegisterName: "always-true-0",
+				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7",
 				Condition:             &condition,
 				ConditionCheck:        v1alpha1.NewConditionCheck(cc1),
 				PipelineTaskCondition: &ptc1,
 				ResolvedResources:     providedResources,
 			}, {
-				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-mssqb",
+				ConditionRegisterName: "always-true-1",
+				ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-1-mssqb",
 				Condition:             &condition,
 				ConditionCheck:        v1alpha1.NewConditionCheck(cc2),
 				PipelineTaskCondition: &ptc2,
@@ -1776,7 +1780,7 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 
 	ccStatus := make(map[string]*v1alpha1.PipelineRunConditionCheckStatus)
 	ccStatus[ccName] = &v1alpha1.PipelineRunConditionCheckStatus{
-		ConditionName: "always-true",
+		ConditionName: "always-true-0",
 	}
 	trStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
 	trStatus[trName] = &v1alpha1.PipelineRunTaskRunStatus{
@@ -1800,6 +1804,7 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 		t.Fatalf("Did not expect error when resolving PipelineRun without Conditions: %v", err)
 	}
 	expectedConditionChecks := TaskConditionCheckState{{
+		ConditionRegisterName: "always-true-0",
 		ConditionCheckName:    ccName,
 		Condition:             &condition,
 		ConditionCheck:        v1alpha1.NewConditionCheck(cc),
@@ -1881,7 +1886,8 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 					t.Fatalf("Unexpected error when no error expected: %v", err)
 				}
 				expectedConditionChecks := TaskConditionCheckState{{
-					ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-mz4c7",
+					ConditionRegisterName: "always-true-0",
+					ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7",
 					Condition:             condition,
 					PipelineTaskCondition: &ptc,
 					ResolvedResources:     tc.expected,


### PR DESCRIPTION
fix issue #2124 
Use `ConditionRef + index` rather than `ConditionRef` in state of `pelinerun` to display state of `taskrun` of `condiition`.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
Use `ConditionRef` and index of the `Condition` to register `Condition`’s `Taskrun` in state of `Pipelinerun`.	
