### PR TITLE
Add Results to testbuilder

### DIFF
--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -67,6 +67,9 @@ type TaskRunStatusOp func(*v1alpha1.TaskRunStatus)
 // TaskRefOp is an operation which modify a TaskRef struct.
 type TaskRefOp func(*v1alpha1.TaskRef)
 
+// TaskResultOp is an operation which modifies there
+type TaskResultOp func(result *v1beta1.TaskResult)
+
 // TaskRunInputsOp is an operation which modify a TaskRunInputs struct.
 type TaskRunInputsOp func(*v1alpha1.TaskRunInputs)
 
@@ -247,6 +250,17 @@ func TaskResources(ops ...TaskResourcesOp) TaskSpecOp {
 	}
 }
 
+// TaskResults sets the Results to the TaskSpec
+func TaskResults(name, desc string) TaskSpecOp {
+	return func(spec *v1alpha1.TaskSpec) {
+		r := &v1beta1.TaskResult{
+			Name:        name,
+			Description: desc,
+		}
+		spec.Results = append(spec.Results, *r)
+	}
+}
+
 // TaskResourcesInput adds a TaskResource as Inputs to the TaskResources
 func TaskResourcesInput(name string, resourceType v1alpha1.PipelineResourceType, ops ...TaskResourceOp) TaskResourcesOp {
 	return func(r *v1beta1.TaskResources) {
@@ -276,6 +290,19 @@ func TaskResourcesOutput(name string, resourceType v1alpha1.PipelineResourceType
 			op(o)
 		}
 		r.Outputs = append(r.Outputs, *o)
+	}
+}
+
+// TaskResultsOutput adds a TaskResult as Outputs to the TaskResources
+func TaskResultsOutput(name, desc string, ops ...TaskResultOp) TaskResultOp {
+	return func(result *v1beta1.TaskResult) {
+		r := &v1beta1.TaskResult{
+			Name:        name,
+			Description: desc,
+		}
+		for _, op := range ops {
+			op(r)
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Vibhav Bobade <vibhav.bobde@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Adds TaskResults related testbuilders.

I found out that these particular testbuilders were not present as I was trying to write a test for https://github.com/tektoncd/cli/issues/766

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
