### PR TITLE
Add recommended k8s labels

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -16,3 +16,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines

--- a/config/101-podsecuritypolicy.yaml
+++ b/config/101-podsecuritypolicy.yaml
@@ -16,6 +16,9 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -16,6 +16,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-pipelines-controller-cluster-access
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 rules:
   - apiGroups: [""]
     # Namespace access is required because the controller timeout handling logic
@@ -45,6 +49,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   # This is the access that the controller needs on a per-namespace basis.
   name: tekton-pipelines-controller-tenant-access
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims", "limitranges"]
@@ -62,6 +70,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-pipelines-webhook-cluster-access
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 rules:
   # The webhook needs to be able to list and update customresourcedefinitions,
   # mainly to update the webhook certificates.

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -17,6 +17,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -32,6 +36,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]

--- a/config/200-serviceaccount.yaml
+++ b/config/200-serviceaccount.yaml
@@ -16,9 +16,17 @@ kind: ServiceAccount
 metadata:
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines

--- a/config/201-clusterrolebinding.yaml
+++ b/config/201-clusterrolebinding.yaml
@@ -16,6 +16,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelines-controller-cluster-access
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
     name: tekton-pipelines-controller
@@ -33,6 +37,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelines-controller-tenant-access
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
     name: tekton-pipelines-controller
@@ -46,6 +54,10 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: tekton-pipelines-webhook-cluster-access
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
     name: tekton-pipelines-webhook

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -17,6 +17,10 @@ kind: RoleBinding
 metadata:
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
     name: tekton-pipelines-controller
@@ -31,6 +35,10 @@ kind: RoleBinding
 metadata:
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 subjects:
   - kind: ServiceAccount
     name: tekton-pipelines-webhook

--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: clustertasks.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-condition.yaml
+++ b/config/300-condition.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: conditions.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-imagecache.yaml
+++ b/config/300-imagecache.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: pipelines.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: pipelineruns.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: pipelineresources.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: tasks.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -17,6 +17,8 @@ kind: CustomResourceDefinition
 metadata:
   name: taskruns.tekton.dev
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: "devel"
     version: "devel"
 spec:

--- a/config/500-webhooks.yaml
+++ b/config/500-webhooks.yaml
@@ -18,6 +18,9 @@ metadata:
   name: webhook-certs
   namespace: tekton-pipelines
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: devel
 # The data is populated at install time.
 
@@ -27,6 +30,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.pipeline.tekton.dev
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: devel
 webhooks:
 - admissionReviewVersions:
@@ -45,6 +51,9 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.pipeline.tekton.dev
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: devel
 webhooks:
 - admissionReviewVersions:
@@ -63,6 +72,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.pipeline.tekton.dev
   labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     pipeline.tekton.dev/release: devel
 webhooks:
 - admissionReviewVersions:
@@ -74,7 +86,6 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: config.webhook.pipeline.tekton.dev
-  namespaceSelector:
-    matchExpressions:
-    - key: pipeline.tekton.dev/release
-      operator: Exists
+  objectSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: tekton-pipelines

--- a/config/clusterrole-aggregate-edit.yaml
+++ b/config/clusterrole-aggregate-edit.yaml
@@ -17,6 +17,8 @@ kind: ClusterRole
 metadata:
   name: tekton-aggregate-edit
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:

--- a/config/clusterrole-aggregate-view.yaml
+++ b/config/clusterrole-aggregate-view.yaml
@@ -17,6 +17,8 @@ kind: ClusterRole
 metadata:
   name: tekton-aggregate-view
   labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:

--- a/config/config-artifact-bucket.yaml
+++ b/config/config-artifact-bucket.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-artifact-bucket
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 #  data:
 #    # location of the gcs bucket to be used for artifact storage
 #    location: "gs://bucket-name"

--- a/config/config-artifact-pvc.yaml
+++ b/config/config-artifact-pvc.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-artifact-pvc
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 # data:
 #   # size of the PVC volume
 #   size: 5Gi

