### PR TITLE
Add the git resource ref to the ResourceResult for git resources.

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -17,8 +17,10 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/git"
 	"github.com/tektoncd/pipeline/pkg/termination"
 	"go.uber.org/zap"
@@ -61,10 +63,14 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Error parsing commit of git repository: %s", err)
 	}
+	resourceName := os.Getenv("TEKTON_RESOURCE_NAME")
 	output := []v1alpha1.PipelineResourceResult{
 		{
 			Key:   "commit",
 			Value: commit,
+			ResourceRef: v1beta1.PipelineResourceRef{
+				Name: resourceName,
+			},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
+	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
 	github.com/cloudevents/sdk-go v1.0.0
@@ -42,6 +43,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20200214144324-88be01311a71 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
+	google.golang.org/api v0.15.0
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	k8s.io/api v0.17.3

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -100,6 +100,10 @@ func TestKanikoTaskRun(t *testing.T) {
 		case "commit":
 			commit = rr.Value
 		}
+		// Every resource should have a ref with a name
+		if rr.ResourceRef.Name == "" {
+			t.Errorf("Resource ref not set for %v in TaskRun: %v", rr, tr)
+		}
 	}
 	if digest == "" {
 		t.Errorf("Digest not found in TaskRun.Status: %v", tr.Status)


### PR DESCRIPTION
# Changes

This includes the full name of the git resource in the resource result for
git resources. We pass this along in the environment variable already, this
includes it back in the resource result so we can tie the commit sha and
branch name in the result.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The `git` PipelineResource now includes the resourceRef in the `resourcesResult` section. For example:

    "resourcesResult": [
      {
        "key": "commit",
        "value": "6ed7aad5e8a36052ee5f6079fc91368e362121f7",
        "resourceRef": {
           "name": "my-resource"
        }
      },
```
