### PR TITLE
Optimize TaskRun and PipelineRun controller reconciliation

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -29,6 +29,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+const ConditionCleanedUp apis.ConditionType = "CleanedUp"
+
 var (
 	groupVersionKind = schema.GroupVersionKind{
 		Group:   SchemeGroupVersion.Group,
@@ -157,6 +159,11 @@ func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
 // GetOwnerReference gets the pipeline run as owner reference for any related objects
 func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
 	return *metav1.NewControllerRef(pr, groupVersionKind)
+}
+
+// IsCleanedUp returns true if the PipelineRun's status indicates that it is cleaned up.
+func (pr *PipelineRun) IsCleanedUp() bool {
+	return !pr.Status.GetCondition(ConditionCleanedUp).IsUnknown()
 }
 
 // IsDone returns true if the PipelineRun's status indicates that it is done.

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -108,6 +108,21 @@ func TestInitializeConditions(t *testing.T) {
 	}
 }
 
+func TestPipelineRunIsCleanedUp(t *testing.T) {
+	pr := &v1alpha1.PipelineRun{}
+	foo := &apis.Condition{
+		Type:   v1alpha1.ConditionCleanedUp,
+		Status: corev1.ConditionTrue,
+	}
+	if pr.IsCleanedUp() {
+		t.Fatal("Expected pipelinerun status to not be CleanedUp")
+	}
+	pr.Status.SetCondition(foo)
+	if !pr.IsCleanedUp() {
+		t.Fatal("Expected pipelinerun status to be CleanedUp")
+	}
+}
+
 func TestPipelineRunIsDone(t *testing.T) {
 	pr := &v1alpha1.PipelineRun{}
 	foo := &apis.Condition{

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -209,6 +209,11 @@ func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 	return false
 }
 
+// IsCleanedUp returns true if the PipelineRun's status indicates that it is cleaned up.
+func (tr *TaskRun) IsCleanedUp() bool {
+	return !tr.Status.GetCondition(ConditionCleanedUp).IsUnknown()
+}
+
 // IsDone returns true if the TaskRun's status indicates that it is done.
 func (tr *TaskRun) IsDone() bool {
 	return !tr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -92,6 +92,21 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 	}
 }
 