--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-defaults
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 data:
   _example: |
     ################################

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: feature-flags
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 data:
   # Setting this flag to "true" will prevent Tekton overriding your
   # Task container's $HOME environment variable.

--- a/config/config-leader-election.yaml
+++ b/config/config-leader-election.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-leader-election
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 data:
   # An inactive but valid configuration follows; see example.
   resourceLock: "leases"

--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -17,6 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-logging
   namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 data:
   # Common configuration for all knative codebase
   zap-logger-config: |

--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -17,7 +17,9 @@ kind: ConfigMap
 metadata:
   name: config-observability
   namespace: tekton-pipelines
-
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
 data:
   _example: |
     ################################

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -18,25 +18,37 @@ metadata:
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-pipelines
+    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
     pipeline.tekton.dev/release: "devel"
+    # labels below are related to istio and should not be used for resource lookup
     version: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-pipelines-controller
+      app.kubernetes.io/name: controller
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-pipelines
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelines-controller
-        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
         pipeline.tekton.dev/release: "devel"
+        # labels below are related to istio and should not be used for resource lookup
+        app: tekton-pipelines-controller
         version: "devel"
     spec:
       serviceAccountName: tekton-pipelines-controller
@@ -93,8 +105,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: tekton-pipelines-controller
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-pipelines
+    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
     pipeline.tekton.dev/release: "devel"
+    # labels below are related to istio and should not be used for resource lookup
+    app: tekton-pipelines-controller
     version: "devel"
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
@@ -105,4 +124,7 @@ spec:
     protocol: TCP
     targetPort: 9090
   selector:
-    app: tekton-pipelines-controller
+    app.kubernetes.io/name: controller
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -21,26 +21,37 @@ metadata:
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
   labels:
-    app.kubernetes.io/name: tekton-pipelines
-    app.kubernetes.io/component: webhook-controller
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-pipelines
+    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
     pipeline.tekton.dev/release: "devel"
+    # labels below are related to istio and should not be used for resource lookup
     version: "devel"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: tekton-pipelines-webhook
-      role: webhook
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/instance: default
+      app.kubernetes.io/part-of: tekton-pipelines
   template:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
-        app: tekton-pipelines-webhook
-        role: webhook
-        app.kubernetes.io/name: tekton-pipelines
-        app.kubernetes.io/component: webhook-controller
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/component: webhook
+        app.kubernetes.io/instance: default
+        app.kubernetes.io/version: devel
+        app.kubernetes.io/part-of: tekton-pipelines
+        # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
         pipeline.tekton.dev/release: "devel"
+        # labels below are related to istio and should not be used for resource lookup
+        app: tekton-pipelines-webhook
         version: "devel"
     spec:
       serviceAccountName: tekton-pipelines-webhook
@@ -71,7 +82,6 @@ spec:
           value: tekton.dev/pipeline
         securityContext:
           allowPrivilegeEscalation: false
-
         ports:
         - name: metrics
           containerPort: 9090
@@ -84,9 +94,15 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: tekton-pipelines-webhook
-    role: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/version: devel
+    app.kubernetes.io/part-of: tekton-pipelines
+    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
     pipeline.tekton.dev/release: devel
+    # labels below are related to istio and should not be used for resource lookup
+    app: tekton-pipelines-webhook
     version: "devel"
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
@@ -103,5 +119,7 @@ spec:
     port: 443
     targetPort: 8443
   selector:
-    app: tekton-pipelines-webhook
-    role: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines

