### PR TITLE
Make defaults config map name customizable

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -115,9 +115,9 @@ func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 
 		// The configmaps to validate.
 		configmap.Constructors{
-			logging.ConfigMapName():           logging.NewConfigFromConfigMap,
-			defaultconfig.DefaultsConfigName:  defaultconfig.NewDefaultsFromConfigMap,
-			pkgleaderelection.ConfigMapName(): pkgleaderelection.NewConfigFromConfigMap,
+			logging.ConfigMapName():               logging.NewConfigFromConfigMap,
+			defaultconfig.GetDefaultsConfigName(): defaultconfig.NewDefaultsFromConfigMap,
+			pkgleaderelection.ConfigMapName():     pkgleaderelection.NewConfigFromConfigMap,
 		},
 	)
 }

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -27,8 +28,6 @@ import (
 )
 
 const (
-	// ConfigName is the name of the configmap
-	DefaultsConfigName            = "config-defaults"
 	DefaultTimeoutMinutes         = 60
 	NoTimeoutDuration             = 0 * time.Minute
 	defaultTimeoutMinutesKey      = "default-timeout-minutes"
@@ -45,6 +44,15 @@ type Defaults struct {
 	DefaultServiceAccount      string
 	DefaultManagedByLabelValue string
 	DefaultPodTemplate         *pod.Template
+}
+
+// GetBucketConfigName returns the name of the configmap containing all
+// customizations for the storage bucket.
+func GetDefaultsConfigName() string {
+	if e := os.Getenv("CONFIG_DEFAULTS_NAME"); e != "" {
+		return e
+	}
+	return "config-defaults"
 }
 
 // Equals returns true if two Configs are identical

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -38,7 +38,7 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 				DefaultServiceAccount:      "tekton",
 				DefaultManagedByLabelValue: "something-else",
 			},
-			fileName: DefaultsConfigName,
+			fileName: GetDefaultsConfigName(),
 		},
 		{
 			expectedConfig: &Defaults{

--- a/pkg/apis/config/store.go
+++ b/pkg/apis/config/store.go
@@ -70,7 +70,7 @@ func NewStore(logger configmap.Logger, onAfterStore ...func(name string, value i
 			"defaults",
 			logger,
 			configmap.Constructors{
-				DefaultsConfigName: NewDefaultsFromConfigMap,
+				GetDefaultsConfigName(): NewDefaultsFromConfigMap,
 			},
 			onAfterStore...,
 		),
@@ -87,6 +87,6 @@ func (s *Store) ToContext(ctx context.Context) context.Context {
 // Load creates a Config from the current config state of the Store.
 func (s *Store) Load() *Config {
 	return &Config{
-		Defaults: s.UntypedLoad(DefaultsConfigName).(*Defaults).DeepCopy(),
+		Defaults: s.UntypedLoad(GetDefaultsConfigName()).(*Defaults).DeepCopy(),
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
@@ -141,7 +141,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -167,7 +167,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -199,7 +199,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -237,7 +237,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -192,7 +192,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -221,7 +221,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -250,7 +250,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes":        "5",
@@ -282,7 +282,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes":        "5",
@@ -317,7 +317,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -358,7 +358,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -159,7 +159,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -185,7 +185,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -217,7 +217,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -255,7 +255,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -181,7 +181,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",
@@ -207,7 +207,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			s := config.NewStore(logtesting.TestLogger(t))
 			s.OnConfigChanged(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: config.DefaultsConfigName,
+					Name: config.GetDefaultsConfigName(),
 				},
 				Data: map[string]string{
 					"default-timeout-minutes": "5",


### PR DESCRIPTION
This PR makes the defaults config map name customizable.

It allows users to override the defaults config map name by specifying a `CONFIG_DEFAULTS_NAME` environment variable.

This is already the case for artifacts configurations :

https://github.com/tektoncd/pipeline/blob/fbde4aa579102b7664b6f7fb3d22919776e05efd/pkg/artifacts/artifacts_storage.go#L69-L83


If the environment variable is not defined, it uses the `config-defaults` name.

I would like to have this to be able to generate a unique config map name in a helm chart (see https://github.com/tektoncd/experimental/pull/494).
