### PR TITLE
Fix task result substitution (#2387)

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-results-with-params.yml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-results-with-params.yml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: test-case
+  name: test-case-run
+spec:
+  params:
+  - name: prefix
+    value: prefix
+  pipelineSpec:
+    params:
+    - name: prefix
+    tasks:
+    - name: generate-suffix
+      taskSpec:
+        results:
+        - name: suffix
+        steps:
+        - name: generate-suffix
+          image: alpine
+          script: |
+            echo -n "suffix" > $(results.suffix.path)
+    - name: do-something
+      runAfter:
+      - generate-suffix
+      taskSpec:
+        params:
+        - name: arg
+        steps:
+        - name: do-something
+          image: alpine
+          script: |
+            echo "$(params.arg)"
+      params:
+      - name: arg
+        value: "$(params.prefix):$(tasks.generate-suffix.results.suffix)"

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
@@ -136,38 +135,6 @@ func validateGraph(tasks []PipelineTask) error {
 	return nil
 }
 
-// validateParamResults ensure that task result variables are properly configured
-func validateParamResults(tasks []PipelineTask) error {
-	for _, task := range tasks {
-		for _, param := range task.Params {
-			expressions, ok := v1beta1.GetVarSubstitutionExpressionsForParam(param)
-			if ok {
-				if v1beta1.LooksLikeContainsResultRefs(expressions) {
-					if _, err := v1beta1.NewResultRefs(expressions); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// validatePipelineResults ensure that task result variables are properly configured
-func validatePipelineResults(results []PipelineResult) error {
-	for _, result := range results {
-		expressions, ok := v1beta1.GetVarSubstitutionExpressionsForPipelineResult(result)
-		if ok {
-			if v1beta1.LooksLikeContainsResultRefs(expressions) {
-				if _, err := v1beta1.NewResultRefs(expressions); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
 // Validate checks that taskNames in the Pipeline are valid and that the graph
 // of Tasks expressed in the Pipeline makes sense.
 func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
@@ -232,10 +199,6 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrInvalidValue(err.Error(), "spec.tasks")
 	}
 
-	if err := validateParamResults(ps.Tasks); err != nil {
-		return apis.ErrInvalidValue(err.Error(), "spec.tasks.params.value")
-	}
-
 	// The parameter variables should be valid
 	if err := validatePipelineParameterVariables(ps.Tasks, ps.Params); err != nil {
 		return err
@@ -244,11 +207,6 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	// Validate the pipeline's workspaces.
 	if err := validatePipelineWorkspaces(ps.Workspaces, ps.Tasks); err != nil {
 		return err
-	}
-
-	// Validate the pipeline's results
-	if err := validatePipelineResults(ps.Results); err != nil {
-		return apis.ErrInvalidValue(err.Error(), "spec.tasks.params.value")
 	}
 
 	return nil

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -369,15 +369,6 @@ func TestPipeline_Validate(t *testing.T) {
 			tb.PipelineWorkspaceDeclaration("foo"),
 		)),
 		failureExpected: true,
-	}, {
-		name: "task params results malformed variable substitution expression",
-		p: tb.Pipeline("name", "namespace", tb.PipelineSpec(
-			tb.PipelineTask("a-task", "a-task"),
-			tb.PipelineTask("b-task", "b-task",
-				tb.PipelineTaskParam("b-param", "$(tasks.a-task.resultTypo.bResult)"),
-			),
-		)),
-		failureExpected: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -198,6 +198,10 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrInvalidValue(err.Error(), "spec.tasks")
 	}
 
+	if err := validateParamResults(ps.Tasks); err != nil {
+		return apis.ErrInvalidValue(err.Error(), "spec.tasks.params.value")
+	}
+
 	// The parameter variables should be valid
 	if err := validatePipelineParameterVariables(ps.Tasks, ps.Params); err != nil {
 		return err
@@ -206,6 +210,11 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	// Validate the pipeline's workspaces.
 	if err := validatePipelineWorkspaces(ps.Workspaces, ps.Tasks); err != nil {
 		return err
+	}
+
+	// Validate the pipeline's results
+	if err := validatePipelineResults(ps.Results); err != nil {
+		return apis.ErrInvalidValue(err.Error(), "spec.tasks.params.value")
 	}
 
 	return nil
@@ -312,4 +321,48 @@ func validatePipelineNoArrayReferenced(name, value, prefix string, vars map[stri
 
 func validatePipelineArraysIsolated(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
 	return substitution.ValidateVariableIsolated(name, value, prefix, "task parameter", "pipelinespec.params", vars)
+}
+
+// validateParamResults ensure that task result variables are properly configured
+func validateParamResults(tasks []PipelineTask) error {
+	for _, task := range tasks {
+		for _, param := range task.Params {
+			expressions, ok := GetVarSubstitutionExpressionsForParam(param)
+			if ok {
+				if LooksLikeContainsResultRefs(expressions) {
+					expressions = filter(expressions, looksLikeResultRef)
+					if _, err := NewResultRefs(expressions); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func filter(arr []string, cond func(string) bool) []string {
+	result := []string{}
+	for i := range arr {
+		if cond(arr[i]) {
+			result = append(result, arr[i])
+		}
+	}
+	return result
+}
+
+// validatePipelineResults ensure that task result variables are properly configured
+func validatePipelineResults(results []PipelineResult) error {
+	for _, result := range results {
+		expressions, ok := GetVarSubstitutionExpressionsForPipelineResult(result)
+		if ok {
+			if LooksLikeContainsResultRefs(expressions) {
+				expressions = filter(expressions, looksLikeResultRef)
+				if _, err := NewResultRefs(expressions); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -56,7 +56,7 @@ func NewResultRefs(expressions []string) ([]*ResultRef, error) {
 	return resultRefs, nil
 }
 
-// LooksLikeContainsResultRefs attempts to check if param or a pipeline result looks like it contains any
+// looksLikeContainsResultRefs attempts to check if param or a pipeline result looks like it contains any
 // result references.
 // This is useful if we want to make sure the param looks like a ResultReference before
 // performing strict validation
@@ -69,6 +69,8 @@ func LooksLikeContainsResultRefs(expressions []string) bool {
 	return false
 }
 
+// looksLikeResultRef attempts to check if the given string looks like it contains any
+// result references. Returns true if it does, false otherwise
 func looksLikeResultRef(expression string) bool {
 	return strings.HasPrefix(expression, "task") && strings.Contains(expression, ".result")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fix the issue with task results substitution when used with param substitution. See issue #2387

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix issue #2387
```
