### PR TITLE
Fixes issue #1824 test/builder namesace args unnecessary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.47.0 // indirect
-	cloud.google.com/go/storage v1.0.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.12.8 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
 	github.com/cloudevents/sdk-go/v2 v2.0.0-preview8

--- a/pkg/apis/pipeline/v1alpha1/condition_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestConditionCheck_IsDone(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,
@@ -41,7 +41,7 @@ func TestConditionCheck_IsDone(t *testing.T) {
 }
 
 func TestConditionCheck_IsSuccessful(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionTrue,

--- a/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCondition_Validate(t *testing.T) {
-	c := tb.Condition("condname", "foo",
+	c := tb.Condition("condname",
 		tb.ConditionSpec(
 			tb.ConditionSpecCheck("cname", "ubuntu"),
 			tb.ConditionParamSpec("paramname", v1alpha1.ParamTypeString),
@@ -47,14 +47,14 @@ func TestCondition_Invalidate(t *testing.T) {
 		expectedError apis.FieldError
 	}{{
 		name: "invalid meta",
-		cond: tb.Condition("invalid.,name", ""),
+		cond: tb.Condition("invalid.,name"),
 		expectedError: apis.FieldError{
 			Message: "Invalid resource name: special character . must not be present",
 			Paths:   []string{"metadata.name"},
 		},
 	}, {
 		name: "no image",
-		cond: tb.Condition("cond", "foo", tb.ConditionSpec(
+		cond: tb.Condition("cond", tb.ConditionSpec(
 			tb.ConditionSpecCheck("", ""),
 		)),
 		expectedError: apis.FieldError{
@@ -63,7 +63,7 @@ func TestCondition_Invalidate(t *testing.T) {
 		},
 	}, {
 		name: "condition with script and command",
-		cond: tb.Condition("cond", "foo",
+		cond: tb.Condition("cond",
 			tb.ConditionSpec(
 				tb.ConditionSpecCheck("cname", "image", tb.Command("exit 0")),
 				tb.ConditionSpecCheckScript("echo foo"),

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -33,67 +33,67 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected bool
 	}{{
 		name: "valid metadata",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: false,
 	}, {
 		name: "period in name",
-		p: tb.Pipeline("pipe.line", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipe.line", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline name too long",
-		p: tb.Pipeline("asdf123456789012345678901234567890123456789012345678901234567890", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("asdf123456789012345678901234567890123456789012345678901234567890", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name:            "pipeline spec missing",
-		p:               tb.Pipeline("pipeline", "namespace"),
+		p:               tb.Pipeline("pipeline"),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid (duplicate tasks)",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 			tb.PipelineTask("foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec empty task name",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid task name",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("_foo", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid task name 2",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("FooTask", "foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid taskref name",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "_foo-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec missing tasfref and taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("", ""),
 			tb.PipelineTask("", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{})),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec with taskref and taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{
 				TaskSpec: v1beta1.TaskSpec{
 					Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -106,13 +106,13 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "pipeline spec invalid taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo-task", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{})),
 		)),
 		failureExpected: true,
 	}, {
 		name: "pipeline spec valid taskspec",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo-task", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{
 				TaskSpec: v1beta1.TaskSpec{
 					Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -125,7 +125,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "no duplicate tasks",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 			tb.PipelineTask("bar", "bar-task"),
 		)),
@@ -133,7 +133,7 @@ func TestPipeline_Validate(t *testing.T) {
 	}, {
 		// Adding this case because `task.Resources` is a pointer, explicitly making sure this is handled
 		name: "task without resources",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task"),
 			tb.PipelineTask("foo", "foo-task",
@@ -142,7 +142,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid resource declarations and usage",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task",
@@ -158,7 +158,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid condition only resource",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskCondition("some-condition",
@@ -167,7 +167,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeString),
 			tb.PipelineTask("bar", "bar-task",
@@ -176,7 +176,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid array parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("bar", "bar-task",
@@ -185,7 +185,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "valid star array parameter variables",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("bar", "bar-task",
@@ -194,7 +194,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "pipeline parameter nested in task parameter",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "$(input.workspace.$(baz))")),
@@ -202,7 +202,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "from is on first task",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "great-resource", tb.From("bar"))),
@@ -210,7 +210,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "from task doesnt exist",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("baz", "baz-task"),
 			tb.PipelineTask("foo", "foo-task",
@@ -219,7 +219,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "duplicate resource declaration",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("duplicate-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineDeclaredResource("duplicate-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
@@ -228,7 +228,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "output resources missing from declaration",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "great-resource"),
@@ -237,7 +237,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "input resources missing from declaration",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskInputResource("the-resource", "missing-resource"),
@@ -246,7 +246,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "invalid condition only resource",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskCondition("some-condition",
 					tb.PipelineTaskConditionResource("some-workspace", "missing-resource"))),
@@ -254,7 +254,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "invalid from in condition",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task"),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskCondition("some-condition",
@@ -263,7 +263,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "from resource isn't output by task",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
 			tb.PipelineTask("bar", "bar-task",
@@ -274,20 +274,20 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "not defined parameter variable",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskParam("a-param", "$(params.does-not-exist)")))),
 		failureExpected: true,
 	}, {
 		name: "not defined parameter variable with defined",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("foo", v1alpha1.ParamTypeString, tb.ParamSpecDefault("something")),
 			tb.PipelineTask("foo", "foo-task",
 				tb.PipelineTaskParam("a-param", "$(params.foo) and $(params.does-not-exist)")))),
 		failureExpected: true,
 	}, {
 		name: "invalid parameter type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", "invalidtype", tb.ParamSpecDefault("some", "default")),
 			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("bar", "bar-task"),
@@ -295,21 +295,21 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "array parameter mismatching default type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("astring")),
 			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "string parameter mismatching default type",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task"),
 		)),
 		failureExpected: true,
 	}, {
 		name: "array parameter used as string",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "$(params.baz)")),
@@ -317,7 +317,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "star array parameter used as string",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "$(params.baz[*])")),
@@ -325,7 +325,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "array parameter string template not isolated",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz)", "last")),
@@ -333,7 +333,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "star array parameter string template not isolated",
-		p: tb.Pipeline("pipeline", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
 			tb.PipelineTask("bar", "bar-task",
 				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz[*])", "last")),
@@ -341,14 +341,14 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "invalid dependency graph between the tasks",
-		p: tb.Pipeline("foo", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("foo", tb.PipelineSpec(
 			tb.PipelineTask("foo", "foo", tb.RunAfter("bar")),
 			tb.PipelineTask("bar", "bar", tb.RunAfter("foo")),
 		)),
 		failureExpected: true,
 	}, {
 		name: "unused pipeline spec workspaces do not cause an error",
-		p: tb.Pipeline("name", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("name", tb.PipelineSpec(
 			tb.PipelineWorkspaceDeclaration("foo"),
 			tb.PipelineWorkspaceDeclaration("bar"),
 			tb.PipelineTask("foo", "foo"),
@@ -356,7 +356,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: false,
 	}, {
 		name: "workspace bindings relying on a non-existent pipeline workspace cause an error",
-		p: tb.Pipeline("name", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("name", tb.PipelineSpec(
 			tb.PipelineWorkspaceDeclaration("foo"),
 			tb.PipelineTask("taskname", "taskref",
 				tb.PipelineTaskWorkspaceBinding("taskWorkspaceName", "pipelineWorkspaceName")),
@@ -364,7 +364,7 @@ func TestPipeline_Validate(t *testing.T) {
 		failureExpected: true,
 	}, {
 		name: "multiple workspaces sharing the same name are not allowed",
-		p: tb.Pipeline("name", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("name", tb.PipelineSpec(
 			tb.PipelineWorkspaceDeclaration("foo"),
 			tb.PipelineWorkspaceDeclaration("foo"),
 		)),

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -150,7 +150,7 @@ func TestPipelineRunHasVolumeClaimTemplate(t *testing.T) {
 }
 
 func TestPipelineRunKey(t *testing.T) {
-	pr := tb.PipelineRun("prunname", "testns")
+	pr := tb.PipelineRun("prunname")
 	expectedKey := fmt.Sprintf("PipelineRun/%p", pr)
 	if pr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, pr.GetRunKey())
@@ -225,7 +225,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(t.Name(), func(t *testing.T) {
-			pr := tb.PipelineRun("pr", "foo",
+			pr := tb.PipelineRun("pr",
 				tb.PipelineRunSpec("test-pipeline",
 					tb.PipelineRunTimeout(tc.timeout),
 				),
@@ -249,7 +249,7 @@ func TestPipelineRunGetServiceAccountName(t *testing.T) {
 	}{
 		{
 			name: "default SA",
-			pr: tb.PipelineRun("pr", "ns",
+			pr: tb.PipelineRun("pr",
 				tb.PipelineRunSpec("prs",
 					tb.PipelineRunServiceAccountName("defaultSA"),
 					tb.PipelineRunServiceAccountNameTask("taskName", "taskSA"))),
@@ -260,7 +260,7 @@ func TestPipelineRunGetServiceAccountName(t *testing.T) {
 		},
 		{
 			name: "mixed default SA",
-			pr: tb.PipelineRun("defaultSA", "defaultSA",
+			pr: tb.PipelineRun("defaultSA",
 				tb.PipelineRunSpec("defaultSA",
 					tb.PipelineRunServiceAccountName("defaultSA"),
 					tb.PipelineRunServiceAccountNameTask("task1", "task1SA"),

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestTaskRun_GetBuildPodRef(t *testing.T) {
-	tr := tb.TaskRun("taskrunname", "testns")
+	tr := tb.TaskRun("taskrunname", tb.TaskRunNamespace("testns"))
 	if d := cmp.Diff(tr.GetBuildPodRef(), corev1.ObjectReference{
 		APIVersion: "v1",
 		Kind:       "Pod",
@@ -49,11 +49,11 @@ func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 		expectedPVCName string
 	}{{
 		name:            "invalid owner reference",
-		tr:              tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
+		tr:              tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
 		expectedPVCName: "",
 	}, {
 		name:            "valid pipelinerun owner",
-		tr:              tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
+		tr:              tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
 		expectedPVCName: "testpr-pvc",
 	}, {
 		name:            "nil taskrun",
@@ -75,11 +75,11 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 		want bool
 	}{{
 		name: "invalid owner reference",
-		tr:   tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
+		tr:   tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("SomeOtherOwner", "testpr")),
 		want: false,
 	}, {
 		name: "valid pipelinerun owner",
-		tr:   tb.TaskRun("taskrunname", "testns", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
+		tr:   tb.TaskRun("taskrunname", tb.TaskRunOwnerReference("PipelineRun", "testpr")),
 		want: true,
 	}}
 	for _, tt := range tests {
@@ -92,7 +92,7 @@ func TestTaskRun_HasPipelineRun(t *testing.T) {
 }
 
 func TestTaskRunIsDone(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunStatus(tb.StatusCondition(
+	tr := tb.TaskRun("", tb.TaskRunStatus(tb.StatusCondition(
 		apis.Condition{
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionFalse,
@@ -104,7 +104,7 @@ func TestTaskRunIsDone(t *testing.T) {
 }
 
 func TestTaskRunIsCancelled(t *testing.T) {
-	tr := tb.TaskRun("", "", tb.TaskRunSpec(
+	tr := tb.TaskRun("", tb.TaskRunSpec(
 		tb.TaskRunSpecStatus(v1alpha1.TaskRunSpecStatusCancelled)),
 	)
 	if !tr.IsCancelled() {
@@ -132,7 +132,7 @@ func TestTaskRunHasVolumeClaimTemplate(t *testing.T) {
 }
 
 func TestTaskRunKey(t *testing.T) {
-	tr := tb.TaskRun("taskrunname", "")
+	tr := tb.TaskRun("taskrunname")
 	expectedKey := fmt.Sprintf("TaskRun/%p", tr)
 	if tr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, tr.GetRunKey())
@@ -167,7 +167,7 @@ func TestTaskRunHasStarted(t *testing.T) {
 	}}
 	for _, tc := range params {
 		t.Run(tc.name, func(t *testing.T) {
-			tr := tb.TaskRun("taskrunname", "testns")
+			tr := tb.TaskRun("taskrunname")
 			tr.Status = tc.trStatus
 			if tr.HasStarted() != tc.expectedValue {
 				t.Fatalf("Expected taskrun HasStarted() to return %t but got %t", tc.expectedValue, tr.HasStarted())
@@ -185,7 +185,7 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 		expetectedPipelineRun string
 	}{{
 		name: "yes",
-		tr: tb.TaskRun("taskrunname", "testns",
+		tr: tb.TaskRun("taskrunname",
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "pipeline"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "pipelinerun"),
 		),
@@ -194,7 +194,7 @@ func TestTaskRunIsOfPipelinerun(t *testing.T) {
 		expetectedPipelineRun: "pipelinerun",
 	}, {
 		name:          "no",
-		tr:            tb.TaskRun("taskrunname", "testns"),
+		tr:            tb.TaskRun("taskrunname"),
 		expectedValue: false,
 	}}
 
@@ -225,19 +225,19 @@ func TestHasTimedOut(t *testing.T) {
 		expectedStatus bool
 	}{{
 		name: "TaskRun not started",
-		taskRun: tb.TaskRun("test-taskrun-not-started", "foo", tb.TaskRunSpec(
+		taskRun: tb.TaskRun("test-taskrun-not-started", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task-name"),
 		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(zeroTime))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun no timeout",
-		taskRun: tb.TaskRun("test-taskrun-no-timeout", "foo", tb.TaskRunSpec(
+		taskRun: tb.TaskRun("test-taskrun-no-timeout", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task-name"), tb.TaskRunTimeout(0),
 		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Hour)))),
 		expectedStatus: false,
 	}, {
 		name: "TaskRun timed out",
-		taskRun: tb.TaskRun("test-taskrun-timeout", "foo", tb.TaskRunSpec(
+		taskRun: tb.TaskRun("test-taskrun-timeout", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task-name"), tb.TaskRunTimeout(10*time.Second),
 		), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{}), tb.TaskRunStartTime(time.Now().Add(-15*time.Second)))),
 		expectedStatus: true,

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -38,11 +38,11 @@ func TestTaskRun_Invalid(t *testing.T) {
 		want *apis.FieldError
 	}{{
 		name: "invalid taskspec",
-		task: tb.TaskRun("taskmetaname", "default"),
+		task: tb.TaskRun("taskmetaname"),
 		want: apis.ErrMissingField("spec"),
 	}, {
 		name: "invalid taskrun metadata",
-		task: tb.TaskRun("task.name", "default"),
+		task: tb.TaskRun("task.name"),
 		want: &apis.FieldError{
 			Message: "Invalid resource name: special character . must not be present",
 			Paths:   []string{"metadata.name"},
@@ -59,7 +59,7 @@ func TestTaskRun_Invalid(t *testing.T) {
 }
 
 func TestTaskRun_Validate(t *testing.T) {
-	tr := tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+	tr := tb.TaskRun("taskname", tb.TaskRunSpec(
 		tb.TaskRunTaskRef("taskrefname"),
 	))
 	if err := tr.Validate(context.Background()); err != nil {
@@ -74,7 +74,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 		wantErr *apis.FieldError
 	}{{
 		name: "make sure WorkspaceBinding validation invoked",
-		tr: tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+		tr: tb.TaskRun("taskname", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task"),
 			// When using PVC it's required that you provide a volume name
 			tb.TaskRunWorkspacePVC("workspace", "", ""),
@@ -82,7 +82,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 		wantErr: apis.ErrMissingField("workspace.persistentvolumeclaim.claimname"),
 	}, {
 		name: "bind same workspace twice",
-		tr: tb.TaskRun("taskname", "default", tb.TaskRunSpec(
+		tr: tb.TaskRun("taskname", tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task"),
 			tb.TaskRunWorkspaceEmptyDir("workspace", ""),
 			tb.TaskRunWorkspaceEmptyDir("workspace", ""),

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -150,7 +150,7 @@ func TestPipelineRunHasVolumeClaimTemplate(t *testing.T) {
 }
 
 func TestPipelineRunKey(t *testing.T) {
-	pr := tb.PipelineRun("prunname", "testns")
+	pr := tb.PipelineRun("prunname")
 	expectedKey := fmt.Sprintf("PipelineRun/%p", pr)
 	if pr.GetRunKey() != expectedKey {
 		t.Fatalf("Expected taskrun key to be %s but got %s", expectedKey, pr.GetRunKey())

--- a/pkg/apis/resource/v1alpha1/cloudevent/cloud_event_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/cloudevent/cloud_event_resource_test.go
@@ -32,12 +32,12 @@ func TestNewResource_Invalid(t *testing.T) {
 		pipelineResource *resourcev1alpha1.PipelineResource
 	}{{
 		name: "create resource with no parameter",
-		pipelineResource: tb.PipelineResource("cloud-event-resource-no-uri", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("cloud-event-resource-no-uri", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCloudEvent,
 		)),
 	}, {
 		name: "create resource with invalid type",
-		pipelineResource: tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("git-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("URL", "git://fake/repo"),
 			tb.PipelineResourceSpecParam("Revision", "fake_rev"),
@@ -54,7 +54,7 @@ func TestNewResource_Invalid(t *testing.T) {
 }
 
 func TestNewResource_Valid(t *testing.T) {
-	pr := tb.PipelineResource("cloud-event-resource-uri", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("cloud-event-resource-uri", tb.PipelineResourceSpec(
 		resourcev1alpha1.PipelineResourceTypeCloudEvent,
 		tb.PipelineResourceSpecParam("TargetURI", "http://fake-sink"),
 	))

--- a/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
@@ -35,7 +35,7 @@ func TestNewClusterResource(t *testing.T) {
 		want     *cluster.Resource
 	}{{
 		desc: "basic cluster resource",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
@@ -51,7 +51,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "resource with password instead of token",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
@@ -69,7 +69,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "resource with clientKeyData and clientCertificateData instead of token or password",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("username", "user"),
@@ -89,7 +89,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "set insecure flag to true when there is no cert",
-		resource: tb.PipelineResource("test-cluster-resource", "foo", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("token", "my-token"),
@@ -104,7 +104,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "basic cluster resource with namespace",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecParam("cadata", "bXktY2x1c3Rlci1jZXJ0Cg"),
@@ -122,7 +122,7 @@ func TestNewClusterResource(t *testing.T) {
 		},
 	}, {
 		desc: "basic resource with secrets",
-		resource: tb.PipelineResource("test-cluster-resource", "default", tb.PipelineResourceSpec(
+		resource: tb.PipelineResource("test-cluster-resource", tb.PipelineResourceSpec(
 			resourcev1alpha1.PipelineResourceTypeCluster,
 			tb.PipelineResourceSpecParam("url", "http://10.10.10.10"),
 			tb.PipelineResourceSpecSecretParam("cadata", "secret1", "cadatakey"),

--- a/pkg/apis/resource/v1alpha1/git/git_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/git/git_resource_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestNewGitResource_Invalid(t *testing.T) {
-	if _, err := git.NewResource("override-with-git:latest", tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGCS))); err == nil {
+	if _, err := git.NewResource("override-with-git:latest", tb.PipelineResource("git-resource", tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGCS))); err == nil {
 		t.Error("Expected error creating Git resource")
 	}
 }
@@ -41,7 +41,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		want             *git.Resource
 	}{{
 		desc: "With Revision",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -63,7 +63,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without Revision",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 			),
@@ -84,7 +84,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With Refspec",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Refspec", "refs/changes/22/222134"),
@@ -106,7 +106,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without Refspec",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 			),
@@ -127,7 +127,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With Submodules",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -149,7 +149,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without Submodules",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -172,7 +172,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With positive depth",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -195,7 +195,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With zero depth",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -218,7 +218,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "Without SSLVerify",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -242,7 +242,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With HTTPProxy",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -266,7 +266,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With HTTPSProxy",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),
@@ -290,7 +290,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 		},
 	}, {
 		desc: "With NOProxy",
-		pipelineResource: tb.PipelineResource("git-resource", "default",
+		pipelineResource: tb.PipelineResource("git-resource",
 			tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "git@github.com:test/test.git"),
 				tb.PipelineResourceSpecParam("Revision", "test"),

--- a/pkg/apis/resource/v1alpha1/image/image_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/image/image_resource_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestNewImageResource_Invalid(t *testing.T) {
-	r := tb.PipelineResource("git-resource", "default", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
+	r := tb.PipelineResource("git-resource", tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit))
 
 	_, err := image.NewResource(r)
 	if err == nil {
@@ -45,7 +45,6 @@ func TestNewImageResource_Valid(t *testing.T) {
 
 	r := tb.PipelineResource(
 		"image-resource",
-		"default",
 		tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeImage,
 			tb.PipelineResourceSpecParam("URL", "https://test.com/test/test"),

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestPullRequest_NewResource(t *testing.T) {
 	url := "https://github.com/tektoncd/pipeline/pulls/1"
-	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("foo", tb.PipelineResourceSpec(
 		resourcev1alpha1.PipelineResourceTypePullRequest,
 		tb.PipelineResourceSpecParam("url", url),
 		tb.PipelineResourceSpecParam("provider", "github"),
@@ -57,7 +57,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 }
 
 func TestPullRequest_NewResource_error(t *testing.T) {
-	pr := tb.PipelineResource("foo", "default", tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit))
+	pr := tb.PipelineResource("foo", tb.PipelineResourceSpec(resourcev1alpha1.PipelineResourceTypeGit))
 	if _, err := pullrequest.NewResource("override-with-pr:latest", pr); err == nil {
 		t.Error("NewPullRequestResource() want error, got nil")
 	}

--- a/pkg/apis/resource/v1alpha1/storage/build_gcs_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/build_gcs_test.go
@@ -47,28 +47,28 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "no location params",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-location-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-location-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("NotLocation", "doesntmatter"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
 		)),
 	}, {
 		name: "location param with empty value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-location-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-location-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", ""),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
 		)),
 	}, {
 		name: "no artifactType params",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-artifactType-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-no-artifactType-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
 		)),
 	}, {
 		name: "artifactType param with empty value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-artifactType-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-empty-artifactType-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -76,7 +76,7 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 		)),
 	}, {
 		name: "artifactType param with invalid value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -84,7 +84,7 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 		)),
 	}, {
 		name: "artifactType param with secrets value",
-		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param-and-secrets", "default", tb.PipelineResourceSpec(
+		pipelineResource: tb.PipelineResource("buildgcs-resource-with-invalid-artifactType-param-and-secrets", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeStorage,
 			tb.PipelineResourceSpecParam("Location", "gs://test"),
 			tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -102,7 +102,7 @@ func TestBuildGCSResource_Invalid(t *testing.T) {
 }
 
 func TestNewBuildGCSResource_Valid(t *testing.T) {
-	pr := tb.PipelineResource("build-gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("build-gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 		tb.PipelineResourceSpecParam("type", "build-gcs"),
@@ -182,7 +182,7 @@ func TestBuildGCS_GetInputSteps(t *testing.T) {
 }
 
 func TestBuildGCS_InvalidArtifactType(t *testing.T) {
-	pr := tb.PipelineResource("build-gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("build-gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 		tb.PipelineResourceSpecParam("type", "build-gcs"),

--- a/pkg/apis/resource/v1alpha1/storage/gcs_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/gcs_test.go
@@ -33,12 +33,12 @@ func TestInvalidNewStorageResource(t *testing.T) {
 		pipelineResource *v1alpha1.PipelineResource
 	}{{
 		name: "wrong-resource-type",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit),
 		),
 	}, {
 		name: "unimplemented type",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 				tb.PipelineResourceSpecParam("type", "non-existent-type"),
@@ -46,14 +46,14 @@ func TestInvalidNewStorageResource(t *testing.T) {
 		),
 	}, {
 		name: "no type",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 			),
 		),
 	}, {
 		name: "no location params",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("NotLocation", "doesntmatter"),
 				tb.PipelineResourceSpecParam("type", "gcs"),
@@ -61,7 +61,7 @@ func TestInvalidNewStorageResource(t *testing.T) {
 		),
 	}, {
 		name: "location param with empty value",
-		pipelineResource: tb.PipelineResource("gcs-resource", "default",
+		pipelineResource: tb.PipelineResource("gcs-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeStorage,
 				tb.PipelineResourceSpecParam("Location", ""),
 				tb.PipelineResourceSpecParam("type", "gcs"),
@@ -78,7 +78,7 @@ func TestInvalidNewStorageResource(t *testing.T) {
 }
 
 func TestValidNewGCSResource(t *testing.T) {
-	pr := tb.PipelineResource("gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gs://fake-bucket"),
 		tb.PipelineResourceSpecParam("type", "gcs"),
@@ -125,7 +125,7 @@ func TestGCSGetReplacements(t *testing.T) {
 }
 
 func TestGetParams(t *testing.T) {
-	pr := tb.PipelineResource("gcs-resource", "default", tb.PipelineResourceSpec(
+	pr := tb.PipelineResource("gcs-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeStorage,
 		tb.PipelineResourceSpecParam("Location", "gcs://some-bucket.zip"),
 		tb.PipelineResourceSpecParam("type", "gcs"),

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -38,35 +38,35 @@ func TestCancelPipelineRun(t *testing.T) {
 		taskRuns      []*v1alpha1.TaskRun
 	}{{
 		name: "no-resolved-taskrun",
-		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunCancelled,
 			),
 		),
 	}, {
 		name: "1-of-resolved-taskrun",
-		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunCancelled,
 			),
 		),
 		pipelineState: []*resources.ResolvedPipelineRunTask{
-			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
+			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", tb.TaskRunNamespace("foo"))},
 			{TaskRunName: "t2"},
 		},
-		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo")},
+		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", tb.TaskRunNamespace("foo"))},
 	}, {
 		name: "resolved-taskruns",
-		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+		pipelineRun: tb.PipelineRun("test-pipeline-run-cancelled", tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunCancelled,
 			),
 		),
 		pipelineState: []*resources.ResolvedPipelineRunTask{
-			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", "foo")},
-			{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", "foo")},
+			{TaskRunName: "t1", TaskRun: tb.TaskRun("t1", tb.TaskRunNamespace("foo"))},
+			{TaskRunName: "t2", TaskRun: tb.TaskRun("t2", tb.TaskRunNamespace("foo"))},
 		},
-		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", "foo"), tb.TaskRun("t2", "foo")},
+		taskRuns: []*v1alpha1.TaskRun{tb.TaskRun("t1", tb.TaskRunNamespace("foo")), tb.TaskRun("t2", tb.TaskRunNamespace("foo"))},
 	}}
 	for _, tc := range testCases {
 		tc := tc

--- a/pkg/reconciler/pipelinerun/metrics_test.go
+++ b/pkg/reconciler/pipelinerun/metrics_test.go
@@ -55,7 +55,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 		expectedCount     int64
 	}{{
 		name: "for_succeeded_pipeline",
-		taskRun: tb.PipelineRun("pipelinerun-1", "ns",
+		taskRun: tb.PipelineRun("pipelinerun-1", tb.PipelineRunNamespace("ns"),
 			tb.PipelineRunSpec("pipeline-1"),
 			tb.PipelineRunStatus(
 				tb.PipelineRunStartTime(startTime),
@@ -78,7 +78,7 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 		expectedCount:    1,
 	}, {
 		name: "for_failed_pipeline",
-		taskRun: tb.PipelineRun("pipelinerun-1", "ns",
+		taskRun: tb.PipelineRun("pipelinerun-1", tb.PipelineRunNamespace("ns"),
 			tb.PipelineRunSpec("pipeline-1"),
 			tb.PipelineRunStatus(
 				tb.PipelineRunStartTime(startTime),
@@ -138,7 +138,7 @@ func TestRecordRunningPipelineRunsCount(t *testing.T) {
 func addPipelineRun(informer alpha1.PipelineRunInformer, run, pipeline, ns string, status corev1.ConditionStatus, t *testing.T) {
 	t.Helper()
 
-	err := informer.Informer().GetIndexer().Add(tb.PipelineRun(run, ns,
+	err := informer.Informer().GetIndexer().Add(tb.PipelineRun(run, tb.PipelineRunNamespace(ns),
 		tb.PipelineRunSpec(pipeline),
 		tb.PipelineRunStatus(
 			tb.PipelineRunStatusCondition(apis.Condition{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -87,7 +87,8 @@ func TestReconcile(t *testing.T) {
 	names.TestingSeed()
 
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("test-pipeline-run-success", "foo",
+		tb.PipelineRun("test-pipeline-run-success",
+			tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunServiceAccountName("test-sa"),
 				tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("some-repo")),
@@ -108,7 +109,8 @@ func TestReconcile(t *testing.T) {
 	moreFunParam := tb.PipelineTaskParam("bar", "$(params.bar)")
 	templatedParam := tb.PipelineTaskParam("templatedparam", "$(inputs.workspace.$(params.rev-param))")
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline("test-pipeline", "foo",
+		tb.Pipeline("test-pipeline",
+			tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineDeclaredResource("git-repo", "git"),
 				tb.PipelineDeclaredResource("best-image", "image"),
@@ -146,7 +148,7 @@ func TestReconcile(t *testing.T) {
 		),
 	}
 	ts := []*v1alpha1.Task{
-		tb.Task("unit-test-task", "foo", tb.TaskSpec(
+		tb.Task("unit-test-task", tb.TaskSpec(
 			tb.TaskInputs(
 				tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
 				tb.InputsParamSpec("foo", v1alpha1.ParamTypeString), tb.InputsParamSpec("bar", v1alpha1.ParamTypeString), tb.InputsParamSpec("templatedparam", v1alpha1.ParamTypeString),
@@ -155,10 +157,10 @@ func TestReconcile(t *testing.T) {
 				tb.OutputsResource("image-to-use", v1alpha1.PipelineResourceTypeImage),
 				tb.OutputsResource("workspace", v1alpha1.PipelineResourceTypeGit),
 			),
-		)),
-		tb.Task("unit-test-followup-task", "foo", tb.TaskSpec(
+		), tb.TaskNamespace("foo")),
+		tb.Task("unit-test-followup-task", tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
-		)),
+		), tb.TaskNamespace("foo")),
 	}
 	clusterTasks := []*v1alpha1.ClusterTask{
 		tb.ClusterTask("unit-test-cluster-task", tb.ClusterTaskSpec(
@@ -176,7 +178,7 @@ func TestReconcile(t *testing.T) {
 		)),
 	}
 	rs := []*v1alpha1.PipelineResource{
-		tb.PipelineResource("some-repo", "foo", tb.PipelineResourceSpec(
+		tb.PipelineResource("some-repo", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("url", "https://github.com/kristoff/reindeer"),
 		)),
@@ -218,7 +220,8 @@ func TestReconcile(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject()
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-1-mz4c7", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-1-mz4c7",
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-success",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -289,12 +292,14 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 	names.TestingSeed()
 
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("test-pipeline-run-success", "foo",
+		tb.PipelineRun("test-pipeline-run-success",
+			tb.PipelineRunNamespace("foo"),
 			tb.PipelineRunSpec("test-pipeline"),
 		),
 	}
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline("test-pipeline", "foo",
+		tb.Pipeline("test-pipeline",
+			tb.PipelineNamespace("foo"),
 			tb.PipelineSpec(
 				tb.PipelineTask("unit-test-task-spec", "", tb.PipelineTaskSpec(&v1alpha1.TaskSpec{TaskSpec: v1beta1.TaskSpec{
 					Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -336,7 +341,8 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := clients.Pipeline.Actions()[0].(ktesting.CreateAction).GetObject()
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-task-spec-9l9zj", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-task-spec-9l9zj",
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-success",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -368,51 +374,51 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 
 func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 	ts := []*v1alpha1.Task{
-		tb.Task("a-task-that-exists", "foo"),
-		tb.Task("a-task-that-needs-params", "foo", tb.TaskSpec(
-			tb.TaskInputs(tb.InputsParamSpec("some-param", v1alpha1.ParamTypeString)))),
-		tb.Task("a-task-that-needs-array-params", "foo", tb.TaskSpec(
-			tb.TaskInputs(tb.InputsParamSpec("some-param", v1alpha1.ParamTypeArray)))),
-		tb.Task("a-task-that-needs-a-resource", "ns", tb.TaskSpec(
+		tb.Task("a-task-that-exists", tb.TaskNamespace("foo")),
+		tb.Task("a-task-that-needs-params", tb.TaskSpec(
+			tb.TaskInputs(tb.InputsParamSpec("some-param", v1alpha1.ParamTypeString))), tb.TaskNamespace("foo")),
+		tb.Task("a-task-that-needs-array-params", tb.TaskSpec(
+			tb.TaskInputs(tb.InputsParamSpec("some-param", v1alpha1.ParamTypeArray))), tb.TaskNamespace("foo")),
+		tb.Task("a-task-that-needs-a-resource", tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", "git")),
-		)),
+		), tb.TaskNamespace("foo")),
 	}
 	ps := []*v1alpha1.Pipeline{
-		tb.Pipeline("pipeline-missing-tasks", "foo", tb.PipelineSpec(
+		tb.Pipeline("pipeline-missing-tasks", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineTask("myspecialtask", "sometask"),
 		)),
-		tb.Pipeline("a-pipeline-without-params", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-pipeline-without-params", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineTask("some-task", "a-task-that-needs-params"))),
-		tb.Pipeline("a-fine-pipeline", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-fine-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineDeclaredResource("a-resource", v1alpha1.PipelineResourceTypeGit),
 			tb.PipelineTask("some-task", "a-task-that-exists",
 				tb.PipelineTaskInputResource("needed-resource", "a-resource")))),
-		tb.Pipeline("a-pipeline-that-should-be-caught-by-admission-control", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-pipeline-that-should-be-caught-by-admission-control", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineTask("some-task", "a-task-that-exists",
 				tb.PipelineTaskInputResource("needed-resource", "a-resource")))),
-		tb.Pipeline("a-pipeline-with-array-params", "foo", tb.PipelineSpec(
+		tb.Pipeline("a-pipeline-with-array-params", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 			tb.PipelineParamSpec("some-param", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("some-task", "a-task-that-needs-array-params"))),
-		tb.Pipeline("a-pipeline-with-missing-conditions", "foo", tb.PipelineSpec(tb.PipelineTask("some-task", "a-task-that-exists", tb.PipelineTaskCondition("condition-does-not-exist")))),
+		tb.Pipeline("a-pipeline-with-missing-conditions", tb.PipelineNamespace("foo"), tb.PipelineSpec(tb.PipelineTask("some-task", "a-task-that-exists", tb.PipelineTaskCondition("condition-does-not-exist")))),
 	}
 	prs := []*v1alpha1.PipelineRun{
-		tb.PipelineRun("invalid-pipeline", "foo", tb.PipelineRunSpec("pipeline-not-exist")),
-		tb.PipelineRun("pipelinerun-missing-tasks", "foo", tb.PipelineRunSpec("pipeline-missing-tasks")),
-		tb.PipelineRun("pipeline-params-dont-exist", "foo", tb.PipelineRunSpec("a-pipeline-without-params")),
-		tb.PipelineRun("pipeline-resources-not-bound", "foo", tb.PipelineRunSpec("a-fine-pipeline")),
-		tb.PipelineRun("pipeline-resources-dont-exist", "foo", tb.PipelineRunSpec("a-fine-pipeline",
+		tb.PipelineRun("invalid-pipeline", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("pipeline-not-exist")),
+		tb.PipelineRun("pipelinerun-missing-tasks", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("pipeline-missing-tasks")),
+		tb.PipelineRun("pipeline-params-dont-exist", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-without-params")),
+		tb.PipelineRun("pipeline-resources-not-bound", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-fine-pipeline")),
+		tb.PipelineRun("pipeline-resources-dont-exist", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-fine-pipeline",
 			tb.PipelineRunResourceBinding("a-resource", tb.PipelineResourceBindingRef("missing-resource")))),
-		tb.PipelineRun("pipeline-resources-not-declared", "foo", tb.PipelineRunSpec("a-pipeline-that-should-be-caught-by-admission-control")),
-		tb.PipelineRun("pipeline-mismatching-param-type", "foo", tb.PipelineRunSpec("a-pipeline-with-array-params", tb.PipelineRunParam("some-param", "stringval"))),
-		tb.PipelineRun("pipeline-conditions-missing", "foo", tb.PipelineRunSpec("a-pipeline-with-missing-conditions")),
-		tb.PipelineRun("embedded-pipeline-resources-not-bound", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineRun("pipeline-resources-not-declared", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-that-should-be-caught-by-admission-control")),
+		tb.PipelineRun("pipeline-mismatching-param-type", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-with-array-params", tb.PipelineRunParam("some-param", "stringval"))),
+		tb.PipelineRun("pipeline-conditions-missing", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("a-pipeline-with-missing-conditions")),
+		tb.PipelineRun("embedded-pipeline-resources-not-bound", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 			tb.PipelineTask("some-task", "a-task-that-needs-a-resource"),
 			tb.PipelineDeclaredResource("workspace", "git"),
 		))),
-		tb.PipelineRun("embedded-pipeline-invalid", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineRun("embedded-pipeline-invalid", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 			tb.PipelineTask("bad-t@$k", "b@d-t@$k"),
 		))),
-		tb.PipelineRun("embedded-pipeline-mismatching-param-type", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+		tb.PipelineRun("embedded-pipeline-mismatching-param-type", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 			tb.PipelineParamSpec("some-param", v1alpha1.ParamTypeArray),
 			tb.PipelineTask("some-task", "a-task-that-needs-array-params")),
 			tb.PipelineRunParam("some-param", "stringval"),
@@ -560,21 +566,23 @@ func TestReconcile_InvalidPipelineRunNames(t *testing.T) {
 }
 
 func TestUpdateTaskRunsState(t *testing.T) {
-	pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+	pr := tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("test-pipeline"))
 	pipelineTask := v1alpha1.PipelineTask{
 		Name:    "unit-test-1",
 		TaskRef: &v1alpha1.TaskRef{Name: "unit-test-task"},
 	}
-	task := tb.Task("unit-test-task", "foo", tb.TaskSpec(
+	task := tb.Task("unit-test-task", tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
-	))
-	taskrun := tb.TaskRun("test-pipeline-run-success-unit-test-1", "foo", tb.TaskRunSpec(
-		tb.TaskRunTaskRef("unit-test-task"),
-		tb.TaskRunServiceAccountName("test-sa"),
-	), tb.TaskRunStatus(
-		tb.StatusCondition(apis.Condition{Type: apis.ConditionSucceeded}),
-		tb.StepState(tb.StateTerminated(0)),
-	))
+	), tb.TaskNamespace("foo"))
+	taskrun := tb.TaskRun("test-pipeline-run-success-unit-test-1",
+		tb.TaskRunNamespace("foo"),
+		tb.TaskRunSpec(
+			tb.TaskRunTaskRef("unit-test-task"),
+			tb.TaskRunServiceAccountName("test-sa"),
+		), tb.TaskRunStatus(
+			tb.StatusCondition(apis.Condition{Type: apis.ConditionSucceeded}),
+			tb.StepState(tb.StateTerminated(0)),
+		))
 
 	expectedTaskRunsStatus := make(map[string]*v1alpha1.PipelineRunTaskRunStatus)
 	expectedTaskRunsStatus["test-pipeline-run-success-unit-test-1"] = &v1alpha1.PipelineRunTaskRunStatus{
@@ -618,8 +626,8 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 	successConditionCheckName := "success-condition"
 	failingConditionCheckName := "fail-condition"
 
-	successCondition := tb.Condition("cond-1", "foo")
-	failingCondition := tb.Condition("cond-2", "foo")
+	successCondition := tb.Condition("cond-1", tb.ConditionNamespace("foo"))
+	failingCondition := tb.Condition("cond-2", tb.ConditionNamespace("foo"))
 
 	pipelineTask := v1alpha1.PipelineTask{
 		TaskRef: &v1alpha1.TaskRef{Name: "unit-test-task"},
@@ -630,20 +638,24 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 		}},
 	}
 
-	successConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(successConditionCheckName, "foo", tb.TaskRunStatus(
-		tb.StatusCondition(apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionTrue,
-		}),
-		tb.StepState(tb.StateTerminated(0)),
-	)))
-	failingConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(failingConditionCheckName, "foo", tb.TaskRunStatus(
-		tb.StatusCondition(apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionFalse,
-		}),
-		tb.StepState(tb.StateTerminated(127)),
-	)))
+	successConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(successConditionCheckName,
+		tb.TaskRunNamespace("foo"),
+		tb.TaskRunStatus(
+			tb.StatusCondition(apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionTrue,
+			}),
+			tb.StepState(tb.StateTerminated(0)),
+		)))
+	failingConditionCheck := conditionCheckFromTaskRun(tb.TaskRun(failingConditionCheckName,
+		tb.TaskRunNamespace("foo"),
+		tb.TaskRunStatus(
+			tb.StatusCondition(apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionFalse,
+			}),
+			tb.StepState(tb.StateTerminated(127)),
+		)))
 
 	successrcc := resources.ResolvedConditionCheck{
 		ConditionRegisterName: successCondition.Name + "-0",
@@ -731,7 +743,7 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pr := tb.PipelineRun("test-pipeline-run", "foo", tb.PipelineRunSpec("test-pipeline"))
+			pr := tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("test-pipeline"))
 
 			state := []*resources.ResolvedPipelineRunTask{{
 				PipelineTask:            &pipelineTask,
@@ -752,7 +764,8 @@ func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 
 func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 	taskRunName := "test-pipeline-run-completed-hello-world"
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed",
+		tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa")),
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -766,11 +779,12 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 			}),
 		),
 	)}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world")))}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun(taskRunName, "foo",
+		tb.TaskRun(taskRunName,
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-completed"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -843,17 +857,19 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 }
 
 func TestReconcileOnCancelledPipelineRun(t *testing.T) {
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-cancelled", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-cancelled",
+		tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunCancelled,
 		),
 	)}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("test-pipeline-run-cancelled-hello-world", "foo",
+		tb.TaskRun("test-pipeline-run-cancelled-hello-world",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-cancelled"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -897,10 +913,11 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 }
 
 func TestReconcileWithTimeout(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout",
+		tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunTimeout(12*time.Hour),
@@ -908,7 +925,7 @@ func TestReconcileWithTimeout(t *testing.T) {
 		tb.PipelineRunStatus(
 			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -954,15 +971,15 @@ func TestReconcileWithTimeout(t *testing.T) {
 }
 
 func TestReconcileWithoutPVC(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 		tb.PipelineTask("hello-world-2", "hello-world"),
 	))}
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline")),
 	}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1002,15 +1019,15 @@ func TestReconcileWithoutPVC(t *testing.T) {
 }
 
 func TestReconcileCancelledPipelineRun(t *testing.T) {
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world", tb.Retries(1)),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-timeout", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunCancelled,
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1053,17 +1070,17 @@ func TestReconcilePropagateLabels(t *testing.T) {
 	names.TestingSeed()
 	taskName := "hello-world-1"
 
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask(taskName, "hello-world"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-labels", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-labels", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunLabel("PipelineRunLabel", "PipelineRunValue"),
 		tb.PipelineRunLabel("tekton.dev/pipeline", "WillNotBeUsed"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1071,7 +1088,8 @@ func TestReconcilePropagateLabels(t *testing.T) {
 		Tasks:        ts,
 	}
 
-	expected := tb.TaskRun("test-pipeline-run-with-labels-hello-world-1-9l9zj", "foo",
+	expected := tb.TaskRun("test-pipeline-run-with-labels-hello-world-1-9l9zj",
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-labels",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1116,18 +1134,18 @@ func TestReconcilePropagateLabels(t *testing.T) {
 func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-0", "hello-world-task"),
 		tb.PipelineTask("hello-world-1", "hello-world-task"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa-0"),
 			tb.PipelineRunServiceAccountNameTask("hello-world-1", "test-sa-1"),
 		),
 	)}
 	ts := []*v1alpha1.Task{
-		tb.Task("hello-world-task", "foo"),
+		tb.Task("hello-world-task", tb.TaskNamespace("foo")),
 	}
 
 	d := test.Data{
@@ -1155,7 +1173,8 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 	taskRunNames := []string{"test-pipeline-run-different-service-accs-hello-world-0-9l9zj", "test-pipeline-run-different-service-accs-hello-world-1-mz4c7"}
 
 	expectedTaskRuns := []*v1alpha1.TaskRun{
-		tb.TaskRun(taskRunNames[0], "foo",
+		tb.TaskRun(taskRunNames[0],
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 				tb.Controller, tb.BlockOwnerDeletion,
@@ -1168,7 +1187,8 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 			tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 			tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-0"),
 		),
-		tb.TaskRun(taskRunNames[1], "foo",
+		tb.TaskRun(taskRunNames[1],
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 				tb.Controller, tb.BlockOwnerDeletion,
@@ -1218,10 +1238,10 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 	for _, tc := range tcs {
 
 		t.Run(tc.name, func(t *testing.T) {
-			ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline-retry", "foo", tb.PipelineSpec(
+			ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline-retry", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 				tb.PipelineTask("hello-world-1", "hello-world", tb.Retries(tc.retries)),
 			))}
-			prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-retry-run-with-timeout", "foo",
+			prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-retry-run-with-timeout", tb.PipelineRunNamespace("foo"),
 				tb.PipelineRunSpec("test-pipeline-retry",
 					tb.PipelineRunServiceAccountName("test-sa"),
 					tb.PipelineRunTimeout(12*time.Hour),
@@ -1231,10 +1251,11 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 			)}
 
 			ts := []*v1alpha1.Task{
-				tb.Task("hello-world", "foo"),
+				tb.Task("hello-world", tb.TaskNamespace("foo")),
 			}
 			trs := []*v1alpha1.TaskRun{
-				tb.TaskRun("hello-world-1", "foo",
+				tb.TaskRun("hello-world-1",
+					tb.TaskRunNamespace("foo"),
 					tb.TaskRunStatus(
 						tb.PodName("my-pod-name"),
 						tb.StatusCondition(apis.Condition{
@@ -1297,16 +1318,16 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 func TestReconcilePropagateAnnotations(t *testing.T) {
 	names.TestingSeed()
 
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-annotations", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-annotations", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1335,7 +1356,8 @@ func TestReconcilePropagateAnnotations(t *testing.T) {
 	if actual == nil {
 		t.Errorf("Expected a TaskRun to be created, but it wasn't.")
 	}
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-annotations-hello-world-1-9l9zj", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-annotations-hello-world-1-9l9zj",
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-annotations",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1367,7 +1389,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected *metav1.Duration
 	}{{
 		name: "nil timeout duration",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunNilTimeout),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
@@ -1379,7 +1401,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected: &metav1.Duration{Duration: 60 * time.Minute},
 	}, {
 		name: "timeout specified in pr",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(20*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
@@ -1391,7 +1413,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
 	}, {
 		name: "0 timeout duration",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(0*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
@@ -1403,7 +1425,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected: &metav1.Duration{Duration: 0 * time.Minute},
 	}, {
 		name: "taskrun being created after timeout expired",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(1*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now().Add(-2*time.Minute)))),
 		rprt: &resources.ResolvedPipelineRunTask{
@@ -1414,7 +1436,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected: &metav1.Duration{Duration: 1 * time.Second},
 	}, {
 		name: "taskrun being created with timeout for PipelineTask",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(20*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
@@ -1426,7 +1448,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		expected: &metav1.Duration{Duration: 2 * time.Minute},
 	}, {
 		name: "0 timeout duration for PipelineRun, PipelineTask timeout still applied",
-		pr: tb.PipelineRun(prName, ns,
+		pr: tb.PipelineRun(prName, tb.PipelineRunNamespace(ns),
 			tb.PipelineRunSpec(p, tb.PipelineRunTimeout(0*time.Minute)),
 			tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
 		),
@@ -1451,7 +1473,8 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 	names.TestingSeed()
 	prName := "test-pipeline-run"
 	conditions := []*v1alpha1.Condition{
-		tb.Condition("cond-1", "foo",
+		tb.Condition("cond-1",
+			tb.ConditionNamespace("foo"),
 			tb.ConditionLabels(
 				map[string]string{
 					"label-1": "value-1",
@@ -1460,7 +1483,8 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 			tb.ConditionSpec(
 				tb.ConditionSpecCheck("", "foo", tb.Args("bar")),
 			)),
-		tb.Condition("cond-2", "foo",
+		tb.Condition("cond-2",
+			tb.ConditionNamespace("foo"),
 			tb.ConditionLabels(
 				map[string]string{
 					"label-3": "value-3",
@@ -1470,18 +1494,18 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 				tb.ConditionSpecCheck("", "foo", tb.Args("bar")),
 			)),
 	}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world",
 			tb.PipelineTaskCondition("cond-1"),
 			tb.PipelineTaskCondition("cond-2")),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(prName, "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(prName, tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 		),
 	)}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1531,7 +1555,7 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 func TestReconcileWithFailingConditionChecks(t *testing.T) {
 	names.TestingSeed()
 	conditions := []*v1alpha1.Condition{
-		tb.Condition("always-false", "foo", tb.ConditionSpec(
+		tb.Condition("always-false", tb.ConditionNamespace("foo"), tb.ConditionSpec(
 			tb.ConditionSpecCheck("", "foo", tb.Args("bar")),
 		)),
 	}
@@ -1543,13 +1567,13 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		ConditionName: "always-false-0",
 		Status:        &v1alpha1.ConditionCheckStatus{},
 	}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("task-1", "hello-world"),
 		tb.PipelineTask("task-2", "hello-world", tb.PipelineTaskCondition("always-false")),
 		tb.PipelineTask("task-3", "hello-world", tb.RunAfter("task-1")),
 	))}
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-conditions", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-conditions", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
@@ -1569,9 +1593,10 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		})),
 	)}
 
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun(pipelineRunName+"task-1", "foo",
+		tb.TaskRun(pipelineRunName+"task-1",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -1582,7 +1607,8 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 			}),
 			),
 		),
-		tb.TaskRun(conditionCheckName, "foo",
+		tb.TaskRun(conditionCheckName,
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
@@ -1624,7 +1650,8 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 	if actual == nil {
 		t.Errorf("Expected a ConditionCheck TaskRun to be created, but it wasn't.")
 	}
-	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-conditions-task-3-9l9zj", "foo",
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-with-conditions-task-3-9l9zj",
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-with-conditions",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1645,7 +1672,8 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 }
 
 func makeExpectedTr(condName, ccName string, labels map[string]string) *v1alpha1.TaskRun {
-	return tb.TaskRun(ccName, "foo",
+	return tb.TaskRun(ccName,
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1689,16 +1717,16 @@ func TestReconcileWithVolumeClaimTemplateWorkspace(t *testing.T) {
 	workspaceName := "ws1"
 	claimName := "myclaim"
 	pipelineRunName := "test-pipeline-run"
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world", tb.PipelineTaskWorkspaceBinding("taskWorkspaceName", workspaceName)),
 		tb.PipelineTask("hello-world-2", "hello-world"),
 		tb.PipelineWorkspaceDeclaration(workspaceName),
 	))}
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(pipelineRunName, "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun(pipelineRunName, tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunWorkspaceBindingVolumeClaimTemplate(workspaceName, claimName))),
 	}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -1766,27 +1794,28 @@ func TestReconcileWithVolumeClaimTemplateWorkspace(t *testing.T) {
 
 func TestReconcileWithTaskResults(t *testing.T) {
 	names.TestingSeed()
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("a-task", "a-task"),
 		tb.PipelineTask("b-task", "b-task",
 			tb.PipelineTaskParam("bParam", "$(tasks.a-task.results.aResult)"),
 		),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa-0"),
 		),
 	)}
 	ts := []*v1alpha1.Task{
-		tb.Task("a-task", "foo"),
-		tb.Task("b-task", "foo",
+		tb.Task("a-task", tb.TaskNamespace("foo")),
+		tb.Task("b-task", tb.TaskNamespace("foo"),
 			tb.TaskSpec(
 				tb.TaskInputs(tb.InputsParamSpec("bParam", v1alpha1.ParamTypeString)),
 			),
 		),
 	}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("test-pipeline-run-different-service-accs-a-task-9l9zj", "foo",
+		tb.TaskRun("test-pipeline-run-different-service-accs-a-task-9l9zj",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 				tb.Controller, tb.BlockOwnerDeletion,
@@ -1829,7 +1858,8 @@ func TestReconcileWithTaskResults(t *testing.T) {
 		t.Fatalf("Somehow had error getting completed reconciled run out of fake client: %s", err)
 	}
 	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task-mz4c7"
-	expectedTaskRun := tb.TaskRun(expectedTaskRunName, "foo",
+	expectedTaskRun := tb.TaskRun(expectedTaskRunName,
+		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 			tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 			tb.Controller, tb.BlockOwnerDeletion,
@@ -1863,14 +1893,14 @@ func TestReconcileWithTaskResults(t *testing.T) {
 
 func TestReconcileWithPipelineResults(t *testing.T) {
 	names.TestingSeed()
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineTask("a-task", "a-task"),
 		tb.PipelineTask("b-task", "b-task",
 			tb.PipelineTaskParam("bParam", "$(tasks.a-task.results.aResult)"),
 		),
 		tb.PipelineResult("result", "$(tasks.a-task.results.aResult)", "pipeline result"),
 	))}
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-different-service-accs", tb.PipelineRunNamespace("foo"),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa-0"),
 		),
@@ -1878,15 +1908,16 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 			tb.PipelineRunResult("result", "aResultValue")),
 	)}
 	ts := []*v1alpha1.Task{
-		tb.Task("a-task", "foo"),
-		tb.Task("b-task", "foo",
+		tb.Task("a-task", tb.TaskNamespace("foo")),
+		tb.Task("b-task", tb.TaskNamespace("foo"),
 			tb.TaskSpec(
 				tb.TaskInputs(tb.InputsParamSpec("bParam", v1alpha1.ParamTypeString)),
 			),
 		),
 	}
 	trs := []*v1alpha1.TaskRun{
-		tb.TaskRun("test-pipeline-run-different-service-accs-a-task-9l9zj", "foo",
+		tb.TaskRun("test-pipeline-run-different-service-accs-a-task-9l9zj",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-different-service-accs",
 				tb.OwnerReferenceAPIVersion("tekton.dev/v1alpha1"),
 				tb.Controller, tb.BlockOwnerDeletion,

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -36,7 +36,7 @@ func TestApplyParameters(t *testing.T) {
 		expected *v1alpha1.Pipeline
 	}{{
 		name: "single parameter",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -45,10 +45,10 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-second-param", "$(params.second-param)"),
 					tb.PipelineTaskParam("first-task-third-param", "static value"),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("second-param", "second-value"))),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -59,7 +59,7 @@ func TestApplyParameters(t *testing.T) {
 				))),
 	}, {
 		name: "pipeline parameter nested inside task parameter",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
@@ -67,9 +67,9 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-first-param", "$(input.workspace.$(params.first-param))"),
 					tb.PipelineTaskParam("first-task-second-param", "$(input.workspace.$(params.second-param))"),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run",
 			tb.PipelineRunSpec("test-pipeline")),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
@@ -79,7 +79,7 @@ func TestApplyParameters(t *testing.T) {
 				))),
 	}, {
 		name: "parameters in task condition",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -89,10 +89,10 @@ func TestApplyParameters(t *testing.T) {
 						tb.PipelineTaskConditionParam("cond-second-param", "$(params.second-param)"),
 					),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("second-param", "second-value"))),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeString, tb.ParamSpecDefault("default-value")),
 				tb.PipelineParamSpec("second-param", v1alpha1.ParamTypeString),
@@ -104,7 +104,7 @@ func TestApplyParameters(t *testing.T) {
 				))),
 	}, {
 		name: "array parameter",
-		original: tb.Pipeline("test-pipeline", "foo",
+		original: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeArray, tb.ParamSpecDefault(
 					"default", "array", "value")),
@@ -116,11 +116,11 @@ func TestApplyParameters(t *testing.T) {
 					tb.PipelineTaskParam("first-task-third-param", "static value"),
 					tb.PipelineTaskParam("first-task-fourth-param", "first", "$(params.fourth-param)"),
 				))),
-		run: tb.PipelineRun("test-pipeline-run", "foo",
+		run: tb.PipelineRun("test-pipeline-run",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("second-param", "second-value", "array"),
 				tb.PipelineRunParam("fourth-param", "fourth-value", "array"))),
-		expected: tb.Pipeline("test-pipeline", "foo",
+		expected: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineParamSpec("first-param", v1alpha1.ParamTypeArray, tb.ParamSpecDefault(
 					"default", "array", "value")),

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
@@ -30,7 +30,7 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-var c = tb.Condition("conditionname", "foo")
+var c = tb.Condition("conditionname")
 
 var notStartedState = TaskConditionCheckState{{
 	ConditionCheckName: "foo",
@@ -192,7 +192,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		want              v1alpha1.TaskSpec
 	}{{
 		name: "user-provided-container-name",
-		cond: tb.Condition("name", "foo", tb.ConditionSpec(
+		cond: tb.Condition("name", tb.ConditionSpec(
 			tb.ConditionSpecCheck("foo", "ubuntu"),
 		)),
 		want: v1alpha1.TaskSpec{
@@ -206,7 +206,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		},
 	}, {
 		name: "default-container-name",
-		cond: tb.Condition("bar", "foo", tb.ConditionSpec(
+		cond: tb.Condition("bar", tb.ConditionSpec(
 			tb.ConditionSpecCheck("", "ubuntu"),
 		)),
 		want: v1alpha1.TaskSpec{
@@ -220,7 +220,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		},
 	}, {
 		name: "with-input-params",
-		cond: tb.Condition("bar", "foo", tb.ConditionSpec(
+		cond: tb.Condition("bar", tb.ConditionSpec(
 			tb.ConditionSpecCheck("$(params.name)", "$(params.img)",
 				tb.WorkingDir("$(params.not.replaced)")),
 			tb.ConditionParamSpec("name", v1alpha1.ParamTypeString),
@@ -246,13 +246,13 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 		},
 	}, {
 		name: "with-resources",
-		cond: tb.Condition("bar", "foo", tb.ConditionSpec(
+		cond: tb.Condition("bar", tb.ConditionSpec(
 			tb.ConditionSpecCheck("name", "ubuntu",
 				tb.Args("$(resources.git-resource.revision)")),
 			tb.ConditionResource("git-resource", v1alpha1.PipelineResourceTypeGit),
 		)),
 		resolvedResources: map[string]*v1alpha1.PipelineResource{
-			"git-resource": tb.PipelineResource("git-resource", "foo",
+			"git-resource": tb.PipelineResource("git-resource",
 				tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 					tb.PipelineResourceSpecParam("revision", "master"),
 				)),
@@ -293,7 +293,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 func TestResolvedConditionCheck_ToTaskResourceBindings(t *testing.T) {
 	rcc := ResolvedConditionCheck{
 		ResolvedResources: map[string]*v1alpha1.PipelineResource{
-			"git-resource": tb.PipelineResource("some-repo", "foo"),
+			"git-resource": tb.PipelineResource("some-repo"),
 		},
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -38,10 +38,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-const (
-	namespace = "foo"
-)
-
 var pts = []v1alpha1.PipelineTask{{
 	Name:    "mytask1",
 	TaskRef: &v1alpha1.TaskRef{Name: "task"},
@@ -1086,7 +1082,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pr := tb.PipelineRun("somepipelinerun", "foo")
+			pr := tb.PipelineRun("somepipelinerun")
 			dag, err := DagFromState(tc.state)
 			if err != nil {
 				t.Fatalf("Unexpected error while buildig DAG for state %v: %v", tc.state, err)
@@ -1100,7 +1096,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings(t *testing.T) {
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 		tb.PipelineRunResourceBinding("image-resource", tb.PipelineResourceBindingResourceSpec(
 			&v1alpha1.PipelineResourceSpec{
@@ -1112,7 +1108,7 @@ func TestGetResourcesFromBindings(t *testing.T) {
 			}),
 		),
 	))
-	r := tb.PipelineResource("sweet-resource", "namespace")
+	r := tb.PipelineResource("sweet-resource")
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
 		if name != "sweet-resource" {
 			return nil, fmt.Errorf("request for unexpected resource %s", name)
@@ -1147,7 +1143,7 @@ func TestGetResourcesFromBindings_Missing(t *testing.T) {
 	//	tb.PipelineDeclaredResource("git-resource", "git"),
 	//	tb.PipelineDeclaredResource("image-resource", "image"),
 	//))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
@@ -1160,7 +1156,7 @@ func TestGetResourcesFromBindings_Missing(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings_ErrorGettingResource(t *testing.T) {
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*v1alpha1.PipelineResource, error) {
@@ -1175,7 +1171,7 @@ func TestGetResourcesFromBindings_ErrorGettingResource(t *testing.T) {
 func TestResolvePipelineRun(t *testing.T) {
 	names.TestingSeed()
 
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineTask("mytask1", "task",
 			tb.PipelineTaskInputResource("input1", "git-resource"),
@@ -1358,14 +1354,14 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 		p    *v1alpha1.Pipeline
 	}{{
 		name: "input doesnt exist",
-		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipelines", tb.PipelineSpec(
 			tb.PipelineTask("mytask1", "task",
 				tb.PipelineTaskInputResource("input1", "git-resource"),
 			),
 		)),
 	}, {
 		name: "output doesnt exist",
-		p: tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+		p: tb.Pipeline("pipelines", tb.PipelineSpec(
 			tb.PipelineTask("mytask1", "task",
 				tb.PipelineTaskOutputResource("input1", "git-resource"),
 			),
@@ -1398,7 +1394,7 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 	names.TestingSeed()
 
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineTask("mytask-with-a-really-long-name-to-trigger-truncation", "task",
 			tb.PipelineTaskInputResource("input1", "git-resource"),
@@ -1462,7 +1458,7 @@ func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 
 func TestResolvedPipelineRun_PipelineTaskHasOptionalResources(t *testing.T) {
 	names.TestingSeed()
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineTask("mytask1", "task",
 			tb.PipelineTaskInputResource("required-input", "git-resource"),
@@ -1820,11 +1816,11 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 func TestResolvedConditionCheck_WithResources(t *testing.T) {
 	names.TestingSeed()
 
-	condition := tb.Condition("always-true", "foo", tb.ConditionSpec(
+	condition := tb.Condition("always-true", tb.ConditionSpec(
 		tb.ConditionResource("workspace", v1alpha1.PipelineResourceTypeGit),
 	))
 
-	gitResource := tb.PipelineResource("some-repo", "foo", tb.PipelineResourceSpec(
+	gitResource := tb.PipelineResource("some-repo", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit))
 
 	ptc := v1alpha1.PipelineTaskCondition{
@@ -1901,10 +1897,10 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 }
 
 func TestValidateResourceBindings(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	err := ValidateResourceBindings(&p.Spec, pr)
@@ -1914,11 +1910,11 @@ func TestValidateResourceBindings(t *testing.T) {
 }
 
 func TestValidateResourceBindings_Missing(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 		tb.PipelineDeclaredResource("image-resource", "image"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	err := ValidateResourceBindings(&p.Spec, pr)
@@ -1928,10 +1924,10 @@ func TestValidateResourceBindings_Missing(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings_Extra(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-resource", "git"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 		tb.PipelineRunResourceBinding("image-resource", tb.PipelineResourceBindingRef("sweet-resource2")),
 	))
@@ -1942,10 +1938,10 @@ func TestGetResourcesFromBindings_Extra(t *testing.T) {
 }
 
 func TestValidateWorkspaceBindings(t *testing.T) {
-	p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
 		tb.PipelineWorkspaceDeclaration("foo"),
 	))
-	pr := tb.PipelineRun("pipelinerun", "namespace", tb.PipelineRunSpec("pipeline",
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunWorkspaceBindingEmptyDir("bar"),
 	))
 	if err := ValidateWorkspaceBindings(&p.Spec, pr); err == nil {

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -32,7 +32,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 				pipelineRunState: PipelineRunState{
 					{
 						TaskRunName: "aTaskRun",
-						TaskRun:     tb.TaskRun("aTaskRun", "namespace"),
+						TaskRun:     tb.TaskRun("aTaskRun"),
 						PipelineTask: &v1alpha1.PipelineTask{
 							Name:    "aTask",
 							TaskRef: &v1alpha1.TaskRef{Name: "aTask"},
@@ -58,7 +58,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 				pipelineRunState: PipelineRunState{
 					{
 						TaskRunName: "aTaskRun",
-						TaskRun: tb.TaskRun("aTaskRun", "namespace", tb.TaskRunStatus(
+						TaskRun: tb.TaskRun("aTaskRun", tb.TaskRunStatus(
 							tb.TaskRunResult("aResult", "aResultValue"),
 						)),
 						PipelineTask: &v1alpha1.PipelineTask{
@@ -97,7 +97,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 				pipelineRunState: PipelineRunState{
 					{
 						TaskRunName: "aTaskRun",
-						TaskRun: tb.TaskRun("aTaskRun", "namespace", tb.TaskRunStatus(
+						TaskRun: tb.TaskRun("aTaskRun", tb.TaskRunStatus(
 							tb.TaskRunResult("aResult", "aResultValue"),
 						)),
 						PipelineTask: &v1alpha1.PipelineTask{
@@ -106,7 +106,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 						},
 					}, {
 						TaskRunName: "bTaskRun",
-						TaskRun: tb.TaskRun("bTaskRun", "namespace", tb.TaskRunStatus(
+						TaskRun: tb.TaskRun("bTaskRun", tb.TaskRunStatus(
 							tb.TaskRunResult("bResult", "bResultValue"),
 						)),
 						PipelineTask: &v1alpha1.PipelineTask{
@@ -155,7 +155,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 				pipelineRunState: PipelineRunState{
 					{
 						TaskRunName: "aTaskRun",
-						TaskRun: tb.TaskRun("aTaskRun", "namespace", tb.TaskRunStatus(
+						TaskRun: tb.TaskRun("aTaskRun", tb.TaskRunStatus(
 							tb.TaskRunResult("aResult", "aResultValue"),
 						)),
 						PipelineTask: &v1alpha1.PipelineTask{
@@ -194,7 +194,7 @@ func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
 				pipelineRunState: PipelineRunState{
 					{
 						TaskRunName: "aTaskRun",
-						TaskRun:     tb.TaskRun("aTaskRun", "namespace"),
+						TaskRun:     tb.TaskRun("aTaskRun"),
 						PipelineTask: &v1alpha1.PipelineTask{
 							Name:    "aTask",
 							TaskRef: &v1alpha1.TaskRef{Name: "aTask"},
@@ -299,7 +299,7 @@ func TestResolveResultRefs(t *testing.T) {
 	pipelineRunState := PipelineRunState{
 		{
 			TaskRunName: "aTaskRun",
-			TaskRun: tb.TaskRun("aTaskRun", "namespace", tb.TaskRunStatus(
+			TaskRun: tb.TaskRun("aTaskRun", tb.TaskRunStatus(
 				tb.TaskRunResult("aResult", "aResultValue"),
 			)),
 			PipelineTask: &v1alpha1.PipelineTask{

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -31,11 +31,11 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		errorExpected bool
 	}{{
 		name: "proper param types",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace, tb.PipelineRunSpec(
+		pr: tb.PipelineRun("a-pipelinerun", tb.PipelineRunSpec(
 			"test-pipeline",
 			tb.PipelineRunParam("correct-type-1", "somestring"),
 			tb.PipelineRunParam("mismatching-type", "astring"),
@@ -43,16 +43,16 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		errorExpected: false,
 	}, {
 		name:          "no params to get wrong",
-		p:             tb.Pipeline("a-pipeline", namespace),
-		pr:            tb.PipelineRun("a-pipelinerun", namespace),
+		p:             tb.Pipeline("a-pipeline"),
+		pr:            tb.PipelineRun("a-pipelinerun"),
 		errorExpected: false,
 	}, {
 		name: "string-array mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "an", "array"),
@@ -60,11 +60,11 @@ func TestValidateParamTypesMatching_Valid(t *testing.T) {
 		errorExpected: true,
 	}, {
 		name: "array-string mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeArray),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "astring"),
@@ -92,22 +92,22 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 		pr   *v1alpha1.PipelineRun
 	}{{
 		name: "string-array mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "an", "array"),
 				tb.PipelineRunParam("correct-type-2", "another", "array"))),
 	}, {
 		name: "array-string mismatch",
-		p: tb.Pipeline("a-pipeline", namespace, tb.PipelineSpec(
+		p: tb.Pipeline("a-pipeline", tb.PipelineSpec(
 			tb.PipelineParamSpec("correct-type-1", v1alpha1.ParamTypeString),
 			tb.PipelineParamSpec("mismatching-type", v1alpha1.ParamTypeArray),
 			tb.PipelineParamSpec("correct-type-2", v1alpha1.ParamTypeArray))),
-		pr: tb.PipelineRun("a-pipelinerun", namespace,
+		pr: tb.PipelineRun("a-pipelinerun",
 			tb.PipelineRunSpec("test-pipeline",
 				tb.PipelineRunParam("correct-type-1", "somestring"),
 				tb.PipelineRunParam("mismatching-type", "astring"),

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -38,7 +38,7 @@ import (
 // Test case for providing recorder in the option
 func TestRecorderOptions(t *testing.T) {
 
-	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed", "foo",
+	prs := []*v1alpha1.PipelineRun{tb.PipelineRun("test-pipeline-run-completed",
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa")),
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
@@ -47,10 +47,10 @@ func TestRecorderOptions(t *testing.T) {
 			Message: "All Tasks have completed executing",
 		})),
 	)}
-	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", "foo", tb.PipelineSpec(
+	ps := []*v1alpha1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hellow-world"),
 	))}
-	ts := []*v1alpha1.Task{tb.Task("hello-world", "foo")}
+	ts := []*v1alpha1.Task{tb.Task("hello-world")}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,

--- a/pkg/reconciler/taskrun/metrics_test.go
+++ b/pkg/reconciler/taskrun/metrics_test.go
@@ -56,7 +56,8 @@ func TestRecordTaskrunDurationCount(t *testing.T) {
 		expectedCount     int64
 	}{{
 		name: "for_succeeded_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
+			tb.TaskRunNamespace("ns"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -81,7 +82,8 @@ func TestRecordTaskrunDurationCount(t *testing.T) {
 		expectedCount:    1,
 	}, {
 		name: "for_failed_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
+			tb.TaskRunNamespace("ns"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -132,7 +134,8 @@ func TestRecordPipelinerunTaskrunDurationCount(t *testing.T) {
 		expectedCount     int64
 	}{{
 		name: "for_succeeded_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
+			tb.TaskRunNamespace("ns"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "pipeline-1"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "pipelinerun-1"),
 			tb.TaskRunSpec(
@@ -161,7 +164,8 @@ func TestRecordPipelinerunTaskrunDurationCount(t *testing.T) {
 		expectedCount:    1,
 	}, {
 		name: "for_failed_task",
-		taskRun: tb.TaskRun("taskrun-1", "ns",
+		taskRun: tb.TaskRun("taskrun-1",
+			tb.TaskRunNamespace("ns"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "pipeline-1"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "pipelinerun-1"),
 			tb.TaskRunSpec(
@@ -231,7 +235,8 @@ func TestRecordPodLatency(t *testing.T) {
 		expectingError bool
 	}{{
 		name: "for_scheduled_pod",
-		pod: tb.Pod("test-taskrun-pod-123456", "foo",
+		pod: tb.Pod("test-taskrun-pod-123456",
+			tb.PodNamespace("foo"),
 			tb.PodCreationTimestamp(creationTime),
 			tb.PodStatus(
 				tb.PodStatusConditions(corev1.PodCondition{
@@ -239,7 +244,8 @@ func TestRecordPodLatency(t *testing.T) {
 					LastTransitionTime: metav1.Time{Time: creationTime.Add(4 * time.Second)},
 				}),
 			)),
-		taskRun: tb.TaskRun("test-taskrun", "foo",
+		taskRun: tb.TaskRun("test-taskrun",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -253,10 +259,12 @@ func TestRecordPodLatency(t *testing.T) {
 		expectedValue: 4e+09,
 	}, {
 		name: "for_non_scheduled_pod",
-		pod: tb.Pod("test-taskrun-pod-123456", "foo",
+		pod: tb.Pod("test-taskrun-pod-123456",
+			tb.PodNamespace("foo"),
 			tb.PodCreationTimestamp(creationTime),
 		),
-		taskRun: tb.TaskRun("test-taskrun", "foo",
+		taskRun: tb.TaskRun("test-taskrun",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("task-1"),
 			),
@@ -285,7 +293,8 @@ func TestRecordPodLatency(t *testing.T) {
 }
 
 func addTaskruns(informer alpha1.TaskRunInformer, taskrun, task, ns string, status corev1.ConditionStatus, t *testing.T) {
-	err := informer.Informer().GetIndexer().Add(tb.TaskRun(taskrun, ns,
+	err := informer.Informer().GetIndexer().Add(tb.TaskRun(taskrun,
+		tb.TaskRunNamespace(ns),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef(task),
 		),

--- a/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/taskrun/resources/cloudevent/cloud_event_controller_test.go
@@ -79,7 +79,8 @@ func TestSendCloudEvents(t *testing.T) {
 		wantTaskRun *v1alpha1.TaskRun
 	}{{
 		name: "testWithMultipleMixedCloudEvents",
-		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSelfLink("/task/1234"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
@@ -93,7 +94,8 @@ func TestSendCloudEvents(t *testing.T) {
 				tb.TaskRunCloudEvent("http//attemptedsucceeded", "", 1, v1alpha1.CloudEventConditionSent),
 			),
 		),
-		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
@@ -132,7 +134,8 @@ func TestSendCloudEventsErrors(t *testing.T) {
 		wantTaskRun *v1alpha1.TaskRun
 	}{{
 		name: "testWithMultipleMixedCloudEvents",
-		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		taskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSelfLink("/task/1234"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
@@ -142,7 +145,8 @@ func TestSendCloudEventsErrors(t *testing.T) {
 				tb.TaskRunCloudEvent("http//sink2", "", 0, v1alpha1.CloudEventConditionUnknown),
 			),
 		),
-		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
@@ -179,7 +183,8 @@ func TestInitializeCloudEvents(t *testing.T) {
 		wantTaskRun       *v1alpha1.TaskRun
 	}{{
 		name: "testWithMultipleMixedResources",
-		taskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources", "foo",
+		taskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSelfLink("/task/1234"), tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 				tb.TaskRunOutputs(
@@ -190,21 +195,22 @@ func TestInitializeCloudEvents(t *testing.T) {
 			),
 		),
 		pipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("ce1", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("ce1", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeCloudEvent,
 				tb.PipelineResourceSpecParam("TargetURI", "http://foosink"),
 			)),
-			tb.PipelineResource("ce2", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("ce2", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeCloudEvent,
 				tb.PipelineResourceSpecParam("TargetURI", "http://barsink"),
 			)),
-			tb.PipelineResource("git", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("git", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "http://git.fake"),
 				tb.PipelineResourceSpecParam("Revision", "abcd"),
 			)),
 		},
-		wantTaskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-multiple-mixed-resources",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
@@ -215,7 +221,8 @@ func TestInitializeCloudEvents(t *testing.T) {
 		),
 	}, {
 		name: "testWithNoCloudEventResources",
-		taskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources", "foo",
+		taskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSelfLink("/task/1234"), tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 				tb.TaskRunOutputs(
@@ -224,13 +231,14 @@ func TestInitializeCloudEvents(t *testing.T) {
 			),
 		),
 		pipelineResources: []*v1alpha1.PipelineResource{
-			tb.PipelineResource("git", "foo", tb.PipelineResourceSpec(
+			tb.PipelineResource("git", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 				v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("URL", "http://git.fake"),
 				tb.PipelineResourceSpecParam("Revision", "abcd"),
 			)),
 		},
-		wantTaskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources", "foo",
+		wantTaskRun: tb.TaskRun("test-taskrun-no-cloudevent-resources",
+			tb.TaskRunNamespace("foo"),
 			tb.TaskRunSpec(
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -36,18 +36,18 @@ func TestValidateResolvedTaskResources_ValidResources(t *testing.T) {
 				tb.TaskResourcesOutput("optional-resource-to-provide", v1alpha1.PipelineResourceTypeImage, tb.ResourceOptional(true)),
 			),
 		),
-		tb.ResolvedTaskResourcesInputs("resource-to-build", tb.PipelineResource("example-resource", "foo",
+		tb.ResolvedTaskResourcesInputs("resource-to-build", tb.PipelineResource("example-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("foo", "bar"),
 			))),
-		tb.ResolvedTaskResourcesInputs("optional-resource-to-build", tb.PipelineResource("example-resource", "foo",
+		tb.ResolvedTaskResourcesInputs("optional-resource-to-build", tb.PipelineResource("example-resource",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeGit,
 				tb.PipelineResourceSpecParam("foo", "bar"),
 			))),
-		tb.ResolvedTaskResourcesOutputs("resource-to-provide", tb.PipelineResource("example-image", "bar",
+		tb.ResolvedTaskResourcesOutputs("resource-to-provide", tb.PipelineResource("example-image",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage)),
 		),
-		tb.ResolvedTaskResourcesOutputs("optional-resource-to-provide", tb.PipelineResource("example-image", "bar",
+		tb.ResolvedTaskResourcesOutputs("optional-resource-to-provide", tb.PipelineResource("example-image",
 			tb.PipelineResourceSpec(v1alpha1.PipelineResourceTypeImage)),
 		))
 	if err := taskrun.ValidateResolvedTaskResources([]v1alpha1.Param{}, rtr); err != nil {
@@ -112,7 +112,7 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 }
 
 func TestValidateResolvedTaskResources_InvalidResources(t *testing.T) {
-	r := tb.PipelineResource("git-test-resource", "foo", tb.PipelineResourceSpec(
+	r := tb.PipelineResource("git-test-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("foo", "bar"),
 	))

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -38,11 +38,11 @@ import (
 var (
 	testNs     = "foo"
 	simpleStep = tb.Step(testNs, tb.StepCommand("/mycmd"))
-	simpleTask = tb.Task("test-task", testNs, tb.TaskSpec(simpleStep))
+	simpleTask = tb.Task("test-task", tb.TaskSpec(simpleStep))
 )
 
 func TestTaskRunCheckTimeouts(t *testing.T) {
-	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", testNs, tb.TaskRunSpec(
+	taskRunTimedout := tb.TaskRun("test-taskrun-run-timedout", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(1*time.Second),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -51,7 +51,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now().Add(-10*time.Second)),
 	))
 
-	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+	taskRunRunning := tb.TaskRun("test-taskrun-running", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -60,7 +60,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now()),
 	))
 
-	taskRunRunningNilTimeout := tb.TaskRun("test-taskrun-running-nil-timeout", testNs, tb.TaskRunSpec(
+	taskRunRunningNilTimeout := tb.TaskRun("test-taskrun-running-nil-timeout", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunNilTimeout,
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -69,7 +69,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		tb.TaskRunStartTime(time.Now()),
 	))
 
-	taskRunDone := tb.TaskRun("test-taskrun-completed", testNs, tb.TaskRunSpec(
+	taskRunDone := tb.TaskRun("test-taskrun-completed", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -77,7 +77,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 		Status: corev1.ConditionTrue}),
 	))
 
-	taskRunCancelled := tb.TaskRun("test-taskrun-run-cancelled", testNs, tb.TaskRunSpec(
+	taskRunCancelled := tb.TaskRun("test-taskrun-run-cancelled", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name),
 		tb.TaskRunCancelled,
 		tb.TaskRunTimeout(1*time.Second),
@@ -158,10 +158,10 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 }
 
 func TestPipelinRunCheckTimeouts(t *testing.T) {
-	simplePipeline := tb.Pipeline("test-pipeline", testNs, tb.PipelineSpec(
+	simplePipeline := tb.Pipeline("test-pipeline", tb.PipelineNamespace(testNs), tb.PipelineSpec(
 		tb.PipelineTask("hello-world-1", "hello-world"),
 	))
-	prTimeout := tb.PipelineRun("test-pipeline-run-with-timeout", testNs,
+	prTimeout := tb.PipelineRun("test-pipeline-run-with-timeout", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunTimeout(1*time.Second),
@@ -169,9 +169,9 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 		tb.PipelineRunStatus(
 			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
 	)
-	ts := tb.Task("hello-world", testNs)
+	ts := tb.Task("hello-world")
 
-	prRunning := tb.PipelineRun("test-pipeline-running", testNs,
+	prRunning := tb.PipelineRun("test-pipeline-running", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 		),
@@ -181,7 +181,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			tb.PipelineRunStartTime(time.Now()),
 		),
 	)
-	prRunningNilTimeout := tb.PipelineRun("test-pipeline-running-nil-timeout", testNs,
+	prRunningNilTimeout := tb.PipelineRun("test-pipeline-running-nil-timeout", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunNilTimeout,
 		),
@@ -191,7 +191,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			tb.PipelineRunStartTime(time.Now()),
 		),
 	)
-	prDone := tb.PipelineRun("test-pipeline-done", testNs,
+	prDone := tb.PipelineRun("test-pipeline-done", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline",
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
 		),
@@ -200,7 +200,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 			Status: corev1.ConditionTrue}),
 		),
 	)
-	prCancelled := tb.PipelineRun("test-pipeline-cancel", testNs,
+	prCancelled := tb.PipelineRun("test-pipeline-cancel", tb.PipelineRunNamespace(testNs),
 		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa"),
 			tb.PipelineRunCancelled,
 			tb.PipelineRunTimeout(config.DefaultTimeoutMinutes*time.Minute),
@@ -283,7 +283,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 
 // TestWithNoFunc does not set taskrun/pipelinerun function and verifies that code does not panic
 func TestWithNoFunc(t *testing.T) {
-	taskRunRunning := tb.TaskRun("test-taskrun-running", testNs, tb.TaskRunSpec(
+	taskRunRunning := tb.TaskRun("test-taskrun-running", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(2*time.Second),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
@@ -321,7 +321,7 @@ func TestWithNoFunc(t *testing.T) {
 // TestSetTaskRunTimer checks that the SetTaskRunTimer method correctly calls the TaskRun
 // callback after a set amount of time.
 func TestSetTaskRunTimer(t *testing.T) {
-	taskRun := tb.TaskRun("test-taskrun-arbitrary-timer", testNs, tb.TaskRunSpec(
+	taskRun := tb.TaskRun("test-taskrun-arbitrary-timer", tb.TaskRunNamespace(testNs), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
 		tb.TaskRunTimeout(2*time.Second),
 	), tb.TaskRunStatus(tb.StatusCondition(apis.Condition{

--- a/test/README.md
+++ b/test/README.md
@@ -256,11 +256,11 @@ import tb "github.com/tektoncd/pipeline/test/builder"
 
 func MyTest(t *testing.T){
     // Pipeline
-    pipeline := tb.Pipeline("tomatoes", "namespace",
+    pipeline := tb.Pipeline("tomatoes",
         tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
     )
     // … and PipelineRun
-    pipelineRun := tb.PipelineRun("pear", "namespace",
+    pipelineRun := tb.PipelineRun("pear",
         tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccount("inexistent")),
     )
     // And do something with them

--- a/test/adoc.go
+++ b/test/adoc.go
@@ -24,11 +24,11 @@ can use the builder (./builder) package to reduce noise:
 
 	func MyTest(t *testing.T){
 		// Pipeline
-		pipeline := tb.Pipeline("tomatoes", "namespace",
+		pipeline := tb.Pipeline("tomatoes",
 			tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 		)
 	 	// … and PipelineRun
-		pipelineRun := tb.PipelineRun("pear", "namespace",
+		pipelineRun := tb.PipelineRun("pear",
 			tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccount("inexistent")),
 		)
 		// And do something with them

--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -136,7 +136,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	defer resetConfigMap(t, c, systemNamespace, artifacts.GetBucketConfigName(), originalConfigMapData)
 
 	t.Logf("Creating Git PipelineResource %s", helloworldResourceName)
-	helloworldResource := tb.PipelineResource(helloworldResourceName, namespace, tb.PipelineResourceSpec(
+	helloworldResource := tb.PipelineResource(helloworldResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/pivotal-nader-ziada/gohelloworld"),
 		tb.PipelineResourceSpecParam("Revision", "master"),

--- a/test/builder/condition.go
+++ b/test/builder/condition.go
@@ -31,17 +31,23 @@ type ConditionSpecOp func(spec *v1alpha1.ConditionSpec)
 
 // Condition creates a Condition with default values.
 // Any number of Condition modifiers can be passed to transform it.
-func Condition(name, namespace string, ops ...ConditionOp) *v1alpha1.Condition {
+func Condition(name string, ops ...ConditionOp) *v1alpha1.Condition {
 	condition := &v1alpha1.Condition{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 	}
 	for _, op := range ops {
 		op(condition)
 	}
 	return condition
+}
+
+// Useful when tests need to specify the namespace
+func ConditionNamespace(namespace string) ConditionOp {
+	return func(t *v1alpha1.Condition) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 func ConditionLabels(labels map[string]string) ConditionOp {

--- a/test/builder/condition_test.go
+++ b/test/builder/condition_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 func TestCondition(t *testing.T) {
-	condition := tb.Condition("cond-name", "foo",
+	condition := tb.Condition("cond-name",
+		tb.ConditionNamespace("foo"),
 		tb.ConditionLabels(
 			map[string]string{
 				"label-1": "label-value-1",
@@ -85,7 +86,8 @@ func TestCondition(t *testing.T) {
 }
 
 func TestConditionWithScript(t *testing.T) {
-	condition := tb.Condition("cond-name", "foo",
+	condition := tb.Condition("cond-name",
+		tb.ConditionNamespace("foo"),
 		tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu"),
 			tb.ConditionSpecCheckScript("ls /tmp"),
 		),

--- a/test/builder/examples_test.go
+++ b/test/builder/examples_test.go
@@ -31,12 +31,12 @@ func ExampleTask() {
 	// You can declare re-usable modifiers
 	myStep := tb.Step("myimage")
 	// … and use them in a Task definition
-	myTask := tb.Task("my-task", "namespace", tb.TaskSpec(
+	myTask := tb.Task("my-task", tb.TaskSpec(
 		tb.Step("myotherimage", tb.StepCommand("/mycmd")),
 		myStep,
 	))
 	// … and another one.
-	myOtherTask := tb.Task("my-other-task", "namespace",
+	myOtherTask := tb.Task("my-other-task",
 		tb.TaskSpec(myStep,
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)),
 		),
@@ -71,11 +71,11 @@ func ExampleClusterTask() {
 
 func ExampleTaskRun() {
 	// A simple definition, with a Task reference
-	myTaskRun := tb.TaskRun("my-taskrun", "namespace", tb.TaskRunSpec(
+	myTaskRun := tb.TaskRun("my-taskrun", tb.TaskRunSpec(
 		tb.TaskRunTaskRef("my-task"),
 	))
 	// … or a more complex one with inline TaskSpec
-	myTaskRunWithSpec := tb.TaskRun("my-taskrun-with-spec", "namespace", tb.TaskRunSpec(
+	myTaskRunWithSpec := tb.TaskRun("my-taskrun-with-spec", tb.TaskRunSpec(
 		tb.TaskRunInputs(
 			tb.TaskRunInputsParam("myarg", "foo"),
 			tb.TaskRunInputsResource("workspace", tb.TaskResourceBindingRef("git-resource")),
@@ -106,7 +106,7 @@ func ExampleTaskRun() {
 }
 
 func ExamplePipeline() {
-	pipeline := tb.Pipeline("tomatoes", "namespace",
+	pipeline := tb.Pipeline("tomatoes",
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
 	expectedPipeline := &v1alpha1.Pipeline{
@@ -119,7 +119,7 @@ func ExamplePipeline() {
 }
 
 func ExamplePipelineRun() {
-	pipelineRun := tb.PipelineRun("pear", "namespace",
+	pipelineRun := tb.PipelineRun("pear",
 		tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccountName("inexistent")),
 	)
 	expectedPipelineRun := &v1alpha1.PipelineRun{
@@ -132,10 +132,10 @@ func ExamplePipelineRun() {
 }
 
 func ExamplePipelineResource() {
-	gitResource := tb.PipelineResource("git-resource", "namespace", tb.PipelineResourceSpec(
+	gitResource := tb.PipelineResource("git-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"),
 	))
-	imageResource := tb.PipelineResource("image-resource", "namespace", tb.PipelineResourceSpec(
+	imageResource := tb.PipelineResource("image-resource", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage, tb.PipelineResourceSpecParam("URL", "gcr.io/kristoff/sven"),
 	))
 	expectedGitResource := v1alpha1.PipelineResource{

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -62,11 +62,10 @@ type PipelineTaskConditionOp func(condition *v1alpha1.PipelineTaskCondition)
 
 // Pipeline creates a Pipeline with default values.
 // Any number of Pipeline modifier can be passed to transform it.
-func Pipeline(name, namespace string, ops ...PipelineOp) *v1alpha1.Pipeline {
+func Pipeline(name string, ops ...PipelineOp) *v1alpha1.Pipeline {
 	p := &v1alpha1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 	}
 
@@ -75,6 +74,13 @@ func Pipeline(name, namespace string, ops ...PipelineOp) *v1alpha1.Pipeline {
 	}
 
 	return p
+}
+
+// Useful when tests need to specify the namespace
+func PipelineNamespace(namespace string) PipelineOp {
+	return func(t *v1alpha1.Pipeline) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 // PipelineSpec sets the PipelineSpec to the Pipeline.
@@ -314,11 +320,10 @@ func PipelineTaskTimeout(duration time.Duration) PipelineTaskOp {
 
 // PipelineRun creates a PipelineRun with default values.
 // Any number of PipelineRun modifier can be passed to transform it.
-func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
+func PipelineRun(name string, ops ...PipelineRunOp) *v1alpha1.PipelineRun {
 	pr := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 		Spec: v1alpha1.PipelineRunSpec{},
 	}
@@ -328,6 +333,13 @@ func PipelineRun(name, namespace string, ops ...PipelineRunOp) *v1alpha1.Pipelin
 	}
 
 	return pr
+}
+
+// Useful when tests need to specify the namespace
+func PipelineRunNamespace(namespace string) PipelineRunOp {
+	return func(t *v1alpha1.PipelineRun) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 // PipelineRunSpec sets the PipelineRunSpec, references Pipeline with specified name, to the PipelineRun.
@@ -527,17 +539,23 @@ func PipelineRunTaskRunsStatus(taskRunName string, status *v1alpha1.PipelineRunT
 
 // PipelineResource creates a PipelineResource with default values.
 // Any number of PipelineResource modifier can be passed to transform it.
-func PipelineResource(name, namespace string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {
+func PipelineResource(name string, ops ...PipelineResourceOp) *v1alpha1.PipelineResource {
 	resource := &v1alpha1.PipelineResource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name: name,
 		},
 	}
 	for _, op := range ops {
 		op(resource)
 	}
 	return resource
+}
+
+// Useful when tests need to specify the namespace
+func PipelineResourceNamespace(namespace string) PipelineResourceOp {
+	return func(t *v1alpha1.PipelineResource) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 // PipelineResourceSpec set the PipelineResourceSpec, with specified type, to the PipelineResource.

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -34,7 +34,7 @@ import (
 func TestPipeline(t *testing.T) {
 	creationTime := time.Now()
 
-	pipeline := tb.Pipeline("tomatoes", "foo", tb.PipelineSpec(
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("my-only-git-resource", "git"),
 		tb.PipelineDeclaredResource("my-only-image-resource", "image"),
 		tb.PipelineDescription("Test Pipeline"),
@@ -159,7 +159,7 @@ func TestPipelineRun(t *testing.T) {
 	startTime := time.Now()
 	completedTime := startTime.Add(5 * time.Minute)
 
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
 		tb.PipelineRunParam("first-param-string", "first-value"),
 		tb.PipelineRunParam("second-param-array", "some", "array"),
@@ -223,7 +223,7 @@ func TestPipelineRunWithPodTemplate(t *testing.T) {
 	startTime := time.Now()
 	completedTime := startTime.Add(5 * time.Minute)
 
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
 		tb.PipelineRunParam("first-param-string", "first-value"),
 		tb.PipelineRunParam("second-param-array", "some", "array"),
@@ -295,7 +295,7 @@ func TestPipelineRunWithResourceSpec(t *testing.T) {
 	startTime := time.Now()
 	completedTime := startTime.Add(5 * time.Minute)
 
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("sa"),
 		tb.PipelineRunParam("first-param-string", "first-value"),
 		tb.PipelineRunParam("second-param-array", "some", "array"),
@@ -367,7 +367,7 @@ func TestPipelineRunWithResourceSpec(t *testing.T) {
 }
 
 func TestPipelineRunWithPipelineSpec(t *testing.T) {
-	pipelineRun := tb.PipelineRun("pear", "foo", tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
 		tb.PipelineTask("a-task", "some-task")),
 		tb.PipelineRunServiceAccountName("sa"),
 	))
@@ -396,7 +396,7 @@ func TestPipelineRunWithPipelineSpec(t *testing.T) {
 }
 
 func TestPipelineResource(t *testing.T) {
-	pipelineResource := tb.PipelineResource("git-resource", "foo", tb.PipelineResourceSpec(
+	pipelineResource := tb.PipelineResource("git-resource", tb.PipelineResourceNamespace("foo"), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit, tb.PipelineResourceSpecParam("URL", "https://foo.git"), tb.PipelineResourceDescription("test description"),
 	))
 	expectedPipelineResource := &v1alpha1.PipelineResource{

--- a/test/builder/pod.go
+++ b/test/builder/pod.go
@@ -35,10 +35,9 @@ type PodStatusOp func(status *corev1.PodStatus)
 
 // Pod creates a Pod with default values.
 // Any number of Pod modifiers can be passed to transform it.
-func Pod(name, namespace string, ops ...PodOp) *corev1.Pod {
+func Pod(name string, ops ...PodOp) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
 			Name:        name,
 			Annotations: map[string]string{},
 		},
@@ -47,6 +46,13 @@ func Pod(name, namespace string, ops ...PodOp) *corev1.Pod {
 		op(pod)
 	}
 	return pod
+}
+
+// Useful when tests need to specify the namespace
+func PodNamespace(namespace string) PodOp {
+	return func(t *corev1.Pod) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 // PodLabel adds an annotation to the Pod.

--- a/test/builder/pod_test.go
+++ b/test/builder/pod_test.go
@@ -35,7 +35,8 @@ func TestPod(t *testing.T) {
 		Name:         "tools-volume",
 		VolumeSource: corev1.VolumeSource{},
 	}
-	got := tb.Pod("foo-pod-123456", "foo",
+	got := tb.Pod("foo-pod-123456",
+		tb.PodNamespace("foo"),
 		tb.PodAnnotation("annotation", "annotation-value"),
 		tb.PodLabel("label", "label-value"),
 		tb.PodOwnerReference("TaskRun", "taskrun-foo",

--- a/test/builder/task.go
+++ b/test/builder/task.go
@@ -94,11 +94,10 @@ var (
 
 // Task creates a Task with default values.
 // Any number of Task modifier can be passed to transform it.
-func Task(name, namespace string, ops ...TaskOp) *v1alpha1.Task {
+func Task(name string, ops ...TaskOp) *v1alpha1.Task {
 	t := &v1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
+			Name: name,
 		},
 	}
 
@@ -123,6 +122,13 @@ func ClusterTask(name string, ops ...ClusterTaskOp) *v1alpha1.ClusterTask {
 	}
 
 	return t
+}
+
+// Useful when tests need to specify the namespace
+func TaskNamespace(namespace string) TaskOp {
+	return func(t *v1alpha1.Task) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 // ClusterTaskSpec sets the specified spec of the cluster task.
@@ -389,10 +395,9 @@ func InputsParamSpec(name string, pt v1alpha1.ParamType, ops ...ParamSpecOp) Inp
 
 // TaskRun creates a TaskRun with default values.
 // Any number of TaskRun modifier can be passed to transform it.
-func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
+func TaskRun(name string, ops ...TaskRunOp) *v1alpha1.TaskRun {
 	tr := &v1alpha1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
 			Name:        name,
 			Annotations: map[string]string{},
 		},
@@ -403,6 +408,13 @@ func TaskRun(name, namespace string, ops ...TaskRunOp) *v1alpha1.TaskRun {
 	}
 
 	return tr
+}
+
+// Useful when tests need to specify the namespace
+func TaskRunNamespace(namespace string) TaskRunOp {
+	return func(t *v1alpha1.TaskRun) {
+		t.ObjectMeta.Namespace = namespace
+	}
 }
 
 // TaskRunStatus sets the TaskRunStatus to tshe TaskRun

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -54,7 +54,7 @@ func TestClusterResource(t *testing.T) {
 	}
 
 	t.Logf("Creating cluster PipelineResource %s", resourceName)
-	if _, err := c.PipelineResourceClient.Create(getClusterResource(namespace, resourceName, secretName)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getClusterResource(resourceName, secretName)); err != nil {
 		t.Fatalf("Failed to create cluster Pipeline Resource `%s`: %s", resourceName, err)
 	}
 
@@ -74,8 +74,8 @@ func TestClusterResource(t *testing.T) {
 	}
 }
 
-func getClusterResource(namespace, name, sname string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
+func getClusterResource(name, sname string) *v1alpha1.PipelineResource {
+	return tb.PipelineResource(name, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCluster,
 		tb.PipelineResourceSpecParam("Name", "helloworld-cluster"),
 		tb.PipelineResourceSpecParam("Url", "https://1.1.1.1"),

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -82,7 +82,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	}
 
 	// Create the repo PipelineResource (doesn't really matter which repo we use)
-	repoResource := tb.PipelineResource("repo", namespace, tb.PipelineResourceSpec(
+	repoResource := tb.PipelineResource("repo", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/githubtraining/example-basic"),
 	))

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -53,7 +53,7 @@ func TestGitPipelineRun(t *testing.T) {
 			defer tearDown(t, c, namespace)
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, revision, "", "true", "", "", "")); err != nil {
+			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(revision, "", "true", "", "", "")); err != nil {
 				t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 			}
 
@@ -106,7 +106,7 @@ func TestGitPipelineRunWithRefspec(t *testing.T) {
 			knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 			defer tearDown(t, c, namespace)
 
-			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, tc.revision, tc.refspec, "true", "", "", "")); err != nil {
+			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(tc.revision, tc.refspec, "true", "", "", "")); err != nil {
 				t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 			}
 
@@ -140,7 +140,7 @@ func TestGitPipelineRun_Disable_SSLVerify(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, "master", "", "false", "", "", "")); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource("master", "", "false", "", "", "")); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 	}
 
@@ -175,7 +175,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, "Idontexistrabbitmonkeydonkey", "", "true", "", "", "")); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource("Idontexistrabbitmonkeydonkey", "", "true", "", "", "")); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 	}
 
@@ -242,7 +242,7 @@ func TestGitPipelineRunFail_HTTPS_PROXY(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, "master", "", "true", "", "invalid.https.proxy.com", "")); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource("master", "", "true", "", "invalid.https.proxy.com", "")); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 	}
 
@@ -299,8 +299,8 @@ func TestGitPipelineRunFail_HTTPS_PROXY(t *testing.T) {
 	}
 }
 
-func getGitPipelineResource(namespace, revision, refspec, sslverify, httpproxy, httpsproxy, noproxy string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(gitSourceResourceName, namespace, tb.PipelineResourceSpec(
+func getGitPipelineResource(revision, refspec, sslverify, httpproxy, httpsproxy, noproxy string) *v1alpha1.PipelineResource {
+	return tb.PipelineResource(gitSourceResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/tektoncd/pipeline"),
 		tb.PipelineResourceSpecParam("Revision", revision),

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -59,12 +59,12 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", sourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGoHelloworldGitResource(namespace)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGoHelloworldGitResource()); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceResourceName, err)
 	}
 
 	t.Logf("Creating Image PipelineResource %s", sourceImageName)
-	if _, err := c.PipelineResourceClient.Create(getHelmImageResource(namespace, repo)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getHelmImageResource(repo)); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceImageName, err)
 	}
 
@@ -104,17 +104,17 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	defer helmCleanup(c, t, namespace)
 }
 
-func getGoHelloworldGitResource(namespace string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(sourceResourceName, namespace, tb.PipelineResourceSpec(
+func getGoHelloworldGitResource() *v1alpha1.PipelineResource {
+	return tb.PipelineResource(sourceResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("url", "https://github.com/tektoncd/pipeline"),
 	))
 }
 
-func getHelmImageResource(namespace, dockerRepo string) *v1alpha1.PipelineResource {
+func getHelmImageResource(dockerRepo string) *v1alpha1.PipelineResource {
 	imageName := fmt.Sprintf("%s/%s", dockerRepo, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(sourceImageName))
 
-	return tb.PipelineResource(sourceImageName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(sourceImageName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage,
 		tb.PipelineResourceSpecParam("url", imageName),
 	))

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -58,12 +58,12 @@ func TestKanikoTaskRun(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", kanikoGitResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitResource(namespace)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitResource()); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", kanikoGitResourceName, err)
 	}
 
 	t.Logf("Creating Image PipelineResource %s", repo)
-	if _, err := c.PipelineResourceClient.Create(getImageResource(namespace, repo)); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getImageResource(repo)); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", kanikoGitResourceName, err)
 	}
 
@@ -122,16 +122,16 @@ func TestKanikoTaskRun(t *testing.T) {
 	}
 }
 
-func getGitResource(namespace string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(kanikoGitResourceName, namespace, tb.PipelineResourceSpec(
+func getGitResource() *v1alpha1.PipelineResource {
+	return tb.PipelineResource(kanikoGitResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/GoogleContainerTools/kaniko"),
 		tb.PipelineResourceSpecParam("Revision", revision),
 	))
 }
 
-func getImageResource(namespace, repo string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(kanikoImageResourceName, namespace, tb.PipelineResourceSpec(
+func getImageResource(repo string) *v1alpha1.PipelineResource {
+	return tb.PipelineResource(kanikoImageResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage,
 		tb.PipelineResourceSpecParam("url", repo),
 	))

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -71,7 +71,7 @@ func TestPipelineRun(t *testing.T) {
 				}
 			}
 
-			for _, res := range getFanInFanOutGitResources(namespace) {
+			for _, res := range getFanInFanOutGitResources() {
 				if _, err := c.PipelineResourceClient.Create(res); err != nil {
 					t.Fatalf("Failed to create Pipeline Resource `%s`: %s", kanikoGitResourceName, err)
 				}
@@ -131,7 +131,7 @@ func TestPipelineRun(t *testing.T) {
 		name: "pipeline succeeds when task skipped due to failed condition",
 		testSetup: func(t *testing.T, c *clients, namespace string, index int) {
 			t.Helper()
-			cond := getFailingCondition(namespace)
+			cond := getFailingCondition()
 			if _, err := c.ConditionClient.Create(cond); err != nil {
 				t.Fatalf("Failed to create Condition `%s`: %s", cond1Name, err)
 			}
@@ -453,9 +453,9 @@ func getFanInFanOutPipeline(suffix int, namespace string) *v1beta1.Pipeline {
 	}
 }
 
-func getFanInFanOutGitResources(namespace string) []*v1alpha1.PipelineResource {
+func getFanInFanOutGitResources() []*v1alpha1.PipelineResource {
 	return []*v1alpha1.PipelineResource{
-		tb.PipelineResource("kritis-resource-git", namespace, tb.PipelineResourceSpec(
+		tb.PipelineResource("kritis-resource-git", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("Url", "https://github.com/grafeas/kritis"),
 			tb.PipelineResourceSpecParam("Revision", "master"),
@@ -716,8 +716,8 @@ func getPipelineWithFailingCondition(suffix int, namespace string) *v1beta1.Pipe
 	}
 }
 
-func getFailingCondition(namespace string) *v1alpha1.Condition {
-	return tb.Condition(cond1Name, namespace, tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
+func getFailingCondition() *v1alpha1.Condition {
+	return tb.Condition(cond1Name, tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
 		tb.Command("/bin/bash"), tb.Args("exit 1"))))
 }
 

--- a/test/v1alpha1/adoc.go
+++ b/test/v1alpha1/adoc.go
@@ -24,11 +24,11 @@ can use the builder (./builder) package to reduce noise:
 
 	func MyTest(t *testing.T){
 		// Pipeline
-		pipeline := tb.Pipeline("tomatoes", "namespace",
+		pipeline := tb.Pipeline("tomatoes",
 			tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 		)
 	 	// … and PipelineRun
-		pipelineRun := tb.PipelineRun("pear", "namespace",
+		pipelineRun := tb.PipelineRun("pear",
 			tb.PipelineRunSpec("tomatoes", tb.PipelineRunServiceAccount("inexistent")),
 		)
 		// And do something with them

--- a/test/v1alpha1/artifact_bucket_test.go
+++ b/test/v1alpha1/artifact_bucket_test.go
@@ -66,7 +66,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	defer deleteBucketSecret(c, t, namespace)
 
 	t.Logf("Creating GCS bucket %s", bucketName)
-	createbuckettask := tb.Task("createbuckettask", namespace, tb.TaskSpec(
+	createbuckettask := tb.Task("createbuckettask", tb.TaskSpec(
 		tb.TaskVolume("bucket-secret-volume", tb.VolumeSource(corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: bucketSecretName,
@@ -86,7 +86,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 		t.Fatalf("Failed to create Task `%s`: %s", "createbuckettask", err)
 	}
 
-	createbuckettaskrun := tb.TaskRun("createbuckettaskrun", namespace,
+	createbuckettaskrun := tb.TaskRun("createbuckettaskrun",
 		tb.TaskRunSpec(tb.TaskRunTaskRef("createbuckettask")))
 
 	t.Logf("Creating TaskRun %s", "createbuckettaskrun")
@@ -118,7 +118,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	defer resetConfigMap(t, c, systemNamespace, artifacts.GetBucketConfigName(), originalConfigMapData)
 
 	t.Logf("Creating Git PipelineResource %s", helloworldResourceName)
-	helloworldResource := tb.PipelineResource(helloworldResourceName, namespace, tb.PipelineResourceSpec(
+	helloworldResource := tb.PipelineResource(helloworldResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/pivotal-nader-ziada/gohelloworld"),
 		tb.PipelineResourceSpecParam("Revision", "master"),
@@ -129,7 +129,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Task %s", addFileTaskName)
-	addFileTask := tb.Task(addFileTaskName, namespace, tb.TaskSpec(
+	addFileTask := tb.Task(addFileTaskName, tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource(helloworldResourceName, v1alpha1.PipelineResourceTypeGit)),
 		tb.TaskOutputs(tb.OutputsResource(helloworldResourceName, v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("ubuntu", tb.StepName("addfile"), tb.StepCommand("/bin/bash"),
@@ -143,7 +143,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Task %s", runFileTaskName)
-	readFileTask := tb.Task(runFileTaskName, namespace, tb.TaskSpec(
+	readFileTask := tb.Task(runFileTaskName, tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource(helloworldResourceName, v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("ubuntu", tb.StepName("runfile"), tb.StepCommand("/workspace/helloworld/newfile")),
 	))
@@ -152,7 +152,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating Pipeline %s", bucketTestPipelineName)
-	bucketTestPipeline := tb.Pipeline(bucketTestPipelineName, namespace, tb.PipelineSpec(
+	bucketTestPipeline := tb.Pipeline(bucketTestPipelineName, tb.PipelineSpec(
 		tb.PipelineDeclaredResource("source-repo", "git"),
 		tb.PipelineTask("addfile", addFileTaskName,
 			tb.PipelineTaskInputResource("helloworldgit", "source-repo"),
@@ -167,7 +167,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	}
 
 	t.Logf("Creating PipelineRun %s", bucketTestPipelineRunName)
-	bucketTestPipelineRun := tb.PipelineRun(bucketTestPipelineRunName, namespace, tb.PipelineRunSpec(
+	bucketTestPipelineRun := tb.PipelineRun(bucketTestPipelineRunName, tb.PipelineRunSpec(
 		bucketTestPipelineName,
 		tb.PipelineRunResourceBinding("source-repo", tb.PipelineResourceBindingRef(helloworldResourceName)),
 	))
@@ -232,7 +232,7 @@ func resetConfigMap(t *testing.T, c *clients, namespace, configName string, valu
 }
 
 func runTaskToDeleteBucket(c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
-	deletelbuckettask := tb.Task("deletelbuckettask", namespace, tb.TaskSpec(
+	deletelbuckettask := tb.Task("deletelbuckettask", tb.TaskSpec(
 		tb.TaskVolume("bucket-secret-volume", tb.VolumeSource(corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: bucketSecretName,
@@ -252,7 +252,7 @@ func runTaskToDeleteBucket(c *clients, t *testing.T, namespace, bucketName, buck
 		t.Fatalf("Failed to create Task `%s`: %s", "deletelbuckettask", err)
 	}
 
-	deletelbuckettaskrun := tb.TaskRun("deletelbuckettaskrun", namespace,
+	deletelbuckettaskrun := tb.TaskRun("deletelbuckettaskrun",
 		tb.TaskRunSpec(tb.TaskRunTaskRef("deletelbuckettask")))
 
 	t.Logf("Creating TaskRun %s", "deletelbuckettaskrun")

--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -64,7 +64,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			defer tearDown(t, c, namespace)
 
 			t.Logf("Creating Task in namespace %s", namespace)
-			task := tb.Task("banana", namespace, tb.TaskSpec(
+			task := tb.Task("banana", tb.TaskSpec(
 				tb.Step("ubuntu", tb.StepCommand("/bin/bash"), tb.StepArgs("-c", "sleep 5000")),
 			))
 			if _, err := c.TaskClient.Create(task); err != nil {
@@ -72,14 +72,14 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 
 			t.Logf("Creating Pipeline in namespace %s", namespace)
-			pipeline := tb.Pipeline("tomatoes", namespace,
+			pipeline := tb.Pipeline("tomatoes",
 				tb.PipelineSpec(pipelineTask),
 			)
 			if _, err := c.PipelineClient.Create(pipeline); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
 			}
 
-			pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name))
+			pipelineRun := tb.PipelineRun("pear", tb.PipelineRunSpec(pipeline.Name))
 
 			t.Logf("Creating PipelineRun in namespace %s", namespace)
 			if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {

--- a/test/v1alpha1/cluster_resource_test.go
+++ b/test/v1alpha1/cluster_resource_test.go
@@ -57,7 +57,7 @@ func TestClusterResource(t *testing.T) {
 	}
 
 	t.Logf("Creating Task %s", taskName)
-	if _, err := c.TaskClient.Create(getClusterResourceTask(namespace, taskName, configName)); err != nil {
+	if _, err := c.TaskClient.Create(getClusterResourceTask(taskName, configName)); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", taskName, err)
 	}
 
@@ -73,7 +73,7 @@ func TestClusterResource(t *testing.T) {
 }
 
 func getClusterResource(namespace, name, sname string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(name, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(name, tb.PipelineResourceNamespace(namespace), tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeCluster,
 		tb.PipelineResourceSpecParam("Name", "helloworld-cluster"),
 		tb.PipelineResourceSpecParam("Url", "https://1.1.1.1"),
@@ -97,8 +97,8 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 	}
 }
 
-func getClusterResourceTask(namespace, name, configName string) *v1alpha1.Task {
-	return tb.Task(name, namespace, tb.TaskSpec(
+func getClusterResourceTask(name, configName string) *v1alpha1.Task {
+	return tb.Task(name, tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("target-cluster", v1alpha1.PipelineResourceTypeCluster)),
 		tb.TaskVolume("config-vol", tb.VolumeSource(corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -122,7 +122,7 @@ func getClusterResourceTask(namespace, name, configName string) *v1alpha1.Task {
 }
 
 func getClusterResourceTaskRun(namespace, name, taskName, resName string) *v1alpha1.TaskRun {
-	return tb.TaskRun(name, namespace, tb.TaskRunSpec(
+	return tb.TaskRun(name, tb.TaskRunNamespace(namespace), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(taskName),
 		tb.TaskRunInputs(tb.TaskRunInputsResource("target-cluster", tb.TaskResourceBindingRef(resName))),
 	))

--- a/test/v1alpha1/dag_test.go
+++ b/test/v1alpha1/dag_test.go
@@ -49,7 +49,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	// Create the Task that echoes text
-	echoTask := tb.Task("echo-task", namespace, tb.TaskSpec(
+	echoTask := tb.Task("echo-task", tb.TaskSpec(
 		tb.TaskInputs(
 			tb.InputsResource("repo", v1alpha1.PipelineResourceTypeGit),
 			tb.InputsParamSpec("text", v1alpha1.ParamTypeString, tb.ParamSpecDescription("The text that should be echoed")),
@@ -63,7 +63,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	}
 
 	// Create the repo PipelineResource (doesn't really matter which repo we use)
-	repoResource := tb.PipelineResource("repo", namespace, tb.PipelineResourceSpec(
+	repoResource := tb.PipelineResource("repo", tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/githubtraining/example-basic"),
 	))
@@ -73,7 +73,7 @@ func TestDAGPipelineRun(t *testing.T) {
 
 	// Intentionally declaring Tasks in a mixed up order to ensure the order
 	// of execution isn't at all dependent on the order they are declared in
-	pipeline := tb.Pipeline("dag-pipeline", namespace, tb.PipelineSpec(
+	pipeline := tb.Pipeline("dag-pipeline", tb.PipelineSpec(
 		tb.PipelineDeclaredResource("repo", "git"),
 		tb.PipelineTask("pipeline-task-3", "echo-task",
 			tb.PipelineTaskInputResource("repo", "repo", tb.From("pipeline-task-2-parallel-1", "pipeline-task-2-parallel-2")),
@@ -105,7 +105,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create dag-pipeline: %s", err)
 	}
-	pipelineRun := tb.PipelineRun("dag-pipeline-run", namespace, tb.PipelineRunSpec("dag-pipeline",
+	pipelineRun := tb.PipelineRun("dag-pipeline-run", tb.PipelineRunSpec("dag-pipeline",
 		tb.PipelineRunResourceBinding("repo", tb.PipelineResourceBindingRef("repo")),
 	))
 	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {

--- a/test/v1alpha1/duplicate_test.go
+++ b/test/v1alpha1/duplicate_test.go
@@ -43,7 +43,7 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 		taskrunName := fmt.Sprintf("duplicate-pod-taskrun-%d", i)
 		t.Logf("Creating taskrun %q.", taskrunName)
 
-		taskrun := tb.TaskRun(taskrunName, namespace, tb.TaskRunSpec(
+		taskrun := tb.TaskRun(taskrunName, tb.TaskRunSpec(
 			tb.TaskRunTaskSpec(tb.Step("busybox",
 				tb.StepCommand("/bin/echo"),
 				tb.StepArgs("simple"),

--- a/test/v1alpha1/embed_test.go
+++ b/test/v1alpha1/embed_test.go
@@ -45,7 +45,7 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(getEmbeddedTask(namespace, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)})); err != nil {
+	if _, err := c.TaskClient.Create(getEmbeddedTask([]string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)})); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", embedTaskName, err)
 	}
 	if _, err := c.TaskRunClient.Create(getEmbeddedTaskRun(namespace)); err != nil {
@@ -61,8 +61,8 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 	// completion of the TaskRun means the TaskRun did what it was intended.
 }
 
-func getEmbeddedTask(namespace string, args []string) *v1alpha1.Task {
-	return tb.Task(embedTaskName, namespace,
+func getEmbeddedTask(args []string) *v1alpha1.Task {
+	return tb.Task(embedTaskName,
 		tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("docs", v1alpha1.PipelineResourceTypeGit)),
 			tb.Step("ubuntu",
@@ -81,7 +81,8 @@ func getEmbeddedTaskRun(namespace string) *v1alpha1.TaskRun {
 			Value: "https://github.com/knative/docs",
 		}},
 	}
-	return tb.TaskRun(embedTaskRunName, namespace,
+	return tb.TaskRun(embedTaskRunName,
+		tb.TaskRunNamespace(namespace),
 		tb.TaskRunSpec(
 			tb.TaskRunInputs(
 				tb.TaskRunInputsResource("docs", tb.TaskResourceBindingResourceSpec(testSpec)),

--- a/test/v1alpha1/entrypoint_test.go
+++ b/test/v1alpha1/entrypoint_test.go
@@ -42,14 +42,14 @@ func TestEntrypointRunningStepsInOrder(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task(epTaskName, namespace, tb.TaskSpec(
+	task := tb.Task(epTaskName, tb.TaskSpec(
 		tb.Step("ubuntu", tb.StepArgs("-c", "sleep 3 && touch foo")),
 		tb.Step("ubuntu", tb.StepArgs("-c", "ls", "foo")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun(epTaskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(epTaskRunName, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(epTaskName), tb.TaskRunServiceAccountName("default"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {

--- a/test/v1alpha1/git_checkout_test.go
+++ b/test/v1alpha1/git_checkout_test.go
@@ -51,22 +51,22 @@ func TestGitPipelineRun(t *testing.T) {
 			defer tearDown(t, c, namespace)
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, revision, "", "true", "", "", "")); err != nil {
+			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(revision, "", "true", "", "", "")); err != nil {
 				t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 			}
 
 			t.Logf("Creating Task %s", gitTestTaskName)
-			if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
+			if _, err := c.TaskClient.Create(getGitCheckTask()); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
 			}
 
 			t.Logf("Creating Pipeline %s", gitTestPipelineName)
-			if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
+			if _, err := c.PipelineClient.Create(getGitCheckPipeline()); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
 			}
 
 			t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-			if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
+			if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun()); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
 			}
 
@@ -104,19 +104,19 @@ func TestGitPipelineRunWithRefspec(t *testing.T) {
 			knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 			defer tearDown(t, c, namespace)
 
-			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, tc.revision, tc.refspec, "true", "", "", "")); err != nil {
+			if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(tc.revision, tc.refspec, "true", "", "", "")); err != nil {
 				t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 			}
 
-			if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
+			if _, err := c.TaskClient.Create(getGitCheckTask()); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
 			}
 
-			if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
+			if _, err := c.PipelineClient.Create(getGitCheckPipeline()); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
 			}
 
-			if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
+			if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun()); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
 			}
 
@@ -138,22 +138,22 @@ func TestGitPipelineRun_Disable_SSLVerify(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, "master", "", "false", "", "", "")); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource("master", "", "false", "", "", "")); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 	}
 
 	t.Logf("Creating Task %s", gitTestTaskName)
-	if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
+	if _, err := c.TaskClient.Create(getGitCheckTask()); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
 	}
 
 	t.Logf("Creating Pipeline %s", gitTestPipelineName)
-	if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
+	if _, err := c.PipelineClient.Create(getGitCheckPipeline()); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
 	}
 
 	t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-	if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
+	if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun()); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
 	}
 
@@ -173,22 +173,22 @@ func TestGitPipelineRunFail(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, "Idontexistrabbitmonkeydonkey", "", "true", "", "", "")); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource("Idontexistrabbitmonkeydonkey", "", "true", "", "", "")); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 	}
 
 	t.Logf("Creating Task %s", gitTestTaskName)
-	if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
+	if _, err := c.TaskClient.Create(getGitCheckTask()); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
 	}
 
 	t.Logf("Creating Pipeline %s", gitTestPipelineName)
-	if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
+	if _, err := c.PipelineClient.Create(getGitCheckPipeline()); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
 	}
 
 	t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-	if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
+	if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun()); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
 	}
 
@@ -240,22 +240,22 @@ func TestGitPipelineRunFail_HTTPS_PROXY(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource(namespace, "master", "", "true", "", "invalid.https.proxy.com", "")); err != nil {
+	if _, err := c.PipelineResourceClient.Create(getGitPipelineResource("master", "", "true", "", "invalid.https.proxy.com", "")); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", gitSourceResourceName, err)
 	}
 
 	t.Logf("Creating Task %s", gitTestTaskName)
-	if _, err := c.TaskClient.Create(getGitCheckTask(namespace)); err != nil {
+	if _, err := c.TaskClient.Create(getGitCheckTask()); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", gitTestTaskName, err)
 	}
 
 	t.Logf("Creating Pipeline %s", gitTestPipelineName)
-	if _, err := c.PipelineClient.Create(getGitCheckPipeline(namespace)); err != nil {
+	if _, err := c.PipelineClient.Create(getGitCheckPipeline()); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineName, err)
 	}
 
 	t.Logf("Creating PipelineRun %s", gitTestPipelineRunName)
-	if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun(namespace)); err != nil {
+	if _, err := c.PipelineRunClient.Create(getGitCheckPipelineRun()); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", gitTestPipelineRunName, err)
 	}
 
@@ -297,8 +297,8 @@ func TestGitPipelineRunFail_HTTPS_PROXY(t *testing.T) {
 	}
 }
 
-func getGitPipelineResource(namespace, revision, refspec, sslverify, httpproxy, httpsproxy, noproxy string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(gitSourceResourceName, namespace, tb.PipelineResourceSpec(
+func getGitPipelineResource(revision, refspec, sslverify, httpproxy, httpsproxy, noproxy string) *v1alpha1.PipelineResource {
+	return tb.PipelineResource(gitSourceResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/tektoncd/pipeline"),
 		tb.PipelineResourceSpecParam("Revision", revision),
@@ -310,15 +310,15 @@ func getGitPipelineResource(namespace, revision, refspec, sslverify, httpproxy, 
 	))
 }
 
-func getGitCheckTask(namespace string) *v1alpha1.Task {
-	return tb.Task(gitTestTaskName, namespace, tb.TaskSpec(
+func getGitCheckTask() *v1alpha1.Task {
+	return tb.Task(gitTestTaskName, tb.TaskSpec(
 		tb.TaskInputs(tb.InputsResource("gitsource", v1alpha1.PipelineResourceTypeGit)),
 		tb.Step("alpine/git", tb.StepArgs("--git-dir=/workspace/gitsource/.git", "show")),
 	))
 }
 
-func getGitCheckPipeline(namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(gitTestPipelineName, namespace, tb.PipelineSpec(
+func getGitCheckPipeline() *v1alpha1.Pipeline {
+	return tb.Pipeline(gitTestPipelineName, tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-repo", "git"),
 		tb.PipelineTask("git-check", gitTestTaskName,
 			tb.PipelineTaskInputResource("gitsource", "git-repo"),
@@ -326,8 +326,8 @@ func getGitCheckPipeline(namespace string) *v1alpha1.Pipeline {
 	))
 }
 
-func getGitCheckPipelineRun(namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(gitTestPipelineRunName, namespace, tb.PipelineRunSpec(
+func getGitCheckPipelineRun() *v1alpha1.PipelineRun {
+	return tb.PipelineRun(gitTestPipelineRunName, tb.PipelineRunSpec(
 		gitTestPipelineName,
 		tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef(gitSourceResourceName)),
 	))

--- a/test/v1alpha1/kaniko_task_test.go
+++ b/test/v1alpha1/kaniko_task_test.go
@@ -117,7 +117,7 @@ func TestKanikoTaskRun(t *testing.T) {
 }
 
 func getGitResource(namespace string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(kanikoGitResourceName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(kanikoGitResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("Url", "https://github.com/GoogleContainerTools/kaniko"),
 		tb.PipelineResourceSpecParam("Revision", revision),
@@ -125,7 +125,7 @@ func getGitResource(namespace string) *v1alpha1.PipelineResource {
 }
 
 func getImageResource(namespace, repo string) *v1alpha1.PipelineResource {
-	return tb.PipelineResource(kanikoImageResourceName, namespace, tb.PipelineResourceSpec(
+	return tb.PipelineResource(kanikoImageResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeImage,
 		tb.PipelineResourceSpecParam("url", repo),
 	))
@@ -155,16 +155,18 @@ func getTask(repo, namespace string) *v1alpha1.Task {
 	sidecar := tb.Sidecar("registry", "registry")
 	taskSpecOps = append(taskSpecOps, sidecar)
 
-	return tb.Task(kanikoTaskName, namespace, tb.TaskSpec(taskSpecOps...))
+	return tb.Task(kanikoTaskName, tb.TaskSpec(taskSpecOps...))
 }
 
 func getTaskRun(namespace string) *v1alpha1.TaskRun {
-	return tb.TaskRun(kanikoTaskRunName, namespace, tb.TaskRunSpec(
-		tb.TaskRunTaskRef(kanikoTaskName),
-		tb.TaskRunTimeout(2*time.Minute),
-		tb.TaskRunInputs(tb.TaskRunInputsResource("gitsource", tb.TaskResourceBindingRef(kanikoGitResourceName))),
-		tb.TaskRunOutputs(tb.TaskRunOutputsResource("builtImage", tb.TaskResourceBindingRef(kanikoImageResourceName))),
-	))
+	return tb.TaskRun(kanikoTaskRunName,
+		tb.TaskRunNamespace(namespace),
+		tb.TaskRunSpec(
+			tb.TaskRunTaskRef(kanikoTaskName),
+			tb.TaskRunTimeout(2*time.Minute),
+			tb.TaskRunInputs(tb.TaskRunInputsResource("gitsource", tb.TaskResourceBindingRef(kanikoGitResourceName))),
+			tb.TaskRunOutputs(tb.TaskRunOutputsResource("builtImage", tb.TaskResourceBindingRef(kanikoImageResourceName))),
+		))
 }
 
 // getRemoteDigest starts a pod to query the registry from the namespace itself, using skopeo (and jq).

--- a/test/v1alpha1/pipelinerun_test.go
+++ b/test/v1alpha1/pipelinerun_test.go
@@ -62,19 +62,19 @@ func TestPipelineRun(t *testing.T) {
 		name: "fan-in and fan-out",
 		testSetup: func(t *testing.T, c *clients, namespace string, index int) {
 			t.Helper()
-			for _, task := range getFanInFanOutTasks(namespace) {
+			for _, task := range getFanInFanOutTasks() {
 				if _, err := c.TaskClient.Create(task); err != nil {
 					t.Fatalf("Failed to create Task `%s`: %s", task.Name, err)
 				}
 			}
 
-			for _, res := range getFanInFanOutGitResources(namespace) {
+			for _, res := range getFanInFanOutGitResources() {
 				if _, err := c.PipelineResourceClient.Create(res); err != nil {
 					t.Fatalf("Failed to create Pipeline Resource `%s`: %s", kanikoGitResourceName, err)
 				}
 			}
 
-			if _, err := c.PipelineClient.Create(getFanInFanOutPipeline(index, namespace)); err != nil {
+			if _, err := c.PipelineClient.Create(getFanInFanOutPipeline(index)); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", getName(pipelineName, index), err)
 			}
 		},
@@ -86,15 +86,15 @@ func TestPipelineRun(t *testing.T) {
 		name: "service account propagation and pipeline param",
 		testSetup: func(t *testing.T, c *clients, namespace string, index int) {
 			t.Helper()
-			if _, err := c.KubeClient.Kube.CoreV1().Secrets(namespace).Create(getPipelineRunSecret(index, namespace)); err != nil {
+			if _, err := c.KubeClient.Kube.CoreV1().Secrets(namespace).Create(getPipelineRunSecret(index)); err != nil {
 				t.Fatalf("Failed to create secret `%s`: %s", getName(secretName, index), err)
 			}
 
-			if _, err := c.KubeClient.Kube.CoreV1().ServiceAccounts(namespace).Create(getPipelineRunServiceAccount(index, namespace)); err != nil {
+			if _, err := c.KubeClient.Kube.CoreV1().ServiceAccounts(namespace).Create(getPipelineRunServiceAccount(index)); err != nil {
 				t.Fatalf("Failed to create SA `%s`: %s", getName(saName, index), err)
 			}
 
-			task := tb.Task(getName(taskName, index), namespace, tb.TaskSpec(
+			task := tb.Task(getName(taskName, index), tb.TaskSpec(
 				tb.TaskInputs(tb.InputsParamSpec("path", v1alpha1.ParamTypeString),
 					tb.InputsParamSpec("dest", v1alpha1.ParamTypeString)),
 				// Reference build: https://github.com/knative/build/tree/master/test/docker-basic
@@ -107,7 +107,7 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to create Task `%s`: %s", getName(taskName, index), err)
 			}
 
-			if _, err := c.PipelineClient.Create(getHelloWorldPipelineWithSingularTask(index, namespace)); err != nil {
+			if _, err := c.PipelineClient.Create(getHelloWorldPipelineWithSingularTask(index)); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", getName(pipelineName, index), err)
 			}
 		},
@@ -124,7 +124,7 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to create Condition `%s`: %s", cond1Name, err)
 			}
 
-			task := tb.Task(getName(taskName, index), namespace, tb.TaskSpec(
+			task := tb.Task(getName(taskName, index), tb.TaskSpec(
 				tb.Step("ubuntu",
 					tb.StepCommand("/bin/bash"),
 					tb.StepArgs("-c", "echo hello, world"),
@@ -133,7 +133,7 @@ func TestPipelineRun(t *testing.T) {
 			if _, err := c.TaskClient.Create(task); err != nil {
 				t.Fatalf("Failed to create Task `%s`: %s", getName(taskName, index), err)
 			}
-			if _, err := c.PipelineClient.Create(getPipelineWithFailingCondition(index, namespace)); err != nil {
+			if _, err := c.PipelineClient.Create(getPipelineWithFailingCondition(index)); err != nil {
 				t.Fatalf("Failed to create Pipeline `%s`: %s", getName(pipelineName, index), err)
 			}
 		},
@@ -228,8 +228,8 @@ func TestPipelineRun(t *testing.T) {
 	}
 }
 
-func getHelloWorldPipelineWithSingularTask(suffix int, namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
+func getHelloWorldPipelineWithSingularTask(suffix int) *v1alpha1.Pipeline {
+	return tb.Pipeline(getName(pipelineName, suffix), tb.PipelineSpec(
 		tb.PipelineParamSpec("path", v1alpha1.ParamTypeString),
 		tb.PipelineParamSpec("dest", v1alpha1.ParamTypeString),
 		tb.PipelineTask(task1Name, getName(taskName, suffix),
@@ -238,11 +238,11 @@ func getHelloWorldPipelineWithSingularTask(suffix int, namespace string) *v1alph
 	))
 }
 
-func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
+func getFanInFanOutTasks() []*v1alpha1.Task {
 	inWorkspaceResource := tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit)
 	outWorkspaceResource := tb.OutputsResource("workspace", v1alpha1.PipelineResourceTypeGit)
 	return []*v1alpha1.Task{
-		tb.Task("create-file", namespace, tb.TaskSpec(
+		tb.Task("create-file", tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit,
 				tb.ResourceTargetPath("brandnewspace"),
 			)),
@@ -254,7 +254,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo other > $(outputs.resources.workspace.path)/other"),
 			),
 		)),
-		tb.Task("check-create-files-exists", namespace, tb.TaskSpec(
+		tb.Task("check-create-files-exists", tb.TaskSpec(
 			tb.TaskInputs(inWorkspaceResource),
 			tb.TaskOutputs(outWorkspaceResource),
 			tb.Step("ubuntu", tb.StepName("read-from-task-0"), tb.StepCommand("/bin/bash"),
@@ -264,7 +264,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo something > $(outputs.resources.workspace.path)/something"),
 			),
 		)),
-		tb.Task("check-create-files-exists-2", namespace, tb.TaskSpec(
+		tb.Task("check-create-files-exists-2", tb.TaskSpec(
 			tb.TaskInputs(inWorkspaceResource),
 			tb.TaskOutputs(outWorkspaceResource),
 			tb.Step("ubuntu", tb.StepName("read-from-task-0"), tb.StepCommand("/bin/bash"),
@@ -274,7 +274,7 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 				tb.StepArgs("-c", "echo else > $(outputs.resources.workspace.path)/else"),
 			),
 		)),
-		tb.Task("read-files", namespace, tb.TaskSpec(
+		tb.Task("read-files", tb.TaskSpec(
 			tb.TaskInputs(tb.InputsResource("workspace", v1alpha1.PipelineResourceTypeGit,
 				tb.ResourceTargetPath("readingspace"),
 			)),
@@ -288,10 +288,10 @@ func getFanInFanOutTasks(namespace string) []*v1alpha1.Task {
 	}
 }
 
-func getFanInFanOutPipeline(suffix int, namespace string) *v1alpha1.Pipeline {
+func getFanInFanOutPipeline(suffix int) *v1alpha1.Pipeline {
 	outGitResource := tb.PipelineTaskOutputResource("workspace", "git-repo")
 
-	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
+	return tb.Pipeline(getName(pipelineName, suffix), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("git-repo", "git"),
 		tb.PipelineTask("create-file-kritis", "create-file",
 			tb.PipelineTaskInputResource("workspace", "git-repo"),
@@ -311,9 +311,9 @@ func getFanInFanOutPipeline(suffix int, namespace string) *v1alpha1.Pipeline {
 	))
 }
 
-func getFanInFanOutGitResources(namespace string) []*v1alpha1.PipelineResource {
+func getFanInFanOutGitResources() []*v1alpha1.PipelineResource {
 	return []*v1alpha1.PipelineResource{
-		tb.PipelineResource("kritis-resource-git", namespace, tb.PipelineResourceSpec(
+		tb.PipelineResource("kritis-resource-git", tb.PipelineResourceSpec(
 			v1alpha1.PipelineResourceTypeGit,
 			tb.PipelineResourceSpecParam("Url", "https://github.com/grafeas/kritis"),
 			tb.PipelineResourceSpecParam("Revision", "master"),
@@ -321,11 +321,10 @@ func getFanInFanOutGitResources(namespace string) []*v1alpha1.PipelineResource {
 	}
 }
 
-func getPipelineRunServiceAccount(suffix int, namespace string) *corev1.ServiceAccount {
+func getPipelineRunServiceAccount(suffix int) *corev1.ServiceAccount {
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      getName(saName, suffix),
+			Name: getName(saName, suffix),
 		},
 		Secrets: []corev1.ObjectReference{{
 			Name: getName(secretName, suffix),
@@ -333,13 +332,13 @@ func getPipelineRunServiceAccount(suffix int, namespace string) *corev1.ServiceA
 	}
 }
 func getFanInFanOutPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(getName(pipelineRunName, suffix), namespace,
+	return tb.PipelineRun(getName(pipelineRunName, suffix), tb.PipelineRunNamespace(namespace),
 		tb.PipelineRunSpec(getName(pipelineName, suffix),
 			tb.PipelineRunResourceBinding("git-repo", tb.PipelineResourceBindingRef("kritis-resource-git")),
 		))
 }
 
-func getPipelineRunSecret(suffix int, namespace string) *corev1.Secret {
+func getPipelineRunSecret(suffix int) *corev1.Secret {
 	// Generated by:
 	//   cat /tmp/key.json | base64 -w 0
 	// This service account is JUST a storage reader on gcr.io/build-crd-testing
@@ -351,8 +350,7 @@ func getPipelineRunSecret(suffix int, namespace string) *corev1.Secret {
 	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      getName(secretName, suffix),
+			Name: getName(secretName, suffix),
 			Annotations: map[string]string{
 				"tekton.dev/docker-0": "https://us.gcr.io",
 				"tekton.dev/docker-1": "https://eu.gcr.io",
@@ -369,7 +367,7 @@ func getPipelineRunSecret(suffix int, namespace string) *corev1.Secret {
 }
 
 func getHelloWorldPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(getName(pipelineRunName, suffix), namespace,
+	return tb.PipelineRun(getName(pipelineRunName, suffix), tb.PipelineRunNamespace(namespace),
 		tb.PipelineRunLabel("hello-world-key", "hello-world-value"),
 		tb.PipelineRunSpec(getName(pipelineName, suffix),
 			tb.PipelineRunParam("path", "docker://gcr.io/build-crd-testing/secret-sauce"),
@@ -538,20 +536,20 @@ func assertAnnotationsMatch(t *testing.T, expectedAnnotations, actualAnnotations
 	}
 }
 
-func getPipelineWithFailingCondition(suffix int, namespace string) *v1alpha1.Pipeline {
-	return tb.Pipeline(getName(pipelineName, suffix), namespace, tb.PipelineSpec(
+func getPipelineWithFailingCondition(suffix int) *v1alpha1.Pipeline {
+	return tb.Pipeline(getName(pipelineName, suffix), tb.PipelineSpec(
 		tb.PipelineTask(task1Name, getName(taskName, suffix), tb.PipelineTaskCondition(cond1Name)),
 		tb.PipelineTask("task2", getName(taskName, suffix), tb.RunAfter(task1Name)),
 	))
 }
 
 func getFailingCondition(namespace string) *v1alpha1.Condition {
-	return tb.Condition(cond1Name, namespace, tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
+	return tb.Condition(cond1Name, tb.ConditionNamespace(namespace), tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
 		tb.Command("/bin/bash"), tb.Args("exit 1"))))
 }
 
 func getConditionalPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {
-	return tb.PipelineRun(getName(pipelineRunName, suffix), namespace,
+	return tb.PipelineRun(getName(pipelineRunName, suffix), tb.PipelineRunNamespace(namespace),
 		tb.PipelineRunLabel("hello-world-key", "hello-world-value"),
 		tb.PipelineRunSpec(getName(pipelineName, suffix)),
 	)

--- a/test/v1alpha1/sidecar_test.go
+++ b/test/v1alpha1/sidecar_test.go
@@ -59,7 +59,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			sidecarTaskName := fmt.Sprintf("%s-%d", sidecarTaskName, i)
 			sidecarTaskRunName := fmt.Sprintf("%s-%d", sidecarTaskRunName, i)
-			task := tb.Task(sidecarTaskName, namespace,
+			task := tb.Task(sidecarTaskName,
 				tb.TaskSpec(
 					tb.Step(
 						"busybox:1.31.0-musl",
@@ -74,7 +74,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 				),
 			)
 
-			taskRun := tb.TaskRun(sidecarTaskRunName, namespace,
+			taskRun := tb.TaskRun(sidecarTaskRunName,
 				tb.TaskRunSpec(tb.TaskRunTaskRef(sidecarTaskName),
 					tb.TaskRunTimeout(1*time.Minute),
 				),

--- a/test/v1alpha1/status_test.go
+++ b/test/v1alpha1/status_test.go
@@ -36,13 +36,13 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task("banana", namespace, tb.TaskSpec(
+	task := tb.Task("banana", tb.TaskSpec(
 		tb.Step("busybox", tb.StepCommand("ls", "-la")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun("apple", namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun("apple", tb.TaskRunSpec(
 		tb.TaskRunTaskRef("banana"), tb.TaskRunServiceAccountName("inexistent"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
@@ -54,10 +54,10 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	pipeline := tb.Pipeline("tomatoes", namespace,
+	pipeline := tb.Pipeline("tomatoes",
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunSpec(
 		"tomatoes", tb.PipelineRunServiceAccountName("inexistent"),
 	))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {

--- a/test/v1alpha1/taskrun_test.go
+++ b/test/v1alpha1/taskrun_test.go
@@ -41,7 +41,7 @@ func TestTaskRunFailure(t *testing.T) {
 	taskRunName := "failing-taskrun"
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task("failing-task", namespace, tb.TaskSpec(
+	task := tb.Task("failing-task", tb.TaskSpec(
 		tb.Step("busybox",
 			tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "echo hello"),
 		),
@@ -55,7 +55,7 @@ func TestTaskRunFailure(t *testing.T) {
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(taskRunName, tb.TaskRunSpec(
 		tb.TaskRunTaskRef("failing-task"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
@@ -118,7 +118,7 @@ func TestTaskRunStatus(t *testing.T) {
 
 	fqImageName := "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := tb.Task("status-task", namespace, tb.TaskSpec(
+	task := tb.Task("status-task", tb.TaskSpec(
 		// This was the digest of the latest tag as of 8/12/2019
 		tb.Step("busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
 			tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "echo hello"),
@@ -127,7 +127,7 @@ func TestTaskRunStatus(t *testing.T) {
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(taskRunName, tb.TaskRunSpec(
 		tb.TaskRunTaskRef("status-task"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {

--- a/test/v1alpha1/timeout_test.go
+++ b/test/v1alpha1/timeout_test.go
@@ -44,16 +44,16 @@ func TestPipelineRunTimeout(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task in namespace %s", namespace)
-	task := tb.Task("banana", namespace, tb.TaskSpec(
+	task := tb.Task("banana", tb.TaskSpec(
 		tb.Step("busybox", tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "sleep 10"))))
 	if _, err := c.TaskClient.Create(task); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", "banana", err)
 	}
 
-	pipeline := tb.Pipeline("tomatoes", namespace,
+	pipeline := tb.Pipeline("tomatoes",
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")),
 	)
-	pipelineRun := tb.PipelineRun("pear", namespace, tb.PipelineRunSpec(pipeline.Name,
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunSpec(pipeline.Name,
 		tb.PipelineRunTimeout(5*time.Second),
 	))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
@@ -119,9 +119,9 @@ func TestPipelineRunTimeout(t *testing.T) {
 
 	// Verify that we can create a second Pipeline using the same Task without a Pipeline-level timeout that will not
 	// time out
-	secondPipeline := tb.Pipeline("peppers", namespace,
+	secondPipeline := tb.Pipeline("peppers",
 		tb.PipelineSpec(tb.PipelineTask("foo", "banana")))
-	secondPipelineRun := tb.PipelineRun("kiwi", namespace, tb.PipelineRunSpec("peppers"))
+	secondPipelineRun := tb.PipelineRun("kiwi", tb.PipelineRunSpec("peppers"))
 	if _, err := c.PipelineClient.Create(secondPipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", secondPipeline.Name, err)
 	}
@@ -144,11 +144,11 @@ func TestTaskRunTimeout(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(tb.Task("giraffe", namespace,
+	if _, err := c.TaskClient.Create(tb.Task("giraffe",
 		tb.TaskSpec(tb.Step("busybox", tb.StepCommand("/bin/sh"), tb.StepArgs("-c", "sleep 3000"))))); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", "giraffe", err)
 	}
-	if _, err := c.TaskRunClient.Create(tb.TaskRun("run-giraffe", namespace, tb.TaskRunSpec(tb.TaskRunTaskRef("giraffe"),
+	if _, err := c.TaskRunClient.Create(tb.TaskRun("run-giraffe", tb.TaskRunSpec(tb.TaskRunTaskRef("giraffe"),
 		// Do not reduce this timeout. Taskrun e2e test is also verifying
 		// if reconcile is triggered from timeout handler and not by pod informers
 		tb.TaskRunTimeout(30*time.Second)))); err != nil {
@@ -169,10 +169,10 @@ func TestPipelineTaskTimeout(t *testing.T) {
 	defer tearDown(t, c, namespace)
 
 	t.Logf("Creating Tasks in namespace %s", namespace)
-	task1 := tb.Task("success", namespace, tb.TaskSpec(
+	task1 := tb.Task("success", tb.TaskSpec(
 		tb.Step("busybox", tb.StepCommand("sleep"), tb.StepArgs("1s"))))
 
-	task2 := tb.Task("timeout", namespace, tb.TaskSpec(
+	task2 := tb.Task("timeout", tb.TaskSpec(
 		tb.Step("busybox", tb.StepCommand("sleep"), tb.StepArgs("10s"))))
 
 	if _, err := c.TaskClient.Create(task1); err != nil {
@@ -182,14 +182,14 @@ func TestPipelineTaskTimeout(t *testing.T) {
 		t.Fatalf("Failed to create Task `%s`: %s", task2.Name, err)
 	}
 
-	pipeline := tb.Pipeline("pipelinetasktimeout", namespace,
+	pipeline := tb.Pipeline("pipelinetasktimeout",
 		tb.PipelineSpec(
 			tb.PipelineTask("pipelinetask1", task1.Name, tb.PipelineTaskTimeout(60*time.Second)),
 			tb.PipelineTask("pipelinetask2", task2.Name, tb.PipelineTaskTimeout(5*time.Second)),
 		),
 	)
 
-	pipelineRun := tb.PipelineRun("prtasktimeout", namespace, tb.PipelineRunSpec(pipeline.Name))
+	pipelineRun := tb.PipelineRun("prtasktimeout", tb.PipelineRunSpec(pipeline.Name))
 
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)

--- a/test/v1alpha1/wait_test.go
+++ b/test/v1alpha1/wait_test.go
@@ -40,9 +40,11 @@ var (
 func TestWaitForTaskRunStateSucceed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{
-			tb.TaskRun("foo", waitNamespace, tb.TaskRunStatus(
-				tb.StatusCondition(success),
-			)),
+			tb.TaskRun("foo",
+				tb.TaskRunNamespace(waitNamespace),
+				tb.TaskRunStatus(
+					tb.StatusCondition(success),
+				)),
 		},
 	}
 	c, cancel := fakeClients(t, d)
@@ -55,9 +57,11 @@ func TestWaitForTaskRunStateSucceed(t *testing.T) {
 func TestWaitForTaskRunStateFailed(t *testing.T) {
 	d := Data{
 		TaskRuns: []*v1alpha1.TaskRun{
-			tb.TaskRun("foo", waitNamespace, tb.TaskRunStatus(
-				tb.StatusCondition(failure),
-			)),
+			tb.TaskRun("foo",
+				tb.TaskRunNamespace(waitNamespace),
+				tb.TaskRunStatus(
+					tb.StatusCondition(failure),
+				)),
 		},
 	}
 	c, cancel := fakeClients(t, d)
@@ -71,7 +75,7 @@ func TestWaitForTaskRunStateFailed(t *testing.T) {
 func TestWaitForPipelineRunStateSucceed(t *testing.T) {
 	d := Data{
 		PipelineRuns: []*v1alpha1.PipelineRun{
-			tb.PipelineRun("bar", waitNamespace, tb.PipelineRunStatus(
+			tb.PipelineRun("bar", tb.PipelineRunNamespace(waitNamespace), tb.PipelineRunStatus(
 				tb.PipelineRunStatusCondition(success),
 			)),
 		},
@@ -87,7 +91,7 @@ func TestWaitForPipelineRunStateSucceed(t *testing.T) {
 func TestWaitForPipelineRunStateFailed(t *testing.T) {
 	d := Data{
 		PipelineRuns: []*v1alpha1.PipelineRun{
-			tb.PipelineRun("bar", waitNamespace, tb.PipelineRunStatus(
+			tb.PipelineRun("bar", tb.PipelineRunNamespace(waitNamespace), tb.PipelineRunStatus(
 				tb.PipelineRunStatusCondition(failure),
 			)),
 		},

--- a/test/v1alpha1/workingdir_test.go
+++ b/test/v1alpha1/workingdir_test.go
@@ -40,7 +40,7 @@ func TestWorkingDirCreated(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(wdTaskName, namespace, tb.TaskSpec(
+	task := tb.Task(wdTaskName, tb.TaskSpec(
 		tb.Step("ubuntu", tb.StepWorkingDir("/workspace/HELLOMOTO"), tb.StepArgs("-c", "echo YES")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
@@ -48,7 +48,7 @@ func TestWorkingDirCreated(t *testing.T) {
 	}
 
 	t.Logf("Creating TaskRun  namespace %s", namespace)
-	taskRun := tb.TaskRun(wdTaskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(wdTaskRunName, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(wdTaskName), tb.TaskRunServiceAccountName("default"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
@@ -94,7 +94,7 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(wdTaskName, namespace, tb.TaskSpec(
+	task := tb.Task(wdTaskName, tb.TaskSpec(
 		tb.Step("ubuntu", tb.StepWorkingDir("/HELLOMOTO"), tb.StepArgs("-c", "echo YES")),
 	))
 	if _, err := c.TaskClient.Create(task); err != nil {
@@ -102,7 +102,7 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 	}
 
 	t.Logf("Creating TaskRun  namespace %s", namespace)
-	taskRun := tb.TaskRun(wdTaskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(wdTaskRunName, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(wdTaskName), tb.TaskRunServiceAccountName("default"),
 	))
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {

--- a/test/v1alpha1/workspace_test.go
+++ b/test/v1alpha1/workspace_test.go
@@ -38,7 +38,7 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(taskName, namespace, tb.TaskSpec(
+	task := tb.Task(taskName, tb.TaskSpec(
 		tb.Step("alpine", tb.StepScript("echo foo > /workspace/test/file")),
 		tb.TaskWorkspace("test", "test workspace", "/workspace/test", true),
 	))
@@ -46,7 +46,7 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	taskRun := tb.TaskRun(taskRunName, namespace, tb.TaskRunSpec(
+	taskRun := tb.TaskRun(taskRunName, tb.TaskRunSpec(
 		tb.TaskRunTaskRef(taskName), tb.TaskRunServiceAccountName("default"),
 		tb.TaskRunWorkspaceEmptyDir("test", ""),
 	))
@@ -95,7 +95,7 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(taskName, namespace, tb.TaskSpec(
+	task := tb.Task(taskName, tb.TaskSpec(
 		tb.Step("alpine", tb.StepScript("cat /workspace/test/file")),
 		tb.TaskWorkspace("test", "test workspace", "/workspace/test/file", true),
 	))
@@ -103,7 +103,7 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	pipeline := tb.Pipeline(pipelineName, namespace, tb.PipelineSpec(
+	pipeline := tb.Pipeline(pipelineName, tb.PipelineSpec(
 		tb.PipelineWorkspaceDeclaration("foo"),
 		tb.PipelineTask("task1", taskName, tb.PipelineTaskWorkspaceBinding("test", "foo")),
 	))
@@ -111,7 +111,7 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
-	pipelineRun := tb.PipelineRun(pipelineRunName, namespace,
+	pipelineRun := tb.PipelineRun(pipelineRunName,
 		tb.PipelineRunSpec(
 			pipelineName,
 			// These are the duplicated workspace entries that are being tested.
@@ -136,7 +136,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 	defer tearDown(t, c, namespace)
 
-	task := tb.Task(taskName, namespace, tb.TaskSpec(
+	task := tb.Task(taskName, tb.TaskSpec(
 		tb.Step("alpine", tb.StepScript("cat /workspace/test/file")),
 		tb.TaskWorkspace("test", "test workspace", "/workspace/test/file", true),
 	))
@@ -144,7 +144,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
 
-	pipeline := tb.Pipeline(pipelineName, namespace, tb.PipelineSpec(
+	pipeline := tb.Pipeline(pipelineName, tb.PipelineSpec(
 		tb.PipelineWorkspaceDeclaration("foo"),
 		tb.PipelineTask("task1", taskName, tb.PipelineTaskWorkspaceBinding("test", "foo")),
 	))
@@ -152,7 +152,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create Pipeline: %s", err)
 	}
 
-	pipelineRun := tb.PipelineRun(pipelineRunName, namespace,
+	pipelineRun := tb.PipelineRun(pipelineRunName,
 		tb.PipelineRunSpec(
 			pipelineName,
 		),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes issue #1824 test/builder namespace args unnecessary

In e2e tests, clients returned from setup(t) are only able to create resources in the namespace created by setup(t).
Attempting to create resources in other namespaces results in an error.
Test builders like tb.Task, tb.TaskRun, etc., were taking a namespace arg that, for e2e tests, must be the namespace value returned from setup(t).

tb.Task et al do not require a namespace arg, and instead use the default one.
e2e tests will create resources in the test's namespace by default.
If a test does care to specify its namespace, it can use a TaskOp (or like) to specify it: tb.Task("my-task", tb.TaskNamespace("my-namespace"))

This makes tests clearer by not forcing the use or an argument, which does not bring anything most of the time.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

