### PR TITLE
PR upload validates comment file extension

### DIFF
--- a/cmd/pullrequest-init/main.go
+++ b/cmd/pullrequest-init/main.go
@@ -26,11 +26,12 @@ import (
 )
 
 var (
-	prURL         = flag.String("url", "", "The url of the pull request to initialize.")
-	path          = flag.String("path", "", "Path of directory under which PR will be copied")
-	mode          = flag.String("mode", "download", "Whether to operate in download or upload mode")
-	provider      = flag.String("provider", "", "The SCM provider to use. Optional")
-	skipTLSVerify = flag.Bool("insecure-skip-tls-verify", false, "Enable skipping TLS certificate verification in the git client. Defaults to false")
+	prURL                     = flag.String("url", "", "The url of the pull request to initialize.")
+	path                      = flag.String("path", "", "Path of directory under which PR will be copied")
+	mode                      = flag.String("mode", "download", "Whether to operate in download or upload mode")
+	provider                  = flag.String("provider", "", "The SCM provider to use. Optional")
+	skipTLSVerify             = flag.Bool("insecure-skip-tls-verify", false, "Enable skipping TLS certificate verification in the git client. Defaults to false")
+	disableStrictJSONComments = flag.Bool("disable-strict-json-comments", false, "Disable strict json parsing for comment files with .json extension")
 )
 
 func main() {
@@ -65,7 +66,7 @@ func main() {
 
 	case "upload":
 		logger.Info("RUNNING UPLOAD!")
-		r, err := pullrequest.FromDisk(*path)
+		r, err := pullrequest.FromDisk(*path, *disableStrictJSONComments)
 		if err != nil {
 			logger.Fatal(err)
 		}

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -506,7 +506,10 @@ References (head and base) describe Git references. They are represented as a
 set of json files.
 
 Comments describe a pull request comment. They are represented as a set of json
-files.
+files. Add a file or modify the `Body` field in an existing json comment file to
+interact with the PR. Files with json extension will be parsed as such.
+The content of any comments file(s) with other/no extensions will be treated as
+body field of the comment.
 
 Other pull request information can be found in `pr.json`. This is a read-only
 resource. Users should use other subresources (labels, comments, etc) to

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource.go
@@ -49,8 +49,9 @@ type Resource struct {
 	// Secrets holds a struct to indicate a field name and corresponding secret name to populate it.
 	Secrets []resourcev1alpha1.SecretParam `json:"secrets"`
 
-	PRImage               string `json:"-"`
-	InsecureSkipTLSVerify bool   `json:"insecure-skip-tls-verify"`
+	PRImage                   string `json:"-"`
+	InsecureSkipTLSVerify     bool   `json:"insecure-skip-tls-verify"`
+	DisableStrictJSONComments bool   `json:"disable-strict-json-comments"`
 }
 
 // NewResource create a new git resource to pass to a Task
@@ -59,11 +60,12 @@ func NewResource(name, prImage string, r *resourcev1alpha1.PipelineResource) (*R
 		return nil, fmt.Errorf("cannot create a PR resource from a %s Pipeline Resource", r.Spec.Type)
 	}
 	prResource := Resource{
-		Name:                  name,
-		Type:                  r.Spec.Type,
-		Secrets:               r.Spec.SecretParams,
-		PRImage:               prImage,
-		InsecureSkipTLSVerify: false,
+		Name:                      name,
+		Type:                      r.Spec.Type,
+		Secrets:                   r.Spec.SecretParams,
+		PRImage:                   prImage,
+		InsecureSkipTLSVerify:     false,
+		DisableStrictJSONComments: false,
 	}
 	for _, param := range r.Spec.Params {
 		switch {
@@ -77,6 +79,12 @@ func NewResource(name, prImage string, r *resourcev1alpha1.PipelineResource) (*R
 				return nil, fmt.Errorf("error occurred converting %q to boolean in Pipeline Resource %s", param.Value, r.Name)
 			}
 			prResource.InsecureSkipTLSVerify = verify
+		case strings.EqualFold(param.Name, "disable-strict-json-comments"):
+			strict, err := strconv.ParseBool(param.Value)
+			if err != nil {
+				return nil, fmt.Errorf("error occurred converting %q to boolean in Pipeline Resource %s", param.Value, r.Name)
+			}
+			prResource.DisableStrictJSONComments = strict
 		}
 	}
 
@@ -101,11 +109,12 @@ func (s *Resource) GetURL() string {
 // Replacements is used for template replacement on a PullRequestResource inside of a Taskrun.
 func (s *Resource) Replacements() map[string]string {
 	return map[string]string{
-		"name":                     s.Name,
-		"type":                     s.Type,
-		"url":                      s.URL,
-		"provider":                 s.Provider,
-		"insecure-skip-tls-verify": strconv.FormatBool(s.InsecureSkipTLSVerify),
+		"name":                         s.Name,
+		"type":                         s.Type,
+		"url":                          s.URL,
+		"provider":                     s.Provider,
+		"insecure-skip-tls-verify":     strconv.FormatBool(s.InsecureSkipTLSVerify),
+		"disable-strict-json-comments": strconv.FormatBool(s.DisableStrictJSONComments),
 	}
 }
 
@@ -130,6 +139,9 @@ func (s *Resource) getSteps(mode string, sourcePath string) []pipelinev1beta1.St
 	}
 	if s.InsecureSkipTLSVerify {
 		args = append(args, "-insecure-skip-tls-verify=true")
+	}
+	if s.DisableStrictJSONComments {
+		args = append(args, "-disable-strict-json-comments=true")
 	}
 
 	evs := []corev1.EnvVar{}

--- a/pkg/pullrequest/api_test.go
+++ b/pkg/pullrequest/api_test.go
@@ -135,7 +135,7 @@ func TestUploadFromDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err = FromDisk(dir)
+	r, err = FromDisk(dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

pullrequest upload now validates the extension of each comment file:
the only valid extensions are none and .json. This allows the upload to
fail if a .json comment file cannot be parsed, rather than posting all
the contents as the comment. Fixes #2168

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Comment files under a PullRequest need to have either:
- no extension: for comment files that contain comment as plain text
- .json extension: for comment files in JSON format
```