--- a/docs/developers/resources-labelling.md
+++ b/docs/developers/resources-labelling.md
@@ -1,0 +1,66 @@
+<!--
+---
+linkTitle: "Resources labelling"
+weight: 10
+---
+-->
+# Resources labelling
+
+Tekton applications sometines need to find resources belonging to other applications (dashboard
+needs to talk to pipelines and triggers, triggers needs to talk to pipelines, etc.).
+
+In order to facilitate identifying resources that belong to an application, the following
+[recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) are added to every resource.
+
+In the end, resource labels are used for two things:
+- Identify the application and/or component resources belong to
+- Allow looking up the resource when necessary
+
+The labels set should not cover more than what is needed, for example, if the resource is not to be looked up, it's probably not necessary to set the `app.kubernetes.io/name` label.
+
+## Supported labels
+
+- `app.kubernetes.io/part-of`: defines the application the resource belongs to (`tekton-pipelines`, `tekton-dashboard`, `tekton-triggers`, etc).
+- `app.kubernetes.io/component`: defines the component the resource belongs to (`controller`, `webhook`). This label is not always present, an application may not be made of multiple components or the resource may not belong to a specific component of the application.
+This label should be present only if the resource belongs to a given component (some resources are )
+- `app.kubernetes.io/instance`: defines the instance of the application the resource belongs to. This label should always be set. It is particularily useful when multiple instances of an application are deployed in the same cluster/namespace.
+- `app.kubernetes.io/name`: this label should uniquely identify a resource when combined with `app.kubernetes.io/part-of`, `app.kubernetes.io/component` and `app.kubernetes.io/instance` labels. Some resources don't need to be looked up, in this case the `app.kubernetes.io/name` label is not necessary.
+- `app.kubernetes.io/version`: defines the version for the resource.
+
+## Looking up resources
+
+Looking up a given resource should not rely on resource names but use the previously documented labels.
+
+For example, if Tekton Pipelines was deployed in the `tekton-pipelines` namespace, and you need to lookup the webhook service.
+This should be done by looking up the `Service` in the `tekton-pipelines` namespace that matches the following labels:
+
+| label | value |
+| --- | --- |
+| `app.kubernetes.io/part-of` | `tekton-pipelines` |
+| `app.kubernetes.io/component` | `webhook` |
+| `app.kubernetes.io/instance` | `default` |
+| `app.kubernetes.io/name` | `webhook` |
+
+Equivalent `kubectl` command:
+```bash
+kubectl --namespace=tekton-pipelines get svc -l "app.kubernetes.io/part-of=tekton-pipelines,app.kubernetes.io/component=webhook,app.kubernetes.io/instance=default,app.kubernetes.io/name=webhook
+```
+
+See below for the list of applications, components, and names for most commonly used resources.
+
+## Reference table
+
+The table below lists applications, components, and names for most commonly used resources.
+
+| resource | type | app.kubernetes.io/part-of | app.kubernetes.io/component | app.kubernetes.io/name |
+| --- | --- | --- | --- | --- |
+| pipelines controller deployment | `Deployment` | `tekton-pipelines` | `controller` | `controller` |
+| pipelines controller service | `Service` | `tekton-pipelines` | `controller` | `controller` |
+| pipelines webhook service | `Service` | `tekton-pipelines` | `webhook` | `webhook` |
+| triggers controller deployment | `Deployment` | `tekton-triggers` | `controller` | `controller` |
+| triggers controller service | `Service` | `tekton-triggers` | `controller` | `controller` |
+| triggers webhook service | `Service` | `tekton-triggers` | `webhook` | `webhook` |
+| dashboard controller deployment | `Deployment` | `tekton-dashboard` | `dashboard` | `dashboard` |
+| dashboard controller service | `Service` | `tekton-dashboard` | `dashboard` | `dashboard` |
+
+**NOTE**: the `app.kubernetes.io/instance` label is set to `default` when deployed with yaml manifests provided in the releases.


### PR DESCRIPTION
This PR adds recommended k8s labels on resources.
Implementation for proposal #2497 

Config: added labels and updated selectors for all resources in `/config`
Doc: added `/docs/developers/resources-labelling.md`

**NOTE**: this will introduce a breaking change when trying to update deployments as label selectors have changed.
