### PR TITLE
Change signature on pr.GetOwnerReference()

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -152,10 +152,8 @@ func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
 }
 
 // GetOwnerReference gets the pipeline run as owner reference for any related objects
-func (pr *PipelineRun) GetOwnerReference() []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		*metav1.NewControllerRef(pr, groupVersionKind),
-	}
+func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
+	return *metav1.NewControllerRef(pr, groupVersionKind)
 }
 
 // IsDone returns true if the PipelineRun's status indicates that it is done.

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -73,10 +73,8 @@ func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
 }
 
 // GetOwnerReference gets the pipeline run as owner reference for any related objects
-func (pr *PipelineRun) GetOwnerReference() []metav1.OwnerReference {
-	return []metav1.OwnerReference{
-		*metav1.NewControllerRef(pr, groupVersionKind),
-	}
+func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
+	return *metav1.NewControllerRef(pr, groupVersionKind)
 }
 
 // IsDone returns true if the PipelineRun's status indicates that it is done.

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -101,7 +101,7 @@ var (
 
 func GetPersistentVolumeClaim(size string, storageClassName *string) *corev1.PersistentVolumeClaim {
 	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: pipelinerun.Namespace, OwnerReferences: pipelinerun.GetOwnerReference()},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: pipelinerun.Namespace, OwnerReferences: []metav1.OwnerReference{pipelinerun.GetOwnerReference()}},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources:        corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)}},

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -314,7 +314,7 @@ func GetPVCSpec(pr *v1alpha1.PipelineRun, pvcSize resource.Quantity, storageClas
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       pr.Namespace,
 			Name:            GetPVCName(pr),
-			OwnerReferences: pr.GetOwnerReference(),
+			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},


### PR DESCRIPTION
# Changes

A small refactoring of PipelineRun function. Change signature so it corresponds with the name.
From:

    func (pr *PipelineRun) GetOwnerReference() []metav1.OwnerReference

To:

    func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference

 This signature change leads to more _idiomatic code_ and avoids code like:

     pr.GetOwnerReference()[0]

 to be replaced with:

     pr.GetOwnerReference()

 This is a small Go function API change, but it does not change the type structure API (e.g. Yaml). Code that before this change used

     pr.GetOwnerReference()

 need to change the function call to

     []metav1.OwnerReference{pr.GetOwnerReference()}


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```

- Signature on public function is changed: `func (pr *PipelineRun) GetOwnerReference() []metav1.OwnerReference` is changed to `func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference`

```
