### PR TITLE
Change TimeoutHandler to respect namespace scoping

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -70,7 +70,7 @@ func main() {
 		ImageDigestExporterImage: *imageDigestExporterImage,
 	}
 	sharedmain.MainWithContext(injection.WithNamespaceScope(signals.NewContext(), *namespace), ControllerLogKey,
-		taskrun.NewController(images),
-		pipelinerun.NewController(images),
+		taskrun.NewController(*namespace, images),
+		pipelinerun.NewController(*namespace, images),
 	)
 }

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -45,7 +45,7 @@ const (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(namespace string, images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -87,7 +87,7 @@ func NewController(images pipeline.Images) func(context.Context, configmap.Watch
 		impl := controller.NewImpl(c, c.Logger, pipeline.PipelineRunControllerName)
 
 		timeoutHandler.SetPipelineRunCallbackFunc(impl.Enqueue)
-		timeoutHandler.CheckTimeouts(kubeclientset, pipelineclientset)
+		timeoutHandler.CheckTimeouts(namespace, kubeclientset, pipelineclientset)
 
 		c.Logger.Info("Setting up event handlers")
 		pipelineRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -49,6 +49,7 @@ import (
 )
 
 var (
+	namespace                = ""
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
 	images                   = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",
@@ -77,7 +78,7 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.GetNamespace())
 	ctx, cancel := context.WithCancel(ctx)
 	return test.Assets{
-		Controller: NewController(images)(ctx, configMapWatcher),
+		Controller: NewController(namespace, images)(ctx, configMapWatcher),
 		Clients:    c,
 	}, cancel
 }

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -45,7 +45,7 @@ const (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(namespace string, images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -90,7 +90,7 @@ func NewController(images pipeline.Images) func(context.Context, configmap.Watch
 		impl := controller.NewImpl(c, c.Logger, pipeline.TaskRunControllerName)
 
 		timeoutHandler.SetTaskRunCallbackFunc(impl.Enqueue)
-		timeoutHandler.CheckTimeouts(kubeclientset, pipelineclientset)
+		timeoutHandler.CheckTimeouts(namespace, kubeclientset, pipelineclientset)
 
 		c.Logger.Info("Setting up event handlers")
 		taskRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -63,7 +63,8 @@ const (
 )
 
 var (
-	images = pipeline.Images{
+	namespace = "" // all namespaces
+	images    = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",
 		NopImage:                 "tianon/true",
 		GitImage:                 "override-with-git:latest",
@@ -267,7 +268,7 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 	c, _ := test.SeedTestData(t, ctx, d)
 	configMapWatcher := configmap.NewInformedWatcher(c.Kube, system.GetNamespace())
 	return test.Assets{
-		Controller: NewController(images)(ctx, configMapWatcher),
+		Controller: NewController(namespace, images)(ctx, configMapWatcher),
 		Clients:    c,
 	}, cancel
 }

--- a/pkg/reconciler/timeout_handler_test.go
+++ b/pkg/reconciler/timeout_handler_test.go
@@ -178,8 +178,8 @@ func TestTaskRunSingleNamespaceCheckTimeouts(t *testing.T) {
 	))
 
 	d := test.Data{
-		TaskRuns: []*v1alpha1.TaskRun{taskRunTimedout, taskRunTimedoutOtherNS},
-		Tasks:    []*v1alpha1.Task{simpleTask},
+		TaskRuns: []*v1beta1.TaskRun{taskRunTimedout, taskRunTimedoutOtherNS},
+		Tasks:    []*v1beta1.Task{simpleTask},
 		Namespaces: []*corev1.Namespace{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testNs,
@@ -195,7 +195,7 @@ func TestTaskRunSingleNamespaceCheckTimeouts(t *testing.T) {
 	th := NewTimeoutHandler(stopCh, zap.New(observer).Sugar())
 	gotCallback := sync.Map{}
 	f := func(tr interface{}) {
-		trNew := tr.(*v1alpha1.TaskRun)
+		trNew := tr.(*v1beta1.TaskRun)
 		gotCallback.Store(trNew.Name, struct{}{})
 	}
 
@@ -204,7 +204,7 @@ func TestTaskRunSingleNamespaceCheckTimeouts(t *testing.T) {
 
 	for _, tc := range []struct {
 		name           string
-		taskRun        *v1alpha1.TaskRun
+		taskRun        *v1beta1.TaskRun
 		expectCallback bool
 	}{{
 		name:           "timedout",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* Pass `--namespace` value to taskrun and pipelinerun NewController
to facilitate namespace-scoped behaviors
* Change TimeoutHandler `CheckTimeouts` to timeout taskrun/pipelinerun's
in the scoped namespace or all namespaces (default if unset)

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing) (NA)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Avoid performing a cluster-level namespace list when --namespace is set
```

Fix https://github.com/tektoncd/pipeline/issues/2603