### PR TITLE
Handle conditions in task result substitution

### DIFF
--- a/examples/v1beta1/pipelineruns/pipeline-result-conditions.yaml
+++ b/examples/v1beta1/pipelineruns/pipeline-result-conditions.yaml
@@ -1,0 +1,110 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: condition-1
+spec:
+  check:
+    args:
+    - EXITCODE=$(python -c "import sys; input1=str.rstrip(sys.argv[1]); input2=str.rstrip(sys.argv[2]); print(0) if (input1 == 'heads') else
+      print(1)" '$(params.flip-coin)' 'heads'); exit $EXITCODE
+    command:
+    - sh
+    - -c
+    image: python:alpine3.6
+  params:
+  - name: flip-coin
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: flip-coin
+spec:
+  results:
+  - description: /tmp/output
+    name: output
+  steps:
+  - args:
+    - python -c "import random; result = 'heads' if random.randint(0,1) == 0 else
+      'tails'; result='heads'; print(result)" | tee $(results.output.path)
+    command:
+    - sh
+    - -c
+    image: python:alpine3.6
+    name: flip-coin
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: condition-check
+spec:
+  params:
+  - name: flip-coin
+  results:
+  - description: /tmp/output
+    name: output
+  steps:
+  - args:
+    - EXITCODE=$(python -c "import sys; input1=str.rstrip(sys.argv[1]); input2=str.rstrip(sys.argv[2]); print(input1) if (input1 == 'heads') else
+      print(input1)" '$(params.flip-coin)' 'heads'); echo $EXITCODE | tee $(results.output.path)
+    command:
+    - sh
+    - -c
+    image: python:alpine3.6
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: generate-random-number
+spec:
+  results:
+  - description: /tmp/output
+    name: output
+  steps:
+  - args:
+    - python -c "import random; print(random.randint($0, $1))" | tee $2
+    - '0'
+    - '9'
+    - $(results.output.path)
+    command:
+    - sh
+    - -c
+    image: python:alpine3.6
+    name: generate-random-number
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Shows how to use dsl.Condition().",
+      "name": "Conditional execution pipeline"}'
+  name: flip-cond-gen-pipeline
+spec:
+  params: []
+  tasks:
+  - name: flip-coin
+    params: []
+    taskRef:
+      name: flip-coin
+  - name: condition-check
+    params:
+      - name: flip-coin
+        value: $(tasks.flip-coin.results.output)
+    taskRef:
+      name: condition-check
+  - conditions:
+    - conditionRef: condition-1
+      params:
+      - name: flip-coin
+        value: $(tasks.flip-coin.results.output)
+    name: generate-random-number
+    params: []
+    taskRef:
+      name: generate-random-number
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: flip-cond-gen-pipeline-run
+spec:
+  pipelineRef:
+    name: flip-cond-gen-pipeline

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -167,6 +167,16 @@ func (pt PipelineTask) Deps() []string {
 		for _, rd := range cond.Resources {
 			deps = append(deps, rd.From...)
 		}
+		for _, param := range cond.Params {
+			expressions, ok := v1beta1.GetVarSubstitutionExpressionsForParam(param)
+			if ok {
+				if resultRefs, err := v1beta1.NewResultRefs(expressions); err == nil {
+					for _, resultRef := range resultRefs {
+						deps = append(deps, resultRef.PipelineTask)
+					}
+				}
+			}
+		}
 	}
 	// Add any dependents from task results
 	for _, param := range pt.Params {
@@ -179,6 +189,7 @@ func (pt PipelineTask) Deps() []string {
 			}
 		}
 	}
+
 	return deps
 }
 

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -662,3 +662,49 @@ func TestBuild_TaskParamsFromTaskResults(t *testing.T) {
 	}
 	assertSameDAG(t, expectedDAG, g)
 }
