### PR TITLE
Creds-init writes to fixed location when HOME override is disabled

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
 )
 
@@ -53,6 +54,13 @@ func main() {
 		PostWriter:      &realPostWriter{},
 		Results:         strings.Split(*results, ","),
 	}
+
+	// Copy any creds injected by creds-init into the $HOME directory of the current
+	// user so that they're discoverable by git / ssh.
+	if err := credentials.CopyCredsToHome(credentials.CredsInitCredentials); err != nil {
+		log.Printf("non-fatal error copying credentials: %q", err)
+	}
+
 	if err := e.Go(); err != nil {
 		switch t := err.(type) {
 		case skipError:

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -256,6 +256,15 @@ func TestTaskSpecValidate(t *testing.T) {
 			}}},
 		},
 	}, {
+		name: "valid creds-init path variable",
+		fields: fields{
+			Steps: []v1alpha1.Step{{Container: corev1.Container{
+				Name:  "mystep",
+				Image: "echo",
+				Args:  []string{"$(credentials.path)"},
+			}}},
+		},
+	}, {
 		name: "step template included in validation",
 		fields: fields{
 			Steps: []v1alpha1.Step{{Container: corev1.Container{

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -191,6 +191,19 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				}}},
 			}},
 		},
+	}, {
+		name: "task spec with credentials.path variable",
+		spec: v1alpha1.TaskRunSpec{
+			TaskSpec: &v1alpha1.TaskSpec{TaskSpec: v1beta1.TaskSpec{
+				Steps: []v1alpha1.Step{{
+					Container: corev1.Container{
+						Name:  "mystep",
+						Image: "myimage",
+					},
+					Script: `echo "creds-init writes to $(credentials.path)"`,
+				}},
+			}},
+		},
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -161,6 +161,15 @@ func TestTaskSpecValidate(t *testing.T) {
 			}}},
 		},
 	}, {
+		name: "valid creds-init path variable",
+		fields: fields{
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Name:  "mystep",
+				Image: "echo",
+				Args:  []string{"$(credentials.path)"},
+			}}},
+		},
+	}, {
 		name: "step template included in validation",
 		fields: fields{
 			Steps: []v1beta1.Step{{Container: corev1.Container{

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -241,6 +241,19 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 				}}},
 			},
 		},
