### PR TITLE
taskrun/resources: allow input and output storage resources

### DIFF
--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -283,7 +283,7 @@ func setUp() {
 	}
 }
 
-func TestAddResourceToTask(t *testing.T) {
+func TestAddInputResourceToTask(t *testing.T) {
 	task := &v1alpha1.Task{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "build-from-repo",

--- a/pkg/reconciler/taskrun/resources/input_resources.go
+++ b/pkg/reconciler/taskrun/resources/input_resources.go
@@ -134,7 +134,7 @@ func AddInputResource(
 		taskSpec.Volumes = append(taskSpec.Volumes, GetPVCVolume(pvcName))
 	}
 	if mountSecrets {
-		taskSpec.Volumes = append(taskSpec.Volumes, as.GetSecretsVolumes()...)
+		taskSpec.Volumes = appendNewSecretsVolumes(taskSpec.Volumes, as.GetSecretsVolumes()...)
 	}
 	return taskSpec, nil
 }

--- a/pkg/reconciler/taskrun/resources/output_resource.go
+++ b/pkg/reconciler/taskrun/resources/output_resource.go
@@ -104,7 +104,7 @@ func AddOutputResources(
 				needsPvc = true
 			}
 			taskSpec.Steps = append(taskSpec.Steps, newSteps...)
-			taskSpec.Volumes = append(taskSpec.Volumes, as.GetSecretsVolumes()...)
+			taskSpec.Volumes = appendNewSecretsVolumes(taskSpec.Volumes, as.GetSecretsVolumes()...)
 		}
 
 		// Allow the resource to mutate the task.

--- a/pkg/reconciler/taskrun/resources/volume.go
+++ b/pkg/reconciler/taskrun/resources/volume.go
@@ -29,3 +29,42 @@ func GetPVCVolume(name string) corev1.Volume {
 		},
 	}
 }
+
+// appendNewSecretsVolumes takes a variadic list of secret volumes and a list of volumes, and
+// appends any secret volumes that aren't already present. The secret volumes are volumes whose
+// VolumeSource is set to *corev1.SecretVolumeSource with only the SecretName field filled in.
+// Specifically, they have the following structure as defined by
+// (pkg/apis/resource/v1alpha1/storage.ArtifactBucket).GetSecretsVolumes():
+//
+// corev1.Volume{
+//   Name: fmt.Sprintf("volume-bucket-%s", sec.SecretName),
+//   VolumeSource: corev1.VolumeSource{
+//     Secret: &corev1.SecretVolumeSource{
+//       SecretName: sec.SecretName,
+//     },
+//   },
+// }
+//
+// Any new volumes that don't match this structure are added regardless of whether they are already
+// present in the list of volumes.
+func appendNewSecretsVolumes(vols []corev1.Volume, newVols ...corev1.Volume) []corev1.Volume {
+	for _, newv := range newVols {
+		alreadyExists := false
+		for _, oldv := range vols {
+			if newv.Name != oldv.Name {
+				continue
+			}
+			if oldv.Secret == nil {
+				continue
+			}
+			if oldv.Secret.SecretName == newv.Secret.SecretName {
+				alreadyExists = true
+				break
+			}
+		}
+		if !alreadyExists {
+			vols = append(vols, newv)
+		}
+	}
+	return vols
+}


### PR DESCRIPTION
# Changes

This fixes an issue where a Task that uses a secret for both input and output resources leads to duplicate volumes in the generated Pod. 

This happens because both `resources.AddInputResource()` and `resources.AddOutputResources()` mount the necessary secrets to load artifacts. However, when multiple resources use the same secret the secret volume is added twice and leads to an invalid PodSpec.

This fix extends the work done in https://github.com/tektoncd/pipeline/pull/1370

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
TaskRuns no longer error when using artifact buckets as input and output resources.
```
