### PR TITLE
Documentation and Example on Running Step Containers as Non Root

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -242,7 +242,7 @@ point for the `Pod` in which the container images specified in your `Tasks` will
 customize the `Pod` confguration specifically for each `TaskRun`.
 
 In the following example, the `Task` defines a `volumeMount` object named `my-cache`. The `PipelineRun`
-provisions this object for the `Task` using a `persistentVolumeClaim` and executes it as a non-root user.
+provisions this object for the `Task` using a `persistentVolumeClaim` and executes it as user 1001.
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -279,6 +279,7 @@ spec:
   podTemplate:
     securityContext:
       runAsNonRoot: true
+      runAsUser: 1001
     volumes:
     - name: my-cache
       persistentVolumeClaim:

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -186,6 +186,7 @@ spec:
     hostNetwork: true
     securityContext:
       runAsNonRoot: true
+      runAsUser: 1001
     volumes:
     - name: my-cache
       persistentVolumeClaim:
@@ -630,6 +631,38 @@ data:
   # ssh-keyscan github.com | base64 -w 0
   known_hosts: Z2l0aHViLmNvbSBzc2g.....[example]
 ```
+
+### Running Step Containers as a Non Root User
+
+All steps that do not require to be run as a root user should make use of TaskRun features to 
+designate the container for a step runs as a user without root permissions. As a best practice, 
+running containers as non root should be built into the container image to avoid any possibility 
+of the container being run as root. However, as a further measure of enforcing this practice, 
+TaskRun pod templates can be used to specify how containers should be run within a TaskRun pod. 
+
+An example of using a TaskRun pod template is shown below to specify that containers running via this 
+TaskRun's pod should run as non root and run as user 1001 if the container itself does not specify what 
+user to run as:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: show-non-root-steps-run-
+spec:
+  taskRef:
+    name: show-non-root-steps
+  podTemplate:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+```
+
+If a Task step specifies that it is to run as a different user than what is specified in the pod template, 
+the step's `securityContext` will be applied instead of what is specified at the pod level. An example of 
+this is available as a [TaskRun example](../examples/v1beta1/taskruns/run-steps-as-non-root.yaml).
+
+More information about Pod and Container Security Contexts can be found via the [Kubernetes website](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
 
 ---
 

--- a/examples/v1beta1/taskruns/run-steps-as-non-root.yaml
+++ b/examples/v1beta1/taskruns/run-steps-as-non-root.yaml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: show-non-root-steps
+spec:
+  steps:
+    # no securityContext specified so will use 
+    # securityContext from TaskRun podTemplate
+    - name: show-user-1001
+      image: ubuntu
+      command:
+        - ps
+      args:
+        - "aux"
+    # securityContext specified so will run as  
+    # user 2000 instead of 1001
+    - name: show-user-2000
+      image: ubuntu
+      command:
+        - ps
+      args:
+        - "aux"
+      securityContext:
+        runAsUser: 2000
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: show-non-root-steps-run-
+spec:
+  taskRef:
+    name: show-non-root-steps
+  podTemplate:
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001


### PR DESCRIPTION
Closes #2179 

This pull request adds documentation on running step containers as non root as well as a TaskRun example of doing so.

A follow up to this should be running containers as root best practices especially in Kubernetes clusters that enforce not allowing containers to run as root by default (e.g. clusters provisioned by Tanzu Mission Control).

I have intentionally left out doing this for PipelineRuns as there are features coming in around allowing specifying taskRunSpecs for PipelineRuns that could change best approaches, but I feel that having examples of Tasks/TaskRuns should be enough to illustrate the concept. Let me know if adding this info to PipelineRuns would be helpful, and I can do so.

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add documentation and example on running step containers as non root
```
