### PR TITLE
WIP - implementing finally at the pipeline level 🤞🏼💥😱

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -21,6 +21,7 @@ weight: 3
   - [Configuring execution results at the `Pipeline` level](#configuring-execution-results-at-the-pipeline-level)
   - [Configuring the `Task` execution order](#configuring-the-task-execution-order)
   - [Adding a description](#adding-a-description)
+  - [Adding `Finally` to the `Pipeline`](#adding-finally-to-the-pipeline)
   - [Code examples](#code-examples)
 
 ## Overview
@@ -515,6 +516,203 @@ In particular:
 ## Adding a description
 
 The `description` field is an optional field and can be used to provide description of the `Pipeline`.
+
+## Adding `Finally` to the `Pipeline`
+
+You can specify a list of one or more final tasks under `finally` section. Final tasks are guaranteed to be executed
+after all `PipelineTasks` under `tasks` have completed regardless of success or error. Final tasks are very similar to
+`PipelineTasks` under `tasks` section and follow the same syntax. Each final task must have a
+[valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) `name` and a `taskRef` or
+`taskSpec`. For example:
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+  finally:
+    - name: cleanup-test
+      taskRef:
+        Name: cleanup
+```
+
+### Specifying `Resources` in Final Tasks
+
+Similar to `tasks`, you can use [PipelineResources](#specifying-resources) as inputs and outputs for
+final tasks in the Pipeline. The only difference here is, final tasks with an input resource can have a `from` clause
+but that resource has to rely on output of a `PipelineTask` from `tasks` section. For example:
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+      resources:
+        inputs:
+          - name: source
+            resource: tektoncd-pipeline-repo
+        outputs:
+          - name: workspace
+            resource: my-repo
+  finally:
+    - name: clear-workspace
+      taskRef:
+        Name: clear-workspace
+      resources:
+        inputs:
+          - name: workspace
+            resource: my-repo
+            from:
+              - tests
+```
+
+### Specifying `Workspaces` in Final Tasks
+
+It is possible that the final tasks might require access to the same workspaces which `PipelineTasks` might have utilized
+e.g. a mount point for credentials held in Secrets. To support that requirement, you can specify one or more
+`Workspaces` in the `workspaces` field for the final tasks similar to `tasks`.
+
+```yaml
+spec:
+  resources:
+    - name: app-git
+      type: git
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone-app-source
+      taskRef:
+        name: clone-app-repo-to-workspace
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+      resources:
+        inputs:
+          - name: app-git
+            resource: app-git
+  finally:
+    - name: cleanup-workspace
+      taskRef:
+        name: cleanup-workspace
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+```
+
+### Specifying `Parameters` in Final Tasks
+
+Again, similar to `tasks`, you can specify [`Parameters`](tasks.md#specifying-parameters):
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+  finally:
+    - name: report-results
+      taskRef:
+        Name: report-results
+      params:
+        - name: url
+          value: $(params.url)
+```
+
+### Cannot configure the Final Task execution order
+
+It's not possible to configure or modify the execution order of the final tasks. Unlike `Tasks` in a `Pipeline`,
+all final tasks run simultaneously and starts executing once all `PipelineTasks` under `tasks` have settled which means
+no `runAfter` can be specified in final tasks.
+
+### Cannot specify execution `Conditions` in Final Tasks
+
+`Tasks` in a `Pipeline` can be configured to run only if some conditions are satisfied using `conditions`. But the
+final tasks are guaranteed to be executed after all `PipelineTasks` therefore no `conditions` can be specified in
+final tasks.
+
+### `PipelineRun` Status with `finally`
+
+With `finally`, `PipelineRun` status is calculated based on `PipelineTasks` under `tasks` section and final tasks.
+
+Without `finally`:
+
+| `PipelineTasks` under `tasks` | `PipelineRun` status | Reason |
+| ----------------------------- | -------------------- | ------ |
+| all `PipelineTasks` successful | `true` | `Succeeded` |
+| one or more `PipelineTasks` skipped and rest successful | `true` | `Completed` |
+| single failure of `PipelineTask` | `false` | `failed` |
+
+With `finally`:
+
+| `PipelineTasks` under `tasks` | Final Tasks | `PipelineRun` status | Reason |
+| ----------------------------- | ----------- | -------------------- | ------ |
+| all `PipelineTask` successful | all final tasks successful | `true` | `Succeeded` |
+| all `PipelineTask` successful | one or more failure of final tasks | `false` | `Failed` |
+| one or more `PipelineTask` skipped and rest successful | all final tasks successful | `true` | `Completed` |
+| one or more `PipelineTask` skipped and rest successful | one or more failure of final tasks | `false` | `Failed` |
+| single failure of `PipelineTask` | all final tasks successful | `false` | `failed` |
+| single failure of `PipelineTask` | one or more failure of final tasks | `false` | `failed` |
+
+### Known Limitations
+
+#### Cannot configure `Task` execution results with `finally`
+
+Final tasks can not be configured to consume `Results` of `PipelineTask` from `tasks` section i.e. the following
+example is not supported right now but we are working on adding support for the same.
+
+```yaml
+spec:
+  tasks:
+    - name: count-comments-before
+      taskRef:
+        Name: count-comments
+    - name: add-comment
+      taskRef:
+        Name: add-comment
+    - name: count-comments-after
+      taskRef:
+        Name: count-comments
+  finally:
+    - name: check-count
+      taskRef:
+        Name: check-count
+      params:
+        - name: before-count
+          value: $(tasks.count-comments-before.results.count)
+        - name: after-count
+          value: $(tasks.count-comments-after.results.count)
+```
+
+In this example, container logs for `check-count` might have something like this: 
+
+```
+/tekton/scripts/script-0-zsg5v: 3: tasks.sum-inputs.results.sum-result: not found
+/tekton/scripts/script-0-2g2dr: 3: tasks.count-comments-before.results.count: not found
+```
+
+#### Cannot configure `Pipeline` result with `finally`
+
+Final tasks can emit `Results` but results emitted from the final tasks can not be configured in the
+[Pipeline Results](#configuring-execution-results-at-the-pipeline-level). We are working on adding support for this.
+
+```yaml
+  results:
+    - name: comment-count-validate
+      value: $(finally.check-count.results.comment-count-validate)
+```
+
+In this example, `PipelineResults` is set to:
+
+```
+"pipelineResults": [
+  {
+    "name": "comment-count-validate",
+    "value": "$(finally.check-count.results.comment-count-validate)"
+  }
+],
+```
 
 ## Code examples
 

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -1,0 +1,149 @@
+# Task producing success by exiting with 0
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: successful-task
+spec:
+  steps:
+    - name: success
+      image: ubuntu
+      script: |
+        exit 0
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-with-final-tasks
+spec:
+  tasks:
+    - name: pre-work
+      taskRef:
+        Name: successful-task
+    - name: unit-test
+      taskRef:
+        Name: successful-task
+      runAfter:
+        - pre-work
+    - name: integration-test
+      taskRef:
+        Name: successful-task
+      runAfter:
+        - unit-test
+  finally:
+    - name: cleanup-test
+      taskRef:
+        Name: successful-task
+    - name: report-results
+      taskRef:
+        Name: successful-task
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-final-tasks
+spec:
+  pipelineRef:
+    name: pipeline-with-final-tasks
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-workspace
+spec:
+  resources:
+    requests:
+      storage: 16Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: clone-app-repo-to-workspace
+spec:
+  workspaces:
+    - name: shared-workspace
+  resources:
+    inputs:
+      - name: app-git
+        type: git
+        targetPath: application
+  steps:
+    - name: clone-app-repo-to-workspace
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        cp -avr $(resources.inputs.app-git.path)/ $(workspaces.shared-workspace.path)/
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup-workspace
+spec:
+  workspaces:
+    - name: shared-workspace
+  steps:
+    - name: cleanup-workspace
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        rm -rf $(workspaces.shared-workspace.path)/application/
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: clone-into-workspace-and-cleanup-workspace
+spec:
+  resources:
+    - name: app-git
+      type: git
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone-app-source
+      taskRef:
+        name: clone-app-repo-to-workspace
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+      resources:
+        inputs:
+          - name: app-git
+            resource: app-git
+  finally:
+    - name: cleanup-workspace
+      taskRef:
+        name: cleanup-workspace
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: write-and-cleanup-workspace
+spec:
+  pipelineRef:
+    name: clone-into-workspace-and-cleanup-workspace
+  workspaces:
+    - name: shared-workspace
+      persistentVolumeClaim:
+        claimName: shared-workspace
+  resources:
+    - name: app-git
+      resourceSpec:
+        type: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/pipeline.git
+---

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -51,6 +51,14 @@ func (source *PipelineSpec) ConvertTo(ctx context.Context, sink *v1beta1.Pipelin
 			}
 		}
 	}
+	if len(source.Finally) > 0 {
+		sink.Finally = make([]v1beta1.PipelineTask, len(source.Finally))
+		for i := range source.Finally {
+			if err := source.Finally[i].ConvertTo(ctx, &sink.Finally[i]); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -93,6 +101,14 @@ func (sink *PipelineSpec) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 		sink.Tasks = make([]PipelineTask, len(source.Tasks))
 		for i := range source.Tasks {
 			if err := sink.Tasks[i].ConvertFrom(ctx, source.Tasks[i]); err != nil {
+				return err
+			}
+		}
+	}
+	if len(source.Finally) > 0 {
+		sink.Finally = make([]PipelineTask, len(source.Finally))
+		for i := range source.Finally {
+			if err := sink.Finally[i].ConvertFrom(ctx, source.Finally[i]); err != nil {
 				return err
 			}
 		}

--- a/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
@@ -42,4 +42,12 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)
 	}
+	for _, ft := range ps.Finally {
+		if ft.TaskRef.Kind == "" {
+			ft.TaskRef.Kind = NamespacedTaskKind
+		}
+		if ft.TaskSpec != nil {
+			ft.TaskSpec.SetDefaults(ctx)
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -43,6 +43,10 @@ type PipelineSpec struct {
 	// Results are values that this pipeline can output once run
 	// +optional
 	Results []PipelineResult `json:"results,omitempty"`
+	// Finally declares the list of Tasks that execute just before leaving the Pipeline
+	// i.e. either after all Tasks are finished executing successfully
+	// or after a failure which would result in ending the Pipeline
+	Finally []PipelineTask `json:"finally,omitempty"`
 }
 
 // PipelineResult used to describe the results of a pipeline

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion_test.go
@@ -118,6 +118,19 @@ func TestPipelineRunConversion(t *testing.T) {
 						}},
 						RunAfter: []string{"task1"},
 					}},
+					Finally: []PipelineTask{{
+						Name: "finaltask1",
+						TaskRef: &TaskRef{
+							Name: "taskref",
+						},
+					}, {
+						Name: "finaltask2",
+						TaskSpec: &TaskSpec{TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{Container: corev1.Container{
+								Image: "foo",
+							}}},
+						}},
+					}},
 				},
 				ServiceAccountName: "sa",
 				ServiceAccountNames: []PipelineRunSpecServiceAccountName{{

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -471,6 +471,13 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 		*out = make([]v1beta1.PipelineResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.Finally != nil {
+		in, out := &in.Finally, &out.Finally
+		*out = make([]PipelineTask, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -42,4 +42,12 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)
 	}
+	for _, ft := range ps.Finally {
+		if ft.TaskRef.Kind == "" {
+			ft.TaskRef.Kind = NamespacedTaskKind
+		}
+		if ft.TaskSpec != nil {
+			ft.TaskSpec.SetDefaults(ctx)
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -71,6 +71,10 @@ type PipelineSpec struct {
 	// Results are values that this pipeline can output once run
 	// +optional
 	Results []PipelineResult `json:"results,omitempty"`
+	// Finally declares the list of Tasks that execute just before leaving the Pipeline
+	// i.e. either after all Tasks are finished executing successfully
+	// or after a failure which would result in ending the Pipeline
+	Finally []PipelineTask `json:"finally,omitempty"`
 }
 
 // PipelineResult used to describe the results of a pipeline

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -66,6 +66,16 @@ func validateDeclaredResources(ps *PipelineSpec) error {
 			}
 		}
 	}
+	for _, t := range ps.Finally {
+		if t.Resources != nil {
+			for _, input := range t.Resources.Inputs {
+				required = append(required, input.Resource)
+			}
+			for _, output := range t.Resources.Outputs {
+				required = append(required, output.Resource)
+			}
+		}
+	}
 
 	provided := make([]string, 0, len(ps.Resources))
 	for _, resource := range ps.Resources {
@@ -89,7 +99,7 @@ func isOutput(outputs []PipelineTaskOutputResource, resource string) bool {
 
 // validateFrom ensures that the `from` values make sense: that they rely on values from Tasks
 // that ran previously, and that the PipelineResource is actually an output of the Task it should come from.
-func validateFrom(tasks []PipelineTask) error {
+func validateFrom(tasks []PipelineTask, finalTasks []PipelineTask) *apis.FieldError {
 	taskOutputs := map[string][]PipelineTaskOutputResource{}
 	for _, task := range tasks {
 		var to []PipelineTaskOutputResource
@@ -113,10 +123,32 @@ func validateFrom(tasks []PipelineTask) error {
 			for _, pt := range rd.From {
 				outputs, found := taskOutputs[pt]
 				if !found {
-					return fmt.Errorf("expected resource %s to be from task %s, but task %s doesn't exist", rd.Resource, pt, pt)
+					return apis.ErrInvalidValue(fmt.Sprintf("expected resource %s to be from task %s, but task %s doesn't exist", rd.Resource, pt, pt),
+						"spec.tasks.resources.inputs.from")
 				}
 				if !isOutput(outputs, rd.Resource) {
-					return fmt.Errorf("the resource %s from %s must be an output but is an input", rd.Resource, pt)
+					return apis.ErrInvalidValue(fmt.Sprintf("the resource %s from %s must be an output but is an input", rd.Resource, pt),
+						"spec.tasks.resources.inputs.from")
+				}
+			}
+		}
+	}
+	for _, t := range finalTasks {
+		inputResources := []PipelineTaskInputResource{}
+		if t.Resources != nil {
+			inputResources = append(inputResources, t.Resources.Inputs...)
+		}
+
+		for _, rd := range inputResources {
+			for _, pt := range rd.From {
+				outputs, found := taskOutputs[pt]
+				if !found {
+					return apis.ErrInvalidValue(fmt.Sprintf("expected resource %s to be from task %s, but task %s doesn't exist under spec.tasks", rd.Resource, pt, pt),
+						"spec.finally.resources.inputs.from")
+				}
+				if !isOutput(outputs, rd.Resource) {
+					return apis.ErrInvalidValue(fmt.Sprintf("the resource %s from %s must be an output but is an input", rd.Resource, pt),
+						"spec.finally.resources.inputs.from")
 				}
 			}
 		}
@@ -141,45 +173,13 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 		return apis.ErrGeneric("expected at least one, got none", "spec.description", "spec.params", "spec.resources", "spec.tasks", "spec.workspaces")
 	}
 
-	// Names cannot be duplicated
-	taskNames := map[string]struct{}{}
-	for i, t := range ps.Tasks {
-		if errs := validation.IsDNS1123Label(t.Name); len(errs) > 0 {
-			return &apis.FieldError{
-				Message: fmt.Sprintf("invalid value %q", t.Name),
-				Paths:   []string{fmt.Sprintf("spec.tasks[%d].name", i)},
-				Details: "Pipeline Task name must be a valid DNS Label. For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-			}
-		}
-		// can't have both taskRef and taskSpec at the same time
-		if (t.TaskRef != nil && t.TaskRef.Name != "") && t.TaskSpec != nil {
-			return apis.ErrMultipleOneOf(fmt.Sprintf("spec.tasks[%d].taskRef", i), fmt.Sprintf("spec.tasks[%d].taskSpec", i))
-		}
-		// Check that one of TaskRef and TaskSpec is present
-		if (t.TaskRef == nil || (t.TaskRef != nil && t.TaskRef.Name == "")) && t.TaskSpec == nil {
-			return apis.ErrMissingOneOf(fmt.Sprintf("spec.tasks[%d].taskRef", i), fmt.Sprintf("spec.tasks[%d].taskSpec", i))
-		}
-		// Validate TaskSpec if it's present
-		if t.TaskSpec != nil {
-			if err := t.TaskSpec.Validate(ctx); err != nil {
-				return err
-			}
-		}
-		if t.TaskRef != nil && t.TaskRef.Name != "" {
-			// Task names are appended to the container name, which must exist and
-			// must be a valid k8s name
-			if errSlice := validation.IsQualifiedName(t.Name); len(errSlice) != 0 {
-				return apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf("spec.tasks[%d].name", i))
-			}
-			// TaskRef name must be a valid k8s name
-			if errSlice := validation.IsQualifiedName(t.TaskRef.Name); len(errSlice) != 0 {
-				return apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf("spec.tasks[%d].taskRef.name", i))
-			}
-			if _, ok := taskNames[t.Name]; ok {
-				return apis.ErrMultipleOneOf(fmt.Sprintf("spec.tasks[%d].name", i))
-			}
-			taskNames[t.Name] = struct{}{}
-		}
+	if err := validateFinalTasks(ps); err != nil {
+		return err
+	}
+
+	// PipelineTask must have a valid unique label, at least one of taskRef or taskSpec should be specified
+	if err := validatePipelineTasks(ctx, ps.Tasks, ps.Finally); err != nil {
+		return err
 	}
 
 	// All declared resources should be used, and the Pipeline shouldn't try to use any resources
@@ -189,8 +189,8 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	// The from values should make sense
-	if err := validateFrom(ps.Tasks); err != nil {
-		return apis.ErrInvalidValue(err.Error(), "spec.tasks.resources.inputs.from")
+	if err := validateFrom(ps.Tasks, ps.Finally); err != nil {
+		return err
 	}
 
 	// Validate the pipeline task graph
@@ -207,8 +207,12 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 		return err
 	}
 
+	if err := validatePipelineParameterVariables(ps.Finally, ps.Params); err != nil {
+		return err
+	}
+
 	// Validate the pipeline's workspaces.
-	if err := validatePipelineWorkspaces(ps.Workspaces, ps.Tasks); err != nil {
+	if err := validatePipelineWorkspaces(ps.Workspaces, ps.Tasks, ps.Finally); err != nil {
 		return err
 	}
 
@@ -220,7 +224,85 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
-func validatePipelineWorkspaces(wss []WorkspacePipelineDeclaration, pts []PipelineTask) *apis.FieldError {
+func validateFinalTasks(ps *PipelineSpec) *apis.FieldError {
+	if len(ps.Finally) != 0 && len(ps.Tasks) == 0 {
+		return apis.ErrInvalidValue(fmt.Sprintf("spec.tasks is empty but spec.finally has %d tasks", len(ps.Finally)), "spec.finally")
+	}
+
+	if ps.Finally != nil && len(ps.Finally) == 0 {
+		return apis.ErrInvalidValue("spec.finally is empty", "spec.finally")
+	}
+
+	for _, f := range ps.Finally {
+		if len(f.RunAfter) != 0 {
+			return apis.ErrInvalidValue(fmt.Sprintf("no runAfter allowed under spec.finally, final task %s has runAfter specified", f.Name), "spec.finally")
+		}
+		if len(f.Conditions) != 0 {
+			return apis.ErrInvalidValue(fmt.Sprintf("no conditions allowed under spec.finally, final task %s has conditions specified", f.Name), "spec.finally")
+		}
+	}
+	return nil
+}
+
+func validatePipelineTasks(ctx context.Context, tasks []PipelineTask, finalTasks []PipelineTask) *apis.FieldError {
+	// Names cannot be duplicated
+	taskNames := map[string]struct{}{}
+	var err *apis.FieldError
+	for i, t := range tasks {
+		if err = validatePipelineTaskName(ctx, "spec.tasks", i, t, taskNames); err != nil {
+			return err
+		}
+	}
+	for i, t := range finalTasks {
+		if err = validatePipelineTaskName(ctx, "spec.finally", i, t, taskNames); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePipelineTaskName(ctx context.Context, prefix string, i int, t PipelineTask, taskNames map[string]struct{}) *apis.FieldError {
+	if errs := validation.IsDNS1123Label(t.Name); len(errs) > 0 {
+		return &apis.FieldError{
+			Message: fmt.Sprintf("invalid value %q", t.Name),
+			Paths:   []string{fmt.Sprintf(prefix+"[%d].name", i)},
+			Details: "Pipeline Task name must be a valid DNS Label." +
+				"For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+		}
+	}
+	// can't have both taskRef and taskSpec at the same time
+	if (t.TaskRef != nil && t.TaskRef.Name != "") && t.TaskSpec != nil {
+		return apis.ErrMultipleOneOf(fmt.Sprintf(prefix+"[%d].taskRef", i), fmt.Sprintf(prefix+"[%d].taskSpec", i))
+	}
+	// Check that one of TaskRef and TaskSpec is present
+	if (t.TaskRef == nil || (t.TaskRef != nil && t.TaskRef.Name == "")) && t.TaskSpec == nil {
+		return apis.ErrMissingOneOf(fmt.Sprintf(prefix+"[%d].taskRef", i), fmt.Sprintf(prefix+"[%d].taskSpec", i))
+	}
+	// Validate TaskSpec if it's present
+	if t.TaskSpec != nil {
+		if err := t.TaskSpec.Validate(ctx); err != nil {
+			return err
+		}
+	}
+	if t.TaskRef != nil && t.TaskRef.Name != "" {
+		// Task names are appended to the container name, which must exist and
+		// must be a valid k8s name
+		if errSlice := validation.IsQualifiedName(t.Name); len(errSlice) != 0 {
+			return apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf(prefix+"[%d].name", i))
+		}
+		// TaskRef name must be a valid k8s name
+		if errSlice := validation.IsQualifiedName(t.TaskRef.Name); len(errSlice) != 0 {
+			return apis.ErrInvalidValue(strings.Join(errSlice, ","), fmt.Sprintf(prefix+"[%d].taskRef.name", i))
+		}
+		if _, ok := taskNames[t.Name]; ok {
+			return apis.ErrMultipleOneOf(fmt.Sprintf(prefix+"[%d].name", i))
+		}
+		taskNames[t.Name] = struct{}{}
+	}
+	return nil
+}
+
+func validatePipelineWorkspaces(wss []WorkspacePipelineDeclaration, pts []PipelineTask, finalTasks []PipelineTask) *apis.FieldError {
 	// Workspace names must be non-empty and unique.
 	wsTable := make(map[string]struct{})
 	for i, ws := range wss {
@@ -241,6 +323,16 @@ func validatePipelineWorkspaces(wss []WorkspacePipelineDeclaration, pts []Pipeli
 				return apis.ErrInvalidValue(
 					fmt.Sprintf("pipeline task %q expects workspace with name %q but none exists in pipeline spec", pt.Name, ws.Workspace),
 					fmt.Sprintf("spec.tasks[%d].workspaces[%d]", ptIdx, wsIdx),
+				)
+			}
+		}
+	}
+	for tIdx, t := range finalTasks {
+		for wsIdx, ws := range t.Workspaces {
+			if _, ok := wsTable[ws.Workspace]; !ok {
+				return apis.ErrInvalidValue(
+					fmt.Sprintf("pipeline task %q expects workspace with name %q but none exists in pipeline spec", t.Name, ws.Workspace),
+					fmt.Sprintf("spec.finally[%d].workspaces[%d]", tIdx, wsIdx),
 				)
 			}
 		}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -743,6 +743,211 @@ func TestPipeline_Validate(t *testing.T) {
 			},
 		},
 		failureExpected: false,
+	}, {
+		name: "valid pipeline with one final task",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "non-final-task",
+					TaskSpec: &v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name: "final-task",
+					TaskSpec: &v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+			},
+		},
+		failureExpected: false,
+	}, {
+		name: "invalid pipeline without any non final task but at least one final task",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{}},
+				Finally: []v1beta1.PipelineTask{{
+					Name: "final-task",
+					TaskSpec: &v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "invalid pipeline with empty finally section",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "non-final-task",
+					TaskSpec: &v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+				Finally: []v1beta1.PipelineTask{},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "invalid pipeline with duplicate final tasks",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "non-final-task",
+					TaskSpec: &v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "final-task"},
+				}, {
+					Name:    "final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "final-task"},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "invalid pipeline with final task same as non final task",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name:    "non-final-and-final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name:    "non-final-and-final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "final task missing tasfref and taskspec",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "non-final-task",
+					TaskSpec: &v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name: "final-task",
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "undefined parameter variable in final task",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Params: []v1beta1.ParamSpec{{
+					Name: "foo", Type: v1beta1.ParamTypeString,
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+					Params: []v1beta1.Param{{
+						Name: "final-param", Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "$(params.foo) and $(params.does-not-exist)"},
+					}},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "invalid pipeline with final task specifying runAfter",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name:     "final-task",
+					TaskRef:  &v1beta1.TaskRef{Name: "foo-task"},
+					RunAfter: []string{"non-final-task"},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "invalid pipeline with final task specifying conditions",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+					Conditions: []v1beta1.PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+					}},
+				}},
+			},
+		},
+		failureExpected: true,
+	}, {
+		name: "invalid pipeline with final task output resources referring to other final task input",
+		p: &v1beta1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1beta1.PipelineSpec{
+				Resources: []v1beta1.PipelineDeclaredResource{{
+					Name: "great-resource", Type: v1beta1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1beta1.PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+				}},
+				Finally: []v1beta1.PipelineTask{{
+					Name:    "final-task-1",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+					Resources: &v1beta1.PipelineTaskResources{
+						Inputs: []v1beta1.PipelineTaskInputResource{{
+							Name: "final-input-1", Resource: "great-resource",
+						}},
+						Outputs: []v1beta1.PipelineTaskOutputResource{{
+							Name: "final-output-2", Resource: "great-resource",
+						}},
+					},
+				}, {
+					Name:    "final-task-2",
+					TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+					Resources: &v1beta1.PipelineTaskResources{
+						Inputs: []v1beta1.PipelineTaskInputResource{{
+							Name: "final-input-2", Resource: "great-resource", From: []string{"final-task-1"},
+						}},
+					},
+				}},
+			},
+		},
+		failureExpected: true,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -758,6 +758,13 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 		*out = make([]PipelineResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.Finally != nil {
+		in, out := &in.Finally, &out.Finally
+		*out = make([]PipelineTask, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1211,7 +1211,7 @@ func TestResolvePipelineRun(t *testing.T) {
 	getClusterTask := func(name string) (v1alpha1.TaskInterface, error) { return nil, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
 
-	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, providedResources)
+	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, []v1alpha1.PipelineTask{}, providedResources)
 	if err != nil {
 		t.Fatalf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 	}
@@ -1290,7 +1290,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, providedResources)
+	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, providedResources)
 	if err != nil {
 		t.Fatalf("Did not expect error when resolving PipelineRun without Resources: %v", err)
 	}
@@ -1337,7 +1337,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	_, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, providedResources)
+	_, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, providedResources)
 	switch err := err.(type) {
 	case nil:
 		t.Fatalf("Expected error getting non-existent Tasks for Pipeline %s but got none", p.Name)
@@ -1383,7 +1383,7 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 					Name: "pipelinerun",
 				},
 			}
-			_, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, tt.p.Spec.Tasks, providedResources)
+			_, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, tt.p.Spec.Tasks, []v1alpha1.PipelineTask{}, providedResources)
 			if err == nil {
 				t.Fatalf("Expected error when bindings are in incorrect state for Pipeline %s but got none", p.Name)
 			}
@@ -1433,7 +1433,7 @@ func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 	getClusterTask := func(name string) (v1alpha1.TaskInterface, error) { return nil, nil }
 	getTaskRun := func(name string) (*v1alpha1.TaskRun, error) { return nil, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
-	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, providedResources)
+	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, []v1alpha1.PipelineTask{}, providedResources)
 	if err != nil {
 		t.Fatalf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 	}
@@ -1486,7 +1486,7 @@ func TestResolvedPipelineRun_PipelineTaskHasOptionalResources(t *testing.T) {
 	getClusterTask := func(name string) (v1alpha1.TaskInterface, error) { return nil, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
 
-	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, providedResources)
+	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, []v1alpha1.PipelineTask{}, providedResources)
 	if err != nil {
 		t.Fatalf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
 	}
@@ -1589,7 +1589,7 @@ func TestResolveConditionChecks(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, tc.getTaskRun, getClusterTask, getCondition, pts, providedResources)
+			pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, tc.getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, providedResources)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun without Conditions: %v", err)
 			}
@@ -1682,7 +1682,7 @@ func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, tc.getTaskRun, getClusterTask, getCondition, pts, providedResources)
+			pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, tc.getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, providedResources)
 			if err != nil {
 				t.Fatalf("Did not expect error when resolving PipelineRun without Conditions: %v", err)
 			}
@@ -1726,7 +1726,7 @@ func TestResolveConditionChecks_ConditionDoesNotExist(t *testing.T) {
 		},
 	}
 
-	_, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, providedResources)
+	_, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, providedResources)
 
 	switch err := err.(type) {
 	case nil:
@@ -1795,7 +1795,7 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 		},
 	}
 
-	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, providedResources)
+	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, providedResources)
 	if err != nil {
 		t.Fatalf("Did not expect error when resolving PipelineRun without Conditions: %v", err)
 	}
@@ -1871,7 +1871,7 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, tc.providedResources)
+			pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, pts, []v1alpha1.PipelineTask{}, tc.providedResources)
 
 			if tc.wantErr {
 				if err == nil {
@@ -1958,5 +1958,343 @@ func TestIsBeforeFirstTaskRun_WithNotStartedTask(t *testing.T) {
 func TestIsBeforeFirstTaskRun_WithStartedTask(t *testing.T) {
 	if oneStartedState.IsBeforeFirstTaskRun() {
 		t.Fatalf("Expected state to be after first taskrun")
+	}
+}
+
+func TestIsFinalDone(t *testing.T) {
+
+	var finalTaskCancelledByStatusState = PipelineRunState{{
+		FinalPipelineTask: &pts[4], // 2 retries needed
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           withCancelled(makeRetried(trs[0])),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var finalTaskCancelledBySpecState = PipelineRunState{{
+		FinalPipelineTask: &pts[4],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           withCancelledBySpec(makeRetried(trs[0])),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var finalTaskRunningState = PipelineRunState{{
+		FinalPipelineTask: &pts[4],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           makeStarted(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var finalTaskSucceededState = PipelineRunState{{
+		FinalPipelineTask: &pts[4],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           makeSucceeded(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var finalTaskRetriedState = PipelineRunState{{
+		FinalPipelineTask: &pts[3], // 1 retry needed
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           withCancelled(makeRetried(trs[0])),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var finalTaskExpectedState = PipelineRunState{{
+		FinalPipelineTask: &pts[4], // 2 retries needed
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           withRetries(makeFailed(trs[0])),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var noPipelineTaskState = PipelineRunState{{
+		FinalPipelineTask: nil,
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           withRetries(makeFailed(trs[0])),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var noTaskRunState = PipelineRunState{{
+		FinalPipelineTask: &pts[4], // 2 retries needed
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	tcs := []struct {
+		name       string
+		state      PipelineRunState
+		expected   bool
+		ptExpected []bool
+	}{{
+		name:       "final-task-cancelled-no-candidates",
+		state:      finalTaskCancelledByStatusState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "final-task-cancelled-bySpec-no-candidates",
+		state:      finalTaskCancelledBySpecState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "final-task-running-no-candidates",
+		state:      finalTaskRunningState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "final-task-succeeded-bySpec-no-candidates",
+		state:      finalTaskSucceededState,
+		expected:   true,
+		ptExpected: []bool{true},
+	}, {
+		name:       "final-task-retried-no-candidates",
+		state:      finalTaskRetriedState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "final-task-retried-one-candidates",
+		state:      finalTaskExpectedState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "no-final-pipelineTask",
+		state:      noPipelineTaskState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}, {
+		name:       "No-final-taskrun",
+		state:      noTaskRunState,
+		expected:   false,
+		ptExpected: []bool{false},
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+
+			isDone := tc.state.IsFinalTasksDone()
+			if d := cmp.Diff(isDone, tc.expected); d != "" {
+				t.Errorf("Didn't get expected IsDone: %v", d)
+			}
+			for i, pt := range tc.state {
+				isDone = pt.IsFinalTaskDone()
+				if d := cmp.Diff(isDone, tc.ptExpected[i]); d != "" {
+					t.Errorf("Didn't get expected (ResolvedPipelineRunTask) IsDone: %v", d)
+				}
+
+			}
+		})
+	}
+}
+
+func TestGetPipelineFinalTasksConditionStatus(t *testing.T) {
+
+	var taskRetriedState = PipelineRunState{{
+		FinalPipelineTask: &pts[3], // 1 retry needed
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           withCancelled(makeRetried(trs[0])),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var noneStartedState = PipelineRunState{{
+		FinalPipelineTask: &pts[0],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		FinalPipelineTask: &pts[1],
+		TaskRunName:       "pipelinerun-finaltask2",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var oneStartedState = PipelineRunState{{
+		FinalPipelineTask: &pts[0],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           makeStarted(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		FinalPipelineTask: &pts[1],
+		TaskRunName:       "pipelinerun-finaltask2",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var oneFinishedState = PipelineRunState{{
+		FinalPipelineTask: &pts[0],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           makeSucceeded(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		FinalPipelineTask: &pts[1],
+		TaskRunName:       "pipelinerun-finaltask2",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var oneFailedState = PipelineRunState{{
+		FinalPipelineTask: &pts[0],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           makeFailed(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		FinalPipelineTask: &pts[1],
+		TaskRunName:       "pipelinerun-finaltask2",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var allFinishedState = PipelineRunState{{
+		FinalPipelineTask: &pts[0],
+		TaskRunName:       "pipelinerun-finaltask1",
+		TaskRun:           makeSucceeded(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		FinalPipelineTask: &pts[1],
+		TaskRunName:       "pipelinerun-finaltask2",
+		TaskRun:           makeSucceeded(trs[0]),
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	tcs := []struct {
+		name           string
+		state          []*ResolvedPipelineRunTask
+		expectedStatus corev1.ConditionStatus
+	}{{
+		name:           "no-final-tasks-started",
+		state:          noneStartedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "one-task-started",
+		state:          oneStartedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "one-task-finished",
+		state:          oneFinishedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "one-task-failed",
+		state:          oneFailedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}, {
+		name:           "all-finished",
+		state:          allFinishedState,
+		expectedStatus: corev1.ConditionTrue,
+	}, {
+		name:           "one-retry-needed",
+		state:          taskRetriedState,
+		expectedStatus: corev1.ConditionUnknown,
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := tb.PipelineRun("somepipelinerun")
+			c := GetPipelineFinalTasksConditionStatus(pr, tc.state, zap.NewNop().Sugar())
+			if c.Status != tc.expectedStatus {
+				t.Fatalf("Expected to get status %s but got %s for state %v", tc.expectedStatus, c.Status, tc.state)
+			}
+		})
+	}
+}
+
+func TestResolvePipelineRunWithFinally(t *testing.T) {
+	names.TestingSeed()
+
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
+		tb.PipelineDeclaredResource("git-resource", "git"),
+		tb.PipelineTask("mytask1", "task"),
+		tb.PipelineTask("mytask2", "task"),
+		tb.FinalPipelineTask("finaltask1", "",
+			tb.PipelineTaskSpec(&v1alpha1.TaskSpec{TaskSpec: v1beta1.TaskSpec{
+				Steps: []v1alpha1.Step{{Container: corev1.Container{
+					Name: "step1",
+				}}},
+			}})),
+	))
+
+	providedResources := map[string]*v1alpha1.PipelineResource{}
+	pr := v1alpha1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipelinerun",
+		},
+	}
+	getTask := func(name string) (v1alpha1.TaskInterface, error) { return task, nil }
+	getTaskRun := func(name string) (*v1alpha1.TaskRun, error) { return nil, nil }
+	getClusterTask := func(name string) (v1alpha1.TaskInterface, error) { return nil, nil }
+	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
+
+	pipelineState, err := ResolvePipelineRun(context.Background(), pr, getTask, getTaskRun, getClusterTask, getCondition, p.Spec.Tasks, p.Spec.Finally, providedResources)
+	if err != nil {
+		t.Fatalf("Error getting tasks for fake pipeline %s: %s", p.ObjectMeta.Name, err)
+	}
+
+	expectedState := PipelineRunState{{
+		PipelineTask: &p.Spec.Tasks[0],
+		TaskRunName:  "pipelinerun-mytask1-9l9zj",
+		TaskRun:      nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskName: "task",
+			TaskSpec: &task.Spec,
+			Inputs:   map[string]*v1alpha1.PipelineResource{},
+			Outputs:  map[string]*v1alpha1.PipelineResource{},
+		},
+	}, {
+		PipelineTask: &p.Spec.Tasks[1],
+		TaskRunName:  "pipelinerun-mytask2-mz4c7",
+		TaskRun:      nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskName: "task",
+			TaskSpec: &task.Spec,
+			Inputs:   map[string]*v1alpha1.PipelineResource{},
+			Outputs:  map[string]*v1alpha1.PipelineResource{},
+		},
+	}, {
+		FinalPipelineTask: &p.Spec.Finally[0],
+		TaskRunName:       "pipelinerun-finaltask1-mssqb",
+		TaskRun:           nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskName: "",
+			TaskSpec: &task.Spec,
+			Inputs:   map[string]*v1alpha1.PipelineResource{},
+			Outputs:  map[string]*v1alpha1.PipelineResource{},
+		},
+	}}
+
+	if d := cmp.Diff(expectedState, pipelineState, cmpopts.IgnoreUnexported(v1alpha1.TaskRunSpec{})); d != "" {
+		t.Errorf("Expected to get current pipeline state %v, but actual differed (-want, +got): %s", expectedState, d)
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -122,20 +122,21 @@ func removeDup(refs ResolvedResultRefs) ResolvedResultRefs {
 // convertParamsToResultRefs converts all params of the resolved pipeline run task
 func convertParamsToResultRefs(pipelineRunState PipelineRunState, target *ResolvedPipelineRunTask) (ResolvedResultRefs, error) {
 	var resolvedParams ResolvedResultRefs
-	for _, condition := range target.PipelineTask.Conditions {
-		condRefs, err := convertParams(condition.Params, pipelineRunState, condition.ConditionRef)
+	if target.PipelineTask != nil {
+		for _, condition := range target.PipelineTask.Conditions {
+			condRefs, err := convertParams(condition.Params, pipelineRunState, condition.ConditionRef)
+			if err != nil {
+				return nil, err
+			}
+			resolvedParams = append(resolvedParams, condRefs...)
+		}
+
+		taskParamsRefs, err := convertParams(target.PipelineTask.Params, pipelineRunState, target.PipelineTask.Name)
 		if err != nil {
 			return nil, err
 		}
-		resolvedParams = append(resolvedParams, condRefs...)
+		resolvedParams = append(resolvedParams, taskParamsRefs...)
 	}
-
-	taskParamsRefs, err := convertParams(target.PipelineTask.Params, pipelineRunState, target.PipelineTask.Name)
-	if err != nil {
-		return nil, err
-	}
-	resolvedParams = append(resolvedParams, taskParamsRefs...)
-
 	return resolvedParams, nil
 }
 

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -159,6 +159,25 @@ func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
 	}
 }
 
+// FinalPipelineTask adds a PipelineTask, with specified name and task name, to the PipelineSpec.
+// Any number of PipelineTask modifier can be passed to transform it.
+func FinalPipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
+	return func(ps *v1alpha1.PipelineSpec) {
+		pTask := &v1alpha1.PipelineTask{
+			Name: name,
+		}
+		if taskName != "" {
+			pTask.TaskRef = &v1alpha1.TaskRef{
+				Name: taskName,
+			}
+		}
+		for _, op := range ops {
+			op(pTask)
+		}
+		ps.Finally = append(ps.Finally, *pTask)
+	}
+}
+
 func PipelineResult(name, value, description string, ops ...PipelineOp) PipelineSpecOp {
 	return func(ps *v1alpha1.PipelineSpec) {
 		pResult := &v1beta1.PipelineResult{

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -1,0 +1,353 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	knativetest "knative.dev/pkg/test"
+)
+
+// Pipeline results in failure since non-final task fails but final tasks does get executed
+func TestPipelineLevelFinallyWhenOneNonFinalTaskFailed(t *testing.T) {
+	c, namespace := setup(t)
+
+	taskName := "nonfinaltask"
+	finalTaskName := "finaltask"
+	pipelineName := "pipeline-with-failed-nonfinal-tasks"
+	pipelineRunName := "pipelinerun-with-failed-nonfinal-tasks"
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	task := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 1",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create non final Task: %s", err)
+	}
+
+	finalTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: finalTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name:    "nonfinaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: taskName},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name:    "finaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: finalTaskName},
+			}},
+		},
+	}
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: pipelineName},
+		},
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRunName, err)
+	}
+
+	if err := WaitForPipelineRunState(c, pipelineRunName, timeout, PipelineRunFailed(pipelineRunName), "PipelineRunFailed"); err != nil {
+		t.Fatalf("Waiting for PipelineRun %s to fail: %v", pipelineRunName, err)
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+	}
+
+	// verify non final task failed and final task executed and succeeded
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, pipelineRunName+"-"+finalTaskName):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have succedded", n)
+			}
+		case strings.HasPrefix(n, pipelineRunName+"-"+taskName):
+			if !isFailed(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for non final task should have failed", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and nonfinal tasks")
+		}
+	}
+}
+
+// Pipeline exits with success even if final task execution fails
+func TestPipelineLevelFinallyWhenOneFinalTaskFailed(t *testing.T) {
+	c, namespace := setup(t)
+
+	taskName := "nonfinaltask"
+	finalTaskName := "finaltask"
+	pipelineName := "pipeline-with-failed-final-tasks"
+	pipelineRunName := "pipelinerun-with-failed-final-tasks"
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	task := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create non final Task: %s", err)
+	}
+
+	finalTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: finalTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 1",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name:    "nonfinaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: taskName},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name:    "finaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: finalTaskName},
+			}},
+		},
+	}
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: pipelineName},
+		},
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRunName, err)
+	}
+
+	if err := WaitForPipelineRunState(c, pipelineRunName, timeout, PipelineRunFailed(pipelineRunName), "PipelineRunFailed"); err != nil {
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRunName, err)
+		t.Fatalf("PipelineRun execution failed")
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+	}
+
+	// verify non final task succeeded and final task failed
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, pipelineRunName+"-"+finalTaskName):
+			if !isFailed(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have failed", n)
+			}
+		case strings.HasPrefix(n, pipelineRunName+"-"+taskName):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for non final task should have succedded", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and nonfinal tasks")
+		}
+	}
+}
+
+// The non-final task is skipped due to condition failure, final tasks should still be executed
+func TestPipelineLevelFinallyWhenNonFinalTaskSkipped(t *testing.T) {
+	c, namespace := setup(t)
+
+	taskName := "nonfinaltask"
+	finalTaskName := "finaltask"
+	pipelineName := "pipeline-with-skipped-nonfinal-tasks"
+	pipelineRunName := "pipelinerun-with-skipped-nonfinal-tasks"
+	condName := "failedcondition"
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	cond := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{Name: condName, Namespace: namespace},
+		Spec: v1alpha1.ConditionSpec{
+			Check: v1alpha1.Step{
+				Container: corev1.Container{Image: "ubuntu"},
+				Script:    "exit 1",
+			},
+		},
+	}
+	if _, err := c.ConditionClient.Create(cond); err != nil {
+		t.Fatalf("Failed to create Condition `%s`: %s", cond1Name, err)
+	}
+
+	task := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create non final Task: %s", err)
+	}
+
+	finalTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: finalTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name:    "nonfinaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: taskName},
+				Conditions: []v1beta1.PipelineTaskCondition{{
+					ConditionRef: condName,
+				}},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name:    "finaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: finalTaskName},
+			}},
+		},
+	}
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: pipelineName},
+		},
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRunName, err)
+	}
+
+	if err := WaitForPipelineRunState(c, pipelineRunName, timeout, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted"); err != nil {
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRunName, err)
+		t.Fatalf("PipelineRun execution failed")
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+	}
+
+	// verify non final task skipped but final task executed and succeeded
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, pipelineRunName+"-"+finalTaskName):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have succeeded", n)
+			}
+		case strings.HasPrefix(n, pipelineRunName+"-"+taskName):
+			if !isSkipped(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for non final task should have skipped due to condition failure", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and nonfinal tasks")
+		}
+	}
+}
+
+func isSuccessful(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
+	for _, c := range conds {
+		if c.Type == apis.ConditionSucceeded {
+			if c.Status != corev1.ConditionTrue {
+				t.Errorf("TaskRun status %q is not succeeded, got %q", taskRunName, c.Status)
+			}
+			return true
+		}
+	}
+	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
+	return false
+}
+
+func isSkipped(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
+	for _, c := range conds {
+		if c.Type == apis.ConditionSucceeded {
+			if c.Status != corev1.ConditionFalse && c.Reason != resources.ReasonConditionCheckFailed {
+				t.Errorf("TaskRun status %q is not skipped due to condition failure, got %q", taskRunName, c.Status)
+			}
+			return true
+		}
+	}
+	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
+	return false
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We can now specify a list of tasks that needs to be executed just before
pipeline exits (either after finishing all non-final tasks successfully or after
a single failure)

Most common final tasks could be (1) report test results, (2) cleanup cluster resources, etc

```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: pipeline-with-final-tasks
spec:
  tasks:
    - name: pre-work
      taskRef:
        Name: some-pre-work
    - name: unit-test
      taskRef:
        Name: run-unit-test
      runAfter:
        - pre-work
    - name: integration-test
      taskRef:
        Name: run-integration-test
      runAfter:
        - unit-test
  finally:
    - name: cleanup-test
      taskRef:
        Name: cleanup-cluster
    - name: report-results
      taskRef:
        Name: report-test-results
```

Design doc: https://docs.google.com/document/d/1lxpYQHppiWOxsn4arqbwAFDo4T0-LCqpNa6p-TJdHrw/edit#

Part of https://github.com/tektoncd/pipeline/issues/1684
Fixes https://github.com/tektoncd/pipeline/issues/2446

Depends on: https://github.com/tektoncd/pipeline/pull/2504

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Users can now specify Tasks within a Pipeline that will always execute, even if Tasks fail, via the new `finally` clause
```
