### PR TITLE
Updated taskspec with nodeselector to allow for different nodeselector for each task. 

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -142,6 +142,10 @@ type PipelineTask struct {
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
+	// Set the NodeSelector on PipelineTask level to allow
+	// for different NodeSelectors for different steps.
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 func (pt PipelineTask) HashKey() string {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -587,6 +587,10 @@ func (c *Reconciler) createTaskRun(rprt *resources.ResolvedPipelineRunTask, pr *
 			PodTemplate:        pr.Spec.PodTemplate,
 		}}
 
+	if len(rprt.PipelineTask.NodeSelector) > 0 {
+		tr.Spec.PodTemplate.NodeSelector = rprt.PipelineTask.NodeSelector
+	}
+
 	if rprt.ResolvedTaskResources.TaskName != "" {
 		tr.Spec.TaskRef = &v1alpha1.TaskRef{
 			Name: rprt.ResolvedTaskResources.TaskName,


### PR DESCRIPTION
The goal with this PR is to allow for different task in a Pipeline to have different node selectors.

Currently it is only possible(correct my if I am wrong) to set the nodeslector on the podTemplate spec, which will result in that all task have the same node selector. This limites the node selection to one choice and also limits the workflow usage. 

My first contribution to Tekton, super happy for feedback and any suggestions. 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
