### PR TITLE
webhook.go: golint pass 👼

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -60,7 +60,7 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1beta1.SchemeGroupVersion.WithKind("PipelineRun"): &v1beta1.PipelineRun{},
 }
 
-func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	// Decorate contexts with the current state of the config.
 	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
 	store.WatchConfigs(cmw)
@@ -86,7 +86,7 @@ func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher
 	)
 }
 
-func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+func newValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	// Decorate contexts with the current state of the config.
 	store := defaultconfig.NewStore(logging.FromContext(ctx).Named("config-store"))
 	store.WatchConfigs(cmw)
@@ -111,7 +111,7 @@ func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher
 	)
 }
 
-func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	return configmaps.NewAdmissionController(ctx,
 
 		// Name of the configmap webhook.
@@ -129,11 +129,11 @@ func NewConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 	)
 }
 
-func NewConversionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+func newConversionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 	// nolint: golint
 	var (
-		v1alpha1_ = v1alpha1.SchemeGroupVersion.Version
-		v1beta1_  = v1beta1.SchemeGroupVersion.Version
+		v1alpha1GroupVersion = v1alpha1.SchemeGroupVersion.Version
+		v1beta1GroupVersion  = v1beta1.SchemeGroupVersion.Version
 	)
 
 	return conversion.NewConversionController(ctx,
@@ -144,42 +144,42 @@ func NewConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 		map[schema.GroupKind]conversion.GroupKindConversion{
 			v1beta1.Kind("Task"): {
 				DefinitionName: pipeline.TaskResource.String(),
-				HubVersion:     v1alpha1_,
+				HubVersion:     v1alpha1GroupVersion,
 				Zygotes: map[string]conversion.ConvertibleObject{
-					v1alpha1_: &v1alpha1.Task{},
-					v1beta1_:  &v1beta1.Task{},
+					v1alpha1GroupVersion: &v1alpha1.Task{},
+					v1beta1GroupVersion:  &v1beta1.Task{},
 				},
 			},
 			v1beta1.Kind("ClusterTask"): {
 				DefinitionName: pipeline.ClusterTaskResource.String(),
-				HubVersion:     v1alpha1_,
+				HubVersion:     v1alpha1GroupVersion,
 				Zygotes: map[string]conversion.ConvertibleObject{
-					v1alpha1_: &v1alpha1.ClusterTask{},
-					v1beta1_:  &v1beta1.ClusterTask{},
+					v1alpha1GroupVersion: &v1alpha1.ClusterTask{},
+					v1beta1GroupVersion:  &v1beta1.ClusterTask{},
 				},
 			},
 			v1beta1.Kind("TaskRun"): {
 				DefinitionName: pipeline.TaskRunResource.String(),
-				HubVersion:     v1alpha1_,
+				HubVersion:     v1alpha1GroupVersion,
 				Zygotes: map[string]conversion.ConvertibleObject{
-					v1alpha1_: &v1alpha1.TaskRun{},
-					v1beta1_:  &v1beta1.TaskRun{},
+					v1alpha1GroupVersion: &v1alpha1.TaskRun{},
+					v1beta1GroupVersion:  &v1beta1.TaskRun{},
 				},
 			},
 			v1beta1.Kind("Pipeline"): {
 				DefinitionName: pipeline.PipelineResource.String(),
-				HubVersion:     v1alpha1_,
+				HubVersion:     v1alpha1GroupVersion,
 				Zygotes: map[string]conversion.ConvertibleObject{
-					v1alpha1_: &v1alpha1.Pipeline{},
-					v1beta1_:  &v1beta1.Pipeline{},
+					v1alpha1GroupVersion: &v1alpha1.Pipeline{},
+					v1beta1GroupVersion:  &v1beta1.Pipeline{},
 				},
 			},
 			v1beta1.Kind("PipelineRun"): {
 				DefinitionName: pipeline.PipelineRunResource.String(),
-				HubVersion:     v1alpha1_,
+				HubVersion:     v1alpha1GroupVersion,
 				Zygotes: map[string]conversion.ConvertibleObject{
-					v1alpha1_: &v1alpha1.PipelineRun{},
-					v1beta1_:  &v1beta1.PipelineRun{},
+					v1alpha1GroupVersion: &v1alpha1.PipelineRun{},
+					v1beta1GroupVersion:  &v1beta1.PipelineRun{},
 				},
 			},
 		},
@@ -215,9 +215,9 @@ func main() {
 	sharedmain.WebhookMainWithConfig(ctx, "webhook",
 		sharedmain.ParseAndGetConfigOrDie(),
 		certificates.NewController,
-		NewDefaultingAdmissionController,
-		NewValidationAdmissionController,
-		NewConfigValidationController,
-		NewConversionController,
+		newDefaultingAdmissionController,
+		newValidationAdmissionController,
+		newConfigValidationController,
+		newConversionController,
 	)
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Un-exported local methods and rename `v1alpha1_` and `v1beta1_`
variable to better name.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

