### PR TITLE
Limit namespaces the webhook queries for secrets

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -24,9 +24,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/contexts"
+	"github.com/tektoncd/pipeline/pkg/system"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	pkgleaderelection "knative.dev/pkg/leaderelection"
 	"knative.dev/pkg/logging"
@@ -128,8 +130,11 @@ func main() {
 		serviceName = "tekton-pipelines-webhook"
 	}
 
+	// Scope informers to the webhook's namespace instead of cluster-wide
+	ctx := injection.WithNamespaceScope(signals.NewContext(), system.GetNamespace())
+
 	// Set up a signal context with our webhook options
-	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+	ctx = webhook.WithOptions(ctx, webhook.Options{
 		ServiceName: serviceName,
 		Port:        8443,
 		SecretName:  "webhook-certs",

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -42,3 +42,31 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["tekton-pipelines"]
     verbs: ["use"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-webhook-cluster-access
+rules:
+  - apiGroups: ["admissionregistration.k8s.io"]
+    # The webhook performs a reconciliation on these two resources and continuously
+    # updates configuration.
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    # knative starts informers on these things, which is why we need get, list and watch.
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    # This mutating webhook is responsible for applying defaults to tekton objects
+    # as they are received.
+    resourceNames: ["webhook.pipeline.tekton.dev"]
+    # When there are changes to the configs or secrets, knative updates the mutatingwebhook config
+    # with the updated certificates or the refreshed set of rules.
+    verbs: ["get", "update"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    # validation.webhook.pipeline.tekton.dev performs schema validation when you, for example, create TaskRuns.
+    # config.webhook.pipeline.tekton.dev validates the logging configuration against knative's logging structure
+    resourceNames: ["validation.webhook.pipeline.tekton.dev", "config.webhook.pipeline.tekton.dev"]
+    # When there are changes to the configs or secrets, knative updates the validatingwebhook config
+    # with the updated certificates or the refreshed set of rules.
+    verbs: ["get", "update"]

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -1,0 +1,38 @@
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "watch"]
+  # The webhook needs access to these configmaps for logging information.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+    resourceNames: ["config-logging", "config-observability"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "watch"]
+  # The webhook daemon makes a reconciliation loop on webhook-certs. Whenever
+  # the secret changes it updates the webhook configurations with the certificates
+  # stored in the secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "update"]
+    resourceNames: ["webhook-certs"]

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -24,3 +24,16 @@ roleRef:
   kind: ClusterRole
   name: tekton-pipelines-admin
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-webhook-cluster-access
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-webhook
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-pipelines-webhook-cluster-access
+  apiGroup: rbac.authorization.k8s.io

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -11,14 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: tekton-pipelines-controller
-  namespace: tekton-pipelines
----
-apiVersion: v1
-kind: ServiceAccount
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
 metadata:
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-webhook
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: tekton-pipelines-webhook
+  apiGroup: rbac.authorization.k8s.io

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -43,7 +43,7 @@ spec:
         pipeline.tekton.dev/release: "devel"
         version: "devel"
     spec:
-      serviceAccountName: tekton-pipelines-controller
+      serviceAccountName: tekton-pipelines-webhook
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized


### PR DESCRIPTION
# Changes

The webhook uses informers to watch secrets in order to react when its
self-created certificates get updated. The webhook currently requests
cluster-wide access to secrets in order to do so.  This is unnecessary
however - the certifactes secret always lives alongside the webhook in
the tekton-pipelines namespace.

This commit reduces the scope of the webhook's informers so that they
only look for secrets in the tekton-pipelines namespace. This change
should be transparent to users but results in a relatively large drop
in the permissions the webhook needs to be granted.

In addition, this commit splits the webhook's service account from the
controller's and binds a reduced set of permissions vs those of the
controller via new roles and clusterroles.

Hat-tip to @eddie4941 for designing these changes.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)