### PR TITLE
updating doc to add note on task results

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -490,6 +490,13 @@ params:
     value: "$(tasks.checkout-source.results.commit)"
 ```
 
+**Note:** If `checkout-source` exits successfully without initializing `commit` `Result`,
+the receiving `Task` fails and causes the `Pipeline` to fail with `InvalidTaskResultReference`:
+
+```
+unable to find result referenced by param 'foo' in 'task';: Could not find result with name 'commit' for task run 'checkout-source'
+```
+
 In the snippet below, a `WhenExpression` is provided its value from the `exists` `Result` emitted by the
 `check-file` `Task`. Tekton will make sure that the `check-file` `Task` runs before this one.
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -98,6 +98,9 @@ const (
 	// ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
 	// all of the running TaskRuns as cancelled failed.
 	ReasonCouldntCancel = "PipelineRunCouldntCancel"
+	// ReasonInvalidTaskResultReference indicates a task result was declared
+	// but was not initialized by that task
+	ReasonInvalidTaskResultReference = "InvalidTaskResultReference"
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.
@@ -514,8 +517,8 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 
 	resolvedResultRefs, err := resources.ResolveResultRefs(pipelineRunState, nextRprts)
 	if err != nil {
-		logger.Infof("Failed to resolve all task params for %q with error %v", pr.Name, err)
-		pr.Status.MarkFailed(ReasonFailedValidation, err.Error())
+		logger.Infof("Failed to resolve task result reference for %q with error %v", pr.Name, err)
+		pr.Status.MarkFailed(ReasonInvalidTaskResultReference, err.Error())
 		return controller.NewPermanentError(err)
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Task execution order is set such that the task producing a result is executed before the task referencing that result. In case of a failure of a referenced task, pipeline exits without executing the rest of the pipeline tasks. But when a referenced task succeeds but does not instantiate the result, the task with referencing result is not executed and pipeline fails. Pipeline exits with `InvalidTaskResultReference` since the result did not exist.

An example of such task and pipeline execution [here](https://gist.github.com/pritidesai/931936e2bd61c50df29fdc767442b494).

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
