### PR TITLE
Add labels to namespaces created during end to end tests

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -124,9 +124,13 @@ func initializeLogsAndMetrics(t *testing.T) {
 
 func createNamespace(t *testing.T, namespace string, kubeClient *knativetest.KubeClient) {
 	t.Logf("Create namespace %s to deploy to", namespace)
+	labels := map[string]string{
+		"tekton.dev/test-e2e": "true",
+	}
 	if _, err := kubeClient.Kube.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: labels,
 		},
 	}); err != nil {
 		t.Fatalf("Failed to create namespace %s for tests: %s", namespace, err)

--- a/test/v1alpha1/init_test.go
+++ b/test/v1alpha1/init_test.go
@@ -124,9 +124,13 @@ func initializeLogsAndMetrics(t *testing.T) {
 
 func createNamespace(t *testing.T, namespace string, kubeClient *knativetest.KubeClient) {
 	t.Logf("Create namespace %s to deploy to", namespace)
+	labels := map[string]string{
+		"tekton.dev/test-e2e": "true",
+	}
 	if _, err := kubeClient.Kube.CoreV1().Namespaces().Create(&corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: labels,
 		},
 	}); err != nil {
 		t.Fatalf("Failed to create namespace %s for tests: %s", namespace, err)


### PR DESCRIPTION
Besides that it is a good practice to label resources created this allows in this case easy deletion of the namespaces if:
- there was an issue while running the tests
- the variable TEST_KEEP_NAMESPACES was set
- the tests were abruptly stopped by the developer

Currently you have to run something like:
$ kubectl get namespaces --no-headers=true -o custom-columns=:metadata.name | grep arendelle | xargs kubectl delete namespace
This would become:
$ kubectl delete ns -l "tekton.dev/test-e2e=true"

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Changes are minimal:
- a few lines added to  test/init_test.go and  test/v1alpha1/init_test.go

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

