### PR TITLE
Fix typo introduced in git-init (#2598)

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -169,7 +169,7 @@ func SubmoduleFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 	}
 	updateArgs := []string{"submodule", "update", "--recursive"}
 	if spec.Depth > 0 {
-		updateArgs = append(updateArgs, "--depth", fmt.Sprintf("--depth=%d", spec.Depth))
+		updateArgs = append(updateArgs, fmt.Sprintf("--depth=%d", spec.Depth))
 	}
 	if _, err := run(logger, "", updateArgs...); err != nil {
 		return err


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

submodule update failed due to a typo in git-init.go appending --depth twice.
