### PR TITLE
Invalid Sink URI CloudEvent test sometimes includes quotes

### DIFF
--- a/pkg/reconciler/taskrun/resources/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloudevent_test.go
@@ -73,7 +73,7 @@ func TestSendCloudEvent(t *testing.T) {
 		eventSourceURI:   defaultEventSourceURI,
 		cloudEventClient: defaultCloudEventClient,
 		wantErr:          true,
-		errRegexp:        fmt.Sprintf("%s: unsupported protocol scheme", invalidSinkURI),
+		errRegexp:        fmt.Sprintf("\"?%s\"?: unsupported protocol scheme", invalidSinkURI),
 	}, {
 		desc:             "send a cloud event, fail to send",
 		sinkURI:          defaultSinkURI,


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

In the logs for the latest pipeline nightly we saw a failed unit test for CloudEvents with the following message:

```
TestSendCloudEvent/send_a_cloud_event_with_invalid_sink_URI: cloudevent_test.go:106: I expected an error like invalid_URI: unsupported protocol scheme, but I got Post "invalid_URI": unsupported protocol scheme ""
```

It appears that sometimes the "invalid_URI" part of the error message will include quotes, and sometimes (like when running locally) it won't.

This PR updates the regex to allow for these quotes in the error message.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).