### PR TITLE
Add propagated labels to API Compatibility Policy

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -16,6 +16,7 @@ The API is considered to consist of:
 - The structure of the CRDs including the `spec` and `status` sections, as well as:
   - The ordering of the `steps` within the `status`
   - The naming of the `step` containers within the `status`
+  - The labels propagated from `PipelineRuns` to `TaskRuns` and `TaskRuns` to `Pods`.
 - The structure of the [directories created in executing containers by Tekton](docs/tasks.md#reserved-directories)
 - The order that `PipelineResources` declared within a `Task` are applied in
 - The interfaces of the images that are built as part of Tekton Pipelines,


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/2388

During an API Working Group call on Mon Apr 20th folks generally agreed that the labels propagated from PipelineRuns to TaskRuns and TaskRuns to Pods should be considered part of the API Compatibility Policy.

As of v0.11.2 these labels include:

```
tekton.dev/task=<Task Name>
tekton.dev/taskRun=<TaskRun Name>
tekton.dev/pipeline=<Pipeline Name>
tekton.dev/pipelineRun=<PipelineRun Name>
tekton.dev/pipelineTask=<Pipeline Task Name>
tekton.dev/conditionCheck=<Condition Check Name>
```

And starting with v0.12.0 will also include:

```
tekton.dev/clusterTask=<ClusterTask Name>
```

At least one team already relies on these labels as the means to identify resources created during Run execution.  Tagging @skaegi here as he mentioned this during our API WG call.

This PR adds the labels to the list of items that are considered covered by the API compatibility policy.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The API Compatibility Policy was amended to add explicit coverage of the labels added to resources created during PipelineRun and TaskRun execution.
```
