### PR TITLE
Make feature-flags config map name customizable

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -71,6 +71,8 @@ spec:
           value: config-artifact-bucket
         - name: CONFIG_ARTIFACT_PVC_NAME
           value: config-artifact-pvc
+        - name: CONFIG_FEATURE_FLAGS_NAME
+          value: feature-flags
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
       volumes:

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -813,14 +814,14 @@ func TestShouldOverrideHomeEnv(t *testing.T) {
 	}{{
 		description: "Default behaviour: A missing disable-home-env-overwrite flag should result in true",
 		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: featureFlagConfigMapName, Namespace: system.GetNamespace()},
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
 			Data:       map[string]string{},
 		},
 		expected: true,
 	}, {
 		description: "Setting disable-home-env-overwrite to false should result in true",
 		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: featureFlagConfigMapName, Namespace: system.GetNamespace()},
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
 			Data: map[string]string{
 				featureFlagDisableHomeEnvKey: "false",
 			},
@@ -829,7 +830,7 @@ func TestShouldOverrideHomeEnv(t *testing.T) {
 	}, {
 		description: "Setting disable-home-env-overwrite to true should result in false",
 		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: featureFlagConfigMapName, Namespace: system.GetNamespace()},
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
 			Data: map[string]string{
 				featureFlagDisableHomeEnvKey: "true",
 			},
@@ -847,6 +848,37 @@ func TestShouldOverrideHomeEnv(t *testing.T) {
 	}
 }
 
+func TestGetFeatureFlagsConfigName(t *testing.T) {
+	for _, tc := range []struct {
+		description         string
+		featureFlagEnvValue string
+		expected            string
+	}{{
+		description:         "Feature flags config value not set",
+		featureFlagEnvValue: "",
+		expected:            "feature-flags",
+	}, {
+		description:         "Feature flags config value set",
+		featureFlagEnvValue: "feature-flags-test",
+		expected:            "feature-flags-test",
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			original := os.Getenv("CONFIG_FEATURE_FLAGS_NAME")
+			defer t.Cleanup(func() {
+				os.Setenv("CONFIG_FEATURE_FLAGS_NAME", original)
+			})
+			if tc.featureFlagEnvValue != "" {
+				os.Setenv("CONFIG_FEATURE_FLAGS_NAME", tc.featureFlagEnvValue)
+			}
+			got := GetFeatureFlagsConfigName()
+			want := tc.expected
+			if got != want {
+				t.Errorf("GetFeatureFlagsConfigName() = %s, want %s", got, want)
+			}
+		})
+	}
+}
+
 func TestShouldOverrideWorkingDir(t *testing.T) {
 	for _, tc := range []struct {
 		description string
@@ -855,14 +887,14 @@ func TestShouldOverrideWorkingDir(t *testing.T) {
 	}{{
 		description: "Default behaviour: A missing disable-working-directory-overwrite flag should result in true",
 		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: featureFlagConfigMapName, Namespace: system.GetNamespace()},
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
 			Data:       map[string]string{},
 		},
 		expected: true,
 	}, {
 		description: "Setting disable-working-directory-overwrite to false should result in true",
 		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: featureFlagConfigMapName, Namespace: system.GetNamespace()},
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
 			Data: map[string]string{
 				featureFlagDisableWorkingDirKey: "false",
 			},
@@ -871,7 +903,7 @@ func TestShouldOverrideWorkingDir(t *testing.T) {
 	}, {
 		description: "Setting disable-working-directory-overwrite to true should result in false",
 		configMap: &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: featureFlagConfigMapName, Namespace: system.GetNamespace()},
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
 			Data: map[string]string{
 				featureFlagDisableWorkingDirKey: "true",
 			},


### PR DESCRIPTION
The config maps used by Tekton Pipeline should be able to take custom
names to avoid collisions with other services.

However, the feature-flags config map wasn't customizable because its
name hardcoded its usages.

By defining an env var in controller.yaml, from which the feature-flags
config map name can be derived, we enable it to be customizable.

Fixes #1805.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
feature-flags config map name can be specified by the user
```
