### PR TITLE
Replace ZenHub project with GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,19 +31,6 @@ You can find details on our automation infrastructure in
 
 For more Pipelines specific guidelines, see:
 
-- [The Tekton Pipelines ZenHub project](#zenhub-project)
+- [The Tekton Pipelines GitHub project](https://github.com/orgs/tektoncd/projects/3)
 - [The Tekton Pipelines roadmap](roadmap-2019.md)
 - [The Tekton Pipelines API compatibility policy](api_compatibility_policy.md)
-
-## ZenHub project
-
-You can see project details (including a burndown, issues in epics, etc.) on our
-[ZenHub board](https://app.zenhub.com/workspaces/pipelines-5bc61a054b5806bc2bed4fb2/boards?repos=146641150).
-
-To see this board, you must:
-
-- Ask [an OWNER](OWNERS) via
-  [slack](https://github.com/tektoncd/community/blob/master/contact.md#slack)
-  for an invitation
-- Add [the ZenHub browser extension](https://www.zenhub.com/extension) to see
-  new info via GitHub (or just use zenhub.com directly)


### PR DESCRIPTION
# Changes

We've started using GitHub for project tracking instead of ZenHub! We were using ZenHub for 2 reasons:
1. Burndown
2. Cross repo project planning

GitHub projects now provide (2) and we don't really use (1) anymore, so now we're using GitHub projects which have a lower barrier to usage.

@vdemeester @afrittoli @dibyom @sbwsg @wlynch 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).