### PR TITLE
Base entrypoint image on distroless

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,3 @@
 baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
-  github.com/tektoncd/pipeline/cmd/entrypoint: busybox  # image must have `cp` in $PATH

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -88,9 +88,11 @@ var (
 // TODO(#1605): Also use entrypoint injection to order sidecar start/stop.
 func orderContainers(entrypointImage string, steps []corev1.Container, results []v1alpha1.TaskResult) (corev1.Container, []corev1.Container, error) {
 	initContainer := corev1.Container{
-		Name:         "place-tools",
-		Image:        entrypointImage,
-		Command:      []string{"cp", "/ko-app/entrypoint", entrypointBinary},
+		Name:  "place-tools",
+		Image: entrypointImage,
+		// Invoke the entrypoint binary in "cp mode" to copy itself
+		// into the correct location for later steps.
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointBinary},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -97,7 +97,7 @@ func TestOrderContainers(t *testing.T) {
 	wantInit := corev1.Container{
 		Name:         "place-tools",
 		Image:        images.EntrypointImage,
-		Command:      []string{"cp", "/ko-app/entrypoint", entrypointBinary},
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointBinary},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 	if d := cmp.Diff(wantInit, gotInit); d != "" {

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -62,7 +62,7 @@ func TestMakePod(t *testing.T) {
 	placeToolsInit := corev1.Container{
 		Name:         "place-tools",
 		Image:        images.EntrypointImage,
-		Command:      []string{"cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 
@@ -609,7 +609,7 @@ script-heredoc-randomly-generated-78c5n
 				{
 					Name:         "place-tools",
 					Image:        images.EntrypointImage,
-					Command:      []string{"cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
+					Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
 					VolumeMounts: []corev1.VolumeMount{toolsMount},
 				}},
 			Containers: []corev1.Container{{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources/cloudevent"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
@@ -40,7 +39,6 @@ import (
 	test "github.com/tektoncd/pipeline/test/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -241,7 +239,7 @@ var (
 
 	getPlaceToolsInitContainer = func(ops ...tb.ContainerOp) tb.PodSpecOp {
 		actualOps := []tb.ContainerOp{
-			tb.Command("cp", "/ko-app/entrypoint", entrypointLocation),
+			tb.Command("/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointLocation),
 			tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 			tb.Args(),
 		}


### PR DESCRIPTION
The only reason it was based on busybox was to have access to `cp`,
which it used to copy its binary to /tekton/tools for use in later
steps.

Instead of relying on `cp`, this adds a "cp mode" to the entrypoint
binary itself. When invoked with the positional args `cp <src> <dst>`,
it copies src to dst using Go's os and io packages.

/hold for discussion

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
Entrypoint image is no longer based on busybox, now based on distroless like other images.
```
