### PR TITLE
Add Reason and Message into terminationMessage

### DIFF
--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"os/exec"
 
@@ -15,13 +16,13 @@ type realRunner struct{}
 
 var _ entrypoint.Runner = (*realRunner)(nil)
 
-func (*realRunner) Run(args ...string) error {
+func (*realRunner) Run(ctx context.Context, args ...string) error {
 	if len(args) == 0 {
 		return nil
 	}
 	name, args := args[0], args[1:]
 
-	cmd := exec.Command(name, args...)
+	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -95,6 +95,7 @@ func TestTaskRunFailure(t *testing.T) {
 			Terminated: &corev1.ContainerStateTerminated{
 				ExitCode: 1,
 				Reason:   "Error",
+				Message:  `[{"key":"Message","value":"exit status 1","resourceRef":{}},{"key":"Reason","value":"Unknown","resourceRef":{}}]`,
 			},
 		},
 		Name:          "unnamed-1",

--- a/test/v1alpha1/taskrun_test.go
+++ b/test/v1alpha1/taskrun_test.go
@@ -86,6 +86,7 @@ func TestTaskRunFailure(t *testing.T) {
 			Terminated: &corev1.ContainerStateTerminated{
 				ExitCode: 1,
 				Reason:   "Error",
+				Message:  `[{"key":"Message","value":"exit status 1","resourceRef":{}},{"key":"Reason","value":"Unknown","resourceRef":{}}]`,
 			},
 		},
 		Name:          "unnamed-1",


### PR DESCRIPTION
Signed-off-by: jtcheng <jtcheng0616@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Add Reason and Message into terminationMessage
We should get a detail information in order to indicate the reason of why entrypointer failed.
Sometimes, it would be `DeadlineExecced` or others and we want to represent it on TaskStep.

It is a PRE-PR to implement the issue #1690 described as https://github.com/tektoncd/pipeline/issues/1690#issuecomment-614060225

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._