### PR TITLE
SetDefaults for embedded specs (Pipeline, Task) 🥄

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
@@ -35,6 +35,9 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 				pt.TaskRef.Kind = NamespacedTaskKind
 			}
 		}
+		if pt.TaskSpec != nil {
+			pt.TaskSpec.SetDefaults(ctx)
+		}
 	}
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
@@ -56,4 +56,8 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	if prs.PodTemplate == nil {
 		prs.PodTemplate = defaultPodTemplate
 	}
+
+	if prs.PipelineSpec != nil {
+		prs.PipelineSpec.SetDefaults(ctx)
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -35,6 +35,9 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 				pt.TaskRef.Kind = NamespacedTaskKind
 			}
 		}
+		if pt.TaskSpec != nil {
+			pt.TaskSpec.SetDefaults(ctx)
+		}
 	}
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -56,4 +56,8 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	if prs.PodTemplate == nil {
 		prs.PodTemplate = defaultPodTemplate
 	}
+
+	if prs.PipelineSpec != nil {
+		prs.PipelineSpec.SetDefaults(ctx)
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -120,6 +120,29 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		},
 		wc: contexts.WithUpgradeViaDefaulting,
 	}, {
+		name: "Embedded PipelineSpec default",
+		in: &v1beta1.PipelineRun{
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "foo",
+					}},
+				},
+			},
+		},
+		want: &v1beta1.PipelineRun{
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "foo",
+						Type: "string",
+					}},
+				},
+				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			},
+		},
+		wc: contexts.WithUpgradeViaDefaulting,
+	}, {
 		name: "PipelineRef default config context",
 		in: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Embedded TaskSpec and PipelineSpec were not being *set defaults* when
the resource embedding it was. This fixes that.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @bobcatfish 
Fix #2157 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix defaults not being applied for embedded Pipeline(s) and Task(s)
```
