### PR TITLE
Fix Broken Params Link in tasks.md

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -77,7 +77,7 @@ following fields:
       to run in your `Task`.
 - Optional:
   - [`description`](#description) - Description of the Task.
-  - [`params`](#params) - Specifies parameters
+  - [`params`](#parameters) - Specifies parameters
   - [`resources`](#resources) - Specifies
     [`PipelineResources`](resources.md) needed or created by your
     `Task`. *Note: this is an alpha field, it is not supported as the


### PR DESCRIPTION
The section is called Parameters, not Params. Changing the link from `#params` -> `#parameters`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
N/A
```
