### PR TITLE
Validate PullRequest resource secrets fields

### DIFF
--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -103,6 +104,12 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
+	if rs.Type == PipelineResourceTypePullRequest {
+		if err := validatePullRequest(rs); err != nil {
+			return err
+		}
+	}
+
 	for _, allowedType := range AllResourceTypes {
 		if allowedType == rs.Type {
 			return nil
@@ -129,6 +136,15 @@ func validateURL(u, path string) *apis.FieldError {
 	_, err := url.ParseRequestURI(u)
 	if err != nil {
 		return apis.ErrInvalidValue(u, path)
+	}
+	return nil
+}
+
+func validatePullRequest(s *PipelineResourceSpec) *apis.FieldError {
+	for _, param := range s.SecretParams {
+		if param.FieldName != "authToken" {
+			return apis.ErrInvalidValue(fmt.Sprintf("invalid field name %q in secret parameter. Expected %q", param.FieldName, "authToken"), "spec.secrets.fieldName")
+		}
 	}
 	return nil
 }

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -139,6 +139,17 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			name: "missing spec",
 			res:  &v1alpha1.PipelineResource{},
 			want: apis.ErrMissingField("spec.type"),
+		}, {
+			name: "pull request with invalid field name in secrets",
+			res: &v1alpha1.PipelineResource{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypePullRequest,
+					SecretParams: []v1alpha1.SecretParam{{
+						FieldName: "INVALID_FIELD_NAME",
+					}},
+				},
+			},
+			want: apis.ErrInvalidValue("invalid field name \"INVALID_FIELD_NAME\" in secret parameter. Expected \"authToken\"", "spec.secrets.fieldName"),
 		},
 	}
 	for _, tt := range tests {
@@ -191,6 +202,14 @@ func TestClusterResourceValidation_Valid(t *testing.T) {
 					}, {
 						Name: "insecure", Value: "true",
 					}},
+				},
+			},
+		},
+		{
+			name: "specify pullrequest with no secrets",
+			res: &v1alpha1.PipelineResource{
+				Spec: v1alpha1.PipelineResourceSpec{
+					Type: v1alpha1.PipelineResourceTypePullRequest,
 				},
 			},
 		},


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A PullRequest type pipeline resource is now validated: an unrecognised
'fieldName' in secrets will trigger an error.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
As stated in #1818, this will help improve the debuggability of the
PullRequst pipeline resource, as the validatiob will cause a failure in
response to invalid input as early as possible.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Specifying a value other than `authToken` in the `fieldName` field of `secrets` in a PullRequest resource will cause a validation failure, preventing the PullRequest resource from being created. 
```
