### PR TITLE
Adds validation for Task.Script

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -266,6 +266,9 @@ func validateArrayUsage(steps []Step, prefix string, vars map[string]struct{}) *
 		if err := validateTaskNoArrayReferenced("workingDir", step.WorkingDir, prefix, vars); err != nil {
 			return err
 		}
+		if err := validateTaskNoArrayReferenced("script", step.Script, prefix, vars); err != nil {
+			return err
+		}
 		for i, cmd := range step.Command {
 			if err := validateTaskArraysIsolated(fmt.Sprintf("command[%d]", i), cmd, prefix, vars); err != nil {
 				return err
@@ -305,6 +308,9 @@ func validateVariables(steps []Step, prefix string, vars map[string]struct{}) *a
 			return err
 		}
 		if err := validateTaskVariable("workingDir", step.WorkingDir, prefix, vars); err != nil {
+			return err
+		}
+		if err := validateTaskVariable("script", step.Script, prefix, vars); err != nil {
 			return err
 		}
 		for i, cmd := range step.Command {


### PR DESCRIPTION
Task.Script was not being validated at all which showed up when a user was trying to illegaly use an array star expression in a script element.

# Changes
This commit adds the validation and appropriate validation tests for the Script field.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

