### PR TITLE
Use v1beta1 for git-init and imagedigestexporter 👼

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"os"
 
-	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/git"
 	"github.com/tektoncd/pipeline/pkg/termination"
@@ -59,7 +58,7 @@ func main() {
 		logger.Fatalf("Error parsing revision %s of git repository: %s", fetchSpec.Revision, err)
 	}
 	resourceName := os.Getenv("TEKTON_RESOURCE_NAME")
-	output := []v1alpha1.PipelineResourceResult{
+	output := []v1beta1.PipelineResourceResult{
 		{
 			Key:   "commit",
 			Value: commit,

--- a/cmd/imagedigestexporter/main.go
+++ b/cmd/imagedigestexporter/main.go
@@ -24,7 +24,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/google/go-containerregistry/pkg/v1/layout"
-	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1/image"
 )
 
@@ -52,7 +52,7 @@ func main() {
 		logger.Fatalf("Error reading images array: %v", err)
 	}
 
-	output := []v1alpha1.PipelineResourceResult{}
+	output := []v1beta1.PipelineResourceResult{}
 	for _, imageResource := range imageResources {
 		ii, err := layout.ImageIndexFromPath(imageResource.OutputImageDir)
 		if err != nil {
@@ -63,10 +63,10 @@ func main() {
 		if err != nil {
 			logger.Fatalf("Unexpected error getting image digest for %s: %v", imageResource.Name, err)
 		}
-		output = append(output, v1alpha1.PipelineResourceResult{
+		output = append(output, v1beta1.PipelineResourceResult{
 			Key:   "digest",
 			Value: digest.String(),
-			ResourceRef: v1alpha1.PipelineResourceRef{
+			ResourceRef: v1beta1.PipelineResourceRef{
 				Name: imageResource.Name,
 			},
 		})

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -24,11 +24,11 @@ import (
 
 const (
 	// TaskRunResultType default task run result value
-	TaskRunResultType ResultType = "TaskRunResult"
+	TaskRunResultType ResultType = v1beta1.TaskRunResultType
 	// PipelineResourceResultType default pipeline result value
-	PipelineResourceResultType ResultType = "PipelineResourceResult"
+	PipelineResourceResultType ResultType = v1beta1.PipelineResourceResultType
 	// UnknownResultType default unknown result type value
-	UnknownResultType ResultType = ""
+	UnknownResultType ResultType = v1beta1.UnknownResultType
 )
 
 func (t *Task) TaskSpec() TaskSpec {

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -21,6 +21,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// TaskRunResultType default task run result value
+	TaskRunResultType ResultType = "TaskRunResult"
+	// PipelineResourceResultType default pipeline result value
+	PipelineResourceResultType ResultType = "PipelineResourceResult"
+	// UnknownResultType default unknown result type value
+	UnknownResultType ResultType = ""
+)
+
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/termination"
 	"go.uber.org/zap"
 )
@@ -83,7 +83,7 @@ func (e Entrypointer) Go() error {
 	prod, _ := zap.NewProduction()
 	logger := prod.Sugar()
 
-	output := []v1alpha1.PipelineResourceResult{}
+	output := []v1beta1.PipelineResourceResult{}
 	defer func() {
 		if wErr := termination.WriteMessage(e.TerminationPath, output); wErr != nil {
 			logger.Fatalf("Error while writing message: %s", wErr)
@@ -96,7 +96,7 @@ func (e Entrypointer) Go() error {
 			// An error happened while waiting, so we bail
 			// *but* we write postfile to make next steps bail too.
 			e.WritePostFile(e.PostFile, err)
-			output = append(output, v1alpha1.PipelineResourceResult{
+			output = append(output, v1beta1.PipelineResourceResult{
 				Key:   "StartedAt",
 				Value: time.Now().Format(time.RFC3339),
 			})
@@ -108,7 +108,7 @@ func (e Entrypointer) Go() error {
 	if e.Entrypoint != "" {
 		e.Args = append([]string{e.Entrypoint}, e.Args...)
 	}
-	output = append(output, v1alpha1.PipelineResourceResult{
+	output = append(output, v1beta1.PipelineResourceResult{
 		Key:   "StartedAt",
 		Value: time.Now().Format(time.RFC3339),
 	})
@@ -130,7 +130,7 @@ func (e Entrypointer) Go() error {
 }
 
 func (e Entrypointer) readResultsFromDisk() error {
-	output := []v1alpha1.PipelineResourceResult{}
+	output := []v1beta1.PipelineResourceResult{}
 	for _, resultFile := range e.Results {
 		if resultFile == "" {
 			continue
@@ -142,10 +142,10 @@ func (e Entrypointer) readResultsFromDisk() error {
 			return err
 		}
 		// if the file doesn't exist, ignore it
-		output = append(output, v1alpha1.PipelineResourceResult{
+		output = append(output, v1beta1.PipelineResourceResult{
 			Key:        resultFile,
 			Value:      string(fileContents),
-			ResultType: v1alpha1.TaskRunResultType,
+			ResultType: v1beta1.TaskRunResultType,
 		})
 	}
 	// push output to termination path


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

It is not required to use v1alpha1 for those commands.
Related to #2410 :stuck_out_tongue_closed_eyes: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
