### PR TITLE
Emit events from the PipelineRun controller

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -27,13 +27,21 @@ No events are emitted for `Conditions` today (https://github.com/tektoncd/pipeli
   successfully, including post-steps injected by Tekton.
 - `Failed`: this is triggered if the `TaskRun` is completed, but not successfully.
   Causes of failure may be: one the steps failed, the `TaskRun` was cancelled or
-  the `TaskRun` timed out.
+  the `TaskRun` timed out. `Failed` events are also triggered in case the `TaskRun`
+  cannot be executed at all because of validation issues.
 
 ## PipelineRuns
 
 `PipelineRun` events are generated for the following `Reasons`:
+- `Started`: this is triggered the first time the `PipelineRun` is picked by the
+  reconciler from its work queue, so it only happens if web-hook validation was
+  successful. Note that this event does not imply that a step started executing,
+  as pipeline, task and bound resource validation must be successful first.
+- `Running`: this is triggered when the `PipelineRun` passes validation and
+  actually starts running.
 - `Succeeded`: this is triggered once all `Tasks` reachable via the DAG are
   executed successfully.
 - `Failed`: this is triggered if the `PipelineRun` is completed, but not
   successfully. Causes of failure may be: one the `Tasks` failed or the
-  `PipelineRun` was cancelled.
+  `PipelineRun` was cancelled or timed out. `Failed` events are also triggered
+  in case the `PipelineRun` cannot be executed at all because of validation issues.

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -67,6 +67,7 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 			KubeClientSet:     kubeclientset,
 			PipelineClientSet: pipelineclientset,
 			Logger:            logger,
+			Recorder:          controller.GetEventRecorder(ctx),
 		}
 
 		c := &Reconciler{

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -384,7 +384,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun,
 		go c.timeoutHandler.WaitTaskRun(tr, tr.Status.StartTime)
 	}
 	if err := c.tracker.Track(tr.GetBuildPodRef(), tr); err != nil {
-		c.Logger.Errorf("Failed to create tracker for build pod %q for taskrun %q: %v", tr.Name, tr.Name, err)
+		c.Logger.Errorf("Failed to create tracker for pod %q for taskrun %q: %v", tr.Name, tr.Name, err)
 		return err
 	}
 
@@ -420,8 +420,8 @@ func (c *Reconciler) updateStatusLabelsAndAnnotations(tr, original *v1beta1.Task
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 		if _, err := c.updateStatus(tr); err != nil {
-			c.Logger.Warn("Failed to update taskRun status", zap.Error(err))
-			return err
+			c.Logger.Warn("Failed to update TaskRun status", zap.Error(err))
+			return fmt.Errorf("failed to update TaskRun status: %s", err.Error())
 		}
 		updated = true
 	}
@@ -433,7 +433,7 @@ func (c *Reconciler) updateStatusLabelsAndAnnotations(tr, original *v1beta1.Task
 	if !reflect.DeepEqual(original.ObjectMeta.Labels, tr.ObjectMeta.Labels) || !reflect.DeepEqual(original.ObjectMeta.Annotations, tr.ObjectMeta.Annotations) {
 		if _, err := c.updateLabelsAndAnnotations(tr); err != nil {
 			c.Logger.Warn("Failed to update TaskRun labels/annotations", zap.Error(err))
-			return err
+			return fmt.Errorf("failed to update TaskRun labels/annotations: %s", err.Error())
 		}
 		updated = true
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -297,9 +297,10 @@ func checkEvents(fr *record.FakeRecorder, testName string, wantEvents []string) 
 				return fmt.Errorf("Expected event \"%s\" but got \"%s\" instead for %s", wantEvent, event, testName)
 			}
 		case <-timer.C:
-			if len(foundEvents) > len(wantEvents) {
-				return fmt.Errorf("Received %d events for %s but %d expected. Found events: %#v", len(foundEvents), testName, len(wantEvents), foundEvents)
+			if len(foundEvents) == len(wantEvents) {
+				return nil
 			}
+			return fmt.Errorf("Received %d events for %s but %d expected. Found events: %#v", len(foundEvents), testName, len(wantEvents), foundEvents)
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Emit events from the PipelineRun controller

Emit events:
- Pipeline Start
- Pipeline Started Running
- Various Error Conditions, Cancel, Timeout

Emit all events through the events.go module.
Align and simplify the reconcile structure to have clear points
for error handling and emitting events.

Added test for the normal reconcile to completion case.
Added more event checks to existing tests.

Partially addresses #2474
Partially addresses #2082

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
PipelineRuns emit an additional k8s event when starting to execute, to run and on different failure scenarios.
```