### PR TITLE
Fix default-timeout from config not correctly set 😓

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/contexts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -35,16 +34,7 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil {
-		var timeout *metav1.Duration
-		if contexts.IsUpgradeViaDefaulting(ctx) {
-			// This case is for preexisting `TaskRun` before 0.5.0, so let's
-			// add the old default timeout.
-			// Most likely those TaskRun passing here are already done and/or already running
-			timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
-		} else {
-			timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
-		}
-		prs.Timeout = timeout
+		prs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
 	}
 
 	defaultSA := cfg.Defaults.DefaultServiceAccount

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/contexts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -39,16 +38,7 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	}
 
 	if trs.Timeout == nil {
-		var timeout *metav1.Duration
-		if contexts.IsUpgradeViaDefaulting(ctx) {
-			// This case is for preexisting `TaskRun` before 0.5.0, so let's
-			// add the old default timeout.
-			// Most likely those TaskRun passing here are already done and/or already running
-			timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
-		} else {
-			timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
-		}
-		trs.Timeout = timeout
+		trs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
 	}
 
 	defaultSA := cfg.Defaults.DefaultServiceAccount


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Make sure we always read from the config-default map to set the
timeout on PipelineRun and TaskRun.
Remove the pre 0.5.0 behavior, it has been 6 release since then.

Closes #2324 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @danielhelfand @sbwsg @bobcatfish 

We may need a 0.11.1 soon-ish :sweat_smile: 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix default-timeout from config not being correctly set on TaskRuns and PipelineRuns.
```
