### PR TITLE
Support overriding the webhook names in order to support multiple Tekton installations

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -60,6 +60,14 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1beta1.SchemeGroupVersion.WithKind("PipelineRun"): &v1beta1.PipelineRun{},
 }
 
+func defaultEnv(envVar string, defaultValue string) string {
+	envValue := os.Getenv(envVar)
+	if envValue == "" {
+		envValue = defaultValue
+	}
+	return envValue
+}
+
 func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	// Decorate contexts with the current state of the config.
 	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
@@ -68,7 +76,7 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 	return defaulting.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
-		"webhook.pipeline.tekton.dev",
+		defaultEnv("MUTATING_WEBHOOK_NAME", "webhook.pipeline.tekton.dev"),
 
 		// The path on which to serve the webhook.
 		"/defaulting",
@@ -93,7 +101,7 @@ func newValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 	return validation.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
-		"validation.webhook.pipeline.tekton.dev",
+		defaultEnv("VALIDATION_WEBHOOK_NAME", "validation.webhook.pipeline.tekton.dev"),
 
 		// The path on which to serve the webhook.
 		"/resource-validation",
@@ -115,7 +123,7 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 	return configmaps.NewAdmissionController(ctx,
 
 		// Name of the configmap webhook.
-		"config.webhook.pipeline.tekton.dev",
+		defaultEnv("CONFIG_WEBHOOK_NAME", "config.webhook.pipeline.tekton.dev"),
 
 		// The path on which to serve the webhook.
 		"/config-validation",

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -76,7 +76,7 @@ func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 	return defaulting.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
-		defaultEnv("MUTATING_WEBHOOK_NAME", "webhook.pipeline.tekton.dev"),
+		os.Getenv("MUTATING_WEBHOOK_NAME"),
 
 		// The path on which to serve the webhook.
 		"/defaulting",
@@ -101,7 +101,7 @@ func newValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 	return validation.NewAdmissionController(ctx,
 
 		// Name of the resource webhook.
-		defaultEnv("VALIDATION_WEBHOOK_NAME", "validation.webhook.pipeline.tekton.dev"),
+		os.Getenv("VALIDATION_WEBHOOK_NAME"),
 
 		// The path on which to serve the webhook.
 		"/resource-validation",
@@ -123,7 +123,7 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 	return configmaps.NewAdmissionController(ctx,
 
 		// Name of the configmap webhook.
-		defaultEnv("CONFIG_WEBHOOK_NAME", "config.webhook.pipeline.tekton.dev"),
+		os.Getenv("CONFIG_WEBHOOK_NAME"),
 
 		// The path on which to serve the webhook.
 		"/config-validation",

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -80,6 +80,12 @@ spec:
           value: webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
+        - name: MUTATING_WEBHOOK_NAME
+          value: webhook.pipeline.tekton.dev
+        - name: VALIDATION_WEBHOOK_NAME
+          value: validation.webhook.pipeline.tekton.dev
+        - name: CONFIG_WEBHOOK_NAME
+          value: config.webhook.pipeline.tekton.dev
         securityContext:
           allowPrivilegeEscalation: false
         ports:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously the webhook names were hardcoded, which caused issues if the webhook name was changed:

```
{"level":"error","logger":"webhook","caller":"controller/controller.go:376","msg":"Reconcile error","commit":"82e2758","error":"error retrieving webhook: mutatingwebhookconfiguration.admissionregistration.k8s.io \"webhook.pipeline.tekton.dev\" not found","stacktrace":"github.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller.(*Impl).handleErr\n\tgithub.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller/controller.go:376\ngithub.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller.(*Impl).processNextWorkItem\n\tgithub.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller/controller.go:362\ngithub.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller.(*Impl).Run.func2\n\tgithub.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller/controller.go:310"}
```
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
The webhook names are now configurable via the `MUTATING_WEBHOOK_NAME`, `VALIDATION_WEBHOOK_NAME`, and `CONFIG_WEBHOOK_NAME` environment variables.
```
