### PR TITLE
Add `--upgrade` to `./hack/update-deps.sh`

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -22,6 +22,35 @@ source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scri
 
 cd ${REPO_ROOT_DIR}
 
+VERSION="master"
+
+# The list of dependencies that we track at HEAD and periodically
+# float forward in this repository.
+FLOATING_DEPS=(
+  "knative.dev/pkg@${VERSION}"
+  "knative.dev/caching@${VERSION}"
+  "knative.dev/serving@${VERSION}"
+  "knative.dev/eventing@${VERSION}"
+  "knative.dev/eventing-contrib@${VERSION}"
+)
+
+# Parse flags to determine any we should pass to dep.
+GO_GET=0
+while [[ $# -ne 0 ]]; do
+  parameter=$1
+  case ${parameter} in
+    --upgrade) GO_GET=1 ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+readonly GO_GET
+
+if (( GO_GET )); then
+  go get -d ${FLOATING_DEPS[@]}
+fi
+
+
 # Prune modules.
 go mod tidy
 go mod vendor


### PR DESCRIPTION
For Knative, we have bots that update our inter-repo dependencies each weekday morning (PST), which enables us to very quickly detect and resolve breakages.

I hadn't enabled this for Tekton (thus far) because it used `go mod`, which was foreign enough to me that I avoided it like the plague.  However, a number of factors have pushed me in the direction of having a standard `./hack/update-deps.sh` mechanism for bumping certain dependencies, which enables us to support `go mod` (in Tekton as well as our own in the future).

This trivially enables us to enable the bots for Tekton because `go mod` becomes a hidden implementation detail.

For an example breaking change this would catch quickly: https://github.com/tektoncd/pipeline/pull/2126