### PR TITLE
Fix copying description also during upgrade

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -42,6 +42,7 @@ func (source *PipelineSpec) ConvertTo(ctx context.Context, sink *v1beta1.Pipelin
 	sink.Resources = source.Resources
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
+	sink.Description = source.Description
 	if len(source.Tasks) > 0 {
 		sink.Tasks = make([]v1beta1.PipelineTask, len(source.Tasks))
 		for i := range source.Tasks {
@@ -86,6 +87,7 @@ func (sink *PipelineSpec) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 	sink.Resources = source.Resources
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
+	sink.Description = source.Description
 	if len(source.Tasks) > 0 {
 		sink.Tasks = make([]PipelineTask, len(source.Tasks))
 		for i := range source.Tasks {

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
@@ -56,6 +56,7 @@ func TestPipelineConversion(t *testing.T) {
 				Generation: 1,
 			},
 			Spec: PipelineSpec{
+				Description: "test",
 				Resources: []PipelineDeclaredResource{{
 					Name: "resource1",
 					Type: resource.PipelineResourceTypeGit,

--- a/pkg/apis/pipeline/v1alpha1/task_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/task_conversion.go
@@ -47,6 +47,7 @@ func (source *TaskSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskSpec) e
 	sink.Results = source.Results
 	sink.Resources = source.Resources
 	sink.Params = source.Params
+	sink.Description = source.Description
 	if source.Inputs != nil {
 		if len(source.Inputs.Params) > 0 && len(source.Params) > 0 {
 			// This shouldn't happen as it shouldn't pass validation
@@ -120,5 +121,6 @@ func (sink *TaskSpec) ConvertFrom(ctx context.Context, source *v1beta1.TaskSpec)
 	sink.Results = source.Results
 	sink.Params = source.Params
 	sink.Resources = source.Resources
+	sink.Description = source.Description
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_conversion_test.go
@@ -57,6 +57,7 @@ func TestTaskConversion(t *testing.T) {
 			},
 			Spec: TaskSpec{
 				TaskSpec: v1beta1.TaskSpec{
+					Description: "test",
 					Steps: []v1beta1.Step{{Container: corev1.Container{
 						Image: "foo",
 					}}},


### PR DESCRIPTION
This will add copying the description also
while upgrading from v1alpha1 to v1beta1
for pipeline, task and clustertask

Related to https://github.com/tektoncd/cli/issues/819

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Copy description also while upgrade
```
