### PR TITLE
Fix references to API version in Tasks and PipelineRuns docs

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -37,7 +37,7 @@ following fields:
 
 - Required:
   - [`apiVersion`][kubernetes-overview] - Specifies the API version, for example
-    `tekton.dev/vbeta1`
+    `tekton.dev/v1beta1`
   - [`kind`][kubernetes-overview] - Specify the `PipelineRun` resource object.
   - [`metadata`][kubernetes-overview] - Specifies data to uniquely identify the
     `PipelineRun` resource object, for example a `name`.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -37,7 +37,7 @@ weight: 1
 ## Overview
 
 A `Task` is a collection of `Steps` that you
-define and arrange in a specific order of execution as part of your continuous integration flow. 
+define and arrange in a specific order of execution as part of your continuous integration flow.
 A `Task` executes as a Pod on your Kubernetes cluster. A `Task` is available within a specific
 namespace, while a `ClusterTask` is available across the entire cluster.
 
@@ -54,13 +54,13 @@ A `Task` declaration includes the following elements:
 A `Task` definition supports the following fields:
 
 - Required:
-  - [`apiVersion`][kubernetes-overview] - Specifies the API version. For example, 
-    `tekton.dev/v1beta`.
+  - [`apiVersion`][kubernetes-overview] - Specifies the API version. For example,
+    `tekton.dev/v1beta1`.
   - [`kind`][kubernetes-overview] - Identifies this resource object as a `Task` object.
   - [`metadata`][kubernetes-overview] - Specifies metadata that uniquely identifies the
     `Task` resource object. For example, a `name`.
   - [`spec`][kubernetes-overview] - Specifies the configuration information for
-    this `Task` resource object. 
+    this `Task` resource object.
   - [`steps`](#defining-steps) - Specifies one or more container images to run in the `Task`.
 - Optional:
   - [`description`](#adding-a-description) - An informative description of the `Task`.
@@ -123,7 +123,7 @@ A `ClusterTask` behaves identically to a `Task` and therefore everything in this
 applies to both.
 
 **Note:** When using a `ClusterTask`, you must explicitly set the `kind` sub-field in the `taskRef` field to `ClusterTask`.
-          If not specified, the `kind` sub-field defaults to `Task.` 
+          If not specified, the `kind` sub-field defaults to `Task.`
 
 Below is an example of a Pipeline declaration that uses a `ClusterTask`:
 
@@ -151,7 +151,7 @@ which the `Steps` appear in this list is the order in which they will execute.
 
 The following requirements apply to each container image referenced in a `steps` field:
 
-- The container image must abide by the [container contract](./container-contract.md). 
+- The container image must abide by the [container contract](./container-contract.md).
 - Each container image runs to completion or until the first failure occurs.
 - The CPU, memory, and ephemeral storage resource requests will be set to zero, or, if
   specified, the minimums set through `LimitRanges` in that `Namespace`,
@@ -176,7 +176,7 @@ line will have the following default preamble prepended:
 set -xe
 ```
 
-You can override this default preamble by prepending a shebang that specifies the desired parser. 
+You can override this default preamble by prepending a shebang that specifies the desired parser.
 This parser must be present within that `Step's` container image.
 
 The example below executes a Bash script:
@@ -543,7 +543,7 @@ variable values as follows:
   ```shell
   $(params.<name>)
   ```
-- To access parameter values from resources, see [variable substitution](resources.md#variable-substitution)  
+- To access parameter values from resources, see [variable substitution](resources.md#variable-substitution)
 
 #### Substituting `Array' parameters
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Tasks doc had incorrect reference to `v1beta`
PipelineRuns had incorrect refrence to `vbeta1`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

