### PR TITLE
Update golangci configuration ☕

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,8 @@
-run:
-  build-tags:
-  - e2e
-  skip-dirs:
-  - vendor
-  - pkg/client
-  timeout: 5m
 linters-settings:
   errcheck:
     exclude: .errcheck.txt
 linters:
+  disable-all: true
   enable:
   - errcheck
   - gofmt
@@ -16,3 +10,22 @@ linters:
   - gosec
   - gocritic
   - golint
+output:
+  uniq-by-line: false
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
+    - errcheck
+    - gosec
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  issues-exit-code: 1
+  build-tags:
+  - e2e
+  skip-dirs:
+  - vendor
+  - pkg/client
+  timeout: 10m
+  modules-download-mode: vendor

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -32,8 +32,7 @@ source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scri
 function post_build_tests() {
   header "running golangci-lint"
   # deadline of 5m, and show all the issues
-  golangci-lint -j 1 --color=never \
-                run --modules-download-mode=vendor --max-issues-per-linter=0 --max-same-issues=0 --deadline 10m
+  golangci-lint -j 1 --color=never run
 }
 
 # We use the default build, unit and integration test runners.


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This removes some flags that are now in the configuration, and add
more information. Trying `disable-all` with `enable` to limit the
linter run to only the one we specify. Also trying to run less linters
on `_test.go`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
