### PR TITLE
reconciler: fix store*Spec tests 🐛

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2163,6 +2163,7 @@ func Test_storePipelineSpec(t *testing.T) {
 	pr := tb.PipelineRun("foo")
 
 	ps := tb.Pipeline("some-pipeline", tb.PipelineSpec(tb.PipelineDescription("foo-pipeline"))).Spec
+	ps1 := tb.Pipeline("some-pipeline", tb.PipelineSpec(tb.PipelineDescription("bar-pipeline"))).Spec
 	want := &v1beta1.PipelineSpec{}
 	if err := ps.ConvertTo(ctx, want); err != nil {
 		t.Errorf("error converting to v1beta1: %v", err)
@@ -2176,9 +2177,8 @@ func Test_storePipelineSpec(t *testing.T) {
 		t.Fatalf("-want, +got: %v", d)
 	}
 
-	ps.Description = "new-pipeline"
 	// The next time, it should not get overwritten
-	if err := storePipelineSpec(ctx, pr, &ps); err != nil {
+	if err := storePipelineSpec(ctx, pr, &ps1); err != nil {
 		t.Errorf("storePipelineSpec() error = %v", err)
 	}
 	if d := cmp.Diff(pr.Status.PipelineSpec, want); d != "" {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2496,6 +2496,7 @@ func Test_storeTaskSpec(t *testing.T) {
 	tr := tb.TaskRun("foo", tb.TaskRunSpec(tb.TaskRunTaskRef("foo-task")))
 
 	ts := tb.Task("some-task", tb.TaskSpec(tb.TaskDescription("foo-task"))).Spec
+	ts1 := tb.Task("some-task", tb.TaskSpec(tb.TaskDescription("bar-task"))).Spec
 	want := &v1beta1.TaskSpec{}
 	if err := ts.ConvertTo(ctx, want); err != nil {
 		t.Errorf("error converting to v1beta1: %v", err)
@@ -2509,9 +2510,8 @@ func Test_storeTaskSpec(t *testing.T) {
 		t.Fatalf("-want, +got: %v", d)
 	}
 
-	ts.Description = "new-task"
 	// The next time, it should not get overwritten
-	if err := storeTaskSpec(ctx, tr, &ts); err != nil {
+	if err := storeTaskSpec(ctx, tr, &ts1); err != nil {
 		t.Errorf("storeTaskSpec() error = %v", err)
 	}
 	if d := cmp.Diff(tr.Status.TaskSpec, want); d != "" {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
The two tests on `storePipelineSpec` and `storeTaskSpec` are not
correctly writing and do not test anything except pointers in Go.

The functions `storePipelineSpec` and `storeTaskSpec` are using
pointers to set the spec in the status. This means if we change the
object that it points to the value will have change.
Additionally passing the same pointer to the function doesn't help
knowing if the spec inside the status changed or not.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/area testing

/cc @afrittoli @sbwsg @bobcatfish @dlorenc 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

