### PR TITLE
Fetch remote task refs from images in taskruns

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -83,7 +83,18 @@ spec:
     name: read-task
 ```
 
-Or you can embed the spec of the `Task` directly in the `TaskRun`:
+You can also reference a `Task` contained in an OCI-compliant `Image`.
+
+```yaml
+spec:
+  taskRef:
+    name: read-task
+    image: docker.com/my-repo/my-image
+```
+
+These images can be generated using [this](https://github.com/tektoncd/experimental/tree/master/oci) cli and uploaded to most registries. You can also specify a digest or tag on the image. If access is required to read the image, a [service account](#service-account) must be specified on the `TaskRun` with an `ImagePullSecret` to properly fetch the image.
+
+You can also embed the spec of the `Task` directly in the `TaskRun`:
 
 ```yaml
 spec:

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -138,6 +138,9 @@ type TaskRef struct {
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
+	// Image reference that contains the task referenced.
+	// +optional
+	Image string `json:"image,omitempty"`
 }
 
 // Check that Pipeline may be validated and defaulted.

--- a/pkg/remote/oci_test.go
+++ b/pkg/remote/oci_test.go
@@ -17,56 +17,16 @@ limitations under the License.
 package remote
 
 import (
-	"fmt"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
-	imgv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/empty"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/tektoncd/pipeline/test"
+	tb "github.com/tektoncd/pipeline/test/builder"
 )
-
-func pushImage(imgRef name.Reference, task *v1beta1.Task) (imgv1.Image, error) {
-	taskRaw, err := yaml.Marshal(task)
-	if err != nil {
-		return nil, fmt.Errorf("invalid sample task def %s", err.Error())
-	}
-
-	img := mutate.MediaType(empty.Image, types.MediaType("application/vnd.cdf.tekton.catalog.v1beta1+yaml"))
-	layer, err := tarball.LayerFromReader(strings.NewReader(string(taskRaw)))
-	if err != nil {
-		return nil, fmt.Errorf("unexpected error adding task layer to image %s", err.Error())
-	}
-
-	img, err = mutate.Append(img, mutate.Addendum{
-		Layer: layer,
-		Annotations: map[string]string{
-			"org.opencontainers.image.title": fmt.Sprintf("task/%s", task.GetName()),
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("could not add layer to image %s", err.Error())
-	}
-
-	if err := remoteimg.Write(imgRef, img); err != nil {
-		return nil, fmt.Errorf("could not push example image to registry")
-	}
-
-	return img, nil
-}
 
 func TestOCIResolver(t *testing.T) {
 	// Set up a fake registry to push an image to.
@@ -77,48 +37,25 @@ func TestOCIResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	imgRef, err := name.ParseReference(fmt.Sprintf("%s/test/ociresolver", u.Host))
-	if err != nil {
-		t.Errorf("undexpected error producing image reference %s", err.Error())
-	}
-
 	// Create the image using an example task.
-	task := v1beta1.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "hello-world",
-		},
-		Spec: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{
-				{
-					Container: v1.Container{
-						Image: "ubuntu",
-					},
-					Script: "echo \"Hello World!\"",
-				},
-			},
-		},
-	}
-	img, err := pushImage(imgRef, &task)
+	task := tb.Task("hello-world", "", tb.TaskType(), tb.TaskSpec(tb.Step("ubuntu", tb.StepCommand("echo 'Hello'"))))
+	imgRef, err := test.CreateTaskImage(u.Host, task)
 	if err != nil {
-		t.Error(err)
+		t.Errorf("unexpected error pushing task image %w", err)
 	}
 
 	// Now we can call our resolver and see if the spec returned is the same.
-	digest, err := img.Digest()
-	if err != nil {
-		t.Errorf("unexpected error getting digest of image: %s", err.Error())
-	}
 	resolver := OCIResolver{
-		imageReference:   imgRef.Context().Digest(digest.String()).String(),
-		keychainProvider: func() (authn.Keychain, error) { return authn.DefaultKeychain, nil },
+		imageReference: imgRef,
+		keychain:       authn.DefaultKeychain,
 	}
 
-	actual, err := resolver.GetTask("hello-world")
+	ta, err := resolver.GetTask("hello-world")
 	if err != nil {
-		t.Errorf("failed to fetch task hello-world: %s", err.Error())
+		t.Errorf("failed to fetch task hello-world: %w", err)
 	}
 
