### PR TITLE
Run tekton containers as nonroot

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,12 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
+  # These base images run as root, which is needed for how they handle SSH credentials.
+  # They are produced from ./images/Dockerfile
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
-  github.com/tektoncd/pipeline/cmd/entrypoint: busybox  # image must have `cp` in $PATH
+
+  # GCS fetcher needs root due to workspace permissions
+  github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher: gcr.io/distroless/static:latest
+
+  # Our entrypoint image does not need root, it simply needs to be able to 'cp' the binary into a shared location.
+  github.com/tektoncd/pipeline/cmd/entrypoint: gcr.io/distroless/base:debug-nonroot

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -56,8 +56,11 @@ spec:
 
           # These images are pulled from Dockerhub, by digest, as of April 15, 2020.
           "-nop-image", "tianon/true@sha256:009cce421096698832595ce039aa13fa44327d96beedb84282a69d3dbcf5a81b",
-          "-shell-image", "busybox@sha256:a2490cec4484ee6c1068ba3a05f89934010c85242f736280b35343483b2264b6",
           "-gsutil-image", "google/cloud-sdk@sha256:6e8676464c7581b2dc824956b112a61c95e4144642bec035e6db38e3384cae2e",
+
+          # The shell image must be root in order to create directories and copy files to PVCs.
+          # As of April 17, 2020
+          "-shell-image", "gcr.io/distroless/base:debug@sha256:dac57423f6d9210198e1ac25de9f6d48753196a112aa2deb22f54e984cfd462d",
         ]
         volumeMounts:
         - name: config-logging


### PR DESCRIPTION
This changes a slew of containers that Tekton runs to use non-root base images.

I was hoping to use Tekton's CI to verify what blows up from this, but I am now realizing I'm not an org member, so someone is going to need to `/ok-to-test` this.

cc @bobcatfish @dlorenc @ImJasonH @vdemeester How do I ascend to such prestige? 🙏 


Release notes:
```release-notes
Switch many of the Tekton images (e.g. controllers) to non-root by default.
```