### PR TITLE
Add default for condition

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/condition_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_defaults.go
@@ -29,4 +29,7 @@ func (c *Condition) SetDefaults(ctx context.Context) {
 }
 
 func (cs *ConditionSpec) SetDefaults(ctx context.Context) {
+	for i := range cs.Params {
+		cs.Params[i].SetDefaults(ctx)
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/condition_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_defaults_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Tetkon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/test/builder"
+)
+
+func TestConditionSpec_SetDefaults(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  *v1alpha1.ConditionSpec
+		output *v1alpha1.ConditionSpec
+	}{
+		{
+			name:   "No Param",
+			input:  &v1alpha1.ConditionSpec{},
+			output: &v1alpha1.ConditionSpec{},
+		},
+		{
+			name: "One Param",
+			input: &v1alpha1.ConditionSpec{
+				Params: []v1alpha1.ParamSpec{
+					{
+						Name:    "test-1",
+						Default: builder.ArrayOrString("an", "array"),
+					},
+				},
+			},
+			output: &v1alpha1.ConditionSpec{
+				Params: []v1alpha1.ParamSpec{
+					{
+						Name:    "test-1",
+						Type:    v1alpha1.ParamTypeArray,
+						Default: builder.ArrayOrString("an", "array"),
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple Param",
+			input: &v1alpha1.ConditionSpec{
+				Params: []v1alpha1.ParamSpec{
+					{
+						Name:    "test-1",
+						Default: builder.ArrayOrString("array"),
+					},
+					{
+						Name:    "test-2",
+						Default: builder.ArrayOrString("an", "array"),
+					},
+				},
+			},
+			output: &v1alpha1.ConditionSpec{
+				Params: []v1alpha1.ParamSpec{
+					{
+						Name:    "test-1",
+						Type:    v1alpha1.ParamTypeString,
+						Default: builder.ArrayOrString("array"),
+					},
+					{
+						Name:    "test-2",
+						Type:    v1alpha1.ParamTypeArray,
+						Default: builder.ArrayOrString("an", "array"),
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			tc.input.SetDefaults(ctx)
+			if diff := cmp.Diff(tc.output, tc.input); diff != "" {
+				t.Errorf("Mismatch of PipelineRunSpec: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The default for condition is not doing anything. This
will add to apply defaults for param in condition

Add test

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add default for condition
```
