### PR TITLE
Adds "commented" website front matter to docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,12 @@
+<!--
+---
+title: "Tasks and Pipelines"
+linkTitle: "Tasks and Pipelines"
+weight: 2
+description: >
+  Building Blocks of Tekton CI/CD Workflow
+---
+-->
 # Tekton Pipelines
 
 Tekton Pipelines is a Kubernetes extension that installs and runs on your Kubernetes cluster.
@@ -39,7 +48,7 @@ Tekton Pipelines defines the following entities:
 
 ## Getting started
 
-To get started, complete the [Tekton Pipelines Tutorial](tutorial.md) and go through our 
+To get started, complete the [Tekton Pipelines Tutorial](https://github.com/tektoncd/pipeline/blob/master/docs/tutorial.md) and go through our 
 [examples](https://github.com/tektoncd/pipeline/tree/master/examples).
 
 ## Understanding Tekton Pipelines

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Authentication"
+weight: 6
+---
+-->
 # Authentication
 
 This document defines how authentication is provided during execution of a

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Conditions"
+weight: 10
+---
+-->
 # Conditions
 
 This document defines `Conditions` and their capabilities.

--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Container Contracts"
+weight: 7
+---
+-->
 # Container Contract
 
 Each container image used as a step in a [`Task`](tasks.md) must comply with a

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Labels"
+weight: 9
+---
+-->
 # Labels
 
 In order to make it easier to identify objects that are all part of the same

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Logs"
+weight: 8
+---
+-->
 # Logs
 
 Logs for [`PipelineRuns`](pipelineruns.md) and [`TaskRuns`](taskruns.md) are

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Pipeline Metrics"
+weight: 13
+---
+-->
 # Pipeline Controller Metrics
 
 Following pipeline metrics are exposed at `controller-service` on port `9090`

--- a/docs/migrating-from-knative-build.md
+++ b/docs/migrating-from-knative-build.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Migration from KNative Build"
+weight: 12
+---
+-->
 # Migrating from [Knative Build](https://github.com/knative/build)
 
 This doc describes a process for users who are familiar with Knative `Build` and

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "PipelineRuns"
+weight: 4
+---
+-->
 # PipelineRuns
 
 This document defines `PipelineRuns` and their capabilities.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Pipelines"
+weight: 3
+---
+-->
 # Pipelines
 
 This document defines `Pipelines` and their capabilities.

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Pod Templates"
+weight: 11
+---
+-->
 # PodTemplates
 
 A pod template specifies a subset of
@@ -6,7 +12,7 @@ configuration that will be used as the basis for the `Task` pod.
 
 This allows to customize some Pod specific field per `Task` execution, aka `TaskRun`.
 
-Alternatively, you can also define a default pod template in tekton config, see [here](./install.md)
+Alternatively, you can also define a default pod template in tekton config, see [here](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
 When a pod template is specified for a `PipelineRun` or `TaskRun`, the default pod template is ignored, i.e.
 both templates are **NOT** merged, it's always one or the other.
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "PipelineResources"
+weight: 5
+---
+-->
 # PipelineResources
 
 `PipelineResources` in a pipeline are the set of objects that are going to be

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "TaskRuns"
+weight: 2
+---
+-->
 # TaskRuns
 
 Use the `TaskRun` resource object to create and run on-cluster processes to

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Tasks"
+weight: 1
+---
+-->
 # Tasks
 
 A `Task` (or a [`ClusterTask`](#clustertask)) is a collection of sequential

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -17,7 +17,7 @@ specific to a given cloud computing service.
 
 ## Before you begin
 
-Before you begin this tutorial, make sure you have [installed and configured](install.md)
+Before you begin this tutorial, make sure you have [installed and configured](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
 the latest release of Tekton on your Kubernetes cluster, including the
 [Tekton CLI](https://github.com/tektoncd/cli).
 


### PR DESCRIPTION
This change adds the front matter needed for the website without altering the site markdown or adding titles. It does this by adding the front matter in comment tags.

The tutorial and install are not part of the website currently so links to them under docs/ use absolute urls to allow them to work in both the website and in the pipeline repo

# Changes
update /docs markdown files with front matter

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
