### PR TITLE
Add skipRootUserTests flag required by PR #1563

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -172,6 +172,8 @@ You can also use
   [the idiomatic way to disable test caching](https://golang.org/doc/go1.10#test).
 - The end to end tests take a long time to run so a value like `-timeout=20m`
   can be useful depending on what you're running
+- TestKanikoTaskRun requires containers to run with root user. Using
+  `-skipRootUserTests=true` skips it.
 
 You can [use test flags](#flags) to control the environment your tests run
 against, i.e. override

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -44,6 +45,10 @@ const (
 var (
 	skipRootUserTests = "false"
 )
+
+func init() {
+	flag.StringVar(&skipRootUserTests, "skipRootUserTests", "false", "Skip tests that require root user")
+}
 
 // TestTaskRun is an integration test that will verify a TaskRun using kaniko
 func TestKanikoTaskRun(t *testing.T) {


### PR DESCRIPTION
PR #1563 adds logic to skip TestKanikoTaskRun test when a flag is set as it requires to run containers with root user.
The registration of the flag was however missing. This aims to fix it.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

flag added to TestKanikoTaskRun
test/README.md amended to have the flag documented

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

