### PR TITLE
Add variable substitution for PVC name

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -25,6 +25,7 @@ in `Tasks` and `Pipelines`.
 | `resources.outputs.<resource name>.path` | The path to the output resource's directory. |
 | `results.<result name>.path` | The path to the file where a Task's result should be written. |
 | `workspaces.<workspace name>.path` | The path to the mounted workspace. |
+| `workspaces.<workspace name>.claim` | The name of the PersistentVolumeClaim used as a volume source for the workspace or empty string if a volume source other than PersistentVolumeClaim was used. |
 | `workspaces.<workspace name>.volume` | The name of the volume populating the workspace. |
 | `credentials.path` | The path to the location of credentials written by the `creds-init` init container. |
 

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -96,8 +96,9 @@ func ApplyResources(spec *v1alpha1.TaskSpec, resolvedResources map[string]v1alph
 	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
-// ApplyWorkspaces applies the substitution from paths that the workspaces in w are mounted to and the
-// volumes that wb are realized with in the task spec ts.
+// ApplyWorkspaces applies the substitution from paths that the workspaces in w are mounted to, the
+// volumes that wb are realized with in the task spec ts and the PersistentVolumeClaim names for the
+// workspaces.
 func ApplyWorkspaces(spec *v1alpha1.TaskSpec, w []v1alpha1.WorkspaceDeclaration, wb []v1alpha1.WorkspaceBinding) *v1alpha1.TaskSpec {
 	stringReplacements := map[string]string{}
 
@@ -107,6 +108,13 @@ func ApplyWorkspaces(spec *v1alpha1.TaskSpec, w []v1alpha1.WorkspaceDeclaration,
 	v := workspace.GetVolumes(wb)
 	for name, vv := range v {
 		stringReplacements[fmt.Sprintf("workspaces.%s.volume", name)] = vv.Name
+	}
+	for _, w := range wb {
+		if w.PersistentVolumeClaim != nil {
+			stringReplacements[fmt.Sprintf("workspaces.%s.claim", w.Name)] = w.PersistentVolumeClaim.ClaimName
+		} else {
+			stringReplacements[fmt.Sprintf("workspaces.%s.claim", w.Name)] = ""
+		}
 	}
 	return ApplyReplacements(spec, stringReplacements, map[string][]string{})
 }

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -609,6 +609,12 @@ func TestApplyWorkspaces(t *testing.T) {
 			Env: []corev1.EnvVar{{
 				Name:  "template-var",
 				Value: "$(workspaces.myws.volume)",
+			}, {
+				Name:  "pvc-name",
+				Value: "$(workspaces.myws.claim)",
+			}, {
+				Name:  "non-pvc-name",
+				Value: "$(workspaces.otherws.claim)",
 			}},
 		},
 		Steps: []v1alpha1.Step{{Container: corev1.Container{
@@ -671,6 +677,8 @@ func TestApplyWorkspaces(t *testing.T) {
 	}}
 	want := applyMutation(ts, func(spec *v1alpha1.TaskSpec) {
 		spec.StepTemplate.Env[0].Value = "ws-9l9zj"
+		spec.StepTemplate.Env[1].Value = "foo"
+		spec.StepTemplate.Env[2].Value = ""
 
 		spec.Steps[0].Name = "ws-9l9zj"
 		spec.Steps[0].Image = "ws-mz4c7"


### PR DESCRIPTION
# Changes

There may be use cases when a Task should initiate a PipelineRun or TaskRun.
It can be beneficial to use the **same PVC** in the PipelineRun or TaskRun
that is initiated, e.g. populated with cached data or a cloned git repository.

When using a workspace with a PersistentVolumeClaim as volume source, the name
of the PVC is known, and can be set in the new PipelineRun or
TaskRun. But when a VolumeClaimTemplate is used as a volume source, the name
is generated. In such use cases, it is useful to be able to "look up" the PVC
name using variable substitution.

This commit introduces `$(workspaces.ws-name.claim)` so that it is possible to get the PVC name. This is similar to how it is possible to get the volume name with `$(workspaces.ws-name.volume)`

Fixes #2505

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
New substitution variable for PersistentVolumeClaim name.
```
