### PR TITLE
Allow omitting metadata in volumeclaimtemplate

### DIFF
--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package volumeclaim
 
 import (
@@ -74,5 +90,8 @@ func getPersistentVolumeClaims(workspaceBindings []v1alpha1.WorkspaceBinding, ow
 // GetPersistentVolumeClaimName gets the name of PersistentVolumeClaim for a Workspace and PipelineRun or TaskRun. claim
 // must be a PersistentVolumeClaim from set's VolumeClaims template.
 func GetPersistentVolumeClaimName(claim *corev1.PersistentVolumeClaim, wb v1alpha1.WorkspaceBinding, owner metav1.OwnerReference) string {
+	if claim.Name == "" {
+		return fmt.Sprintf("%s-%s", wb.Name, owner.Name)
+	}
 	return fmt.Sprintf("%s-%s-%s", claim.Name, wb.Name, owner.Name)
 }


### PR DESCRIPTION
# Changes

Workspaces can be backed by a PVC that is created from a user provied template, e.g.

    workspaces:
    - name: ws
      volumeClaimTemplate:
        metadata:
          name: ws-pvc
        spec:
          accessModes: ["ReadWriteOnce"]
          resources:
             requests:
                storage: 1Gi

 but this might fail if the user did not provide a `metadata.name` on the
 template, since the PVC name would be `-<ws-name>-<run-name>` and names
 starting with a `-` is not allowed for PVCs.

 This commits omit the first `-` in the PVC name, if the user did not
 provide a name or metadata part of the volumeclaimtemplate.

Now this is a valid template:

    workspaces:
    - name: ws
      volumeClaimTemplate:
        spec:
          accessModes: ["ReadWriteOnce"]
          resources:
             requests:
                storage: 1Gi

 I also added license banners to the two pvc-related go files.

 Fixes #2450 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

