### PR TITLE
Add a link from API Policy to Deprecations Table

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -78,3 +78,8 @@ to adjust their usage in order to use the new version.
 
 These changes must be approved by [more than half of the project OWNERS](OWNERS)
 (i.e. 50% + 1).
+
+## Deprecated Features
+
+Tekton Pipelines [maintains a list of features that have been deprecated](https://github.com/tektoncd/pipeline/tree/master/docs/deprecations.md)
+which includes the earliest date each feature will be removed.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In a prior commit we added a table of deprecations which lists
the earliest date at which deprecated features can be removed
in line with our API policy.

This commit adds a link to the deprecations table from the API
policy document.

Suggested in [previous PR comment](https://github.com/tektoncd/pipeline/pull/2532#issuecomment-623693635).

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)