### PR TITLE
Add Signal Forwarding to Entrypoint Runner

### DIFF
--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"os/exec"
+	"os/signal"
+	"syscall"
 
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
 )
@@ -11,22 +13,52 @@ import (
 // stdout/stderr are collected -- needs e2e tests.
 
 // realRunner actually runs commands.
-type realRunner struct{}
+type realRunner struct {
+	signals chan os.Signal
+}
 
 var _ entrypoint.Runner = (*realRunner)(nil)
 
-func (*realRunner) Run(args ...string) error {
+func (rr *realRunner) Run(args ...string) error {
 	if len(args) == 0 {
 		return nil
 	}
 	name, args := args[0], args[1:]
 
+	// Receive system signals on "rr.signals"
+	if rr.signals == nil {
+		rr.signals = make(chan os.Signal, 1)
+	}
+	defer close(rr.signals)
+	signal.Notify(rr.signals)
+	defer signal.Reset()
+
 	cmd := exec.Command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	// dedicated PID group used to forward signals to
+	// main process and all children
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
-	if err := cmd.Run(); err != nil {
+	// Start defined command
+	if err := cmd.Start(); err != nil {
 		return err
 	}
+
+	// Goroutine for signals forwarding
+	go func() {
+		for s := range rr.signals {
+			// Forward signal to main process and all children
+			if s != syscall.SIGCHLD {
+				_ = syscall.Kill(-cmd.Process.Pid, s.(syscall.Signal))
+			}
+		}
+	}()
+
+	// Wait for command to exit
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// TestRealRunnerSignalForwarding will artificially put an interrupt signal (SIGINT) in the rr.signals chan.
+// The chan will not be reinitialized in the runner considering we have already initialized it here.
+// Once the sleep process starts, if the signal is successfully received by the parent process, it
+// will interrupt and stop the sleep command.
+func TestRealRunnerSignalForwarding(t *testing.T) {
+	rr := realRunner{}
+	rr.signals = make(chan os.Signal, 1)
+	rr.signals <- syscall.SIGINT
+	if err := rr.Run("sleep", "3600"); err.Error() == "signal: interrupt" {
+		t.Logf("SIGINT forwarded to Entrypoint")
+	} else {
+		t.Fatalf("Unexpected error received: %v", err)
+	}
+}


### PR DESCRIPTION
The Entrypoint process should be notified and signals
received should be propogated as necessary. This signal
forwarding mimics the one in
https://github.com/pablo-ruth/go-init which is an golang
implementation of https://github.com/Yelp/dumb-init .

The cmd.Run() has also been replaced with a cmd.Start()
and cmd.Wait() to systematically start the command
and Wait for it's completion without prematurely exiting.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The Entrypoint process is now notified for signals and the same are propogated using a dedicated PID Group of the Entrypoint process.
```
