### PR TITLE
Add version labels on CRDs 🏷

### DIFF
--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clustertasks.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   versions:

--- a/config/300-condition.yaml
+++ b/config/300-condition.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: conditions.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   names:

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pipelines.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   versions:

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineruns.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   versions:

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineresources.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   names:

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: tasks.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   versions:

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -16,6 +16,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: taskruns.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: "devel"
+    version: "devel"
 spec:
   group: tekton.dev
   versions:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The main reason is to make it easier for tooling to get the released
version that is serving the CRDs. Adding those to CRDs as there is a
higher chances for users to be able to get/list CRDs that to get/list
deployments on the `tekton-pipelines` namespace (or another one if
used).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @bobcatfish @dibyom @sbwsg @ImJasonH 

(btw, this is what knative does :stuck_out_tongue: too)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add pipleine versions information to the CRDs labels in addition to the deployments
```
