### PR TITLE
Add a jq-base image to be used by imagedigestexporter

### DIFF
--- a/images/Dockerfile.jq
+++ b/images/Dockerfile.jq
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+RUN apk add --update git openssh-client jq \
+    && apk update \
+    && apk upgrade

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -128,6 +128,7 @@ To use [`tkn`](https://github.com/tektoncd/cli) to run the `publish-tekton-pipel
 		--resource=source-repo=${GIT_RESOURCE_NAME} \
 		--resource=bucket=pipeline-tekton-bucket \
 		--resource=builtBaseImage=base-image \
+		--resource=builtJqBaseImage=jq-base-image \
 		--resource=builtEntrypointImage=entrypoint-image \
 		--resource=builtKubeconfigWriterImage=kubeconfigwriter-image \
 		--resource=builtCredsInitImage=creds-init-image \

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -23,6 +23,8 @@ spec:
       type: storage
     - name: builtBaseImage
       type: image
+    - name: builtJqBaseImage
+      type: image
     - name: builtEntrypointImage
       type: image
     - name: builtKubeconfigWriterImage
@@ -45,13 +47,29 @@ spec:
       type: cloudEvent
   steps:
 
-  - name: build-push-base-images
+  - name: build-push-build-base-images
     image: gcr.io/kaniko-project/executor:v0.17.1
     command:
     - /kaniko/executor
     args:
     - --dockerfile=/workspace/go/src/github.com/tektoncd/pipeline/images/Dockerfile
     - --destination=$(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtBaseImage.url)
+    - --context=/workspace/go/src/github.com/tektoncd/pipeline
+
+    volumeMounts:
+      - name: gcp-secret
+        mountPath: /secret
+    env:
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /secret/release.json
+
+  - name: build-push-jq-base-images
+    image: gcr.io/kaniko-project/executor:v0.17.1
+    command:
+    - /kaniko/executor
+    args:
+    - --dockerfile=/workspace/go/src/github.com/tektoncd/pipeline/images/Dockerfile.jq
+    - --destination=$(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtJqBaseImage.url)
     - --context=/workspace/go/src/github.com/tektoncd/pipeline
 
     volumeMounts:

--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -18,6 +18,8 @@ spec:
     type: storage
   - name: builtBaseImage
     type: image
+  - name: builtJqBaseImage
+    type: image
   - name: builtEntrypointImage
     type: image
   - name: builtKubeconfigWriterImage
@@ -97,6 +99,8 @@ spec:
             resource: bucket
           - name: builtBaseImage
             resource: builtBaseImage
+          - name: builtJqBaseImage
+            resource: builtJqBaseImage
           - name: builtEntrypointImage
             resource: builtEntrypointImage
           - name: builtKubeconfigWriterImage

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -19,6 +19,8 @@ spec:
     type: storage
   - name: builtBaseImage
     type: image
+  - name: builtJqBaseImage
+    type: image
   - name: builtEntrypointImage
     type: image
   - name: builtKubeconfigWriterImage
@@ -117,6 +119,8 @@ spec:
             resource: bucket
           - name: builtBaseImage
             resource: builtBaseImage
+          - name: builtJqBaseImage
+            resource: builtJqBaseImage
           - name: builtEntrypointImage
             resource: builtEntrypointImage
           - name: builtKubeconfigWriterImage

--- a/tekton/resources.yaml
+++ b/tekton/resources.yaml
@@ -61,6 +61,16 @@ spec:
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
+  name: jq-base-image
+spec:
+  type: image
+  params:
+  - name: url
+    value: jq-base  # Registry is provided via parameter, this is a hack see #569
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
   name: entrypoint-image
 spec:
   type: image


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This will make imagedigestexporter more useful on its own.

First part of  #2212.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).