+func TestTaskRunIsCleanedUp(t *testing.T) {
+	tr := &v1alpha1.TaskRun{}
+	foo := &apis.Condition{
+		Type:   v1alpha1.ConditionCleanedUp,
+		Status: corev1.ConditionTrue,
+	}
+	if tr.IsCleanedUp() {
+		t.Fatal("Expected taskrun status to not be CleanedUp")
+	}
+	tr.Status.SetCondition(foo)
+	if !tr.IsCleanedUp() {
+		t.Fatal("Expected taskrun status to be CleanedUp")
+	}
+}
+
 func TestTaskRunIsDone(t *testing.T) {
 	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -29,6 +29,8 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
+const ConditionCleanedUp apis.ConditionType = "CleanedUp"
+
 var (
 	groupVersionKind = schema.GroupVersionKind{
 		Group:   SchemeGroupVersion.Group,
@@ -81,6 +83,11 @@ func (pr *PipelineRun) GetStatusCondition() apis.ConditionAccessor {
 // GetOwnerReference gets the pipeline run as owner reference for any related objects
 func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
 	return *metav1.NewControllerRef(pr, groupVersionKind)
+}
+
+// IsCleanedUp returns true if the PipelineRun's status indicates that it is cleaned up.
+func (pr *PipelineRun) IsCleanedUp() bool {
+	return !pr.Status.GetCondition(ConditionCleanedUp).IsUnknown()
 }
 
 // IsDone returns true if the PipelineRun's status indicates that it is done.

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -125,6 +125,21 @@ func TestInitializePipelineRunConditions(t *testing.T) {
 	}
 }
 
+func TestPipelineRunIsCleanedUp(t *testing.T) {
+	pr := &v1beta1.PipelineRun{}
+	foo := &apis.Condition{
+		Type:   v1beta1.ConditionCleanedUp,
+		Status: corev1.ConditionTrue,
+	}
+	if pr.IsCleanedUp() {
+		t.Fatal("Expected pipelinerun status to not be CleanedUp")
+	}
+	pr.Status.SetCondition(foo)
+	if !pr.IsCleanedUp() {
+		t.Fatal("Expected pipelinerun status to be CleanedUp")
+	}
+}
+
 func TestPipelineRunIsDone(t *testing.T) {
 	pr := &v1beta1.PipelineRun{}
 	foo := &apis.Condition{

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -369,6 +369,11 @@ func (tr *TaskRun) HasPipelineRunOwnerReference() bool {
 	return false
 }
 
+// IsCleanedUp returns true if the PipelineRun's status indicates that it is cleaned up.
+func (tr *TaskRun) IsCleanedUp() bool {
+	return !tr.Status.GetCondition(ConditionCleanedUp).IsUnknown()
+}
+
 // IsDone returns true if the TaskRun's status indicates that it is done.
 func (tr *TaskRun) IsDone() bool {
 	return !tr.Status.GetCondition(apis.ConditionSucceeded).IsUnknown()

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -125,6 +125,21 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 	}
 }
 
+func TestTaskRunIsCleanedUp(t *testing.T) {
+	tr := &v1beta1.TaskRun{}
+	foo := &apis.Condition{
+		Type:   v1beta1.ConditionCleanedUp,
+		Status: corev1.ConditionTrue,
+	}
+	if tr.IsCleanedUp() {
+		t.Fatal("Expected taskrun status to not be CleanedUp")
+	}
+	tr.Status.SetCondition(foo)
+	if !tr.IsCleanedUp() {
+		t.Fatal("Expected taskrun status to be CleanedUp")
+	}
+}
+
 func TestTaskRunIsDone(t *testing.T) {
 	tr := &v1beta1.TaskRun{
 		Status: v1beta1.TaskRunStatus{

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -135,7 +135,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 
 	// If the PipelineRun has already been cleaned up, we return early to skip reconciliation.
 	if pr.IsCleanedUp() {
-		c.Logger.Info("Not reconciling cleaned up PipelineRun")
+		logger.Info("Not reconciling cleaned up PipelineRun")
 		return nil
 	}
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2396,6 +2396,11 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 		tb.PipelineRunStatus(
 			tb.PipelineRunResult("result", "aResultValue"),
 			tb.PipelineRunStatusCondition(apis.Condition{
+				Type:    v1beta1.ConditionCleanedUp,
+				Status:  corev1.ConditionTrue,
+				Reason: "Cleaned Up",
+			}),
+			tb.PipelineRunStatusCondition(apis.Condition{
 				Type:    apis.ConditionSucceeded,
 				Status:  corev1.ConditionTrue,
 				Reason:  v1beta1.PipelineRunReasonSuccessful.String(),


### PR DESCRIPTION
The Tekton controller will try running cleanup tasks for TaskRuns and
PipelineRuns everytime they are reconciled, which on controller startup
means that the controller spends around 200ms per TaskRun and
PipelineRun that it reconciles.

This adds a new status condition to the TaskRun and PipelineRun statuses
that indicates that the Tekton controller has completed all cleanup
tasks. If it is set, then we skip reconciliation of the objects. As the
objects are already in cache, the reconciler only takes around
200nanoseconds to get the object from cache and check if it needs to be
reconciled.

On my Kubernetes cluster with ~3500 TaskRuns and ~300 PipelineRuns, this drops controller start time (the time for the initial reconcile of all objects to complete) from 10-15 minutes to ~1 minute.

Signed-off-by: jbarrick@mesosphere.com <jbarrick@mesosphere.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
- Optimized reconcilation of TaskRun and PipelineRun objects to improve controller start time.
```
