### PR TITLE
Re-add tekton.dev/task label to taskruns from ClusterTasks

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -54,7 +54,8 @@ The following labels are added to resources automatically:
   references.
 - `tekton.dev/clusterTask` is added to `TaskRuns` (and propagated to `Pods`) that
   reference an existing `ClusterTask`and contains the name of the `ClusterTask` 
-  that the `TaskRun` references.
+  that the `TaskRun` references. For backwards compatibility, `TaskRuns` that
+  reference a `ClusterTask` will also receive `tekton.dev/task`.
 - `tekton.dev/taskRun` is added to `Pods`, and contains the name of the
   `TaskRun` that created the `Pod`.
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -224,10 +224,9 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1alpha1.TaskRun) error 
 		tr.ObjectMeta.Labels[key] = value
 	}
 	if tr.Spec.TaskRef != nil {
+		tr.ObjectMeta.Labels[pipeline.GroupName+pipeline.TaskLabelKey] = taskMeta.Name
 		if tr.Spec.TaskRef.Kind == "ClusterTask" {
 			tr.ObjectMeta.Labels[pipeline.GroupName+pipeline.ClusterTaskLabelKey] = taskMeta.Name
-		} else {
-			tr.ObjectMeta.Labels[pipeline.GroupName+pipeline.TaskLabelKey] = taskMeta.Name
 		}
 	}
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -795,6 +795,7 @@ func TestReconcile(t *testing.T) {
 		wantPod: tb.Pod("test-taskrun-with-cluster-task-pod-abcde",
 			tb.PodNamespace("foo"),
 			tb.PodAnnotation(podconvert.ReleaseAnnotation, podconvert.ReleaseAnnotationValue),
+			tb.PodLabel(taskNameLabelKey, "test-cluster-task"),
 			tb.PodLabel(clusterTaskNameLabelKey, "test-cluster-task"),
 			tb.PodLabel(taskRunNameLabelKey, "test-taskrun-with-cluster-task"),
 			tb.PodLabel("app.kubernetes.io/managed-by", "tekton-pipelines"),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In #2390 `TaskRuns` referencing `ClusterTasks` had their label changed from `tekton.dev/task=<Name>` to `tekton.dev/clusterTask=<Name>`. This is a backwards-incompatible change for teams relying on that original taskrun label. In an API Working Group call yesterday there was general agreement that we should cover these labels as part of [Tekton Pipeline's API Compatibility Policy](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md).

This commit adds both labels to `TaskRuns` referencing `ClusterTasks`. We can then deprecate the `tekton.dev/task=` label on these `TaskRuns` in line with [the API Compatibility Policy](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Keep tekton.dev/task label in addition to tekton.dev/clusterTask on taskruns of clustertask for backwards compatibility.
```
