### PR TITLE
Add the command and arguments run in each step to the TaskRun.Status

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -287,6 +287,11 @@ steps:
 - container: step-hello
   imageID: docker-pullable://busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649
   name: hello
+  command:
+  - /mycommand
+  args:
+  - arg1
+  - arg2
   terminated:
     containerID: docker://d5a54f5bbb8e7a6fd3bc7761b78410403244cf4c9c5822087fb0209bf59e3621
     exitCode: 0
@@ -296,7 +301,8 @@ steps:
   ```
 
 Fields include start and stop times for the `TaskRun` and each `Step` and exit codes.
-For each step we also include the fully-qualified image used, with the digest.
+For each step we also include the fully-qualified image used, with the digest, as well
+as the command and arguments run inside the container.
 
 If any pods have been [`OOMKilled`](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/)
 by Kubernetes, the `Taskrun` will be marked as failed even if the exit code is 0.

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -202,17 +202,21 @@ func (trs *TaskRunStatus) SetCondition(newCond *apis.Condition) {
 // StepState reports the results of running a step in a Task.
 type StepState struct {
 	corev1.ContainerState
-	Name          string `json:"name,omitempty"`
-	ContainerName string `json:"container,omitempty"`
-	ImageID       string `json:"imageID,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	ContainerName string   `json:"container,omitempty"`
+	ImageID       string   `json:"imageID,omitempty"`
+	Command       []string `json:"command,omitempty"`
+	Args          []string `json:"args,omitempty"`
 }
 
 // SidecarState reports the results of running a sidecar in a Task.
 type SidecarState struct {
 	corev1.ContainerState
-	Name          string `json:"name,omitempty"`
-	ContainerName string `json:"container,omitempty"`
-	ImageID       string `json:"imageID,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	ContainerName string   `json:"container,omitempty"`
+	ImageID       string   `json:"imageID,omitempty"`
+	Command       []string `json:"command,omitempty"`
+	Args          []string `json:"args,omitempty"`
 }
 
 // CloudEventDelivery is the target of a cloud event along with the state of

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -995,6 +995,16 @@ func (in *ResultRef) DeepCopy() *ResultRef {
 func (in *SidecarState) DeepCopyInto(out *SidecarState) {
 	*out = *in
 	in.ContainerState.DeepCopyInto(&out.ContainerState)
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -1029,6 +1039,16 @@ func (in *Step) DeepCopy() *Step {
 func (in *StepState) DeepCopyInto(out *StepState) {
 	*out = *in
 	in.ContainerState.DeepCopyInto(&out.ContainerState)
+	if in.Command != nil {
+		in, out := &in.Command, &out.Command
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -111,6 +111,11 @@ func MakeTaskRunStatus(logger *zap.SugaredLogger, tr v1alpha1.TaskRun, pod *core
 		})
 	}
 
+	containerMap := map[string]corev1.Container{}
+	for _, c := range pod.Spec.Containers {
+		containerMap[c.Name] = c
+	}
+
 	trs.PodName = pod.Name
 	trs.Steps = []v1alpha1.StepState{}
 	trs.Sidecars = []v1alpha1.SidecarState{}
@@ -127,6 +132,8 @@ func MakeTaskRunStatus(logger *zap.SugaredLogger, tr v1alpha1.TaskRun, pod *core
 				Name:           trimStepPrefix(s.Name),
 				ContainerName:  s.Name,
 				ImageID:        s.ImageID,
+				Command:        containerMap[s.Name].Command,
+				Args:           containerMap[s.Name].Args,
 			})
 		} else if isContainerSidecar(s.Name) {
 			trs.Sidecars = append(trs.Sidecars, v1alpha1.SidecarState{
@@ -134,6 +141,8 @@ func MakeTaskRunStatus(logger *zap.SugaredLogger, tr v1alpha1.TaskRun, pod *core
 				Name:           TrimSidecarPrefix(s.Name),
 				ContainerName:  s.Name,
 				ImageID:        s.ImageID,
+				Command:        containerMap[s.Name].Command,
+				Args:           containerMap[s.Name].Args,
 			})
 		}
 	}


### PR DESCRIPTION
# Changes

The TaskRun.Status currently serves as the best log of what happened in a TaskRun.
It contains the container digests for each step, as well as their exit code and
termination message. However, it is currently missing the Command and Arguments,
making it impossible to verify what was run inside of the container after the
pod completes.

This commit adds those fields to the API, and copies them over from the Pod
when the rest of the Status is populated.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
TaskRun.Status.Steps now includes the Command and Args run inside each container.
```
