### PR TITLE
Add jq to the imagedigestexporter image 💫

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,5 @@
 baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
+  github.com/tektoncd/pipeline/cmd/imagedigestexporter: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/jq-base:latest
   github.com/tektoncd/pipeline/cmd/entrypoint: busybox  # image must have `cp` in $PATH

--- a/.ko.yaml.release
+++ b/.ko.yaml.release
@@ -1,4 +1,5 @@
 baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tektoncd-release/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tektoncd-release/github.com/tektoncd/pipeline/build-base:latest
+  github.com/tektoncd/pipeline/cmd/imagedigestexporter: gcr.io/tekton-release/github.com/tektoncd/pipeline/jq-base:latest
   github.com/tektoncd/pipeline/cmd/entrypoint: busybox # image should have shell in $PATH

--- a/images/Dockerfile.jq
+++ b/images/Dockerfile.jq
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN apk add --update git openssh-client jq \
+    && apk update \
+    && apk upgrade

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -23,6 +23,8 @@ spec:
       type: storage
     - name: builtBaseImage
       type: image
+    - name: builtBaseJqImage
+      type: image
     - name: builtEntrypointImage
       type: image
     - name: builtKubeconfigWriterImage
@@ -45,14 +47,30 @@ spec:
       type: cloudEvent
   steps:
 
-  - name: build-push-base-images
+  - name: build-push-build-base-images
     image: gcr.io/kaniko-project/executor:v0.17.1
     command:
     - /kaniko/executor
     args:
     - --dockerfile=/workspace/go/src/github.com/tektoncd/pipeline/images/Dockerfile
     - --destination=$(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtBaseImage.url)
-    - --context=/workspace/go/src/github.com/tektoncd/pipeline
+    - --context=/workspace/go/src/github.com/tektoncd/pipeline/images
+
+    volumeMounts:
+      - name: gcp-secret
+        mountPath: /secret
+    env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /secret/release.json
+
+  - name: build-push-jq-base-images
+    image: gcr.io/kaniko-project/executor:v0.17.1
+    command:
+    - /kaniko/executor
+    args:
+    - --dockerfile=/workspace/go/src/github.com/tektoncd/pipeline/images/Dockerfile.jq
+    - --destination=$(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtJqBaseImage.url)
+    - --context=/workspace/go/src/github.com/tektoncd/pipeline/images/
 
     volumeMounts:
       - name: gcp-secret


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This will make the `imagedigestexporter` useful in a step in a
Task (from the catalog for example).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add jq to the imagedigestexporter image
```
