### PR TITLE
Dereference the PipelineSpec into PipelineRun.Status

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -30,6 +30,11 @@ executed successfully or a failure occurs.
 **Note:** A `PipelineRun` automatically creates corresponding `TaskRuns` for every
 `Task` in your `Pipeline`.
 
+The `Status` field tracks the current state of a `PipelineRun`, and can be used to monitor
+progress.
+This field contains the status of every `TaskRun`, as well as the full `PipelineSpec` used
+to instantiate this `PipelineRun`, for full auditability.
+
 ## Configuring a `PipelineRun`
 
 A `PipelineRun` definition supports the following fields:

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20200214144324-88be01311a71 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0
-	google.golang.org/api v0.15.0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	k8s.io/api v0.17.3
 	k8s.io/apiextensions-apiserver v0.17.3 // indirect

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -255,6 +255,9 @@ type PipelineRunStatusFields struct {
 	// PipelineResults are the list of results written out by the pipeline task's containers
 	// +optional
 	PipelineResults []PipelineRunResult `json:"pipelineResults,omitempty"`
+
+	// PipelineRunSpec contains the exact spec used to instantiate the run
+	PipelineSpec *PipelineSpec `json:"pipelineSpec,omitempty"`
 }
 
 // PipelineRunResult used to describe the results of a pipeline

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -672,6 +672,11 @@ func (in *PipelineRunStatusFields) DeepCopyInto(out *PipelineRunStatusFields) {
 		*out = make([]PipelineRunResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.PipelineSpec != nil {
+		in, out := &in.PipelineSpec, &out.PipelineSpec
+		*out = new(PipelineSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
# Changes

The Pipeline definition used for a PipelineRun can change after the
PipelineRun has started. This poses problems for auditability post-run. Rather
than chase down every part of a Pipeline that we might like to audit later,
let's just add the entire thing here.

This is a follow up to #2444.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The PipelineRun.Status field now contains the PipelineSpec used to instantiate this PipelineRun for auditability.
```
