### PR TITLE
Makefile: add bin/*, resolve and watch-resolve target 🚕

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ cmd/*/kodata/source.tar.gz
 # binaries
 test/pullrequest/pullrequest-init
 /.bin/
+/bin/

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,15 @@ apply: | $(KO) ; $(info $(M) ko apply -f config/) @ ## Apply config to the curre
 
 .PHONY: resolve
 resolve: | $(KO) ; $(info $(M) ko resolve -f config/) @ ## Resolve config to the current cluster
-	$Q $(KO) resolve --push=false -f config
+	$Q $(KO) resolve --push=false --oci-layout-path=$(BIN)/oci -f config
+
+.PHONY: generated
+generated: | vendor ; $(info $(M) update generated files) ## Update generated files
+	$Q ./hack/update-codegen.sh
+
+.PHONY: vendor
+vendor:
+	$Q ./hack/update-deps.sh
 
 ## Tests
 TEST_UNIT_TARGETS := test-unit-verbose test-unit-race
@@ -85,7 +93,7 @@ watch-test: | $(RAM) ; $(info $(M) watch and run tests) @ ## Watch and run tests
 
 .PHONY: watch-resolve
 watch-resolve: | $(KO) ; $(info $(M) watch and resolve config) @ ## Watch and build to the current cluster
-	$Q $(KO) resolve -W --push=false -f config 1>/dev/null
+	$Q $(KO) resolve -W --push=false --oci-layout-path=$(BIN)/oci -f config 1>/dev/null
 
 .PHONY: watch-config
 watch-config: | $(KO) ; $(info $(M) watch and apply config) @ ## Watch and apply to the current cluster


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Those targets are there to build binaries using `go` and the images
using `ko resolve` without applying the changes.

This also adds a `generated` target.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/cc @afrittoli @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add bin/*, resolve, watch-resolve and generated target to the Makefile
```
