### PR TITLE
Correct missing field(s) error

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -154,7 +154,7 @@ func validateParamResults(tasks []PipelineTask) error {
 // of Tasks expressed in the Pipeline makes sense.
 func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(ps, &PipelineSpec{}) {
-		return apis.ErrMissingField(apis.CurrentField)
+		return apis.ErrGeneric("expected at least one, got none", "spec.description", "spec.params", "spec.resources", "spec.tasks", "spec.workspaces")
 	}
 
 	// Names cannot be duplicated

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -50,9 +50,8 @@ func TestPipeline_Validate(t *testing.T) {
 		)),
 		failureExpected: true,
 	}, {
-		name: "pipeline spec missing",
-		p: tb.Pipeline("pipeline", "namespace",
-		),
+		name:            "pipeline spec missing",
+		p:               tb.Pipeline("pipeline", "namespace"),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid (duplicate tasks)",

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -50,6 +50,11 @@ func TestPipeline_Validate(t *testing.T) {
 		)),
 		failureExpected: true,
 	}, {
+		name: "pipeline spec missing",
+		p: tb.Pipeline("pipeline", "namespace",
+		),
+		failureExpected: true,
+	}, {
 		name: "pipeline spec invalid (duplicate tasks)",
 		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -26,7 +26,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
@@ -41,9 +40,6 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
-	if equality.Semantic.DeepEqual(ts, &TaskSpec{}) {
-		return apis.ErrMissingField(apis.CurrentField)
-	}
 
 	if len(ts.Steps) == 0 {
 		return apis.ErrMissingField("steps")

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -368,7 +368,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		name: "nil",
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
-			Paths:   []string{""},
+			Paths:   []string{"steps"},
 		},
 	}, {
 		name: "no build",

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -365,7 +365,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		fields        fields
 		expectedError apis.FieldError
 	}{{
-		name: "nil",
+		name: "empty spec",
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
 			Paths:   []string{"steps"},

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -138,7 +138,7 @@ func validateGraph(tasks []PipelineTask) error {
 // of Tasks expressed in the Pipeline makes sense.
 func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(ps, &PipelineSpec{}) {
-		return apis.ErrMissingField(apis.CurrentField)
+		return apis.ErrGeneric("expected at least one, got none", "spec.description", "spec.params", "spec.resources", "spec.tasks", "spec.workspaces")
 	}
 
 	// Names cannot be duplicated

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -100,6 +100,12 @@ func TestPipeline_Validate(t *testing.T) {
 		},
 		failureExpected: true,
 	}, {
+		name: "pipeline spec missing",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+		},
+		failureExpected: true,
+	}, {
 		name: "pipeline spec missing taskref and taskspec",
 		p: &v1beta1.Pipeline{
 			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -25,7 +25,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
@@ -40,9 +39,6 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 }
 
 func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
-	if equality.Semantic.DeepEqual(ts, &TaskSpec{}) {
-		return apis.ErrMissingField(apis.CurrentField)
-	}
 
 	if len(ts.Steps) == 0 {
 		return apis.ErrMissingField("steps")

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -285,7 +285,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		name: "nil",
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
-			Paths:   []string{""},
+			Paths:   []string{"steps"},
 		},
 	}, {
 		name: "no step",

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -282,7 +282,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		fields        fields
 		expectedError apis.FieldError
 	}{{
-		name: "nil",
+		name: "empty spec",
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
 			Paths:   []string{"steps"},

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
@@ -39,7 +39,7 @@ func (r *PipelineResource) Validate(ctx context.Context) *apis.FieldError {
 
 func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(rs, &PipelineResourceSpec{}) {
-		return apis.ErrMissingField(apis.CurrentField)
+		return apis.ErrMissingField("spec.type")
 	}
 	if rs.Type == PipelineResourceTypeCluster {
 		var authFound, cadataFound, isInsecure bool

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -135,6 +135,11 @@ func TestResourceValidation_Invalid(t *testing.T) {
 				},
 			},
 			want: apis.ErrInvalidValue("spec.type", "not-supported"),
+		}, {
+			name: "missing spec",
+			res: &v1alpha1.PipelineResource{
+			},
+			want: apis.ErrMissingField("spec.type"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -137,7 +137,7 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrInvalidValue("spec.type", "not-supported"),
 		}, {
 			name: "missing spec",
-			res: &v1alpha1.PipelineResource{},
+			res:  &v1alpha1.PipelineResource{},
 			want: apis.ErrMissingField("spec.type"),
 		},
 	}

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -137,8 +137,7 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrInvalidValue("spec.type", "not-supported"),
 		}, {
 			name: "missing spec",
-			res: &v1alpha1.PipelineResource{
-			},
+			res: &v1alpha1.PipelineResource{},
 			want: apis.ErrMissingField("spec.type"),
 		},
 	}


### PR DESCRIPTION
Fixes #2235

Fixes #1844

# Changes

As I mentioned in the issue, it is debatable whether a completely empty pipeline spec is an error since all fields are optional.  On the other hand there is value in trying to catch mistakes.  It's unlikely anyone wants to define a pipeline with nothing in it.  So I changed the code to return the following error.

```
	if equality.Semantic.DeepEqual(ps, &PipelineSpec{}) {
		return apis.ErrGeneric("expected at least one, got none", "spec.description", "spec.params", "spec.resources", "spec.tasks", "spec.workspaces")
	}
```

field_error.go doesn't have any methods with canned text for this situation.  I found uses of ErrGeneric with the text "expected at least one, got none" in some places under vendor/knative.dev and decided that was good text for this case.  It produces the following error:

```
Error from server (BadRequest): error when creating "pipelinemissingspec1.yaml": admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: expected at least one, got none: spec.description, spec.params, spec.resources, spec.tasks, spec.workspaces
```

I looked for other resource validation methods that use apis.ErrMissingField(apis.CurrentField).

* task_validation.go:
    Immediately after checking for an empty spec, the validation method checks if any steps are defined.  Therefore the empty spec check is superfluous and I removed it.
* pipelineresource_validation.go:
    I changed this one to specify the path that's required ("spec.type").
* condition_validation.go:
    I could not reproduce the ErrMissingField error with condition.  I left the code alone to be safe.
* workspace_validation.go:
    I could not reproduce the ErrMissingField error with workspace.  I left the code alone to be safe.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
