### PR TITLE
Add validation for "ServiceAccountNames"  to avoid wrong taskname

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -262,6 +262,21 @@ func ValidateWorkspaceBindings(p *v1alpha1.PipelineSpec, pr *v1alpha1.PipelineRu
 	return nil
 }
 
+// ValidateServiceaccountMapping validates that the ServiceAccountNames defined by a PipelineRun are not correct.
+func ValidateServiceaccountMapping(p *v1alpha1.PipelineSpec, pr *v1alpha1.PipelineRun) error {
+	pipelineTasks := make(map[string]string)
+	for _, task := range p.Tasks {
+		pipelineTasks[task.Name] = task.Name
+	}
+
+	for _, name := range pr.Spec.ServiceAccountNames {
+		if _, ok := pipelineTasks[name.TaskName]; !ok {
+			return fmt.Errorf("PipelineRun's ServiceAccountNames defined wrong taskName: %q, not existed in Pipeline", name.TaskName)
+		}
+	}
+	return nil
+}
+
 // TaskNotFoundError indicates that the resolution failed because a referenced Task couldn't be retrieved
 type TaskNotFoundError struct {
 	Name string

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1949,6 +1949,19 @@ func TestValidateWorkspaceBindings(t *testing.T) {
 	}
 }
 
+func TestValidateServiceaccountMapping(t *testing.T) {
+	p := tb.Pipeline("pipelines", tb.PipelineSpec(
+		tb.PipelineTask("mytask1", "task",
+			tb.PipelineTaskInputResource("input1", "git-resource")),
+	))
+	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
+		tb.PipelineRunServiceAccountNameTask("mytaskwrong", "default"),
+	))
+	if err := ValidateServiceaccountMapping(&p.Spec, pr); err == nil {
+		t.Fatalf("Expected error indicating `mytaskwrong` was not defined as `task` in Pipeline but got no error")
+	}
+}
+
 func TestIsBeforeFirstTaskRun_WithNotStartedTask(t *testing.T) {
 	if !noneStartedState.IsBeforeFirstTaskRun() {
 		t.Fatalf("Expected state to be before first taskrun")


### PR DESCRIPTION
Fix issue #2582
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
If define `PipelineRun.Spec.ServiceAccountNames` with a wrong `TaskName` (not existed in `Pipeline` definition), the `PipelineRun` will failed with `InvalidServiceAccountMappings`
