### PR TITLE
Refactor remote.Resolver interface and implementation

### DIFF
--- a/pkg/remote/oci.go
+++ b/pkg/remote/oci.go
@@ -17,6 +17,7 @@ limitations under the License.
 package remote
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -25,36 +26,59 @@ import (
 	imgname "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
 )
 
-// KeychainProvider is an input to the OCIResolver which returns a keychain for fetching remote images with
-// authentication.
-type KeychainProvider func() (authn.Keychain, error)
-
 // OCIResolver will attempt to fetch Tekton resources from an OCI compliant image repository.
 type OCIResolver struct {
-	imageReference   string
-	keychainProvider KeychainProvider
+	imageReference string
+	keychain       authn.Keychain
+}
+
+func NewOCIResolver(image string, keychain authn.Keychain) OCIResolver {
+	return OCIResolver{
+		imageReference: image,
+		keychain:       keychain,
+	}
 }
 
 // GetTask will retrieve the specified task from the resolver's defined image and return its spec. If it cannot be
 // retrieved for any reason, an error is returned.
-func (o OCIResolver) GetTask(taskName string) (*v1beta1.TaskSpec, error) {
+func (o OCIResolver) GetTask(taskName string) (v1alpha1.TaskInterface, error) {
 	taskContents, err := o.readImageLayer("task", taskName)
 	if err != nil {
 		return nil, err
 	}
 
-	// Deserialize the task into a valid task spec.
-	var task v1beta1.Task
-	_, _, err = scheme.Codecs.UniversalDeserializer().Decode(taskContents, nil, &task)
+	// Deserialize the contents into a valid task spec.
+	obj, kind, err := scheme.Codecs.UniversalDeserializer().Decode(taskContents, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid remote task %s: %w", taskName, err)
 	}
 
-	return &task.Spec, nil
+	if t, ok := obj.(*v1alpha1.Task); ok {
+		return t, nil
+	}
+
+	if t, ok := obj.(*v1beta1.Task); ok {
+		var tt v1alpha1.Task
+		err = tt.ConvertFrom(context.Background(), t)
+		return &tt, err
+	}
+
+	if t, ok := obj.(*v1alpha1.ClusterTask); ok {
+		return t, nil
+	}
+
+	if t, ok := obj.(*v1beta1.ClusterTask); ok {
+		var ct v1alpha1.Task
+		err = ct.ConvertFrom(context.Background(), t)
+		return &ct, err
+	}
+
+	return nil, fmt.Errorf("unknown task kind %s", kind.String())
 }
 
 func (o OCIResolver) readImageLayer(kind string, name string) ([]byte, error) {
@@ -63,19 +87,9 @@ func (o OCIResolver) readImageLayer(kind string, name string) ([]byte, error) {
 		return nil, fmt.Errorf("%s is an unparseable task image reference: %w", o.imageReference, err)
 	}
 
-	// Create a keychain for use in authenticating against the remote repository.
-	keychain, err := o.keychainProvider()
-	if err != nil {
-		return nil, err
-	}
-
-	img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(keychain))
+	img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(o.keychain))
 	if err != nil {
 		return nil, fmt.Errorf("Error pulling image %q: %w", o.imageReference, err)
-	}
-	// Ensure the media type is exclusively the Tekton catalog media type.
-	if mt, err := img.MediaType(); err != nil || string(mt) != "application/vnd.cdf.tekton.catalog.v1beta1+yaml" {
-		return nil, fmt.Errorf("cannot parse reference from image type %s: %w", string(mt), err)
 	}
 
 	m, err := img.Manifest()

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -96,6 +96,10 @@ var (
 // Any number of Task modifier can be passed to transform it.
 func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
 	t := &v1alpha1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "Task",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -137,6 +141,14 @@ func ClusterTaskSpec(ops ...TaskSpecOp) ClusterTaskOp {
 	}
 }
 
+// TaskType sets the innate TypeMeta of the task. This is useful if you need to serialize/deserialize a task.
+func ClusterTaskType() ClusterTaskOp {
+	return func(t *v1alpha1.ClusterTask) {
+		t.TypeMeta.APIVersion = "tekton.dev/v1alpha1"
+		t.TypeMeta.Kind = "ClusterTask"
+	}
+}
+
 // TaskSpec sets the specified spec of the task.
 // Any number of TaskSpec modifier can be passed to create/modify it.
 func TaskSpec(ops ...TaskSpecOp) TaskOp {
@@ -146,6 +158,14 @@ func TaskSpec(ops ...TaskSpecOp) TaskOp {
 			op(spec)
 		}
 		t.Spec = *spec
+	}
+}
+
+// TaskType sets the innate TypeMeta of the task. This is useful if you need to serialize/deserialize a task.
+func TaskType() TaskOp {
+	return func(t *v1alpha1.Task) {
+		t.TypeMeta.APIVersion = "tekton.dev/v1alpha1"
+		t.TypeMeta.Kind = "Task"
 	}
 }
 

