### PR TITLE
Fix default-timeout-minutes from Config Not Being Set Correctly for v1alpha1

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/contexts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -35,16 +34,7 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil {
-		var timeout *metav1.Duration
-		if contexts.IsUpgradeViaDefaulting(ctx) {
-			// This case is for preexisting `TaskRun` before 0.5.0, so let's
-			// add the old default timeout.
-			// Most likely those TaskRun passing here are already done and/or already running
-			timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
-		} else {
-			timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
-		}
-		prs.Timeout = timeout
+		prs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
 	}
 
 	defaultSA := cfg.Defaults.DefaultServiceAccount

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -63,16 +63,7 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	}
 
 	if trs.Timeout == nil {
-		var timeout *metav1.Duration
-		if contexts.IsUpgradeViaDefaulting(ctx) {
-			// This case is for preexisting `TaskRun` before 0.5.0, so let's
-			// add the old default timeout.
-			// Most likely those TaskRun passing here are already done and/or already running
-			timeout = &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute}
-		} else {
-			timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
-		}
-		trs.Timeout = timeout
+		trs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
 	}
 
 	defaultSA := cfg.Defaults.DefaultServiceAccount


### PR DESCRIPTION
This pull request is a follow up of #2333 and #2324. #2333 fixed #2323 for `v1beta1` PipelineRuns/TaskRuns not having the `default-timeout-minutes` correctly applied. Unfortunately, this issue will still apply to `v1alpha1` PipelineRuns/TaskRuns.

This pull request fixes this issue by applying the same changes from #2333 to `v1alpha1` PipelineRun/TaskTun defaults.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
Fix default-timeout-minutes not being applied to v1alpha1 PipelineRuns/TaskRuns
```
