### PR TITLE
Run tekton containers as nonroot 🐰

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,14 @@
+defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
+  # These base images run as root, which is needed for how they handle SSH credentials.
+  # They are produced from ./images/Dockerfile
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
-  github.com/tektoncd/pipeline/cmd/entrypoint: busybox  # image must have `cp` in $PATH
+  # GCS fetcher needs root due to workspace permissions
+  github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher: gcr.io/distroless/static:latest
+
+  # Our entrypoint image does not need root, it simply needs to be able to 'cp' the binary into a shared location.
+  github.com/tektoncd/pipeline/cmd/entrypoint: gcr.io/distroless/base:debug-nonroot
 baseBuildOverrides:
   github.com/tektoncd/pipeline/cmd/controller:
     flags:

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -56,8 +56,10 @@ spec:
 
           # These images are pulled from Dockerhub, by digest, as of April 15, 2020.
           "-nop-image", "tianon/true@sha256:009cce421096698832595ce039aa13fa44327d96beedb84282a69d3dbcf5a81b",
-          "-shell-image", "busybox@sha256:a2490cec4484ee6c1068ba3a05f89934010c85242f736280b35343483b2264b6",
           "-gsutil-image", "google/cloud-sdk@sha256:6e8676464c7581b2dc824956b112a61c95e4144642bec035e6db38e3384cae2e",
+          # The shell image must be root in order to create directories and copy files to PVCs.
+          # As of April 17, 2020
+          "-shell-image", "gcr.io/distroless/base:debug@sha256:dac57423f6d9210198e1ac25de9f6d48753196a112aa2deb22f54e984cfd462d",
         ]
         volumeMounts:
         - name: config-logging


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This changes a slew of containers that Tekton runs to use non-root base images.

This carry #2435 (discussed with @mattmoor)
Closes #2435

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Switch many of the Tekton images (e.g. controllers) to non-root by default.
```
