### PR TITLE
Document Task Results maximum size

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -283,7 +283,9 @@ Instead of hardcoding the path to the result file, the user can also use a varia
 
 ### Known issues
 
-When using a podTemplate to specify a non-root user for all containers, a task will not be able to modify the contents of the results directory and may fail.
+- When using a podTemplate to specify a non-root user for all containers, a task will not be able to modify the contents of the results directory and may fail.
+- Task Results are returned to the TaskRun controller via the container's
+termination log. At time of writing this has a capped maximum size of ["2048 bytes or 80 lines, whichever is smaller"](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message).
 
 ## How task results can be used in pipeline's tasks
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -393,6 +393,18 @@ spec:
 
 defines two results `current-date-unix-timestamp` and `current-date-human-readable`. To define a result, you specify a `name` that will correspond to the file name in the `/tekton/results` folder and a `description` where you can explain the purpose of the result.
 
+Note: The maximum size of a Task's results is limited by Kubernetes' container termination log feature. The results
+are passed back to the controller via this mechanism. At time of writing this has a capped maximum size of
+["2048 bytes or 80 lines, whichever is smaller"](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message).
+
+A Task Result is encoded as a JSON object when it is written to the termination log and Tekton also uses this
+object to pass some other information back to the controller as well. As such Task Results are best utilized for
+_small_ pieces of data.  Good candidates are commit SHAs, branch names, ephemeral namespace names, and so on.
+
+If you are writing many small Task Results from a single Task you can work around this size limit by writing
+the results from separate Steps - each Step has its own termination log. But for data larger than a kilobyte
+the next best alternative is to use a [Workspace](#workspaces) to shuttle data between Tasks in a Pipeline.
+
 ### Volumes
 
 Specifies one or more


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Task Results are returned from a Step to the controller through kubernetes' container termination log feature. This feature has a max size of 2KB or 80 lines, whichever is smaller.

This PR adds a bit of documentation to capture that info and links out to the kubernetes docs that describe this as well.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
