### PR TITLE
Find first error step based on "FinishAt" and "StartAt"

### DIFF
--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -29,6 +29,11 @@ import (
 	"go.uber.org/zap"
 )
 
+//RFC3339 with millisecond
+const (
+	timeFormat = "2006-01-02T15:04:05.000Z07:00"
+)
+
 // Entrypointer holds fields for running commands with redirected
 // entrypoints.
 type Entrypointer struct {
@@ -98,7 +103,7 @@ func (e Entrypointer) Go() error {
 			e.WritePostFile(e.PostFile, err)
 			output = append(output, v1alpha1.PipelineResourceResult{
 				Key:   "StartedAt",
-				Value: time.Now().Format(time.RFC3339),
+				Value: time.Now().Format(timeFormat),
 			})
 
 			return err
@@ -110,7 +115,7 @@ func (e Entrypointer) Go() error {
 	}
 	output = append(output, v1alpha1.PipelineResourceResult{
 		Key:   "StartedAt",
-		Value: time.Now().Format(time.RFC3339),
+		Value: time.Now().Format(timeFormat),
 	})
 
 	err := e.Runner.Run(e.Args...)

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -70,6 +70,9 @@ const (
 
 	// ReasonFailed indicates that the reason for the failure status is unknown or that one of the steps failed
 	ReasonFailed = "Failed"
+
+	//timeFormat is RFC3339 with millisecond
+	timeFormat = "2006-01-02T15:04:05.000Z07:00"
 )
 
 const oomKilled = "OOMKilled"
@@ -164,7 +167,7 @@ func updateStatusStartTime(s *corev1.ContainerStatus) error {
 	}
 	for index, result := range r {
 		if result.Key == "StartedAt" {
-			t, err := time.Parse(time.RFC3339, result.Value)
+			t, err := time.Parse(timeFormat, result.Value)
 			if err != nil {
 				return fmt.Errorf("could not parse time value %q in StartedAt field: %w", result.Value, err)
 			}
@@ -264,12 +267,18 @@ func areStepsComplete(pod *corev1.Pod) bool {
 
 func sortContainerStatuses(podInstance *corev1.Pod) {
 	sort.Slice(podInstance.Status.ContainerStatuses, func(i, j int) bool {
-		var ifinish, jfinish time.Time
+		var ifinish, istart, jfinish, jstart time.Time
 		if term := podInstance.Status.ContainerStatuses[i].State.Terminated; term != nil {
 			ifinish = term.FinishedAt.Time
+			istart = term.StartedAt.Time
 		}
 		if term := podInstance.Status.ContainerStatuses[j].State.Terminated; term != nil {
 			jfinish = term.FinishedAt.Time
+			jstart = term.StartedAt.Time
+		}
+
+		if ifinish.Equal(jfinish) {
+			return istart.Before(jstart)
 		}
 		return ifinish.Before(jfinish)
 	})


### PR DESCRIPTION
Fix issue: #2415

Introduce `StartAt` for the sorting when `FinishedAt` are exactly the same.
Since the goal is to find the first failed step, the StartAt and FinishedAt are most simple and directly solution.
Moreover, adopt a higher resolution format for `StartAt` to make it more accurately.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

