### PR TITLE
Add validation for condition check name

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
@@ -22,10 +22,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"knative.dev/pkg/apis"
-
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	tb "github.com/tektoncd/pipeline/test/builder"
+	"knative.dev/pkg/apis"
 )
 
 func TestCondition_Validate(t *testing.T) {
@@ -71,6 +70,18 @@ func TestCondition_Invalidate(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: "step 0 script cannot be used with command",
 			Paths:   []string{"Spec.Check.script"},
+		},
+	}, {
+		name: "condition with invalid check name",
+		cond: tb.Condition("cond",
+			tb.ConditionSpec(
+				tb.ConditionSpecCheck("Cname", "image", tb.Command("exit 0")),
+				tb.ConditionSpecCheckScript("echo foo"),
+			)),
+		expectedError: apis.FieldError{
+			Message: "invalid value \"Cname\"",
+			Paths:   []string{"Spec.Check.name"},
+			Details: "Condition check name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
 		},
 	}}
 


### PR DESCRIPTION
This will add validation for condition check name like the
one we are doing for task step name

Right now the condition is getting created with
invalid name format but when we use it in pipeline
its not working

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Fix validation for condition check name
```
