### PR TITLE
Small refactoring of Wait* commands 🐏

### DIFF
--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -81,9 +81,7 @@ func TestKanikoTaskRun(t *testing.T) {
 
 	// Verify status of TaskRun (wait for it)
 
-	if err := WaitForTaskRunState(c, kanikoTaskRunName, func(tr *v1alpha1.TaskRun) (bool, error) {
-		return TaskRunSucceed(kanikoTaskRunName)(tr)
-	}, "TaskRunCompleted"); err != nil {
+	if err := WaitForTaskRunState(c, kanikoTaskRunName, Succeed(kanikoTaskRunName), "TaskRunCompleted"); err != nil {
 		t.Errorf("Error waiting for TaskRun %s to finish: %s", kanikoTaskRunName, err)
 	}
 

--- a/test/wait_example_test.go
+++ b/test/wait_example_test.go
@@ -21,7 +21,8 @@ package test
 import (
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 )
 
 var (
@@ -39,9 +40,12 @@ type testingT interface {
 
 func ExampleWaitForTaskRunState() {
 	// […] setup the test, get clients
-	if err := WaitForTaskRunState(c, "taskRunName", func(tr *v1alpha1.TaskRun) (bool, error) {
-		if len(tr.Status.Conditions) > 0 {
-			return true, nil
+	if err := WaitForTaskRunState(c, "taskRunName", func(ca apis.ConditionAccessor) (bool, error) {
+		c := ca.GetCondition(apis.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue {
+				return true, nil
+			}
 		}
 		return false, nil
 	}, "TaskRunHasCondition"); err != nil {
@@ -51,9 +55,12 @@ func ExampleWaitForTaskRunState() {
 
 func ExampleWaitForPipelineRunState() {
 	// […] setup the test, get clients
-	if err := WaitForPipelineRunState(c, "pipelineRunName", 1*time.Minute, func(pr *v1alpha1.PipelineRun) (bool, error) {
-		if len(pr.Status.Conditions) > 0 {
-			return true, nil
+	if err := WaitForPipelineRunState(c, "pipelineRunName", 1*time.Minute, func(ca apis.ConditionAccessor) (bool, error) {
+		c := ca.GetCondition(apis.ConditionSucceeded)
+		if c != nil {
+			if c.Status == corev1.ConditionTrue {
+				return true, nil
+			}
 		}
 		return false, nil
 	}, "PipelineRunHasCondition"); err != nil {

--- a/test/wait_test.go
+++ b/test/wait_test.go
@@ -47,7 +47,7 @@ func TestWaitForTaskRunStateSucceed(t *testing.T) {
 	}
 	c, cancel := fakeClients(t, d)
 	defer cancel()
-	err := WaitForTaskRunState(c, "foo", TaskRunSucceed("foo"), "TestTaskRunSucceed")
+	err := WaitForTaskRunState(c, "foo", Succeed("foo"), "TestTaskRunSucceed")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestWaitForPipelineRunStateFailed(t *testing.T) {
 	}
 	c, cancel := fakeClients(t, d)
 	defer cancel()
-	err := WaitForPipelineRunState(c, "bar", 2*time.Second, PipelineRunFailed("bar"), "TestWaitForPipelineRunFailed")
+	err := WaitForPipelineRunState(c, "bar", 2*time.Second, Failed("bar"), "TestWaitForPipelineRunFailed")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -23,12 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	tb "github.com/tektoncd/pipeline/test/builder"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/apis"
-	"knative.dev/pkg/apis/duck/v1beta1"
 	knativetest "knative.dev/pkg/test"
 )
 
@@ -164,23 +161,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
-	conditions := make(v1beta1.Conditions, 0)
-
-	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, func(pr *v1alpha1.PipelineRun) (bool, error) {
-		if len(pr.Status.Conditions) > 0 {
-			conditions = pr.Status.Conditions
-			return true, nil
-		}
-		return false, nil
-	}, "PipelineRunHasCondition"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline expects workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
 		t.Fatalf("Failed to wait for PipelineRun %q to finish: %s", pipelineRunName, err)
 	}
-
-	for _, condition := range conditions {
-		if condition.Type == apis.ConditionSucceeded && condition.Status == corev1.ConditionFalse && strings.Contains(condition.Message, `pipeline expects workspace with name "foo" be provided by pipelinerun`) {
-			return
-		}
-	}
-
-	t.Fatalf("Expected failure condition after creating pipelinerun with missing workspace but did not receive one.")
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This makes WaitFor* with pipeline resource more generic, you can use
`Succeed` or `Failed` with `WaitForPipelineRunState` and
`WaitForTaskrRunState`.

This reduces some duplication. Keeping the old function so that we
don't need to fix all those call at the current time.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
