### PR TITLE
Update docs to use v1beta1 🙃

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -68,7 +68,7 @@ aggregates them into their respective files in `$HOME`.
 1. Then use that `ServiceAccount` in your `TaskRun` (in `run.yaml`):
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: build-push-task-run-2
@@ -81,7 +81,7 @@ spec:
 1. Or use that `ServiceAccount` in your `PipelineRun` (in `run.yaml`):
 
    ```yaml
-   apiVersion: tekton.dev/v1alpha1
+   apiVersion: tekton.dev/v1beta1
    kind: PipelineRun
    metadata:
      name: demo-pipeline
@@ -140,7 +140,7 @@ to authenticate when retrieving any `PipelineResources`.
 1. Then use that `ServiceAccount` in your `TaskRun` (in `run.yaml`):
 
    ```yaml
-   apiVersion: tekton.dev/v1alpha1
+   apiVersion: tekton.dev/v1beta1
    kind: TaskRun
    metadata:
      name: build-push-task-run-2
@@ -153,7 +153,7 @@ to authenticate when retrieving any `PipelineResources`.
 1. Or use that `ServiceAccount` in your `PipelineRun` (in `run.yaml`):
 
    ```yaml
-   apiVersion: tekton.dev/v1alpha1
+   apiVersion: tekton.dev/v1beta1
    kind: PipelineRun
    metadata:
      name: demo-pipeline
@@ -213,7 +213,7 @@ credentials are then used to authenticate when retrieving any
 1. Then use that `ServiceAccount` in your `TaskRun` (in `run.yaml`):
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: build-push-task-run-2
@@ -226,7 +226,7 @@ spec:
 1. Or use that `ServiceAccount` in your `PipelineRun` (in `run.yaml`):
 
    ```yaml
-   apiVersion: tekton.dev/v1alpha1
+   apiVersion: tekton.dev/v1beta1
    kind: PipelineRun
    metadata:
      name: demo-pipeline
@@ -250,7 +250,7 @@ credentials are then used to authenticate when retrieving any
 
 ## Kubernetes's Docker registry's secret
 
-Kubernetes defines two types of secrets for Docker registries : 
+Kubernetes defines two types of secrets for Docker registries :
 the old format `kubernetes.io/dockercfg` and the new
 `kubernetes.io/dockerconfigjson`. Tekton supports those secrets in
 addition to the one described above.
@@ -278,7 +278,7 @@ addition to the one described above.
 1. Use that `ServiceAccount` in your `TaskRun`:
 
    ```yaml
-   apiVersion: tetkon.dev/v1alpha1
+   apiVersion: tetkon.dev/v1beta1
    kind: TaskRun
    metadata:
      name: build-with-basic-auth

--- a/docs/migrating-from-knative-build.md
+++ b/docs/migrating-from-knative-build.md
@@ -80,19 +80,19 @@ spec:
 This is the equivalent Task:
 
 ```
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: go-test
 spec:
-  inputs:
-    params:
-    - name: TARGET
-      description: The Go target to test
-      default: ./...
+  params:
+  - name: TARGET
+    description: The Go target to test
+    default: ./...
 
-    # The Task must operate on some source, e.g., in a Git repo.
-    resources:
+  # The Task must operate on some source, e.g., in a Git repo.
+  resources:
+    inputs:
     - name: source
       type: git
 
@@ -100,7 +100,7 @@ spec:
   - name: go-test  # <-- the step must specify a name.
     image: golang
     workingDir: /workspace/source  # <-- set workingdir
-    command: ['go', 'test', '$(inputs.params.TARGET)']  # <-- specify inputs.params.TARGET
+    command: ['go', 'test', '$(params.TARGET)']  # <-- specify params.TARGET
 ```
 
 ### Build -> TaskRun
@@ -128,18 +128,18 @@ spec:
 This is the equivalent TaskRun:
 
 ```
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: example-run
 spec:
   taskRef:
     name: go-test
-  inputs:
-    params:
-    - name: TARGET
-      value: ./path/to/test/...
-    resources:
+  params:
+  - name: TARGET
+    value: ./path/to/test/...
+  resources:
+    inputs:
     - name: source
       resourceSpec:
         type: git

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -30,7 +30,7 @@ following fields:
 
 - Required:
   - [`apiVersion`][kubernetes-overview] - Specifies the API version, for example
