### PR TITLE
Make results folder writable (Fix for #2131)

### DIFF
--- a/cmd/entrypoint/README.md
+++ b/cmd/entrypoint/README.md
@@ -5,6 +5,7 @@ wrapping it. In `tektoncd/pipeline` this is used to make sure `Task`'s
 steps are executed in order, or for sidecars.
 
 The following flags are available :
+
 - `-entrypoint`: "original" command to be executed (as
   entrypoint). This will be executed as a sub-process on `entrypoint`
 - `-post_file`: file path to write once the sub-process has
@@ -22,13 +23,13 @@ The following flags are available :
 The following example of usage for `entrypoint`, wait's for
 `/tekton/downward/ready` file to exists and have some content before
 executing `/ko-app/bash -- -args mkdir -p /workspace/git-resource`,
-and will write to `/tekton/tools/0` in casse of succes, or
+and will write to `/tekton/tools/0` in case of succes, or
 `/tekton/tools/0.err` in case of failure.
 
-```
+```shell
 entrypoint \
-	-wait_file /tekton/downward/ready \
-	-post_file /tekton/tools/0" \
-	-wait_file_content  \
-	-entrypoint /ko-app/bash -- -args mkdir -p /workspace/git-resource
+ -wait_file /tekton/downward/ready \
+ -post_file /tekton/tools/0" \
+ -wait_file_content  \
+ -entrypoint /ko-app/bash -- -args mkdir -p /workspace/git-resource
 ```

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -25,7 +25,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
 )
 
@@ -53,13 +52,6 @@ func main() {
 		Runner:          &realRunner{},
 		PostWriter:      &realPostWriter{},
 		Results:         strings.Split(*results, ","),
-	}
-	// strings.Split(..) with an empty string returns an array that contains one element, an empty string.
-	// The result folder should only be created if there are actual results to defined for the entrypoint.
-	if len(e.Results) >= 1 && e.Results[0] != "" {
-		if err := os.MkdirAll(pipeline.DefaultResultPath, 0755); err != nil {
-			log.Fatalf("Error creating the results directory: %v", err)
-		}
 	}
 	if err := e.Go(); err != nil {
 		switch t := err.(type) {

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -281,6 +281,10 @@ status:
 
 Instead of hardcoding the path to the result file, the user can also use a variable. So `/tekton/results/current-date-unix-timestamp` can be replaced with: `$(results.current-date-unix-timestamp.path)`. This is more flexible if the path to result files ever changes.
 
+### Known issues
+
+When using a podTemplate to specify a non-root user for all containers, a task will not be able to modify the contents of the results directory and may fail.
+
 ## How task results can be used in pipeline's tasks
 
 Now that we have tasks that can return a result, the user can refer to a task result in a pipeline by using the syntax

--- a/examples/pipelineruns/task_results_example_user.yaml
+++ b/examples/pipelineruns/task_results_example_user.yaml
@@ -1,0 +1,97 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: sum-and-multiply-pipeline-user
+spec:
+  params:
+    - name: a
+      type: string
+      default: "1"
+    - name: b
+      type: string
+      default: "1"
+  tasks:
+    - name: sum-inputs
+      taskRef:
+        name: sum-user
+      params:
+        - name: a
+          value: "$(params.a)"
+        - name: b
+          value: "$(params.b)"
+    - name: multiply-inputs
+      taskRef:
+        name: multiply-user
+      params:
+        - name: a
+          value: "$(params.a)"
+        - name: b
+          value: "$(params.b)"
+    - name: sum-and-multiply
+      taskRef:
+        name: sum-user
+      params:
+        - name: a
+          value: "$(tasks.multiply-inputs.results.product)$(tasks.sum-inputs.results.sum)"
+        - name: b
+          value: "$(tasks.multiply-inputs.results.product)$(tasks.sum-inputs.results.sum)"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: sum-user
+  annotations:
+    description: |
+      A simple task that sums the two provided integers
+spec:
+  inputs:
+    params:
+      - name: a
+        type: string
+        default: "1"
+        description: The first integer
+      - name: b
+        type: string
+        default: "1"
+        description: The second integer
+  results:
+    - name: sum
+      description: The sum of the two provided integers
+  steps:
+    - name: sum
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" )) | tee $(results.sum.path)
+      securityContext:
+        runAsUser: 1000
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: multiply-user
+  annotations:
+    description: |
+      A simple task that multiplies the two provided integers
+spec:
+  inputs:
+    params:
+      - name: a
+        type: string
+        default: "1"
+        description: The first integer
+      - name: b
+        type: string
+        default: "1"
+        description: The second integer
+  results:
+    - name: product
+      description: The product of the two provided integers
+  steps:
+    - name: product
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n $(( "$(inputs.params.a)" * "$(inputs.params.b)" )) | tee $(results.product.path)
+      securityContext:
+        runAsUser: 1000

--- a/pkg/pod/tekton_folder_writable.go
+++ b/pkg/pod/tekton_folder_writable.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// makeTektonResultsFolderWritable returns a Container that make the tekton folder writable by any user.
+func makeTektonResultsFolderWritable(shellImage string, volumeMounts []corev1.VolumeMount) *corev1.Container {
+	return &corev1.Container{
+		Name:         "tekton-results-folder-writable",
+		Image:        shellImage,
+		Command:      []string{"sh"},
+		Args:         []string{"-c", "chmod 777 " + ResultsDir},
+		VolumeMounts: volumeMounts,
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Make sure the results folder is writable by any user. See #2131.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Make sure the results folder is writable by any user.
```
