### PR TITLE
Add config-leader-election configmap

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -25,7 +25,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-    resourceNames: ["config-logging", "config-observability", "config-artifact-bucket", "config-artifact-pvc", "feature-flags"]
+    resourceNames: ["config-logging", "config-observability", "config-artifact-bucket", "config-artifact-pvc", "feature-flags", "config-leader-election"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -73,6 +73,8 @@ spec:
           value: config-artifact-pvc
         - name: CONFIG_FEATURE_FLAGS_NAME
           value: feature-flags
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
       volumes:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -58,6 +58,8 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
         - name: METRICS_DOMAIN


### PR DESCRIPTION
A configmap for leader election was added a while ago but
did not include the env var configuration in the deployments that we include for
other configmaps.

This commit adds explicit env vars for config-leader-election
to the controller & webhook deployments. This allows the map's
name to be overridden. Additionally, the cluster-access Role for
the controller us set up to be able to read the ConfigMap as well. The
webhook does not need this same "get" access to the configmap because
it receives the configuration through other means.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Added a CONFIG_LEADERELECTION_NAME env var to controller and webhook deployments so that the leader election configmap's name can be overridden.
```
