### PR TITLE
Split reconcile into prepare and reconcile

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -64,6 +64,10 @@ const (
 	// config error of container
 	ReasonCreateContainerConfigError = "CreateContainerConfigError"
 
+	// ReasonPodCreationFailed indicates that the reason for the current condition
+	// is that the creation of the pod backing the TaskRun failed
+	ReasonPodCreationFailed = "PodCreationFailed"
+
 	// ReasonSucceeded indicates that the reason for the finished status is that all of the steps
 	// completed successfully
 	ReasonSucceeded = "Succeeded"

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -119,7 +119,7 @@ var (
 // converge the two. It then updates the Status block of the Pipeline Run
 // resource with the current status of the resource.
 func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
-	c.Logger.Infof("Reconciling %v", time.Now())
+	c.Logger.Infof("Reconciling key %s at %v", key, time.Now())
 
 	// Convert the namespace/name string into a distinct namespace and name
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -97,7 +97,13 @@ func NewBase(opt Options, controllerAgentName string, images pipeline.Images) *B
 	if recorder == nil {
 		// Create event broadcaster
 		logger.Debug("Creating event broadcaster")
-		eventBroadcaster := record.NewBroadcaster()
+
+		correlatorOptions := record.CorrelatorOptions{
+			// The default burst size is 25
+			BurstSize: 50,
+			QPS:       1,
+		}
+		eventBroadcaster := record.NewBroadcasterWithCorrelatorOptions(correlatorOptions)
 		eventBroadcaster.StartLogging(logger.Named("event-broadcaster").Infof)
 		eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: opt.KubeClientSet.CoreV1().Events("")})
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -568,12 +568,14 @@ func TestReconcile(t *testing.T) {
 		PipelineResources: []*v1alpha1.PipelineResource{gitResource, anotherGitResource, imageResource},
 	}
 	for _, tc := range []struct {
-		name    string
-		taskRun *v1alpha1.TaskRun
-		wantPod *corev1.Pod
+		name       string
+		taskRun    *v1alpha1.TaskRun
+		wantPod    *corev1.Pod
+		wantEvents int
 	}{{
-		name:    "success",
-		taskRun: taskRunSuccess,
+		name:       "success",
+		taskRun:    taskRunSuccess,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-run-success-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -611,8 +613,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "serviceaccount",
-		taskRun: taskRunWithSaSuccess,
+		name:       "serviceaccount",
+		taskRun:    taskRunWithSaSuccess,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-with-sa-run-success-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -651,8 +654,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "params",
-		taskRun: taskRunSubstitution,
+		name:       "params",
+		taskRun:    taskRunSubstitution,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-substitution-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -733,8 +737,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "taskrun-with-taskspec",
-		taskRun: taskRunWithTaskSpec,
+		name:       "taskrun-with-taskspec",
+		taskRun:    taskRunWithTaskSpec,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-with-taskspec-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -790,8 +795,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "success-with-cluster-task",
-		taskRun: taskRunWithClusterTask,
+		name:       "success-with-cluster-task",
+		taskRun:    taskRunWithClusterTask,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-with-cluster-task-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -829,8 +835,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "taskrun-with-resource-spec-task-spec",
-		taskRun: taskRunWithResourceSpecAndTaskSpec,
+		name:       "taskrun-with-resource-spec-task-spec",
+		taskRun:    taskRunWithResourceSpecAndTaskSpec,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-with-resource-spec-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -885,8 +892,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "taskrun-with-pod",
-		taskRun: taskRunWithPod,
+		name:       "taskrun-with-pod",
+		taskRun:    taskRunWithPod,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-with-pod-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -923,8 +931,9 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "taskrun-with-credentials-variable-default-tekton-home",
-		taskRun: taskRunWithCredentialsVariable,
+		name:       "taskrun-with-credentials-variable-default-tekton-home",
+		taskRun:    taskRunWithCredentialsVariable,
+		wantEvents: 1,
 		wantPod: tb.Pod("test-taskrun-with-credentials-variable-pod-9l9zj",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
@@ -1023,6 +1032,17 @@ func TestReconcile(t *testing.T) {
 			}
 			if len(clients.Kube.Actions()) == 0 {
 				t.Fatalf("Expected actions to be logged in the kubeclient, got none")
+			}
+
+			actions := clients.Kube.Actions()
+			var eventCount = 0
+			for _, action := range actions {
+				if action.GetVerb() == "create" && action.GetResource().Resource == "events" {
+					eventCount++
+				}
+			}
+			if d := cmp.Diff(tc.wantEvents, eventCount); d != "" {
+				t.Errorf("Event count does not match (-want, +got): %s. ", d)
 			}
 		})
 	}
@@ -1178,7 +1198,7 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 		taskRun: noTaskRun,
 		reason:  podconvert.ReasonFailedResolution,
 	}, {
-		name:    "task run with no task",
+		name:    "task run with wrong ref",
 		taskRun: withWrongRef,
 		reason:  podconvert.ReasonFailedResolution,
 	}}
