### PR TITLE
Add HostNetwork Support to PodTemplate in TaskRun Pod

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -204,7 +204,8 @@ allows to customize some Pod specific field per `Task` execution, aka `TaskRun`.
 In the following example, the Task is defined with a `volumeMount`
 (`my-cache`), that is provided by the TaskRun, using a
 PersistentVolumeClaim. The SchedulerName has also been provided to define which scheduler should be used to
-dispatch the Pod. The Pod will also run as a non-root user.
+dispatch the Pod. The Pod will also run as a non-root user. HostNetwork has been allowed to carry out
+operations in the Node's Network Namespace (on which the Pod is scheduled).
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -232,6 +233,7 @@ spec:
     name: mytask
   podTemplate:
     schedulerName: volcano
+    hostNetwork: true
     securityContext:
       runAsNonRoot: true
     volumes:

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -93,6 +93,9 @@ type Template struct {
 	// SchedulerName specifies the scheduler to be used to dispatch the Pod
 	// +optional
 	SchedulerName string `json:"schedulerName"`
+	// HostNetwork specifies whether the pod may use the node network namespace
+	// +optional
+	HostNetwork bool `json:"hostNetwork"`
 }
 
 func (tpl *Template) Equals(other *Template) bool {

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -261,6 +261,7 @@ func MakePod(images pipeline.Images, taskRun *v1alpha1.TaskRun, taskSpec v1alpha
 			RuntimeClassName:             podTemplate.RuntimeClassName,
 			AutomountServiceAccountToken: podTemplate.AutomountServiceAccountToken,
 			SchedulerName:                podTemplate.SchedulerName,
+			HostNetwork:                  podTemplate.HostNetwork,
 			DNSPolicy:                    dnsPolicy,
 			DNSConfig:                    podTemplate.DNSConfig,
 			EnableServiceLinks:           podTemplate.EnableServiceLinks,

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -730,6 +730,54 @@ script-heredoc-randomly-generated-78c5n
 				TerminationMessagePath: "/tekton/termination",
 			}},
 		},
+	}, {
+		desc: "using hostNetwork",
+		ts: v1alpha1.TaskSpec{
+			TaskSpec: v1beta1.TaskSpec{
+				Steps: []v1alpha1.Step{
+					{
+						Container: corev1.Container{
+							Name:    "use-my-hostNetwork",
+							Image:   "image",
+							Command: []string{"cmd"}, // avoid entrypoint lookup.
+						},
+					},
+				},
+			},
+		},
+		trs: v1alpha1.TaskRunSpec{
+			PodTemplate: &v1alpha1.PodTemplate{
+				HostNetwork: true,
+			},
+		},
+		want: &corev1.PodSpec{
+			RestartPolicy:  corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{placeToolsInit},
+			HostNetwork:    true,
+			Volumes:        append(implicitVolumes, toolsVolume, downwardVolume),
+			Containers: []corev1.Container{{
+				Name:    "step-use-my-hostNetwork",
+				Image:   "image",
+				Command: []string{"/tekton/tools/entrypoint"},
+				Args: []string{
+					"-wait_file",
+					"/tekton/downward/ready",
+					"-wait_file_content",
+					"-post_file",
+					"/tekton/tools/0",
+					"-termination_path",
+					"/tekton/termination",
+					"-entrypoint",
+					"cmd",
+					"--",
+				},
+				Env:                    implicitEnvVars,
+				VolumeMounts:           append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
+				WorkingDir:             pipeline.WorkspaceDir,
+				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
+				TerminationMessagePath: "/tekton/termination",
+			}},
+		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()


### PR DESCRIPTION
# Changes

fixes https://github.com/tektoncd/pipeline/issues/2183

Add HostNetwork support in PodTemplate
used by a TaskRun as the TaskRun Pod which
is created would at times need to be executed
in the network namespace of the node.

Requirement for this feature has also been noted in
https://github.com/tektoncd/pipeline/issues/2183

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Added functionality to support HostNetwork bool in TaskRuns

```
