### PR TITLE
Emit events when we fail to update the taskrun

### DIFF
--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -30,6 +30,8 @@ const (
 	EventReasonFailed = "Failed"
 	// EventReasonStarted is the reason set for events about the start of TaskRuns / PipelineRuns
 	EventReasonStarted = "Started"
+	// EventReasonError is the reason set for events related to TaskRuns / PipelineRuns reconcile errors
+	EventReasonError = "Error"
 )
 
 // EmitEvent emits an event for object if afterCondition is different from beforeCondition
@@ -61,5 +63,12 @@ func EmitEvent(c record.EventRecorder, beforeCondition *apis.Condition, afterCon
 				c.Event(object, corev1.EventTypeNormal, afterCondition.Reason, afterCondition.Message)
 			}
 		}
+	}
+}
+
+// EmitErrorEvent emits a failure associated to an error
+func EmitErrorEvent(c record.EventRecorder, err error, object runtime.Object) {
+	if err != nil {
+		c.Event(object, corev1.EventTypeWarning, EventReasonError, err.Error())
 	}
 }

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -171,6 +172,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			wg.Wait()
 
 			matchKinds := map[string][]string{"PipelineRun": {"pear"}, "TaskRun": trName}
+			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
 			expectedNumberOfEvents := 1 + len(trName)
 			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)
 			events, err := collectMatchingEvents(c.KubeClient, namespace, matchKinds, "Failed")
@@ -178,7 +180,14 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				t.Fatalf("Failed to collect matching events: %q", err)
 			}
 			if len(events) != expectedNumberOfEvents {
-				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of received events : %#v", expectedNumberOfEvents, len(events), events)
+				collectedEvents := ""
+				for i, event := range events {
+					collectedEvents += fmt.Sprintf("%#v", event)
+					if i < (len(events) - 1) {
+						collectedEvents += ", "
+					}
+				}
+				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of received events : %#v", expectedNumberOfEvents, len(events), collectedEvents)
 			}
 		})
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Similarly to how the pipeline controller does, we should emit events
when we fail to update the taskrun.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
We now emit warning events from the taskrun controller if the controller fails to sync the updated taskrun back.
```