-	if diff := cmp.Diff(actual, &task.Spec); diff != "" {
+	if diff := cmp.Diff(ta, task); diff != "" {
 		t.Error(diff)
 	}
 }

--- a/pkg/remote/resolver.go
+++ b/pkg/remote/resolver.go
@@ -17,22 +17,27 @@ limitations under the License.
 package remote
 
 import (
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"k8s.io/client-go/kubernetes"
 )
 
-// Resolver will retrieve Tekton resources like Tasks from remote repositories like an OCI image repositories.
+// Resolver will retreive Tekton resources like Tasks from remote repositories like an OCI image repository.
 type Resolver interface {
-	GetTask(taskName string) (*v1beta1.TaskSpec, error)
+	GetTask(string) (v1alpha1.TaskInterface, error)
 }
 
-// TODO: Right now, there is only one resolver type. When more are added, this will need to be updated.
-func NewResolver(imageReference string, serviceAccountName string) Resolver {
-	return OCIResolver{
-		imageReference: imageReference,
-		keychainProvider: func() (authn.Keychain, error) {
-			return k8schain.NewInCluster(k8schain.Options{ServiceAccountName: serviceAccountName})
-		},
+// ImageTaskResolver will return a GetTask function capable of returning a Task from an OCI compliant image using the
+// image pull secrets of the included service account.
+func ImageTaskResolver(k8s kubernetes.Interface, imgRef, ns, serviceAccountName string) (resources.GetTask, error) {
+	kc, err := k8schain.New(k8s, k8schain.Options{
+		Namespace:          ns,
+		ServiceAccountName: serviceAccountName,
+	})
+	if err != nil {
+		return nil, err
 	}
+	resolver := NewOCIResolver(imgRef, kc)
+	return resolver.GetTask, nil
 }

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -93,6 +93,10 @@ var (
 // Any number of Task modifier can be passed to transform it.
 func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
 	t := &v1alpha1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "Task",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -134,6 +138,14 @@ func ClusterTaskSpec(ops ...TaskSpecOp) ClusterTaskOp {
 	}
 }
 
+// TaskType sets the innate TypeMeta of the task. This is useful if you need to serialize/deserialize a task.
+func ClusterTaskType() ClusterTaskOp {
+	return func(t *v1alpha1.ClusterTask) {
+		t.TypeMeta.APIVersion = "tekton.dev/v1alpha1"
+		t.TypeMeta.Kind = "ClusterTask"
+	}
+}
+
 // TaskSpec sets the specified spec of the task.
 // Any number of TaskSpec modifier can be passed to create/modify it.
 func TaskSpec(ops ...TaskSpecOp) TaskOp {
@@ -143,6 +155,14 @@ func TaskSpec(ops ...TaskSpecOp) TaskOp {
 			op(spec)
 		}
 		t.Spec = *spec
+	}
+}
+
+// TaskType sets the innate TypeMeta of the task. This is useful if you need to serialize/deserialize a task.
+func TaskType() TaskOp {
+	return func(t *v1alpha1.Task) {
+		t.TypeMeta.APIVersion = "tekton.dev/v1alpha1"
+		t.TypeMeta.Kind = "Task"
 	}
 }
 
@@ -669,6 +689,13 @@ func TaskRefKind(kind v1alpha1.TaskKind) TaskRefOp {
 func TaskRefAPIVersion(version string) TaskRefOp {
 	return func(ref *v1alpha1.TaskRef) {
 		ref.APIVersion = version
+	}
+}
+
+// TaskRefImage sets the remote image reference for the task ref.
+func TaskRefImage(image string) TaskRefOp {
+	return func(ref *v1alpha1.TaskRef) {
+		ref.Image = image
 	}
 }
 

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func TestTask(t *testing.T) {
-	task := tb.Task("test-task", "foo", tb.TaskSpec(
+	task := tb.Task("test-task", "foo", tb.TaskType(), tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceTargetPath("/foo/bar")),
 			tb.InputsResource("optional_workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true)),
@@ -67,6 +67,10 @@ func TestTask(t *testing.T) {
 		tb.TaskWorkspace("bread", "kind of bread", "/bread/path", false),
 	))
 	expectedTask := &v1alpha1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "Task",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test-task", Namespace: "foo"},
 		Spec: v1alpha1.TaskSpec{
 			TaskSpec: v1beta1.TaskSpec{
@@ -143,12 +147,16 @@ func TestTask(t *testing.T) {
 }
 
 func TestClusterTask(t *testing.T) {
-	task := tb.ClusterTask("test-clustertask", tb.ClusterTaskSpec(
+	task := tb.ClusterTask("test-clustertask", tb.ClusterTaskType(), tb.ClusterTaskSpec(
 		tb.Step("myimage", tb.StepCommand("/mycmd"), tb.StepArgs(
 			"--my-other-arg=$(inputs.resources.workspace.url)",
 		)),
 	))
 	expectedTask := &v1alpha1.ClusterTask{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "ClusterTask",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test-clustertask"},
 		Spec: v1alpha1.TaskSpec{TaskSpec: v1beta1.TaskSpec{
 			Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -178,6 +186,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 			tb.TaskRunTaskRef("task-output",
 				tb.TaskRefKind(v1alpha1.ClusterTaskKind),
 				tb.TaskRefAPIVersion("a1"),
+				tb.TaskRefImage("docker.com/remote/task"),
 			),
 			tb.TaskRunInputs(
 				tb.TaskRunInputsResource(gitResource.Name,
@@ -273,6 +282,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 				Name:       "task-output",
 				Kind:       v1alpha1.ClusterTaskKind,
 				APIVersion: "a1",
+				Image:      "docker.com/remote/task",
 			},
 			Workspaces: []v1alpha1.WorkspaceBinding{{
 				Name:     "bread",

--- a/test/remote.go
+++ b/test/remote.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// CreateTaskImage will push a new OCI image artifact with the provided task as a layer and return the full image
+// reference with a digest to fetch the image.
+func CreateTaskImage(registryHost string, task v1alpha1.TaskInterface) (string, error) {
+	imgRef, err := name.ParseReference(fmt.Sprintf("%s/taskimage/%s", registryHost, task.TaskMetadata().Name))
+	if err != nil {
+		return "", fmt.Errorf("undexpected error producing image reference %w", err)
+	}
+
+	raw, err := yaml.Marshal(task)
+	if err != nil {
+		return "", fmt.Errorf("invalid sample task def %w", err)
+	}
+
+	layer, err := tarball.LayerFromReader(strings.NewReader(string(raw)))
+	if err != nil {
+		return "", fmt.Errorf("unexpected error adding task layer to image %w", err)
+	}
+
+	img, err := mutate.Append(empty.Image, mutate.Addendum{
+		Layer: layer,
+		Annotations: map[string]string{
+			"org.opencontainers.image.title": fmt.Sprintf("task/%s", task.TaskMetadata().Name),
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not add layer to image %w", err)
+	}
+
+	if err := remoteimg.Write(imgRef, img); err != nil {
+		return "", fmt.Errorf("could not push example image to registry")
+	}
+
+	digest, err := img.Digest()
+	if err != nil {
+		return "", fmt.Errorf("could not read image digest: %w", err)
+	}
+
+	return imgRef.Context().Digest(digest.String()).String(), nil
+}


### PR DESCRIPTION
This includes several smaller refactors that came to light while
incorporating the fetching into the taskruns.

1. The OCIResolver is edited to return a TaskInterface. This is so that
   OCIResolver.GetTask can be used 1:1 with the `resources.GetTask` and
   remote task fetching can be substituted for local task fetching.

2. Instead of using a Keychain provider, we instead directly instaniate
   the keychain we need. This is exactly how the entrypoint impl works as
   well. The reason for doing this is to avoid the "in-cluster" calls that
   the previous API had. We already are piping through a
   `kubernetes.Interface` so we can just reuse that for in-cluster access
   and to mock it out in testing.
3. We allow  `GetTask` to return either a Task or ClusterTask
4. The testbuilder is updated to have an option to set the `TypeMeta` on
   the resources so that they can be marshalled properly.
5. A new test helper is created to take a url for a local registry and
   to upload a task definition as an image and return the reference.
6. The TaskRun reconciler is updated to return the proper `GetTask`
   func. If the `taskRef` specifies an `image` field (which has been added
   to the API with docs), then a remote resolver is constructed and it's
   `GetTask` is returned. Test cases are added for both NamespacedTasks and
   ClusterTasks. Specifically, this introduces no changes to the
   `resources/taskspec.go` which calls `GetTask` and returns the task's
   metadata and spec.

Part of #1839 


These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.


If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

## Release Notes

```
You can also reference a `Task` contained in an OCI-compliant `Image`
```