### PR TITLE
Fix resources doc  url broken

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -267,10 +267,10 @@ spec:
 You can refer to different examples demonstrating usage of optional resources in
 `Task`, `Condition`, and `Pipeline`:
 
--   [Task](../examples/taskruns/optional-resources.yaml)
--   [Cluster Task](../examples/taskruns/optional-resources-with-clustertask.yaml)
--   [Condition](../examples/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml)
--   [Pipeline](../examples/pipelineruns/demo-optional-resources.yaml)
+-   [Task](../examples/v1alpha1/taskruns/optional-resources.yaml)
+-   [Cluster Task](../examples/v1alpha1/taskruns/optional-resources-with-clustertask.yaml)
+-   [Condition](../examples/v1alpha1/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml)
+-   [Pipeline](../examples/v1alpha1/pipelineruns/demo-optional-resources.yaml)
 
 ## Resource Types
 


### PR DESCRIPTION
fix resources url broken

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
