### PR TITLE
Adding Documentation on PipelineTask Timeout

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -13,6 +13,8 @@ This document defines `Pipelines` and their capabilities.
     - [RunAfter](#runAfter)
     - [Retries](#retries)
     - [Conditions](#conditions)
+    - [Timeout](#timeout)
+- [Results](#results)
 - [Ordering](#ordering)
 - [Examples](#examples)
 
@@ -49,6 +51,10 @@ following fields:
         apply to cancellations.
       - [`conditions`](#conditions) - Used when a task is to be executed only if the specified
         conditions are evaluated to be true.
+      - [`timeout`](#timeout) - Specifies timeout after which the `TaskRun` for a Pipeline Task will 
+        fail. There is no default timeout for a Pipeline Task timeout. If no timeout is specified for 
+        the Pipeline Task, the only timeout taken into account for running a `Pipeline` will be a 
+        [timeout for the `PipelineRun`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md#syntax).
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -350,7 +356,6 @@ In this example, the task "build-the-image" will be executed and if the first
 run fails a second one would triggered. But, if that fails no more would
 triggered: a max of two executions.
 
-
 #### conditions
 
 Sometimes you will need to run tasks only when some conditions are true. The `conditions` field 
@@ -403,6 +408,27 @@ tasks:
       name: echo-hello
 ```
 
+#### Timeout
+
+The Timeout property of a Pipeline Task allows a timeout to be defined for a `TaskRun` that 
+is part of a `PipelineRun`. If the `TaskRun` exceeds the amount of time specified, the `TaskRun` 
+will fail and the `PipelineRun` associated with a `Pipeline` will fail as well. 
+
+There is no default timeout for Pipeline Tasks, so a timeout must be specified with a Pipeline Task 
+when defining a `Pipeline` if one is needed. An example of a Pipeline Task with a Timeout is shown below:
+
+```yaml
+spec:
+  tasks:
+    - name: build-the-image
+      taskRef:
+        name: build-push
+      Timeout: "0h1m30s"
+```
+
+The Timeout property is specified as part of the Pipeline Task on the `Pipeline` spec. The above 
+example has a timeout of one minute and 30 seconds.  
+
 ### Results
 
 Tasks can declare [results](./tasks.md#results) that they will emit during their execution. These results can be used as values for params in subsequent tasks of a Pipeline. Tekton will infer the ordering of these Tasks to ensure that the Task emitting the results runs before the Task consuming those results in its parameters.
@@ -419,7 +445,7 @@ In this example the previous pipeline task has name "previous-task-name" and its
 
 For a complete example demonstrating Task Results in a Pipeline see the [pipelinerun example](../examples/pipelineruns/task_results_example.yaml).
 
-## Ordering
+### Ordering
 
 The [Pipeline Tasks](#pipeline-tasks) in a `Pipeline` can be connected and run
 in a graph, specifically a _Directed Acyclic Graph_ or DAG. Each of the Pipeline


### PR DESCRIPTION
This pull request adds documentation on how to specify a PipelineTask timeout. It is included as part of the documentation on Pipelines. 

Also adds link to Results, which wasn't added during #2042 and adds a `#` from `Ordering` header to keep it consistent with result of headers.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Adding documentation on specifying a PipelineTask timeout
```
