### PR TITLE
Correct the message for "step" failed in "taskrun"

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -287,7 +287,7 @@ func getFailureMessage(pod *corev1.Pod) string {
 		term := status.State.Terminated
 		if term != nil && term.ExitCode != 0 {
 			// Newline required at end to prevent yaml parser from breaking the log help text at 80 chars
-			return fmt.Sprintf(`%q exited with code %d (image: %q); for logs run: kubectl -n %s logs %s -c %s\n`,
+			return fmt.Sprintf("%q exited with code %d (image: %q); for logs run: kubectl -n %s logs %s -c %s\n",
 				status.Name, term.ExitCode, status.ImageID,
 				pod.Namespace, pod.Name, status.Name)
 		}

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -215,7 +215,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
 					Reason:  ReasonFailed,
-					Message: `"step-failure" exited with code 123 (image: "image-id"); for logs run: kubectl -n foo logs pod -c step-failure\n`,
+					Message: "\"step-failure\" exited with code 123 (image: \"image-id\"); for logs run: kubectl -n foo logs pod -c step-failure\n",
 				}},
 			},
 			TaskRunStatusFields: v1alpha1.TaskRunStatusFields{
@@ -653,7 +653,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
 					Reason:  ReasonFailed,
-					Message: `"step-non-json" exited with code 1 (image: "image"); for logs run: kubectl -n foo logs pod -c step-non-json\n`,
+					Message: "\"step-non-json\" exited with code 1 (image: \"image\"); for logs run: kubectl -n foo logs pod -c step-non-json\n",
 				}},
 			},
 			TaskRunStatusFields: v1alpha1.TaskRunStatusFields{


### PR DESCRIPTION
Fix issue: #2518

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
