### PR TITLE
tests/e2e: fix skipRootUserTests flag 🎏

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -44,6 +44,11 @@ import (
 )
 
 var initMetrics sync.Once
+var skipRootUserTests = false
+
+func init() {
+	flag.BoolVar(&skipRootUserTests, "skipRootUserTests", false, "Skip tests that require root user")
+}
 
 func setup(t *testing.T, fn ...func(*testing.T, *clients, string)) (*clients, string) {
 	t.Helper()
@@ -146,6 +151,7 @@ func verifyServiceAccountExistence(t *testing.T, namespace string, kubeClient *k
 // TestMain initializes anything global needed by the tests. Right now this is just log and metric
 // setup since the log and metric libs we're using use global state :(
 func TestMain(m *testing.M) {
+	flag.Parse()
 	c := m.Run()
 	fmt.Fprintf(os.Stderr, "Using kubeconfig at `%s` with cluster `%s`\n", knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster)
 	os.Exit(c)

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package test
 
 import (
-	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -44,17 +43,9 @@ const (
 	revision = "1c9d566ecd13535f93789595740f20932f655905"
 )
 
-var (
-	skipRootUserTests = "false"
-)
-
-func init() {
-	flag.StringVar(&skipRootUserTests, "skipRootUserTests", "false", "Skip tests that require root user")
-}
-
 // TestTaskRun is an integration test that will verify a TaskRun using kaniko
 func TestKanikoTaskRun(t *testing.T) {
-	if skipRootUserTests == "true" {
+	if skipRootUserTests {
 		t.Skip("Skip test as skipRootUserTests set to true")
 	}
 

--- a/test/v1alpha1/init_test.go
+++ b/test/v1alpha1/init_test.go
@@ -44,6 +44,11 @@ import (
 )
 
 var initMetrics sync.Once
+var skipRootUserTests = false
+
+func init() {
+	flag.BoolVar(&skipRootUserTests, "skipRootUserTests", false, "Skip tests that require root user")
+}
 
 func setup(t *testing.T, fn ...func(*testing.T, *clients, string)) (*clients, string) {
 	t.Helper()
@@ -146,6 +151,7 @@ func verifyServiceAccountExistence(t *testing.T, namespace string, kubeClient *k
 // TestMain initializes anything global needed by the tests. Right now this is just log and metric
 // setup since the log and metric libs we're using use global state :(
 func TestMain(m *testing.M) {
+	flag.Parse()
 	c := m.Run()
 	fmt.Fprintf(os.Stderr, "Using kubeconfig at `%s` with cluster `%s`\n", knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster)
 	os.Exit(c)

--- a/test/v1alpha1/kaniko_task_test.go
+++ b/test/v1alpha1/kaniko_task_test.go
@@ -41,13 +41,9 @@ const (
 	revision = "1c9d566ecd13535f93789595740f20932f655905"
 )
 
-var (
-	skipRootUserTests = "false"
-)
-
 // TestTaskRun is an integration test that will verify a TaskRun using kaniko
 func TestKanikoTaskRun(t *testing.T) {
-	if skipRootUserTests == "true" {
+	if skipRootUserTests {
 		t.Skip("Skip test as skipRootUserTests set to true")
 	}
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Before this fix, the flag doesn't set the variable as it might never
be parsed.

- mark the flag as boolean
- flag.parse in `TestMain` to make sure it is parsed

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
tests/e2e: fix skipRootUserTests.
```
