### PR TITLE
Add a dummy.go file to allow vendoring config

### DIFF
--- a/config/dummy.go
+++ b/config/dummy.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package config is a placeholder that allows us to pull in config files
+// via go mod vendor.
+package config


### PR DESCRIPTION
This is needed for go mod vendor to pull in Tekton's config directory.

