### PR TITLE
Allow for setting imagePullSecrets

### DIFF
--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -57,6 +57,7 @@ The current fields supported are:
   to use when dispatching the Pod. This can be used when workloads of specific types need specific schedulers,
   e.g.: If you are using volcano.sh for Machine Learning Workloads, you can pass the schedulerName and have Tasks be 
   dispatched by the volcano.sh scheduler.
+- `imagePullSecret` the name of the [`secret`](https://kubernetes.io/docs/concepts/configuration/secret/) used when [pulling the image if specified](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
 - `hostNetwork`: set this to `true` if the host network namespace should be used.
   Defaults to `false`.
 

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -93,6 +93,10 @@ type Template struct {
 	// SchedulerName specifies the scheduler to be used to dispatch the Pod
 	// +optional
 	SchedulerName string `json:"schedulerName"`
+
+	// ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
+	ImagePullSecrets []corev1.LocalObjectReference
+
 	// HostNetwork specifies whether the pod may use the node network namespace
 	// +optional
 	HostNetwork bool `json:"hostNetwork"`

--- a/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/pod/zz_generated.deepcopy.go
@@ -88,6 +88,11 @@ func (in *Template) DeepCopyInto(out *Template) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -273,6 +273,7 @@ func MakePod(images pipeline.Images, taskRun *v1beta1.TaskRun, taskSpec v1beta1.
 			DNSConfig:                    podTemplate.DNSConfig,
 			EnableServiceLinks:           podTemplate.EnableServiceLinks,
 			PriorityClassName:            priorityClassName,
+			ImagePullSecrets:             podTemplate.ImagePullSecrets,
 		},
 	}, nil
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/system"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -730,6 +731,51 @@ script-heredoc-randomly-generated-78c5n
 			}},
 		},
 	}, {
+		desc: "setting image pull secret",
+		ts: v1beta1.TaskSpec{
+			Steps: []v1alpha1.Step{
+				{
+					Container: corev1.Container{
+						Name:    "image-pull",
+						Image:   "image",
+						Command: []string{"cmd"}, // avoid entrypoint lookup.
+					},
+				},
+			},
+		},
+		trs: v1beta1.TaskRunSpec{
+			PodTemplate: &v1alpha1.PodTemplate{
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "imageSecret"}},
+			},
+		},
+		want: &corev1.PodSpec{
+			RestartPolicy:  corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{placeToolsInit},
+			Volumes:        append(implicitVolumes, toolsVolume, downwardVolume),
+			Containers: []corev1.Container{{
+				Name:    "step-image-pull",
+				Image:   "image",
+				Command: []string{"/tekton/tools/entrypoint"},
+				Args: []string{
+					"-wait_file",
+					"/tekton/downward/ready",
+					"-wait_file_content",
+					"-post_file",
+					"/tekton/tools/0",
+					"-termination_path",
+					"/tekton/termination",
+					"-entrypoint",
+					"cmd",
+					"--",
+				},
+				Env:                    implicitEnvVars,
+				VolumeMounts:           append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
+				WorkingDir:             pipeline.WorkspaceDir,
+				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
+				TerminationMessagePath: "/tekton/termination",
+			}},
+			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "imageSecret"}},
+		}}, {
 		desc: "using hostNetwork",
 		ts: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

NOTE: I am not assigned to the [issue](https://github.com/tektoncd/pipeline/issues/1779), but fixed it since I saw that it was stale for some time and thought it would be fun to try to fix it. 

This PR updates the [PodTemplate](https://github.com/tektoncd/pipeline/blob/a7fb3894310227cfc9e4e4303b8d0322beb6d95b/pkg/apis/pipeline/pod/template.go#L27) with ImagePullSecret to allow for setting image pull secrets. This PR aims to fix issue https://github.com/tektoncd/pipeline/issues/1779. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Allow to specify ImagePullSecrets in the PodTemplate.

```
