### PR TITLE
Fix the link to example of Workspaces Pipelineruns

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -281,7 +281,7 @@ on [configuring a `VolumeSource`](#volumesources-for-workspaces) in your `Pipeli
 #### Example PipelineRun Specs With Workspaces
 
 The examples below show the relevant fields of `PipelineRun` specs when working with
-`Workspaces`. For a more complete end-to-end example, see [the Workspaces PipelineRun](../examples/v1beta1/pipelineruns/workspace.yaml)
+`Workspaces`. For a more complete end-to-end example, see [the Workspaces PipelineRun](../examples/v1beta1/pipelineruns/workspaces.yaml)
 in the examples directory.
 
 Here an existing PersistentVolumeClaim called `mypvc` is used for a Pipeline's `workspace`


### PR DESCRIPTION
Fix the link to example of Workspaces Pipelineruns in workspaces doc.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

