### PR TITLE
Track deprecated Beta features w/ earliest date of removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ a cluster with **Kubernetes version 1.15 or later***.
 _See [our API compatibility policy](api_compatibility_policy.md) for info on the
 stability level of the API._
 
+_See [our Deprecations table](docs/deprecations.md) for features that have been
+deprecated and the earliest date they'll be removed._
+
 ## Migrating
 
 ### v1alpha1 to v1beta1

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,25 @@
+
+<!--
+---
+linkTitle: "Deprecations"
+weight: 16
+---
+-->
+
+# Deprecations
+
+- [Introduction](#introduction)
+- [Deprecation Table](#deprecation-table)
+
+## Introduction
+
+This doc provides a list of features in Tekton Pipelines that are
+being deprecated.
+
+## Deprecation Table
+
+| Feature Being Deprecated | Deprecation Announcement | [API Compatibility Policy](https://github.com/tektoncd/pipeline/tree/master/api_compatibility_policy.md) | Earliest Date of Removal |
+| ------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------ |
+| [`tekton.dev/task` label on ClusterTasks](https://github.com/tektoncd/pipeline/issues/2533) | [v0.12.0](https://github.com/tektoncd/pipeline/releases/tag/v0.12.0) | Beta | January 30 2021 |
+| [Step `$HOME` env var defaults to `/tekton/home`](https://github.com/tektoncd/pipeline/issues/2013) | [v0.11.0-rc1](https://github.com/tektoncd/pipeline/releases/tag/v0.11.0-rc1) | Beta | December 4 2020 |
+| [Step `workingDir` defaults to `/workspace`](https://github.com/tektoncd/pipeline/issues/1836) | [v0.11.0-rc1](https://github.com/tektoncd/pipeline/releases/tag/v0.11.0-rc1) | Beta | December 4 2020 |


### PR DESCRIPTION

# Changes

We don't currently have a centralized place to list the
features that Pipelines has deprecated.

This commit adds a deprecations doc which shows the feature
being deprecated, a link to the release where its deprecation
was announced, and the earliest date by which the feature
will be removed entirely in relation to the announcement.

At the moment I've only listed Beta features that have been
announced as deprecated. I haven't included things which are
still in Alpha or were announced as deprecated prior to
v0.11.0-rc1, since the policy for alpha code was simply that
we'd give 1 release of forewarning.

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

# Release Notes

```
A list of feature deprecations along with the earliest date of their removal has been added to Pipelines' docs.
```
