### PR TITLE
Add checking for duplicate declared resources

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -43,6 +43,13 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func validateDeclaredResources(ps *PipelineSpec) error {
+	encountered := map[string]struct{}{}
+	for _, r := range ps.Resources {
+		if _, ok := encountered[r.Name]; ok {
+			return fmt.Errorf("resource with name %q appears more than once", r.Name)
+		}
+		encountered[r.Name] = struct{}{}
+	}
 	required := []string{}
 	for _, t := range ps.Tasks {
 		if t.Resources != nil {

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -214,6 +214,15 @@ func TestPipeline_Validate(t *testing.T) {
 		)),
 		failureExpected: true,
 	}, {
+		name: "duplicate resource declaration",
+		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+			tb.PipelineDeclaredResource("duplicate-resource", v1alpha1.PipelineResourceTypeGit),
+			tb.PipelineDeclaredResource("duplicate-resource", v1alpha1.PipelineResourceTypeGit),
+			tb.PipelineTask("foo", "foo-task",
+				tb.PipelineTaskInputResource("the-resource", "duplicate-resource")),
+		)),
+		failureExpected: true,
+	}, {
 		name: "output resources missing from declaration",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -42,6 +42,13 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func validateDeclaredResources(ps *PipelineSpec) error {
+	encountered := map[string]struct{}{}
+	for _, r := range ps.Resources {
+		if _, ok := encountered[r.Name]; ok {
+			return fmt.Errorf("resource with name %q appears more than once", r.Name)
+		}
+		encountered[r.Name] = struct{}{}
+	}
 	required := []string{}
 	for _, t := range ps.Tasks {
 		if t.Resources != nil {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -351,6 +351,28 @@ func TestPipeline_Validate(t *testing.T) {
 		},
 		failureExpected: true,
 	}, {
+		name: "duplicate resource declaration",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Resources: []v1beta1.PipelineDeclaredResource{{
+					Name: "duplicate-resource", Type: v1beta1.PipelineResourceTypeGit,
+				}, {
+					Name: "duplicate-resource", Type: v1beta1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1beta1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+					Resources: &v1beta1.PipelineTaskResources{
+						Inputs: []v1beta1.PipelineTaskInputResource{{
+							Name: "the-resource", Resource: "duplicate-resource",
+						}},
+					},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
 		name: "output resources missing from declaration",
 		p: &v1beta1.Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},


### PR DESCRIPTION
Fixes #2241

# Changes

Adds checking for duplicated resource names in a pipeline's declared resources.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