@@ -1190,16 +1210,22 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 			c := testAssets.Controller
 			clients := testAssets.Clients
 			err := c.Reconciler.Reconcile(context.Background(), getRunName(tc.taskRun))
+			// Events are sent in a goroutine, let's sleep a bit to make sure they're
+			// captured by the fake client-go action list
+			time.Sleep(100 * time.Millisecond)
 			// When a TaskRun is invalid and can't run, we don't want to return an error because
 			// an error will tell the Reconciler to keep trying to reconcile; instead we want to stop
 			// and forget about the Run.
 			if err != nil {
 				t.Errorf("Did not expect to see error when reconciling invalid TaskRun but saw %q", err)
 			}
-			if len(clients.Kube.Actions()) != 1 ||
-				clients.Kube.Actions()[0].GetVerb() != "list" ||
-				clients.Kube.Actions()[0].GetResource().Resource != "namespaces" {
-				t.Errorf("expected only one action (list namespaces) created by the reconciler, got %+v", clients.Kube.Actions())
+			actions := clients.Kube.Actions()
+			if len(actions) != 2 ||
+				actions[0].GetVerb() != "list" ||
+				actions[0].GetResource().Resource != "namespaces" ||
+				actions[1].GetVerb() != "create" ||
+				actions[1].GetResource().Resource != "events" {
+				t.Errorf("expected two actions (list namespaces + event) created by the reconciler, got %+v", actions)
 			}
 			// Since the TaskRun is invalid, the status should say it has failed
 			condition := tc.taskRun.Status.GetCondition(apis.ConditionSucceeded)
@@ -1235,7 +1261,7 @@ func TestReconcilePodFetchError(t *testing.T) {
 	})
 
 	if err := c.Reconciler.Reconcile(context.Background(), getRunName(taskRun)); err == nil {
-		t.Fatal("expected error when reconciling a Task for which we couldn't get the corresponding Build Pod but got nil")
+		t.Fatal("expected error when reconciling a Task for which we couldn't get the corresponding Pod but got nil")
 	}
 }
 

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -178,7 +178,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				t.Fatalf("Failed to collect matching events: %q", err)
 			}
 			if len(events) != expectedNumberOfEvents {
-				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", expectedNumberOfEvents, len(events), events)
+				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of received events : %#v", expectedNumberOfEvents, len(events), events)
 			}
 		})
 	}

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -102,7 +102,7 @@ func tearDown(t *testing.T, cs *clients, namespace string) {
 		}
 	}
 
-	if os.Getenv("TEST_KEEP_NAMESPACES") == "" {
+	if os.Getenv("TEST_KEEP_NAMESPACES") == "" && !t.Failed() {
 		t.Logf("Deleting namespace %s", namespace)
 		if err := cs.KubeClient.Kube.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{}); err != nil {
 			t.Errorf("Failed to delete namespace %s: %s", namespace, err)

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -265,7 +265,14 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to collect matching events: %q", err)
 			}
 			if len(events) != td.expectedNumberOfEvents {
-				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", td.expectedNumberOfEvents, len(events), events)
+				collectedEvents := ""
+				for i, event := range events {
+					collectedEvents += fmt.Sprintf("%#v", event)
+					if i < (len(events) - 1) {
+						collectedEvents += ", "
+					}
+				}
+				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", td.expectedNumberOfEvents, len(events), collectedEvents)
 			}
 
 			// Wait for up to 10 minutes and restart every second to check if

--- a/test/v1alpha1/pipelinerun_test.go
+++ b/test/v1alpha1/pipelinerun_test.go
@@ -204,7 +204,14 @@ func TestPipelineRun(t *testing.T) {
 				t.Fatalf("Failed to collect matching events: %q", err)
 			}
 			if len(events) != td.expectedNumberOfEvents {
-				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", td.expectedNumberOfEvents, len(events), events)
+				collectedEvents := ""
+				for i, event := range events {
+					collectedEvents += fmt.Sprintf("%#v", event)
+					if i < (len(events) - 1) {
+						collectedEvents += ", "
+					}
+				}
+				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", td.expectedNumberOfEvents, len(events), collectedEvents)
 			}
 
 			// Wait for up to 10 minutes and restart every second to check if


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The current "reconcile" function does a lot of things, which means
it's hard to test properly, it's hard to follow the logic and
it's hard to handle all possible errors and events properly.

This splits reconcile into two parts, the first one that deals
preparing and validating the taskrun and all the resources it
depends on, the second one that actually reconciles the TaskRun
by creating the pod if required and updating the TaskRun from
the pod.

This adds events that were missing for error situation that
happens during preparation and validation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [WIP] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The TaskRun controller now emits events also when error occurs during the validation of the TaskRun or the resources it depends on.
```
