### PR TITLE
WIP: TaskRun Debug 

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_conversion.go
@@ -57,6 +57,7 @@ func (source *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskRunS
 	sink.Workspaces = source.Workspaces
 	sink.Params = source.Params
 	sink.Resources = source.Resources
+	sink.Debug = source.Debug
 	// Deprecated fields
 	if source.Inputs != nil {
 		if len(source.Inputs.Params) > 0 && len(source.Params) > 0 {
@@ -144,5 +145,6 @@ func (sink *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1beta1.TaskRu
 	sink.Workspaces = source.Workspaces
 	sink.Params = source.Params
 	sink.Resources = source.Resources
+	sink.Debug = source.Debug
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -49,6 +49,9 @@ type TaskRunSpec struct {
 	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
 	// +optional
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
+	// Debug specifies if the TaskRun has to be run in DebugMode
+	// +optional
+	Debug bool `json:"debug"`
 	// From v1beta1
 	// +optional
 	Params []Param `json:"params,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -30,6 +30,8 @@ import (
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {
 	// +optional
+	Debug bool `json:"debug"`
+	// +optional
 	Params []Param `json:"params,omitempty"`
 	// +optional
 	Resources *TaskRunResources `json:"resources,omitempty"`
@@ -152,6 +154,10 @@ type TaskRunStatusFields struct {
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.
 	Sidecars []SidecarState `json:"sidecars,omitempty"`
+
+	// Debug shows if debugMode has been enabled for the TaskRun
+	// +optional
+	Debug bool `json:"debug"`
 }
 
 // TaskRunResult used to describe the results of a task

--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -52,7 +52,7 @@ var credsInitHomeVolumeMount = corev1.VolumeMount{
 //
 // If it finds secrets, it also returns a set of Volumes to attach to the Pod
 // to provide those secrets to this initialization.
-func credsInit(credsImage string, serviceAccountName, namespace string, kubeclient kubernetes.Interface, volumeMounts []corev1.VolumeMount, implicitEnvVars []corev1.EnvVar) (*corev1.Container, []corev1.Volume, error) {
+func credsInit(credsImage, serviceAccountName, namespace string, kubeclient kubernetes.Interface, volumeMounts []corev1.VolumeMount, implicitEnvVars []corev1.EnvVar) (*corev1.Container, []corev1.Volume, error) {
 	if serviceAccountName == "" {
 		serviceAccountName = "default"
 	}

--- a/pkg/pod/helpers.go
+++ b/pkg/pod/helpers.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	debugEntrypointPath = filepath.Join(debugScriptsDebugDir, "debug")
+	superEntrypointPath = filepath.Join(scriptsDir, "super")
+	superExitFilePath   = filepath.Join(mountPoint, "super-exit")
+)
+
+func createHelperContainers(shellImage, entrypointImage string, debugMode bool) (corev1.Container, corev1.Container) {
+	var superContainer, debugContainer corev1.Container
+	volumeMounts := append(implicitVolumeMounts, scriptsVolumeMount, toolsMount)
+	if debugMode {
+		volumeMounts = append(volumeMounts, debugScriptsMount, debugToolsMount)
+		debugContainer = createDebugContainer(entrypointImage, volumeMounts)
+	}
+
+	superContainer = corev1.Container{
+		Name:  "super",
+		Image: shellImage,
+		Command: []string{"sh", "-c"},
+		Args:    []string{superEntrypointPath},
+		TTY:          true,
+		VolumeMounts: volumeMounts,
+	}
+
+	return superContainer, debugContainer
+
+}
+
+func createDebugContainer(entrypointImage string, volumeMounts []corev1.VolumeMount) corev1.Container {
+	argsForEntrypoint := []string{
+		"-wait_file", filepath.Join(downwardMountPoint, readyFile),
+		"-post_file", filepath.Join(debugMountPoint, readyFile),
+		"-termination_path", terminationPath,
+		"-entrypoint", debugEntrypointPath,
+		"--",
+	}
+
+	debugContainer := corev1.Container{
+		Name:                   "debug",
+		Image:                  entrypointImage,
+		Command:                []string{entrypointBinary},
+		Args:                   argsForEntrypoint,
+		VolumeMounts:           volumeMounts,
+		TerminationMessagePath: terminationPath,
+
+	}
+
+	return debugContainer
+}

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -26,10 +26,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type scripTool struct {
+	Path     string
+	Contents string
+}
+
 const (
-	scriptsVolumeName     = "tekton-internal-scripts"
-	scriptsDir            = "/tekton/scripts"
-	defaultScriptPreamble = "#!/bin/sh\nset -xe\n"
+	scriptsVolumeName       = "tekton-internal-scripts"
+	debugScriptsVolumeName  = "tekton-debug-internal-scripts"
+	scriptsDir              = "/tekton/scripts"
+	debugScriptsDebugDir    = "/tekton/debug/scripts"
+	defaultScriptPreamble   = "#!/bin/sh\nset -xe\n"
 )
 
 var (
@@ -43,38 +50,127 @@ var (
 		Name:      scriptsVolumeName,
 		MountPath: scriptsDir,
 	}
+	debugScriptsVolume = corev1.Volume{
+		Name:         debugScriptsVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	debugScriptsMount = corev1.VolumeMount{
+		Name:      debugScriptsVolumeName,
+		MountPath: debugScriptsDebugDir,
+	}
+	debugStartScriptPath    = filepath.Join(debugScriptsDebugDir,"start-task")
+	debugContinueScriptPath = filepath.Join(debugScriptsDebugDir,"continue-task")
+	//superExitScriptPath = filepath.Join(scriptsDir, "super-exit")
 )
 
 // convertScripts converts any steps and sidecars that specify a Script field into a normal Container.
 //
-// It does this by prepending a container that writes specified Script bodies
+// It does this by prefixing a container that writes specified Script bodies
 // to executable files in a shared volumeMount, then produces Containers that
 // simply run those executable files.
-func convertScripts(shellImage string, steps []v1alpha1.Step, sidecars []v1alpha1.Sidecar) (*corev1.Container, []corev1.Container, []corev1.Container) {
+func convertScripts(shellImage string, steps []v1alpha1.Step, sidecars []v1alpha1.Sidecar, debugMode bool) (*corev1.Container, []corev1.Container, []corev1.Container) {
 	placeScripts := false
+	placeScriptsArgs := []string{"-c", ""}
+	placeScriptsVolumeMounts := []corev1.VolumeMount{scriptsVolumeMount}
+
+	// number of steps used to understand when do we stop with the debugging
+	numberOfSteps := len(steps)
+
 	placeScriptsInit := corev1.Container{
 		Name:         "place-scripts",
 		Image:        shellImage,
 		TTY:          true,
 		Command:      []string{"sh"},
-		Args:         []string{"-c", ""},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
+		Args:         placeScriptsArgs,
+		VolumeMounts: placeScriptsVolumeMounts,
+	}
+	addSuperScripts(&placeScriptsInit)
+	if debugMode {
+		addDebugScripts(&placeScriptsInit, numberOfSteps)
 	}
 
-	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, &placeScripts, "script")
-	sidecarContainers := convertListOfSteps(sidecars, &placeScriptsInit, &placeScripts, "sidecar-script")
-
+	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, &placeScripts, "script", debugMode)
+	sidecarContainers := convertListOfSteps(sidecars, &placeScriptsInit, &placeScripts, "sidecar-script", debugMode)
 	if placeScripts {
 		return &placeScriptsInit, convertedStepContainers, sidecarContainers
 	}
 	return nil, convertedStepContainers, sidecarContainers
 }
 
+func addSuperScripts(initContainer *corev1.Container) {
+	heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", "super"))
+	superEntrypointContents := "tail -f /dev/null"
+
+	tooling := []scripTool{
+		{Path: superEntrypointPath, Contents: superEntrypointContents},
+	}
+
+	for _, st := range tooling {
+		// Script which will run in the debug container
+		initContainer.Args[1] += fmt.Sprintf(`superFile="%s"
+touch ${superFile} && chmod +x ${superFile}
+cat > ${superFile} << '%s'
+%s
+%s
+`, st.Path, heredoc, st.Contents, heredoc)
+	}
+
+}
+
+func addDebugScripts(initContainer *corev1.Container, numberOfSteps int) {
+	initContainer.VolumeMounts = append(initContainer.VolumeMounts, debugToolsMount, debugScriptsMount)
+	debugReadyFilePath := filepath.Join(debugMountPoint, readyFile)
+	debugStartContent := fmt.Sprintf(`echo "ready" > "%s"
+echo "Executing step 0..."
+`, debugReadyFilePath)
+
+	debugContinueContent := fmt.Sprintf(`debugMountPoint="%s"
+mountPoint="%s"
+numberOfSteps=%d
+	
+debugPostFile="$(ls ${debugMountPoint} | grep -E '[0-9]+' | tail -1)"
+stepNumber="$(echo ${debugPostFile} | sed 's/[^0-9]*//g')"
+nextStepNumber=$((stepNumber+1))
+if [ $nextStepNumber -lt $numberOfSteps ]; then
+	cp ${debugMountPoint}/${debugPostFile} ${mountPoint}/${stepNumber}
+	echo "Executing step $nextStepNumber..."
+else
+	echo "Last step (no. $stepNumber) has already been executed !"
+fi
+`, debugMountPoint, mountPoint, numberOfSteps)
+
+	debugScriptContents := defaultScriptPreamble+fmt.Sprintf(`debugReady="%s"
+while true
+do
+if [[ ! -f ${debugReady} ]]; then
+	sleep 2
+fi
+done
+`, debugReadyFilePath)
+
+	tooling := []scripTool{
+		{Path: debugEntrypointPath, Contents: debugScriptContents},
+		{Path: debugStartScriptPath, Contents: debugStartContent},
+		{Path: debugContinueScriptPath, Contents: debugContinueContent},
+	}
+
+	for _, dt := range tooling {
+		heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", "debug"))
+		// Script which will run in the debug container
+		initContainer.Args[1] += fmt.Sprintf(`tmpFile="%s"
+touch ${tmpFile} && chmod +x ${tmpFile}
+cat > ${tmpFile} << '%s'
+%s
+%s
+`, dt.Path, heredoc, dt.Contents, heredoc)
+	}
+}
+
 // convertListOfSteps does the heavy lifting for convertScripts.
 //
 // It iterates through the list of steps (or sidecars), generates the script file name and heredoc termination string,
 // adds an entry to the init container args, sets up the step container to run the script, and sets the volume mounts.
-func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, placeScripts *bool, namePrefix string) []corev1.Container {
+func convertListOfSteps(steps []v1alpha1.Step, initContainer *corev1.Container, placeScripts *bool, namePrefix string, debugMode bool) []corev1.Container {
 	containers := []corev1.Container{}
 	for i, s := range steps {
 		if s.Script == "" {
@@ -122,6 +218,9 @@ cat > ${tmpfile} << '%s'
 		// we'll clear out the Args and overwrite Command.
 		steps[i].Command = []string{tmpFile}
 		steps[i].VolumeMounts = append(steps[i].VolumeMounts, scriptsVolumeMount)
+		if debugMode {
+			steps[i].VolumeMounts = append(steps[i].VolumeMounts, debugScriptsMount)
+		}
 		containers = append(containers, steps[i].Container)
 	}
 	return containers

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -102,6 +102,9 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	// Don't modify the informer's copy.
 	tr := original.DeepCopy()
 
+	//Check if TaskRUn in in DebugMode
+	tr.Status.Debug = tr.Spec.Debug
+
 	// If the TaskRun is just starting, this will also set the starttime,
 	// from which the timeout will immediately begin counting down.
 	tr.Status.InitializeConditions()


### PR DESCRIPTION
.spec.debug bool, is added to TaskRun API which enables
debug mode for the particular TaskRun.

Co-authored-by: Vibhav Bobade <vbobade@redhat.com>
Co-authored-by: Nikhil Thomas <nikthoma@redhat.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
