### PR TITLE
Fix to FieldError fields name for duplicate param names

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -104,7 +104,7 @@ func validateParameters(params []Param) *apis.FieldError {
 	seen := map[string]struct{}{}
 	for _, p := range params {
 		if _, ok := seen[strings.ToLower(p.Name)]; ok {
-			return apis.ErrMultipleOneOf("spec.inputs.params")
+			return apis.ErrMultipleOneOf("spec.params.name")
 		}
 		seen[p.Name] = struct{}{}
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -189,7 +189,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
 		},
-		wantErr: apis.ErrMultipleOneOf("spec.inputs.params"),
+		wantErr: apis.ErrMultipleOneOf("spec.params.name"),
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #2192


# Changes
Changes field name from spec.inputs.params to spec.params.name to be consistent with other validation checks.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
