### PR TITLE
Add variable expansion for params in Projected Volume fields

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -545,7 +545,7 @@ The `description` field is an optional field that allows you to add an informati
 
 `Tasks` allow you to substitute variable names for the following entities:
 
-- [Parameters and resources]](#substituting-parameters-and-resources)
+- [Parameters and resources](#substituting-parameters-and-resources)
 - [`Array` parameters](#substituting-array-parameters)
 - [`Workspaces`](#substituting-workspace-paths)
 - [`Volume` names and types](#substituting-volume-names-and-paths)

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -166,6 +166,19 @@ func ApplyReplacements(spec *v1beta1.TaskSpec, stringReplacements map[string]str
 		if v.PersistentVolumeClaim != nil {
 			spec.Volumes[i].PersistentVolumeClaim.ClaimName = substitution.ApplyReplacements(v.PersistentVolumeClaim.ClaimName, stringReplacements)
 		}
+		if v.Projected != nil {
+			for _, s := range spec.Volumes[i].Projected.Sources {
+				if s.ConfigMap != nil {
+					s.ConfigMap.Name = substitution.ApplyReplacements(s.ConfigMap.Name, stringReplacements)
+				}
+				if s.Secret != nil {
+					s.Secret.Name = substitution.ApplyReplacements(s.Secret.Name, stringReplacements)
+				}
+				if s.ServiceAccountToken != nil {
+					s.ServiceAccountToken.Audience = substitution.ApplyReplacements(s.ServiceAccountToken.Audience, stringReplacements)
+				}
+			}
+		}
 	}
 
 	// Apply variable substitution to the sidecar definitions

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -159,6 +159,27 @@ var (
 					ClaimName: "$(inputs.params.FOO)",
 				},
 			},
+		}, {
+			Name: "some-projected-volumes",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{{
+						ConfigMap: &corev1.ConfigMapProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "$(inputs.params.FOO)",
+							},
+						},
+						Secret: &corev1.SecretProjection{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "$(inputs.params.FOO)",
+							},
+						},
+						ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+							Audience: "$(inputs.params.FOO)",
+						},
+					}},
+				},
+			},
 		}},
 		Resources: &v1beta1.TaskResources{
 			Inputs: []v1beta1.TaskResource{{
@@ -515,6 +536,9 @@ func TestApplyParameters(t *testing.T) {
 		spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name = "world"
 		spec.Volumes[1].VolumeSource.Secret.SecretName = "world"
 		spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "world"
+		spec.Volumes[3].VolumeSource.Projected.Sources[0].ConfigMap.Name = "world"
+		spec.Volumes[3].VolumeSource.Projected.Sources[0].Secret.Name = "world"
+		spec.Volumes[3].VolumeSource.Projected.Sources[0].ServiceAccountToken.Audience = "world"
 
 		spec.Sidecars[0].Container.Image = "bar"
 		spec.Sidecars[0].Container.Env[0].Value = "world"


### PR DESCRIPTION
# Changes

A [projected volume](https://kubernetes.io/docs/concepts/storage/volumes/#projected) can mount/project files from `Secrets`, `ConfigMaps` and `ServiceAccountTokens`.

It is good if the end-user can choose the name of `Secrets`, `ConfigMaps` and the audience of `ServiceAccountTokens`. With this commit, the task author can use `params` for `secret.name`, `configmap.name` and `serviceaccounttoken.audience` in a Projected Volume.

Example usage:

```
  volumes:
  - name: ssh-auth
    projected:
      defaultMode: 0400
      sources:
      - secret:
          name: $(params.known-hosts-secret) 
      - secret:
          name: $(params.private-key-secret)
```

See more example use cases in #2597

Fixes #2597
/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Add variable expansion for params in Projected Volume fields
```