--- a/test/builder/task_test.go
+++ b/test/builder/task_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func TestTask(t *testing.T) {
-	task := tb.Task("test-task", "foo", tb.TaskSpec(
+	task := tb.Task("test-task", "foo", tb.TaskType(), tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceTargetPath("/foo/bar")),
 			tb.InputsResource("optional_workspace", v1alpha1.PipelineResourceTypeGit, tb.ResourceOptional(true)),
@@ -67,6 +67,10 @@ func TestTask(t *testing.T) {
 		tb.TaskWorkspace("bread", "kind of bread", "/bread/path", false),
 	))
 	expectedTask := &v1alpha1.Task{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "Task",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test-task", Namespace: "foo"},
 		Spec: v1alpha1.TaskSpec{
 			TaskSpec: v1beta1.TaskSpec{
@@ -143,12 +147,16 @@ func TestTask(t *testing.T) {
 }
 
 func TestClusterTask(t *testing.T) {
-	task := tb.ClusterTask("test-clustertask", tb.ClusterTaskSpec(
+	task := tb.ClusterTask("test-clustertask", tb.ClusterTaskType(), tb.ClusterTaskSpec(
 		tb.Step("myimage", tb.StepCommand("/mycmd"), tb.StepArgs(
 			"--my-other-arg=$(inputs.resources.workspace.url)",
 		)),
 	))
 	expectedTask := &v1alpha1.ClusterTask{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1alpha1",
+			Kind:       "ClusterTask",
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test-clustertask"},
 		Spec: v1alpha1.TaskSpec{TaskSpec: v1beta1.TaskSpec{
 			Steps: []v1alpha1.Step{{Container: corev1.Container{

--- a/test/remote.go
+++ b/test/remote.go
@@ -1,0 +1,48 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	remoteimg "github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+)
+
+// CreateImage will push a new OCI image artifact with the provided raw data object as a layer and return the full image
+// reference with a digest to fetch the image. Key must be specified as [lowercase kind]/[object name]. The image ref
+// with a digest is returned.
+func CreateImage(registryHost, key, data string) (string, error) {
+	imgRef, err := name.ParseReference(fmt.Sprintf("%s/%s", registryHost, key))
+	if err != nil {
+		return "", fmt.Errorf("undexpected error producing image reference %w", err)
+	}
+
+	layer, err := tarball.LayerFromReader(strings.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("unexpected error adding task layer to image %w", err)
+	}
+
+	img, err := mutate.Append(empty.Image, mutate.Addendum{
+		Layer: layer,
+		Annotations: map[string]string{
+			"org.opencontainers.image.title": key,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not add layer to image %w", err)
+	}
+
+	if err := remoteimg.Write(imgRef, img); err != nil {
+		return "", fmt.Errorf("could not push example image to registry")
+	}
+
+	digest, err := img.Digest()
+	if err != nil {
+		return "", fmt.Errorf("could not read image digest: %w", err)
+	}
+
+	return imgRef.Context().Digest(digest.String()).String(), nil
+}

--- a/test/remote_test.go
+++ b/test/remote_test.go
@@ -1,0 +1,74 @@
+package test
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	remote "github.com/google/go-containerregistry/pkg/v1/remote"
+	tb "github.com/tektoncd/pipeline/test/builder"
+)
+
+func TestCreateImage(t *testing.T) {
+	// Set up a fake registry to push an image to.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, _ := url.Parse(s.URL)
+
+	task := tb.Task("test-create-image", "no-ns")
+	raw, err := yaml.Marshal(task)
+	if err != nil {
+		t.Errorf("failed to marshal task to bytes: %w", err)
+	}
+
+	ref, err := CreateImage(u.Host, "task/test-create-image", string(raw))
+	if err != nil {
+		t.Errorf("uploading image failed unexpectedly with an error: %w", err)
+	}
+
+	// Pull the image and ensure the layers are composed correctly.
+	imgRef, err := name.ParseReference(ref)
+	if err != nil {
+		t.Errorf("digest %s is not a valid reference: %w", ref, err)
+	}
+
+	img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		t.Errorf("could not fetch created image: %w", err)
+	}
+
+	m, err := img.Manifest()
+	if err != nil {
+		t.Errorf("failed to fetch img manifest: %w", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil || len(layers) != 1 {
+		t.Errorf("img layers were incorrect. Num Layers: %d. Err: %w", len(layers), err)
+	}
+
+	if diff := cmp.Diff(m.Layers[0].Annotations["org.opencontainers.image.title"], "task/test-create-image"); diff != "" {
+		t.Error(diff)
+	}
+
+	// Read the layer's contents and ensure it matches the task we uploaded.
+	rc, err := layers[0].Uncompressed()
+	if err != nil {
+		t.Errorf("layer contents were corrupted: %w", err)
+	}
+	defer rc.Close()
+	actual, err := ioutil.ReadAll(rc)
+	if err != nil {
+		t.Errorf("layer contents weren't readable: %w", err)
+	}
+
+	if diff := cmp.Diff(string(raw), string(actual)); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
# Changes

The existing implementation has been refactored to better integrate with
the existing logic in the Reconcilers. (This work was started in
https://github.com/tektoncd/pipeline/pull/2233 and pulled out to here).

Included in this is a move for the interface to implement `GetTask`
which is what gets passed into the TaskRun and Pipeline reconciler and
require less changes in the embedding of the task itself into the pod
spec. A couple of test helpers have been modified and a new remote test
helper is added to make pushing to images in a test easier. Tests are
included for both.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [🙅‍♂  ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
