### PR TITLE
Adds logic to handle empty star array expansion

### DIFF
--- a/pkg/jsonpath/expand.go
+++ b/pkg/jsonpath/expand.go
@@ -104,6 +104,12 @@ func expandStringAsList(input string, context interface{}) ([]interface{}, error
 			}
 			return match
 		}
+
+		// if the array or object star expansion is empty, the replacement is the empty string
+		if len(expanded) == 0 {
+			return ""
+		}
+
 		// unless expanded in the context of an array we only want the first list item
 		// at some point we might allow {range} to process JSONPath lists
 		result := expanded[0]
@@ -136,6 +142,10 @@ func expandString(input string, context interface{}) (interface{}, error) {
 	expanded, err := expandStringAsList(input, context)
 	if err != nil {
 		return nil, err
+	}
+	// if the array or object star expansion is empty, return an empty string
+	if len(expanded) == 0 {
+		return "", nil
 	}
 	return expanded[0], nil
 }

--- a/pkg/jsonpath/expand_test.go
+++ b/pkg/jsonpath/expand_test.go
@@ -122,7 +122,8 @@ func TestExpand(t *testing.T) {
 			"a": float64(1),
 			"b": "abcd",
 		},
-		"null": nil,
+		"null":        nil,
+		"empty_array": []interface{}{},
 	}
 
 	tests := []struct {
@@ -157,6 +158,7 @@ func TestExpand(t *testing.T) {
 		{"$('')$(null)", "null"},
 		{"$('')$(obj)", `{"a":1,"b":"abcd"}`},
 		{"$('')$(array)", `[1,2,3,"a","b","c"]`},
+		{"$(empty_array[*])", ""},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When a star array expression is stringified we need to handle the case where the array is zero-length by returning the empty string.

# Changes
This commit adds check and tests for this case.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._



