### PR TITLE
Add tekton.dev/clusterTask in taskrun of clustertask

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -52,6 +52,9 @@ The following labels are added to resources automatically:
   [Specifying a `Task`](taskruns.md#specifying-a-task) section of the `TaskRun`
   documentation), and contains the name of the `Task` that the `TaskRun`
   references.
+- `tekton.dev/clusterTask` is added to `TaskRuns` (and propagated to `Pods`) that
+  reference an existing `ClusterTask`and contains the name of the `ClusterTask` 
+  that the `TaskRun` references.
 - `tekton.dev/taskRun` is added to `Pods`, and contains the name of the
   `TaskRun` that created the `Pod`.
 
@@ -76,4 +79,13 @@ the following command:
 
 ```shell
 kubectl get taskruns --all-namespaces -l tekton.dev/task=test-task
+```
+
+### Finding TaskRuns for a Specific ClusterTask
+
+To find all `TaskRuns` that reference a `ClusterTask` named test-clustertask, you could use
+the following command:
+
+```shell
+kubectl get taskruns --all-namespaces -l tekton.dev/clusterTask=test-clustertask
 ```

--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -20,7 +20,10 @@ const (
 	// GroupName is the Kubernetes resource group name for Pipeline types.
 	GroupName = "tekton.dev"
 
-	// TaskLabelKey is used as the label identifier for a task
+	// ClusterTaskLabelKey is used as the label identifier for a ClusterTask
+	ClusterTaskLabelKey = "/clusterTask"
+
+	// TaskLabelKey is used as the label identifier for a Task
 	TaskLabelKey = "/task"
 
 	// TaskRunLabelKey is used as the label identifier for a TaskRun

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -278,7 +278,11 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 		tr.ObjectMeta.Labels[key] = value
 	}
 	if tr.Spec.TaskRef != nil {
-		tr.ObjectMeta.Labels[pipeline.GroupName+pipeline.TaskLabelKey] = taskMeta.Name
+		if tr.Spec.TaskRef.Kind == "ClusterTask" {
+			tr.ObjectMeta.Labels[pipeline.GroupName+pipeline.ClusterTaskLabelKey] = taskMeta.Name
+		} else {
+			tr.ObjectMeta.Labels[pipeline.GroupName+pipeline.TaskLabelKey] = taskMeta.Name
+		}
 	}
 
 	// Propagate annotations from Task to TaskRun.

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -51,11 +51,12 @@ import (
 )
 
 const (
-	entrypointLocation  = "/tekton/tools/entrypoint"
-	taskNameLabelKey    = pipeline.GroupName + pipeline.TaskLabelKey
-	taskRunNameLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
-	workspaceDir        = "/workspace"
-	currentAPIVersion   = "tekton.dev/v1alpha1"
+	entrypointLocation      = "/tekton/tools/entrypoint"
+	taskNameLabelKey        = pipeline.GroupName + pipeline.TaskLabelKey
+	clusterTaskNameLabelKey = pipeline.GroupName + pipeline.ClusterTaskLabelKey
+	taskRunNameLabelKey     = pipeline.GroupName + pipeline.TaskRunLabelKey
+	workspaceDir            = "/workspace"
+	currentAPIVersion       = "tekton.dev/v1alpha1"
 )
 
 var (
@@ -781,7 +782,7 @@ func TestReconcile(t *testing.T) {
 		taskRun: taskRunWithClusterTask,
 		wantPod: tb.Pod("test-taskrun-with-cluster-task-pod-abcde", "foo",
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
-			tb.PodLabel(taskNameLabelKey, "test-cluster-task"),
+			tb.PodLabel(clusterTaskNameLabelKey, "test-cluster-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-cluster-task"),
 			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-cluster-task",


### PR DESCRIPTION
This will fix the issue of tekton.dev/task label getting
added for taskrun created referencing clustetask
Now it will be tekton.dev/clusterTask

Add docs and fix test

Fix #2377

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add tekton.dev/clusterTask in taskrun of clustertask and remove tekton.dev/task

```