+	}, {
+		name: "task spec with credentials.path variable",
+		spec: v1beta1.TaskRunSpec{
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1alpha1.Step{{
+					Container: corev1.Container{
+						Name:  "mystep",
+						Image: "myimage",
+					},
+					Script: `echo "creds-init writes to $(credentials.path)"`,
+				}},
+			},
+		},
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/credentials/initialize_test.go
+++ b/pkg/credentials/initialize_test.go
@@ -1,0 +1,102 @@
+package credentials
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const credContents string = "hello, world!"
+
+func TestTryCopyCredDir(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+
+	fakeCredDir := filepath.Join(dir, ".docker")
+	err := os.Mkdir(fakeCredDir, 0700)
+	if err != nil {
+		t.Fatalf("unexpected error creating fake credential directory: %v", err)
+	}
+	credFilename := "important-credential.json"
+	writeFakeCred(t, fakeCredDir, credFilename, credContents)
+	destination := filepath.Join(dir, ".docker-copy")
+
+	copiedFile := filepath.Join(destination, credFilename)
+	if err := tryCopyCred(fakeCredDir, destination); err != nil {
+		t.Fatalf("error creating copy of credential directory: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(destination, credFilename)); err != nil {
+		t.Fatalf("error accessing copied credential: %v", err)
+	}
+	b, err := ioutil.ReadFile(copiedFile)
+	if err != nil {
+		t.Fatalf("unexpected error opening copied file: %v", err)
+	}
+	if string(b) != credContents {
+		t.Fatalf("mismatching file contents, expected %q received %q", credContents, string(b))
+	}
+}
+
+func TestTryCopyCredFile(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+	fakeCredFile := writeFakeCred(t, dir, ".git-credentials", credContents)
+	destination := filepath.Join(dir, ".git-credentials-copy")
+
+	if err := tryCopyCred(fakeCredFile, destination); err != nil {
+		t.Fatalf("error creating copy of credential file: %v", err)
+	}
+	if _, err := os.Lstat(destination); err != nil {
+		t.Fatalf("error accessing copied credential: %v", err)
+	}
+	b, err := ioutil.ReadFile(destination)
+	if err != nil {
+		t.Fatalf("unexpected error opening copied file: %v", err)
+	}
+	if string(b) != credContents {
+		t.Fatalf("mismatching file contents, expected %q received %q", credContents, string(b))
+	}
+}
+
+func TestTryCopyCredFileMissing(t *testing.T) {
+	dir, cleanup := createTempDir(t)
+	defer cleanup()
+	fakeCredFile := filepath.Join(dir, "foo")
+	destination := filepath.Join(dir, "foo-copy")
+
+	if err := tryCopyCred(fakeCredFile, destination); err != nil {
+		t.Fatalf("error creating copy of credential file: %v", err)
+	}
+	if _, err := os.Lstat(destination); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("error accessing copied credential: %v", err)
+	}
+	_, err := ioutil.ReadFile(destination)
+	if !os.IsNotExist(err) {
+		t.Fatalf("destination file exists but should not have been copied: %v", err)
+	}
+}
+
+func writeFakeCred(t *testing.T, dir, name, contents string) string {
+	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	path := filepath.Join(dir, name)
+	cred, err := os.OpenFile(path, flags, 0600)
+	if err != nil {
+		t.Fatalf("unexpected error writing fake credential: %v", err)
+	}
+	_, _ = cred.Write([]byte(credContents))
+	_ = cred.Close()
+	return path
+}
+
+func createTempDir(t *testing.T) (string, func()) {
+	dir, err := ioutil.TempDir("", "cred-test-fs-")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp directory: %v", err)
+	}
+	return dir, func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("unexpected error cleaning up temp directory: %v", err)
+		}
+	}
+}

--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -28,6 +28,22 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const homeEnvVar = "HOME"
+const credsInitHomeMountName = "tekton-creds-init-home"
+const credsInitHomeDir = "/tekton/creds"
+
+var credsInitHomeVolume = corev1.Volume{
+	Name: credsInitHomeMountName,
+	VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{
+		Medium: corev1.StorageMediumMemory,
+	}},
+}
+
+var credsInitHomeVolumeMount = corev1.VolumeMount{
+	Name:      credsInitHomeMountName,
+	MountPath: credsInitHomeDir,
+}
+
 // credsInit returns an init container that initializes credentials based on
 // annotated secrets available to the service account.
 //
@@ -86,12 +102,60 @@ func credsInit(credsImage string, serviceAccountName, namespace string, kubeclie
 		return nil, nil, nil
 	}
 
+	env := ensureCredsInitHomeEnv(implicitEnvVars)
+
 	return &corev1.Container{
 		Name:         "credential-initializer",
 		Image:        credsImage,
 		Command:      []string{"/ko-app/creds-init"},
 		Args:         args,
-		Env:          implicitEnvVars,
+		Env:          env,
 		VolumeMounts: volumeMounts,
 	}, volumes, nil
