### PR TITLE
Sort and remove duplicate when set "taskrun.status.taskResults"

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -266,7 +266,8 @@ func areStepsComplete(pod *corev1.Pod) bool {
 	return stepsComplete
 }
 
-func sortContainerStatuses(podInstance *corev1.Pod) {
+//SortContainerStatuses sort ContainerStatuses based on "FinishedAt"
+func SortContainerStatuses(podInstance *corev1.Pod) {
 	sort.Slice(podInstance.Status.ContainerStatuses, func(i, j int) bool {
 		var ifinish, jfinish time.Time
 		if term := podInstance.Status.ContainerStatuses[i].State.Terminated; term != nil {
@@ -281,7 +282,7 @@ func sortContainerStatuses(podInstance *corev1.Pod) {
 }
 
 func getFailureMessage(pod *corev1.Pod) string {
-	sortContainerStatuses(pod)
+	SortContainerStatuses(pod)
 	// First, try to surface an error about the actual build step that failed.
 	for _, status := range pod.Status.ContainerStatuses {
 		term := status.State.Terminated

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -910,7 +910,7 @@ func TestSortContainerStatuses(t *testing.T) {
 			},
 		},
 	}
-	sortContainerStatuses(&samplePod)
+	SortContainerStatuses(&samplePod)
 	var gotNames []string
 	for _, status := range samplePod.Status.ContainerStatuses {
 		gotNames = append(gotNames, status.Name)


### PR DESCRIPTION
Fix issue: #2466
1. Sort `pod.containerStatuses` before parse
2. Overwrite older items

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
