### PR TITLE
The Pipeline Nightly Build Times Out On Lint

### DIFF
--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -48,7 +48,7 @@ spec:
         - name: version
           value: v1.21
         - name: flags
-          value: -v
+          value: "-v --timeout 10m"
       resources:
         inputs:
           - name: source


### PR DESCRIPTION
# Changes

The most recently pipeline nightly timed out during lint. Looks like
this timeout is set to 5 minutes by default.

This PR introduces a timeout of 10 minutes.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)