### PR TITLE
Add subPath to WorkspacePipelineTaskBinding

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -222,6 +222,10 @@ spec:
         - use-ws-from-pipeline # important: use-ws-from-pipeline writes to the workspace first
 ```
 
+Include a `subPath` in the workspace binding to mount different parts of the same volume for different Tasks. See [a full example of this kind of Pipeline](../examples/v1beta1/pipelineruns/pipelinerun-using-different-subpaths-of-workspace.yaml) which writes data to two adjacent directories on the same Volume.
+
+The `subPath` specified in a `Pipeline` will be appended to any `subPath` specified as part of the `PipelineRun` workspace declaration. So a `PipelineRun` declaring a Workspace with `subPath` of `/foo` for a `Pipeline` who binds it to a `Task` with `subPath` of `/bar` will end up mounting the `Volume`'s `/foo/bar` directory.
+
 #### Specifying `Workspace` order in a `Pipeline`
 
 Sharing a `Workspace` between `Tasks` requires you to define the order in which those `Tasks`

--- a/examples/v1beta1/pipelineruns/pipelinerun-using-different-subpaths-of-workspace.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-using-different-subpaths-of-workspace.yaml
@@ -1,0 +1,85 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: writer
+spec:
+  steps:
+    - name: write
+      image: ubuntu
+      script: echo bar > $(workspaces.task-ws.path)/foo
+  workspaces:
+    - name: task-ws
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: read-both
+spec:
+  params:
+    - name: directory1
+      type: string
+    - name: directory2
+      type: string
+  workspaces:
+    - name: local-ws
+  steps:
+    - name: read-1
+      image: ubuntu
+      script: cat $(workspaces.local-ws.path)/$(params.directory1)/foo | grep bar
+    - name: read-2
+      image: ubuntu
+      script: cat $(workspaces.local-ws.path)/$(params.directory2)/foo | grep bar
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-using-different-subpaths
+spec:
+  workspaces:
+    - name: ws
+  tasks:
+    - name: writer-1
+      taskRef:
+        name: writer
+      workspaces:
+        - name: task-ws
+          workspace: ws
+          subPath: dir-1
+    - name: writer-2
+      taskRef:
+        name: writer
+      workspaces:
+        - name: task-ws
+          workspace: ws
+          subPath: dir-2
+    - name: read-all
+      runAfter:
+        - writer-1
+        - writer-2
+      params:
+        - name: directory1
+          value: dir-1
+        - name: directory2
+          value: dir-2
+      taskRef:
+        name: read-both
+      workspaces:
+        - name: local-ws
+          workspace: ws
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pr-
+spec:
+  pipelineRef:
+    name: pipeline-using-different-subpaths
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -359,7 +359,7 @@ func TestPipeline_Validate(t *testing.T) {
 		p: tb.Pipeline("name", tb.PipelineSpec(
 			tb.PipelineWorkspaceDeclaration("foo"),
 			tb.PipelineTask("taskname", "taskref",
-				tb.PipelineTaskWorkspaceBinding("taskWorkspaceName", "pipelineWorkspaceName")),
+				tb.PipelineTaskWorkspaceBinding("taskWorkspaceName", "pipelineWorkspaceName", "")),
 		)),
 		failureExpected: true,
 	}, {

--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -95,4 +95,8 @@ type WorkspacePipelineTaskBinding struct {
 	Name string `json:"name"`
 	// Workspace is the name of the workspace declared by the pipeline
 	Workspace string `json:"workspace"`
+	// SubPath is optionally a directory on the volume which should be used
+	// for this binding (i.e. the volume will be mounted at this sub directory).
+	// +optional
+	SubPath string `json:"subPath,omitempty"`
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -19,6 +19,7 @@ package pipelinerun
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -733,9 +734,9 @@ func (c *Reconciler) createTaskRun(rprt *resources.ResolvedPipelineRunTask, pr *
 		pipelineRunWorkspaces[binding.Name] = binding
 	}
 	for _, ws := range rprt.PipelineTask.Workspaces {
-		taskWorkspaceName, pipelineWorkspaceName := ws.Name, ws.Workspace
+		taskWorkspaceName, pipelineTaskSubPath, pipelineWorkspaceName := ws.Name, ws.SubPath, ws.Workspace
 		if b, hasBinding := pipelineRunWorkspaces[pipelineWorkspaceName]; hasBinding {
-			tr.Spec.Workspaces = append(tr.Spec.Workspaces, taskWorkspaceByWorkspaceVolumeSource(b, taskWorkspaceName, pr.GetOwnerReference()))
+			tr.Spec.Workspaces = append(tr.Spec.Workspaces, taskWorkspaceByWorkspaceVolumeSource(b, taskWorkspaceName, pipelineTaskSubPath, pr.GetOwnerReference()))
 		} else {
 			return nil, fmt.Errorf("expected workspace %q to be provided by pipelinerun for pipeline task %q", pipelineWorkspaceName, rprt.PipelineTask.Name)
 		}
@@ -748,22 +749,34 @@ func (c *Reconciler) createTaskRun(rprt *resources.ResolvedPipelineRunTask, pr *
 
 // taskWorkspaceByWorkspaceVolumeSource is returning the WorkspaceBinding with the TaskRun specified name.
 // If the volume source is a volumeClaimTemplate, the template is applied and passed to TaskRun as a persistentVolumeClaim
-func taskWorkspaceByWorkspaceVolumeSource(wb v1alpha1.WorkspaceBinding, taskWorkspaceName string, owner metav1.OwnerReference) v1alpha1.WorkspaceBinding {
+func taskWorkspaceByWorkspaceVolumeSource(wb v1alpha1.WorkspaceBinding, taskWorkspaceName string, pipelineTaskSubPath string, owner metav1.OwnerReference) v1alpha1.WorkspaceBinding {
 	if wb.VolumeClaimTemplate == nil {
 		binding := *wb.DeepCopy()
 		binding.Name = taskWorkspaceName
+		binding.SubPath = combinedSubPath(wb.SubPath, pipelineTaskSubPath)
 		return binding
 	}
 
 	// apply template
 	binding := v1alpha1.WorkspaceBinding{
-		SubPath: wb.SubPath,
+		SubPath: combinedSubPath(wb.SubPath, pipelineTaskSubPath),
 		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 			ClaimName: volumeclaim.GetPersistentVolumeClaimName(wb.VolumeClaimTemplate, wb, owner),
 		},
 	}
 	binding.Name = taskWorkspaceName
 	return binding
+}
+
+// combinedSubPath returns the combined value of the optional subPath from workspaceBinding and the optional
+// subPath from pipelineTask. If both is set, they are joined with a slash.
+func combinedSubPath(workspaceSubPath string, pipelineTaskSubPath string) string {
+	if workspaceSubPath == "" {
+		return pipelineTaskSubPath
+	} else if pipelineTaskSubPath == "" {
+		return workspaceSubPath
+	}
+	return filepath.Join(workspaceSubPath, pipelineTaskSubPath)
 }
 
 func addRetryHistory(tr *v1alpha1.TaskRun) {

--- a/test/builder/pipeline.go
+++ b/test/builder/pipeline.go
@@ -302,11 +302,12 @@ func PipelineTaskConditionResource(name, resource string, from ...string) Pipeli
 	}
 }
 
-func PipelineTaskWorkspaceBinding(name, workspace string) PipelineTaskOp {
+func PipelineTaskWorkspaceBinding(name, workspace, subPath string) PipelineTaskOp {
 	return func(pt *v1alpha1.PipelineTask) {
 		pt.Workspaces = append(pt.Workspaces, v1alpha1.WorkspacePipelineTaskBinding{
 			Name:      name,
 			Workspace: workspace,
+			SubPath:   subPath,
 		})
 	}
 }
@@ -619,10 +620,11 @@ func PipelineRunWorkspaceBindingEmptyDir(name string) PipelineRunSpecOp {
 }
 
 // PipelineRunWorkspaceBindingVolumeClaimTemplate adds an VolumeClaimTemplate Workspace to the workspaces of a pipelineRun spec.
-func PipelineRunWorkspaceBindingVolumeClaimTemplate(name string, claimName string) PipelineRunSpecOp {
+func PipelineRunWorkspaceBindingVolumeClaimTemplate(name string, claimName string, subPath string) PipelineRunSpecOp {
 	return func(spec *v1alpha1.PipelineRunSpec) {
 		spec.Workspaces = append(spec.Workspaces, v1alpha1.WorkspaceBinding{
-			Name: name,
+			Name:    name,
+			SubPath: subPath,
 			VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: claimName,

--- a/test/builder/pipeline_test.go
+++ b/test/builder/pipeline_test.go
@@ -46,7 +46,7 @@ func TestPipeline(t *testing.T) {
 				tb.PipelineTaskConditionParam("param-name", "param-value"),
 				tb.PipelineTaskConditionResource("some-resource", "my-only-git-resource", "bar", "never-gonna"),
 			),
-			tb.PipelineTaskWorkspaceBinding("task-workspace1", "workspace1"),
+			tb.PipelineTaskWorkspaceBinding("task-workspace1", "workspace1", ""),
 		),
 		tb.PipelineTask("bar", "chocolate",
 			tb.PipelineTaskRefKind(v1alpha1.ClusterTaskKind),

--- a/test/v1alpha1/workspace_test.go
+++ b/test/v1alpha1/workspace_test.go
@@ -105,7 +105,7 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 
 	pipeline := tb.Pipeline(pipelineName, tb.PipelineSpec(
 		tb.PipelineWorkspaceDeclaration("foo"),
-		tb.PipelineTask("task1", taskName, tb.PipelineTaskWorkspaceBinding("test", "foo")),
+		tb.PipelineTask("task1", taskName, tb.PipelineTaskWorkspaceBinding("test", "foo", "")),
 	))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)
@@ -146,7 +146,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 
 	pipeline := tb.Pipeline(pipelineName, tb.PipelineSpec(
 		tb.PipelineWorkspaceDeclaration("foo"),
-		tb.PipelineTask("task1", taskName, tb.PipelineTaskWorkspaceBinding("test", "foo")),
+		tb.PipelineTask("task1", taskName, tb.PipelineTaskWorkspaceBinding("test", "foo", "")),
 	))
 	if _, err := c.PipelineClient.Create(pipeline); err != nil {
 		t.Fatalf("Failed to create Pipeline: %s", err)


### PR DESCRIPTION
# Changes

**Use case:** Use two instances of a task that writes to the same workspace volume - but
they write to different path of the volume. A typical use case is two git-clone tasks
that clone two git repositories, but the files should be located in two different
directories on the workspace volume.

This can currently be solved when using `PersistentVolumeClaim` based workspace, by declaring multiple workspaces using the same PVC but different `subPath` (in the WorkspaceBinding of *Run). But that does not work when using a `VolumeClaimTemplate` based workspace.

**This commit** solves this by adding the `subPath` field to the WorkspacePipelineTaskBinding.

If the WorkspaceBinding in `PipelineRun` also has a `subPath` set, they will be appended, e.g. `subPath/subPath`. This was discussed in the API WG.

Example log output from the example:

```
$ tkn pr logs pr-gj4l9
[writer-1 : write] + echo bar

[writer-2 : write] + echo bar

[read-all : read-1] + cat /workspace/local-ws/dir-1/foo
[read-all : read-1] + grep bar
[read-all : read-1] bar

[read-all : read-2] + cat /workspace/local-ws/dir-2/foo
[read-all : read-2] + grep bar
[read-all : read-2] bar

```

Fixes #2490

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
