### PR TITLE
Correct unavailable link in pipeliines.md

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -41,7 +41,7 @@ A `Pipeline` definition supports the following fields:
     `Pipeline` object. For example, a `name`.
   - [`spec`][kubernetes-overview] - Specifies the configuration information for
     this `Pipeline` object. This must include: 
-    - [`tasks`](#pipeline-tasks) - Specifies the `Tasks` that comprise the `Pipeline`
+    - [`tasks`](#adding-tasks-to-the-pipeline) - Specifies the `Tasks` that comprise the `Pipeline`
       and the details of their execution.
 - Optional:
   - [`resources`](#specifying-resources) - **alpha only** Specifies
@@ -54,10 +54,10 @@ A `Pipeline` definition supports the following fields:
         should execute after one or more other `Tasks` without output linking.
       - [`retries`](#using-the-retries-parameter) - Specifies the number of times to retry the
         execution of a `Task` after a failure. Does not apply to execution cancellations.
-      - [`conditions`](#specifying-conditions) - Specifies `Conditions` that only allow a `Task`
+      - [`conditions`](#specifying-execution-conditions) - Specifies `Conditions` that only allow a `Task`
         to execute if they evaluate to `true`.
       - [`timeout`](#configuring-the-failure-timeout) - Specifies the timeout before a `Task` fails. 
-  - [`results`](#pipeline-results) - Specifies the file to which the `Pipeline` writes its execution results.
+  - [`results`](#monitoring-execution-results-1) - Specifies the file to which the `Pipeline` writes its execution results.
   - [`description`](#adding-a-description) - Holds an informative description of the `Pipeline` object.
 
 [kubernetes-overview]:
@@ -337,7 +337,7 @@ tasks:
 In this example, `my-condition` refers to a [Condition](conditions.md) custom resource. The `build-push`
 task will only be executed if the condition evaluates to true.
 
-Resources in conditions can also use the [`from`](#from) field to indicate that they
+Resources in conditions can also use the [`from`](#using-the-from-parameter) field to indicate that they
 expect the output of a previous task as input. As with regular Pipeline Tasks, using `from`
 implies ordering --  if task has a condition that takes in an output resource from
 another task, the task producing the output resource will run first:
@@ -369,7 +369,7 @@ of the `TaskRun` that executes that `Task` within the `PipelineRun` that execute
 The `Timeout` value is a `duration` conforming to Go's [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration)
 format. For example, valid values are `1h30m`, `1h`, `1m`, and `60s`. 
 
-**Note:** If you do not specify a `Timeout` value, Tekton instead honors the timeout for the [`PipelineRun`](PipelineRun.md#syntax).
+**Note:** If you do not specify a `Timeout` value, Tekton instead honors the timeout for the [`PipelineRun`](pipelineruns.md#syntax).
 
 In the example below, the `build-the-image` `Task` is configured to time out after 90 seconds:
 


### PR DESCRIPTION
Fix several disabled link.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