-    `tekton.dev/v1alpha1`
+    `tekton.dev/vbeta1`
   - [`kind`][kubernetes-overview] - Specify the `PipelineRun` resource object.
   - [`metadata`][kubernetes-overview] - Specifies data to uniquely identify the
     `PipelineRun` resource object, for example a `name`.
@@ -241,7 +241,7 @@ In the following example, the `Task` is defined with a `volumeMount`
 `persistentVolumeClaim`. The Pod will also run as a non-root user.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: mytask
@@ -255,7 +255,7 @@ spec:
         - name: my-cache
           mountPath: /my-cache
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: mypipeline
@@ -265,7 +265,7 @@ spec:
       taskRef:
         name: mytask
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: mypipelineRun
@@ -383,7 +383,7 @@ spec to mark it as cancelled. Related `TaskRun` instances will be marked as
 cancelled and running Pods will be deleted.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: go-example-git
@@ -394,15 +394,15 @@ spec:
 
 ## LimitRanges
 
-In order to request the minimum amount of resources needed to support the containers 
-for `steps` that are part of a `TaskRun`, Tekton only requests the maximum values for CPU, 
-memory, and ephemeral storage from the `steps` that are part of a TaskRun. Only the max 
-resource request values are needed since `steps` only execute one at a time in a `TaskRun` pod. 
-All requests that are not the max values are set to zero as a result. 
+In order to request the minimum amount of resources needed to support the containers
+for `steps` that are part of a `TaskRun`, Tekton only requests the maximum values for CPU,
+memory, and ephemeral storage from the `steps` that are part of a TaskRun. Only the max
+resource request values are needed since `steps` only execute one at a time in a `TaskRun` pod.
+All requests that are not the max values are set to zero as a result.
 
-When a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) is present in a namespace 
-with a minimum set for container resource requests (i.e. CPU, memory, and ephemeral storage) where `PipelineRuns` 
-are attempting to run, Tekton will search through all LimitRanges present in the namespace and use the minimum 
+When a [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) is present in a namespace
+with a minimum set for container resource requests (i.e. CPU, memory, and ephemeral storage) where `PipelineRuns`
+are attempting to run, Tekton will search through all LimitRanges present in the namespace and use the minimum
 set for container resource requests instead of requesting 0.
 
 An example `PipelineRun` with a LimitRange is available [here](../examples/v1beta1/pipelineruns/no-ci/limitrange.yaml).

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -25,7 +25,7 @@ following fields:
 
 - Required:
   - [`apiVersion`][kubernetes-overview] - Specifies the API version, for example
-    `tekton.dev/v1alpha1`.
+    `tekton.dev/v1beta1`.
   - [`kind`][kubernetes-overview] - Specify the `Pipeline` resource object.
   - [`metadata`][kubernetes-overview] - Specifies data to uniquely identify the
     `Pipeline` resource object, for example a `name`.