+}
+
+// CredentialsPath returns a string path to the location that the creds-init
+// helper binary will write its credentials to. The only argument is a boolean
+// true if Tekton will overwrite Steps' default HOME environment variable
+// with /tekton/home.
+func CredentialsPath(shouldOverrideHomeEnv bool) string {
+	if shouldOverrideHomeEnv {
+		return homeDir
+	}
+	return credsInitHomeDir
+}
+
+// ensureCredsInitHomeEnv ensures that creds-init always has its HOME environment
+// variable set to /tekton/creds unless it's already been explicitly set to
+// something else.
+//
+// We do this because Tekton's HOME override is being deprecated:
+// creds-init doesn't know the HOME directories of every Step in
+// the Task, and may not even be able to tell this in advance because
+// of randomized container UIDs like those of OpenShift. So, instead,
+// creds-init writes credentials to a single known location (/tekton/creds)
+// and leaves it up to the user's Steps to put those credentials in the
+// correct place.
+func ensureCredsInitHomeEnv(existingEnvVars []corev1.EnvVar) []corev1.EnvVar {
+	env := []corev1.EnvVar{}
+	setHome := true
+	for _, e := range existingEnvVars {
+		if e.Name == homeEnvVar {
+			setHome = false
+		}
+		env = append(env, e)
+	}
+	if setHome {
+		env = append(env, corev1.EnvVar{
+			Name:  homeEnvVar,
+			Value: credsInitHomeDir,
+		})
+	}
+	return env
+}
+
+// getCredsInitVolume returns the Volume and VolumeMount configuration needed
+// to mount the creds-init volume in Steps.
+func getCredsInitVolume(volumes []corev1.Volume) (corev1.Volume, corev1.VolumeMount) {
+	return credsInitHomeVolume, credsInitHomeVolumeMount
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -768,7 +768,7 @@ script-heredoc-randomly-generated-78c5n
 			// No entrypoints should be looked up.
 			entrypointCache := fakeCache{}
 
-			got, err := MakePod(images, tr, c.ts, kubeclient, entrypointCache)
+			got, err := MakePod(images, tr, c.ts, kubeclient, entrypointCache, true)
 			if err != nil {
 				t.Fatalf("MakePod: %v", err)
 			}
@@ -840,7 +840,7 @@ func TestShouldOverrideHomeEnv(t *testing.T) {
 			kubeclient := fakek8s.NewSimpleClientset(
 				tc.configMap,
 			)
-			if result := shouldOverrideHomeEnv(kubeclient); result != tc.expected {
+			if result := ShouldOverrideHomeEnv(kubeclient); result != tc.expected {
 				t.Errorf("Expected %t Received %t", tc.expected, result)
 			}
 		})

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -125,6 +125,15 @@ func ApplyTaskResults(spec *v1alpha1.TaskSpec) *v1alpha1.TaskSpec {
 	return ApplyReplacements(spec, stringReplacements, map[string][]string{})
 }
 
+// ApplyCredentialsPath applies a substitution of the key $(credentials.path) with the path that the creds-init
+// helper will write its credentials to.
+func ApplyCredentialsPath(spec *v1alpha1.TaskSpec, path string) *v1alpha1.TaskSpec {
+	stringReplacements := map[string]string{
+		"credentials.path": path,
+	}
+	return ApplyReplacements(spec, stringReplacements, map[string][]string{})
+}
+
 // ApplyReplacements replaces placeholders for declared parameters with the specified replacements.
 func ApplyReplacements(spec *v1alpha1.TaskSpec, stringReplacements map[string]string, arrayReplacements map[string][]string) *v1alpha1.TaskSpec {
 	spec = spec.DeepCopy()


### PR DESCRIPTION
# Changes

Fixes #2165
Relates to https://github.com/tektoncd/pipeline/issues/2013

When the disable-home-env-overwrite flag is set to "true" each Step in a Task can conceivably have its own HOME directory. The concept of "HOME" is further muddied in systems that randomize the UID of containers.

When the disanle-home-env-overwite flag is set to "true", creds-init will write its credentials to `/tekton/creds` instead of `/tekton/home`.  Then the entrypoint binary will copy the credentials from `/tekton/creds` into `$HOME` before the Task's Steps are allowed to run.  This change should be completely transparent to the user.

For those users who were for some very specific reason actually relying on the credentials being in `/tekton/home` we'll now expose a new variable substitution: `$(credentials.path)` will get replaced with the directory that creds-init writes to - either `/tekton/home` or `/tekton/creds` depending on the state of the disable-home-env-overwrite flag.

This is a stop-gap measure as we work towards beta. It seems that we will probably need to revisit our recommendations around auth and the contract we're making with creds-init.

- [x] Variable replacement for `$(credentials.path)`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Users who disable Tekton's HOME env overwrite will now find that git and docker credentials are written to a volumeMount, /tekton/creds, before they're copied into $HOME by the entrypoint. A new variable replacement has been introduced, $(credentials.path), which expands to the directory where creds-init writes its credentials, either /tekton/home or /tekton/creds.
```
