### PR TITLE
Dereference the TaskSpec into TaskRun.Status.

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -316,9 +316,9 @@ If multiple `Steps` are defined in the `Task` invoked by the `TaskRun`, you can 
 status in the `steps.results` field using the following command, where `<name>` is the name of the target
 `TaskRun`:
 
-```
-kubectl get taskrun <name>
-```
+The exact Task Spec used to instantiate the TaskRun is also included in the Status for full auditability.
+
+### Steps
 
 The corresponding statuses appear in the `status.steps` list in the order in which the `Steps` have been
 specified in the `Task` definition.

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20200214144324-88be01311a71 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0
-	google.golang.org/api v0.15.0
+	google.golang.org/api v0.15.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.3 // indirect

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -177,6 +177,9 @@ type TaskRunStatusFields struct {
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.
 	Sidecars []SidecarState `json:"sidecars,omitempty"`
+
+	// TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.
+	TaskSpec *TaskSpec `json:"taskSpec,omitempty"`
 }
 
 // TaskRunResult used to describe the results of a task

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1481,6 +1481,11 @@ func (in *TaskRunStatusFields) DeepCopyInto(out *TaskRunStatusFields) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.TaskSpec != nil {
+		in, out := &in.TaskSpec, &out.TaskSpec
+		*out = new(TaskSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -181,4 +181,8 @@ func TestTaskRunStatus(t *testing.T) {
 	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
 		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
 	}
+
+	if d := cmp.Diff(taskrun.Status.TaskSpec, &task.Spec); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
 }


### PR DESCRIPTION
# Changes

The Task definition used for a TaskRun can change after the TaskRun
has started. This poses problems for auditability post-run. Rather
than chase down every part of a Task that we might like to audit later,
let's just add the entire thing here.

This is a replacement for https://github.com/tektoncd/pipeline/pull/2399

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The TaskRun.Status now contains a TaskSpec field, including the full dereferenced Task used to instantiate the run.
```
