### PR TITLE
Update .ko.yaml based on the publish task 🌮

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,3 +2,8 @@ baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/entrypoint: busybox  # image must have `cp` in $PATH
+baseBuildOverrides:
+  github.com/tektoncd/pipeline/cmd/controller:
+    flags:
+    - name: ldflags
+      value: "-X github.com/tektoncd/pipeline/pkg/version.PipelineVersion=devel"

--- a/.ko.yaml.release
+++ b/.ko.yaml.release
@@ -1,4 +1,0 @@
-baseImageOverrides:
-  github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tektoncd-release/github.com/tektoncd/pipeline/build-base:latest
-  github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tektoncd-release/github.com/tektoncd/pipeline/build-base:latest
-  github.com/tektoncd/pipeline/cmd/entrypoint: busybox # image should have shell in $PATH

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -78,9 +78,6 @@ spec:
         $(inputs.params.pathToProject)/$(outputs.resources.builtEntrypointImage.url): busybox # image should have shell in $PATH
       baseBuildOverrides:
         $(inputs.params.pathToProject)/$(outputs.resources.builtControllerImage.url):
-          env:
-            - name: CGO_ENABLED
-              value: 1
           flags:
             - name: ldflags
               value: "-X $(inputs.params.pathToProject)/pkg/version.PipelineVersion=$(inputs.params.versionTag)"


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This also removes the unused .ko.yaml.release file. We re-create a `.ko.yaml` during the release task.
Related to #2510 (but doesn't fix it)

/cc @afrittoli @dibyom @bobcatfish @ImJasonH 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
