### PR TITLE
Make webhook secret configurable

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -130,6 +130,11 @@ func main() {
 		serviceName = "tekton-pipelines-webhook"
 	}
 
+	secretName := os.Getenv("WEBHOOK_SECRET_NAME")
+	if secretName == "" {
+		secretName = "webhook-certs" // #nosec
+	}
+
 	// Scope informers to the webhook's namespace instead of cluster-wide
 	ctx := injection.WithNamespaceScope(signals.NewContext(), system.GetNamespace())
 
@@ -137,7 +142,7 @@ func main() {
 	ctx = webhook.WithOptions(ctx, webhook.Options{
 		ServiceName: serviceName,
 		Port:        8443,
-		SecretName:  "webhook-certs",
+		SecretName:  secretName,
 	})
 
 	sharedmain.WebhookMainWithConfig(ctx, "webhook",

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -65,6 +65,8 @@ spec:
           value: config-leader-election
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
+        - name: WEBHOOK_SECRET_NAME
+          value: webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
         securityContext:


### PR DESCRIPTION
This pull request makes webhook secret name configurable.


# Release Notes

```
The `WEBHOOK_SECRET_NAME`  environment variable  can now be used to configure the secret name for the webook.
```
