### PR TITLE
Update dev docs with inverted resources/inputs/outputs

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -59,8 +59,8 @@ expected in directory path `/workspace/output/resource_name`.
     name: get-gcs-task
     namespace: default
   spec:
-    outputs:
-      resources:
+    resources:
+      outputs:
         - name: gcs-workspace
           type: storage
   ```
@@ -76,8 +76,8 @@ expected in directory path `/workspace/output/resource_name`.
     name: get-gcs-task
     namespace: default
   spec:
-    outputs:
-      resources:
+    resources:
+      outputs:
         - name: gcs-workspace
           type: storage
           targetPath: /workspace/outputstuff
@@ -95,13 +95,12 @@ expected in directory path `/workspace/output/resource_name`.
     name: get-gcs-task
     namespace: default
   spec:
-    inputs:
-      resources:
+    resources:
+      inputs:
         - name: gcs-workspace
           type: storage
           targetPath: random-space
-    outputs:
-      resources:
+      outputs:
         - name: gcs-workspace
           type: storage
   ```
@@ -117,12 +116,11 @@ expected in directory path `/workspace/output/resource_name`.
     name: get-gcs-task
     namespace: default
   spec:
-    inputs:
-      resources:
+    resources:
+      inputs:
         - name: gcs-workspace
           type: storage
-    outputs:
-      resources:
+      outputs:
         - name: gcs-workspace
           type: storage
   ```


### PR DESCRIPTION
# Changes


With https://github.com/tektoncd/pipeline/issues/1185 we resolved a lot
of confusion and inconsistency around how we nested things with
input/output, but we didn't update our developer docs :(

In #2319 we pointed someone toward these docs and the person ended up
using the old syntax and being confused :(

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).