### PR TITLE
Fix PipelineTask timeout not correctly set 💦

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -69,6 +69,7 @@ func (source *PipelineTask) ConvertTo(ctx context.Context, sink *v1beta1.Pipelin
 	sink.Resources = source.Resources
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
+	sink.Timeout = source.Timeout
 	return nil
 }
 
@@ -114,5 +115,6 @@ func (sink *PipelineTask) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 	sink.Resources = source.Resources
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
+	sink.Timeout = source.Timeout
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -100,6 +101,7 @@ func TestPipelineConversion(t *testing.T) {
 						Name:      "w1",
 						Workspace: "workspace1",
 					}},
+					Timeout: &metav1.Duration{Duration: 5 * time.Minute},
 				}, {
 					Name: "task2",
 					TaskSpec: &TaskSpec{TaskSpec: v1beta1.TaskSpec{

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -302,7 +302,7 @@ func TestPipelineTaskTimeout(t *testing.T) {
 
 	t.Logf("Waiting for PipelineRun %s with PipelineTask timeout in namespace %s to fail", pipelineRun.Name, namespace)
 	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(resources.ReasonFailed, pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
-		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
+		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
 	t.Logf("Waiting for TaskRun from PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Those were missing during in the conversion code. This means any
Pipeline that defines timeout per tasks ends up with the default one
instead of the one set by the user.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @danielhelfand @sbwsg 

This most likely needs to be in a 0.11.x release :sweat: 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix PipelineTask timeout not taken into account in certain cases
```
