### PR TITLE
Add some args to dind-sidecar to debug it 🐛

### DIFF
--- a/examples/v1alpha1/taskruns/dind-sidecar.yaml
+++ b/examples/v1alpha1/taskruns/dind-sidecar.yaml
@@ -40,6 +40,10 @@ spec:
     sidecars:
     - image: docker:dind
       name: server
+      args:
+        - --storage-driver=vfs
+        - --userland-proxy=false
+        - --debug
       securityContext:
         privileged: true
       env:

--- a/examples/v1beta1/taskruns/dind-sidecar.yaml
+++ b/examples/v1beta1/taskruns/dind-sidecar.yaml
@@ -40,6 +40,10 @@ spec:
     sidecars:
     - image: docker:dind
       name: server
+      args:
+        - --storage-driver=vfs
+        - --userland-proxy=false
+        - --debug
       securityContext:
         privileged: true
       env:

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -129,7 +129,11 @@ function run_yaml_tests() {
 
 function install_pipeline_crd() {
   echo ">> Deploying Tekton Pipelines"
-  ko apply -f config/ || fail_test "Build pipeline installation failed"
+  ko resolve -f config/ \
+      | sed -e 's%"level": "info"%"level": "debug"%' \
+      | sed -e 's%loglevel.controller: "info"%loglevel.controller: "debug"%' \
+      | sed -e 's%loglevel.webhook: "info"%loglevel.webhook: "debug"%' \
+      | kubectl apply -f - || fail_test "Build pipeline installation failed"
   verify_pipeline_installation
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

- Use vfs storage driver: it's slow but safer
- Disable userland-proxy, we don't need it
- Add --debug flag in case it fails to have more informations

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