@@ -51,9 +51,9 @@ following fields:
         apply to cancellations.
       - [`conditions`](#conditions) - Used when a task is to be executed only if the specified
         conditions are evaluated to be true.
-      - [`timeout`](#timeout) - Specifies timeout after which the `TaskRun` for a Pipeline Task will 
-        fail. There is no default timeout for a Pipeline Task timeout. If no timeout is specified for 
-        the Pipeline Task, the only timeout taken into account for running a `Pipeline` will be a 
+      - [`timeout`](#timeout) - Specifies timeout after which the `TaskRun` for a Pipeline Task will
+        fail. There is no default timeout for a Pipeline Task timeout. If no timeout is specified for
+        the Pipeline Task, the only timeout taken into account for running a `Pipeline` will be a
         [timeout for the `PipelineRun`](https://github.com/tektoncd/pipeline/blob/master/docs/pipelineruns.md#syntax).
 
 [kubernetes-overview]:
@@ -166,7 +166,7 @@ a parameter are optional, and if the `default` field is specified and this
 the `default` value will be used.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: pipeline-with-parameters
@@ -190,7 +190,7 @@ spec:
 The following `PipelineRun` supplies a value for `context`:
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: pipelinerun-with-parameters
@@ -205,7 +205,7 @@ spec:
 ### Pipeline Tasks
 
 A `Pipeline` will execute a graph of [`Tasks`](tasks.md) (see
-[ordering](#ordering) for how to express this graph). A valid `Pipeline` 
+[ordering](#ordering) for how to express this graph). A valid `Pipeline`
 declaration must include a reference to at least one [`Task`](tasks.md). Each
 `Task` within a `Pipeline` must have a
 [valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)
@@ -358,11 +358,11 @@ triggered: a max of two executions.
 
 #### conditions
 
-Sometimes you will need to run tasks only when some conditions are true. The `conditions` field 
+Sometimes you will need to run tasks only when some conditions are true. The `conditions` field
 allows you to list a series of references to [`Conditions`](./conditions.md) that are run before the task
 is run. If all of the conditions evaluate to true, the task is run. If any of the conditions are false,
 the Task is not run. Its status.ConditionSucceeded is set to False with the reason set to  `ConditionCheckFailed`.
-However, unlike regular task failures, condition failures do not automatically fail the entire pipeline 
+However, unlike regular task failures, condition failures do not automatically fail the entire pipeline
 run -- other tasks that are not dependent on the task (via `from` or `runAfter`) are still run.
 
 ```yaml
@@ -380,10 +380,10 @@ tasks:
             resource: source-repo
 ```
 
-In this example, `my-condition` refers to a [Condition](conditions.md) custom resource. The `build-push` 
-task will only be executed if the condition evaluates to true. 
+In this example, `my-condition` refers to a [Condition](conditions.md) custom resource. The `build-push`
+task will only be executed if the condition evaluates to true.
 
-Resources in conditions can also use the [`from`](#from) field to indicate that they 
+Resources in conditions can also use the [`from`](#from) field to indicate that they
 expect the output of a previous task as input. As with regular Pipeline Tasks, using `from`
 implies ordering --  if task has a condition that takes in an output resource from
 another task, the task producing the output resource will run first:
@@ -410,11 +410,11 @@ tasks:
 
 #### Timeout
 
-The Timeout property of a Pipeline Task allows a timeout to be defined for a `TaskRun` that 
-is part of a `PipelineRun`. If the `TaskRun` exceeds the amount of time specified, the `TaskRun` 
-will fail and the `PipelineRun` associated with a `Pipeline` will fail as well. 
+The Timeout property of a Pipeline Task allows a timeout to be defined for a `TaskRun` that
+is part of a `PipelineRun`. If the `TaskRun` exceeds the amount of time specified, the `TaskRun`
+will fail and the `PipelineRun` associated with a `Pipeline` will fail as well.
 
-There is no default timeout for Pipeline Tasks, so a timeout must be specified with a Pipeline Task 
+There is no default timeout for Pipeline Tasks, so a timeout must be specified with a Pipeline Task
 when defining a `Pipeline` if one is needed. An example of a Pipeline Task with a Timeout is shown below:
 
 ```yaml
@@ -426,8 +426,8 @@ spec:
       Timeout: "0h1m30s"
 ```
 
-The Timeout property is specified as part of the Pipeline Task on the `Pipeline` spec. The above 
-example has a timeout of one minute and 30 seconds.  
+The Timeout property is specified as part of the Pipeline Task on the `Pipeline` spec. The above
+example has a timeout of one minute and 30 seconds.
 
 ### Results
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -80,7 +80,7 @@ variables such as `path` using the variable substitution syntax below where
 
 #### In Task Spec:
 
-For an input resource in a `Task` spec: `shell $(inputs.resources.<name>.<key>)`
+For an input resource in a `Task` spec: `shell $(resources.inputs.<name>.<key>)`
 
 Or for an output resource:
 
@@ -99,7 +99,7 @@ $(resources.<name>.<key>)
 #### Accessing local path to resource
 
 The `path` key is pre-defined and refers to the local path to a resource on the
-mounted volume `shell $(inputs.resources.<name>.path)`
+mounted volume `shell $(resources.inputs.<name>.path)`
 
 ### Controlling where resources are mounted
 
@@ -110,14 +110,14 @@ will be initialized under `/workspace`. The following example demonstrates how
 git input repository could be initialized in `$GOPATH` to run tests:
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: task-with-input
   namespace: default
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: workspace
         type: git
         targetPath: go/src/github.com/tektoncd/pipeline
@@ -160,18 +160,17 @@ resource `java-git-resource` (including the war artifact) copied to the
 destination path `/custom/workspace/`.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: volume-task
   namespace: default
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: workspace
         type: git
-  outputs:
-    resources:
+    outputs:
       - name: workspace
   steps:
     - name: build-war
@@ -184,7 +183,7 @@ spec:
 ```
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
   name: volume-taskrun
@@ -192,13 +191,12 @@ metadata:
 spec:
   taskRef:
     name: volume-task
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: workspace
         resourceRef:
           name: java-git-resource
-  outputs:
-    resources:
+    outputs:
       - name: workspace
         paths:
           - /custom/workspace/
@@ -234,13 +232,13 @@ for that resource. Resources declared as `optional` in a `Task` does not have be
 specified in `TaskRun`.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: task-check-optional-resources
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: git-repo
         type: git
         optional: true
@@ -250,7 +248,7 @@ Similarly, resources declared as `optional` in a `Pipeline` does not have to be
 specified in `PipelineRun`.
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: pipeline-build-image
@@ -267,10 +265,10 @@ spec:
 You can refer to different examples demonstrating usage of optional resources in
 `Task`, `Condition`, and `Pipeline`:
 
--   [Task](../examples/v1alpha1/taskruns/optional-resources.yaml)
--   [Cluster Task](../examples/v1alpha1/taskruns/optional-resources-with-clustertask.yaml)
--   [Condition](../examples/v1alpha1/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml)
--   [Pipeline](../examples/v1alpha1/pipelineruns/demo-optional-resources.yaml)
+-   [Task](../examples/v1beta1/taskruns/optional-resources.yaml)
+-   [Cluster Task](../examples/v1beta1/taskruns/optional-resources-with-clustertask.yaml)
+-   [Condition](../examples/v1beta1/pipelineruns/conditional-pipelinerun-with-optional-resources.yaml)
+-   [Pipeline](../examples/v1beta1/pipelineruns/demo-optional-resources.yaml)
 
 ## Resource Types
 
@@ -542,17 +540,16 @@ exported. For example this build-push task defines the `outputImageDir` for the
 `builtImage` resource in `/workspace/buildImage`
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: build-push
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: workspace
         type: git
-  outputs:
-    resources:
+    outputs:
       - name: builtImage
         type: image
         targetPath: /workspace/builtImage
@@ -674,14 +671,14 @@ Example usage of the `cluster` resource in a `Task`, using
 [variable substitution](tasks.md#variable-substitution):
 
 ```yaml
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: deploy-image
   namespace: default
 spec:
-  inputs:
-    resources:
+  resources:
+    inputs:
       - name: workspace
         type: git
       - name: dockerimage
@@ -695,8 +692,8 @@ spec:
       args:
         - "-c"
         - kubectl --kubeconfig
-          /workspace/$(inputs.resources.testcluster.name)/kubeconfig --context
-          $(inputs.resources.testcluster.name) apply -f /workspace/service.yaml'
+          /workspace/$(resources.inputs.testcluster.name)/kubeconfig --context
+          $(resources.inputs.testcluster.name) apply -f /workspace/service.yaml'
 ```
 
 To use the `cluster` resource with Google Kubernetes Engine, you should use the
@@ -940,7 +937,7 @@ The content of an event is for example:
 Context Attributes,
   SpecVersion: 0.2
   Type: dev.tekton.event.task.successful
-  Source: /apis/tekton.dev/v1alpha1/namespaces/default/taskruns/pipeline-run-api-16aa55-source-to-image-task-rpndl
+  Source: /apis/tekton.dev/v1beta1/namespaces/default/taskruns/pipeline-run-api-16aa55-source-to-image-task-rpndl
   ID: pipeline-run-api-16aa55-source-to-image-task-rpndl
   Time: 2019-07-04T11:03:53.058694712Z
   ContentType: application/json


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Update the `docs/` folder to use `v1beta1` struct when possible
instead of `v1alpha1`. This is a follow-up to "expose v1beta1"
pull-request and is required for the next release.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind documentation

/cc @sbwsg @skaegi @bobcatfish @danielhelfand @dibyom 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Update documentation to use `v1beta1` instead of `v1alpha1`
```
