### PR TITLE
Add Header to Workspaces Doc for Website

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Authentication"
-weight: 6
+weight: 7
 ---
 -->
 # Authentication

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Conditions"
-weight: 10
+weight: 11
 ---
 -->
 # Conditions

--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Container Contracts"
-weight: 7
+weight: 8
 ---
 -->
 # Container Contract

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Labels"
-weight: 9
+weight: 10
 ---
 -->
 # Labels

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Logs"
-weight: 8
+weight: 9
 ---
 -->
 # Logs

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Pipeline Metrics"
-weight: 13
+weight: 14
 ---
 -->
 # Pipeline Controller Metrics

--- a/docs/migrating-from-knative-build.md
+++ b/docs/migrating-from-knative-build.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Migration from KNative Build"
-weight: 12
+weight: 13
 ---
 -->
 # Migrating from [Knative Build](https://github.com/knative/build)

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Pod Templates"
-weight: 11
+weight: 12
 ---
 -->
 # PodTemplates

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "PipelineResources"
-weight: 5
+weight: 6
 ---
 -->
 # PipelineResources

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,3 +1,9 @@
+<!--
+---
+linkTitle: "Workspaces"
+weight: 5
+---
+-->
 # Workspaces
 
 - [Overview](#overview)


### PR DESCRIPTION
# Changes

Our website needs a header on the docs that it consumes to indicate
ordering and page title.

This PR adds the needed header to the Workspaces doc and inserts it
just before PipelineResources in the ordering.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)