### PR TITLE
Provide more guidance on not using PipelineResources 🚧

### DIFF
--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -2,12 +2,13 @@
 
 - [Changes to fields](#changes-to-fields)
 - [Changes to input parameters](#changes-to-input-parameters)
-- [Changes to `PipelineResources`](#changes-to-pipelineresources)
 - [Replacing `PipelineResources` with `Tasks`](#replacing-pipelineresources-with-tasks)
   - [Replacing a `git` resource](#replacing-a-git-resource)
   - [Replacing a `pullrequest` resource](#replacing-a-pullrequest-resource)
   - [Replacing a `gcs` resource](#replacing-a-gcs-resource)
   - [Replacing an `image` resource](#replacing-an-image-resource)
+  - [Replacing a `cluster` resource](#replacing-a-cluster-resource)
+- [Changes to `PipelineResources`](#changes-to-pipelineresources)
 
 This document describes the differences between `v1alpha` Tekton entities and their
 `v1beta1` counterparts. It also describes how to replace the supported types of
@@ -19,12 +20,11 @@ In Tekton `v1beta`, the following fields have been changed:
 
 | Old field | New field |
 | --------- | ----------|
-| `spec.inputs.params` | `spec.params` |
-|  `spec.inputs.resources` | `spec.resources.inputs` |
-| `spec.outputs.resources` | `spec.resources.outputs` |
+| `spec.inputs.params` | [`spec.params`](#changes-to-input-parameters) |
 | `spec.inputs` | Removed from `Tasks` |
 | `spec.outputs` | Removed from `Tasks` | 
-
+| `spec.inputs.resources` | [`spec.resources.inputs`](#changes-to-pipelineresources) |
+| `spec.outputs.resources` | [`spec.resources.outputs`](#changes-to-pipelineresources) |
 
 ## Changes to input parameters
 
@@ -66,7 +66,144 @@ spec:
     value: https://example.com/foo.json
 ```
 
-## Changes to `PipelineResources`
+## Replacing `PipelineResources` with Tasks
+
+`PipelineResources` are remaining in alpha while the other resource kinds are
+promoted to beta.
+
+At some point this feature in its current form could be redesigned, replaced, deprecated or
+removed entirely, and until this has been resolved, we encourage people to use `Tasks` instead of
+`PipelineResources` when they can.
+
+_More on the reasoning and what's left to do in
+[Why aren't PipelineResources in Beta?](docs/resources.md#why-arent-pipelineresources-in-beta)._
+
+To ease migration away from `PipelineResources`
+[some types have an equivalent `Task` in the Catalog](#pipelineresource-equivalent-catalog-tasks).
+To use these replacement `Tasks` you will need to combine them with your existing `Tasks` via a `Pipeline`.
+
+For example, if you were using this `Task` which was fetching from `git` and building with
+`Kaniko`:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: build-push-kaniko
+spec:
+  inputs:
+    resources:
+    - name: workspace
+      type: git
+    params:
+    - name: pathToDockerFile
+      description: The path to the dockerfile to build
+      default: /workspace/workspace/Dockerfile
+    - name: pathToContext
+      description: The build context used by Kaniko
+      default: /workspace/workspace
+  outputs:
+    resources:
+    - name: builtImage
+      type: image
+  steps:
+  - name: build-and-push
+    image: gcr.io/kaniko-project/executor:v0.17.1
+    env:
+    - name: "DOCKER_CONFIG"
+      value: "/tekton/home/.docker/"
+    args:
+    - --dockerfile=$(inputs.params.pathToDockerFile)
+    - --destination=$(outputs.resources.builtImage.url)
+    - --context=$(inputs.params.pathToContext)
+    - --oci-layout-path=$(inputs.resources.builtImage.path)
+    securityContext:
+      runAsUser: 0
+```
+
+To do the same thing with the `git` catalog `Task` and the kaniko `Task` you will need to combine them in a
+`Pipeline`.
+
+For exmaple this Pipeline uses the Kaniko and `git` catalog Tasks:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: kaniko-pipeline
+spec:
+  params:
+  - name: git-url
+  - name: git-revision
+  - name: image-name
+  - name: path-to-image-context
+  - name: path-to-dockerfile
+  workspaces:
+  - name: git-source
+  tasks:
+  - name: fetch-from-git
+    taskRef:
+      name: git-clone
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.git-revision)
+    workspaces:
+    - name: output
+      workspace: git-source
+  - name: build-image
+    taskRef:
+      name: kaniko
+    params:
+    - name: IMAGE
+      value: $(params.image-name)
+    - name: CONTEXT
+      value: $(params.path-to-image-context)
+    - name: DOCKERFILE
+      value: $(params.path-to-docker-file)
+    workspaces:
+    - name: source
+      workspace: git-source
+  # If you want you can add a Task that uses the IMAGE_DIGEST from the kaniko task
+  # via $(tasks.build-image.results.IMAGE_DIGEST) - this was a feature we hadn't been
+  # able to fully deliver with the Image PipelineResource!
+```
+
+_Note that [the `image` `PipelineResource` is gone in this example](#image-resource) (replaced with
+a [`result`](docs/tasks.md#resultes)), and also that now the `Task` doesn't need to know anything
+about where the files come from that it builds from._
+
+### Replacing a `git` resource
+
+You can replace a `git` resource with the [`git-clone` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/git).
+
+### Replacing a `pullrequest` resource
+
+You can replace a `pullrequest` resource with the [`pullrequest` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/pullrequest).
+
+### Replacing a `gcs` resource
+
+You can replace a `gcs` resource with the [`gcs` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/gcs).
+
+### Replacing an `image` resource
+
+Since the `image` resource is simply a way to share the digest of a built image with subsequent
+`Tasks` in your `Pipeline`, you can use [`Task` results](tasks.md#storing-execution-results) to
+achieve equivalent functionality.
+
+For examples of replacing an `image` resource, see the following Catalog `Tasks`:
+
+- The [Kaniko Catalog `Task`](https://github.com/tektoncd/catalog/blob/v1beta1/kaniko/)
+  illustrates how to write the digest of an image to a result.
+- The [Buildah Catalog `Task`](https://github.com/tektoncd/catalog/blob/v1beta1/buildah/)
+  illustrates how to accept an image digest as a parameter.
+
+### Replacing a `cluster` resource
+
+You can replace a `cluster` resource with the [`kubeconfig-creator` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/kubeconfig-creator).
+
+## Changes to PipelineResources
 
 In Tekton `v1beta`, `PipelineResources` have been moved from `spec.input.respources`
 and `spec.output.resources` to `spec.resources.inputs` and `spec.resources.outputs`,
@@ -141,44 +278,3 @@ spec:
         - name: url
           value: gcr.io/foo/bar
 ```
-
-## Replacing `PipelineResources` with `Tasks`
-
-While Tekton Pipelines has advanced to beta, `PipelineResources` remain in alpha
-in a deliberate effort to migrate users away from `PipelineResources` and onto
-a broader suite of reusable `Tasks` in the Tekton Catalog.
-
-In the near term, Tekton continues to support `PipelineResources`; however, they
-will be eventually deprecated and removed from Tekton.
-
-You can replace the types of `PipelineResources` listed below with `Tasks` from the
-Tekton Catalog of equivalent functionality as described below.
-
-### Replacing a `git` resource
-
-You can replace a `git` resource with the [`git-clone` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/git).
-
-### Replacing a `pullrequest` resource
-
-You can replace a `pullrequest` resource with the [`pullrequest` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/pullrequest).
-
-### Replacing a `gcs` resource
-
-You can replace a `gcs` resource with the [`gcs` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/gcs).
-
-### Replacing an `image` resource
-
-Since the `image` resource is simply a way to share the digest of a built image with subsequent
-`Tasks` in your `Pipeline`, you can use [`Task` results](tasks.md#storing-execution-results) to
-achieve equivalent functionality.
-
-For examples of replacing an `image` resource, see the following Catalog `Tasks`:
-
-- The [Kaniko Catalog `Task`](https://github.com/tektoncd/catalog/blob/v1beta1/kaniko/)
-  illustrates how to write the digest of an image to a result.
-- The [Buildah Catalog `Task`](https://github.com/tektoncd/catalog/blob/v1beta1/buildah/)
-  illustrates how to accept an image digest as a parameter.
-
-### Replacing a `cluster` resource
-
-You can replace a `cluster` resource with the [`kubeconfig-creator` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/kubeconfig-creator).

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1107,7 +1107,7 @@ They also present challenges from a documentation perspective:
 - Perhaps the one thing you can say about the `PipelineResource` CRD is that it can create
   side-effects for your `Tasks`.
 
-### Next steps
+### What's still missing
 
 So what are PipelineResources still good for?  We think we've identified some of the most important things:
 


### PR DESCRIPTION
# Changes

This commit makes some updates to the migration guide:
- The section on how the inputs/outputs PipelineResources spec
  has changed is now at the end of the guide, since it's a bit confusing
  to tell ppl to try to migrate away from them and have the new syntax
  for these front and center at the same time
- There is now an example of how you can make a Pipeline that does the
  equivalent of what you used to get with a Task that used image and git
  resources

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
