### PR TITLE
Add link from migrate doc to GCS task in catalog

### DIFF
--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -8,11 +8,7 @@
     - [Git Resource](#git-resource)
     - [Pull Request Resource](#pull-request-resource)
     - [Image Resource](#image-resource)
-    - [Cluster Resource](#cluster-resource)
-    - [Storage Resources](#storage-resources)
     - [GCS Resource](#gcs-resource)
-    - [BuildGCS Resource](#buildgcs-resource)
-    - [Cloud Event Resource](#cloud-event-resource)
 
 This doc describes the changes you'll need to make when converting your `Task`s,
 `Pipeline`s, `TaskRun`s, and `PipelineRun`s from the `v1alpha1` `apiVersion` to
@@ -174,3 +170,8 @@ the [Kaniko Catalog Task](https://github.com/tektoncd/catalog/blob/v1beta1/kanik
 which demonstrates writing the image digest to a result, and the
 [Buildah Catalog Task](https://github.com/tektoncd/catalog/blob/v1beta1/buildah/)
 which shows how to accept an image digest as a parameter.
+
+### GCS Resource
+
+The [`gcs` Tasks in the Catalog](https://github.com/tektoncd/catalog/tree/v1beta1/gcs) provide
+an equivalent to the GCS Resource.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We're progressively providing replacements for PipelineResources as Tasks in the Tekton catalog and documeting those replacements.

This commit links to the new GCS task in the catalog from our migration docs. It also removes table of contents entries for tasks that have not yet been added.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).