### PR TITLE
Updating Broken Links for LimitRange Examples in Docs

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -386,7 +386,7 @@ with a minimum set for container resource requests (i.e. CPU, memory, and epheme
 are attempting to run, Tekton will search through all LimitRanges present in the namespace and use the minimum 
 set for container resource requests instead of requesting 0.
 
-An example `PipelineRun` with a LimitRange is available [here](../examples/pipelineruns/no-ci/limitrange.yaml).
+An example `PipelineRun` with a LimitRange is available [here](../examples/v1beta1/pipelineruns/no-ci/limitrange.yaml).
 
 ---
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -716,7 +716,7 @@ with a minimum set for container resource requests (i.e. CPU, memory, and epheme
 are attempting to run, Tekton will search through all LimitRanges present in the namespace and use the minimum 
 set for container resource requests instead of requesting 0.
 
-An example `TaskRun` with a LimitRange is available [here](../examples/taskruns/no-ci/limitrange.yaml).
+An example `TaskRun` with a LimitRange is available [here](../examples/v1beta1/taskruns/no-ci/limitrange.yaml).
 
 ---
 


### PR DESCRIPTION
Similar to #2145 

The changes to the examples folder structure broke links for LimitRange examples. Updating the links to the new location. 

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
N/A
```
