### PR TITLE
Try to make path usage less confusing 🛣️

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -196,13 +196,13 @@ spec:
     - name: pathToDockerFile
       type: string
       description: The path to the dockerfile to build
-      default: /workspace/docker-source/Dockerfile
+      default: $(resources.inputs.docker-source.path)/Dockerfile
     - name: pathToContext
       type: string
       description: |
         The build context used by Kaniko
         (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
-      default: /workspace/docker-source
+      default: $(resources.inputs.docker-source.path)
   resources:
     inputs:
       - name: docker-source
@@ -275,7 +275,7 @@ spec:
     - name: pathToDockerFile
       value: Dockerfile
     - name: pathToContext
-      value: /workspace/docker-source/examples/microservices/leeroy-web #configure: may change according to your source
+      value: $(resources.inputs.docker-source.path)/examples/microservices/leeroy-web #configure: may change according to your source
   resources:
     inputs:
       - name: docker-source

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -64,7 +64,7 @@ spec:
     env:
     - name: GOPATH
       value: /workspace/go
-    workingDir: /workspace/go/src/github.com/GoogleContainerTools/skaffold
+    workingDir: $(resources.inputs.workspace.path)
     command:
     - echo
     args:
@@ -78,13 +78,13 @@ spec:
   params:
   - name: pathToDockerFile
     description: The path to the dockerfile to build
-    default: /workspace/workspace/Dockerfile
+    default: $(resources.inputs.docker-source.path)/Dockerfile
   - name: pathToContext
     description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
-    default: /workspace/workspace
+    default: $(resources.inputs.docker-source.path)
   resources:
     inputs:
-    - name: workspace
+    - name: docker-source
       type: git
     outputs:
     - name: builtImage
@@ -177,10 +177,10 @@ spec:
     - name: pathToDockerFile
       value: Dockerfile
     - name: pathToContext
-      value: /workspace/workspace/examples/microservices/leeroy-web
+      value: $(resources.inputs.docker-source.path)/examples/microservices/leeroy-web
     resources:
       inputs:
-      - name: workspace
+      - name: docker-source
         resource: source-repo
       outputs:
       - name: builtImage
@@ -193,10 +193,10 @@ spec:
     - name: pathToDockerFile
       value: Dockerfile
     - name: pathToContext
-      value: /workspace/workspace/examples/microservices/leeroy-app
+      value: $(resources.inputs.docker-source.path)/examples/microservices/leeroy-app
     resources:
       inputs:
-      - name: workspace
+      - name: docker-source
         resource: source-repo
       outputs:
       - name: builtImage
@@ -214,7 +214,7 @@ spec:
         - build-skaffold-app
     params:
     - name: path
-      value: /workspace/workspace/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+      value: $(resources.inputs.workspace.path)/examples/microservices/leeroy-app/kubernetes/deployment.yaml
     - name: yqArg
       value: "-d1"
     - name: yamlPathToImage
@@ -232,7 +232,7 @@ spec:
         - build-skaffold-web
     params:
     - name: path
-      value: /workspace/workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+      value: $(resources.inputs.workspace.path)/examples/microservices/leeroy-web/kubernetes/deployment.yaml
     - name: yqArg
       value: "-d1"
     - name: yamlPathToImage


### PR DESCRIPTION
# Changes

In #2408 it was confusing how the the path to the resource input worked
in the tutorial. I think this can be slightly improved by using variable
interpolation to get the path so the author of the Tasks etc. doesn't
have to worry as much about exactly where on disk it is.

I thought about updating the v1alpha1 example as well but I'm assuming
we'll be getting rid of those once we merge #2410 so it didn't seem
worth it. Plus there are other examples that probably could be updated
but I feel like a small improvement is better than none at all :D

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).