+
+func TestBuild_ConditionsParamsFromTaskResults(t *testing.T) {
+	a := v1alpha1.PipelineTask{Name: "a"}
+	xDependsOnA := v1alpha1.PipelineTask{
+		Name: "x",
+		Conditions: []v1beta1.PipelineTaskCondition{{
+			ConditionRef: "cond",
+			Params: []v1alpha1.Param{
+				{
+					Name: "paramX",
+					Value: v1beta1.ArrayOrString{
+						Type:      v1alpha1.ParamTypeString,
+						StringVal: "$(tasks.a.results.resultA)",
+					},
+				},
+			},
+		},
+		},
+	}
+
+	//   a
+	//   |
+	//   x
+	nodeA := &dag.Node{Task: a}
+	nodeX := &dag.Node{Task: xDependsOnA}
+
+	nodeA.Next = []*dag.Node{nodeX}
+	nodeX.Prev = []*dag.Node{nodeA}
+	expectedDAG := &dag.Graph{
+		Nodes: map[string]*dag.Node{
+			"a": nodeA,
+			"x": nodeX,
+		},
+	}
+	p := &v1alpha1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+		Spec: v1alpha1.PipelineSpec{
+			Tasks: []v1alpha1.PipelineTask{a, xDependsOnA},
+		},
+	}
+	g, err := dag.Build(v1alpha1.PipelineTaskList(p.Spec.Tasks))
+	if err != nil {
+		t.Fatalf("didn't expect error creating valid Pipeline %v but got %v", p, err)
+	}
+	assertSameDAG(t, expectedDAG, g)
+}

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -64,9 +64,17 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 	}
 
 	for _, resolvedPipelineRunTask := range targets {
-		pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
-		pipelineTask.Params = replaceParamValues(pipelineTask.Params, stringReplacements, nil)
-		resolvedPipelineRunTask.PipelineTask = pipelineTask
+		// also make substitution for resolved condition checks
+		for _, resolvedConditionCheck := range resolvedPipelineRunTask.ResolvedConditionChecks {
+			pipelineTaskCondition := resolvedConditionCheck.PipelineTaskCondition.DeepCopy()
+			pipelineTaskCondition.Params = replaceParamValues(pipelineTaskCondition.Params, stringReplacements, nil)
+			resolvedConditionCheck.PipelineTaskCondition = pipelineTaskCondition
+		}
+		if resolvedPipelineRunTask.PipelineTask != nil {
+			pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
+			pipelineTask.Params = replaceParamValues(pipelineTask.Params, stringReplacements, nil)
+			resolvedPipelineRunTask.PipelineTask = pipelineTask
+		}
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -124,10 +124,29 @@ func removeDup(refs ResolvedResultRefs) ResolvedResultRefs {
 // convertParamsToResultRefs converts all params of the resolved pipeline run task
 func convertParamsToResultRefs(pipelineRunState PipelineRunState, target *ResolvedPipelineRunTask) (ResolvedResultRefs, error) {
 	var resolvedParams ResolvedResultRefs
-	for _, param := range target.PipelineTask.Params {
+	for _, condition := range target.PipelineTask.Conditions {
+		condRefs, err := convertParams(condition.Params, pipelineRunState, condition.ConditionRef)
+		if err != nil {
+			return nil, err
+		}
+		resolvedParams = append(resolvedParams, condRefs...)
+	}
+
+	taskParamsRefs, err := convertParams(target.PipelineTask.Params, pipelineRunState, target.PipelineTask.Name)
+	if err != nil {
+		return nil, err
+	}
+	resolvedParams = append(resolvedParams, taskParamsRefs...)
+
+	return resolvedParams, nil
+}
+
+func convertParams(params []v1beta1.Param, pipelineRunState PipelineRunState, name string) (ResolvedResultRefs, error) {
+	var resolvedParams ResolvedResultRefs
+	for _, param := range params {
 		resolvedResultRefs, err := extractResultRefsForParam(pipelineRunState, param)
 		if err != nil {
-			return nil, fmt.Errorf("unable to find result referenced by param %q in pipeline task %q: %w", param.Name, target.PipelineTask.Name, err)
+			return nil, fmt.Errorf("unable to find result referenced by param %q in %q: %w", param.Name, name, err)
 		}
 		if resolvedResultRefs != nil {
 			resolvedParams = append(resolvedParams, resolvedResultRefs...)

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -62,9 +62,6 @@ func ApplyParameters(spec *v1alpha1.TaskSpec, tr *v1alpha1.TaskRun, defaults ...
 			arrayReplacements[fmt.Sprintf("inputs.params.%s", p.Name)] = p.Value.ArrayVal
 		}
 	}
-
-	fmt.Println("stringReplacements", stringReplacements)
-	fmt.Println("arrayReplacements", arrayReplacements)
 	return ApplyReplacements(spec, stringReplacements, arrayReplacements)
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Handle conditions in task result substitution. Fix for #2336.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
- Handle conditions in task result substitution. Fix for #2336.
```
