### PR TITLE
Propagate annotations from Conditions to TaskRuns/Pods

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -14,7 +14,7 @@ This document defines `Conditions` and their capabilities.
   - [Check](#check)
   - [Parameters](#parameters)
   - [Resources](#resources)
-- [Labels](#labels)
+- [Labels and Annotations](#labels-and-annotations)
 - [Examples](#examples)
 
 ## Syntax
@@ -80,9 +80,9 @@ Resources in Conditions work similar to the way they work in `Tasks` i.e. they c
 [variable substitution](./resources.md#variable-substitution) and the `targetPath` field can be used
 to [control where the resource is mounted](./resources.md#controlling-where-resources-are-mounted)
 
-## Labels
+## Labels and Annotations
 
-[Labels](labels.md) defined as part of the `Condition` metadata will be automatically propagated to the `Pod`.
+[Labels](labels.md) and annotations defined as part of the `Condition` metadata will be automatically propagated to the `Pod`.
 
 ## Examples
 

--- a/internal/builder/v1alpha1/condition.go
+++ b/internal/builder/v1alpha1/condition.go
@@ -62,6 +62,18 @@ func ConditionLabels(labels map[string]string) ConditionOp {
 	}
 }
 
+// ConditionAnnotations sets the annotations on the condition.
+func ConditionAnnotations(annotations map[string]string) ConditionOp {
+	return func(Condition *v1alpha1.Condition) {
+		if Condition.ObjectMeta.Annotations == nil {
+			Condition.ObjectMeta.Annotations = map[string]string{}
+		}
+		for key, value := range annotations {
+			Condition.ObjectMeta.Annotations[key] = value
+		}
+	}
+}
+
 // ConditionSpec creates a ConditionSpec with default values.
 // Any number of ConditionSpec modifiers can be passed to transform it.
 func ConditionSpec(ops ...ConditionSpecOp) ConditionOp {

--- a/internal/builder/v1alpha1/condition_test.go
+++ b/internal/builder/v1alpha1/condition_test.go
@@ -35,6 +35,11 @@ func TestCondition(t *testing.T) {
 				"label-1": "label-value-1",
 				"label-2": "label-value-2",
 			}),
+		tb.ConditionAnnotations(
+			map[string]string{
+				"annotation-1": "annotation-value-1",
+				"annotation-2": "annotation-value-2",
+			}),
 		tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu", tb.Command("exit 0")),
 			tb.ConditionDescription("Test Condition"),
 			tb.ConditionParamSpec("param-1", v1alpha1.ParamTypeString,
@@ -52,6 +57,10 @@ func TestCondition(t *testing.T) {
 			Labels: map[string]string{
 				"label-1": "label-value-1",
 				"label-2": "label-value-2",
+			},
+			Annotations: map[string]string{
+				"annotation-1": "annotation-value-1",
+				"annotation-2": "annotation-value-2",
 			},
 		},
 		Spec: v1alpha1.ConditionSpec{

--- a/internal/builder/v1alpha1/task.go
+++ b/internal/builder/v1alpha1/task.go
@@ -653,6 +653,18 @@ func TaskRunLabel(key, value string) TaskRunOp {
 	}
 }
 
+// TaskRunAnnotations adds the specified annotations to the TaskRun.
+func TaskRunAnnotations(annotations map[string]string) TaskRunOp {
+	return func(tr *v1alpha1.TaskRun) {
+		if tr.ObjectMeta.Annotations == nil {
+			tr.ObjectMeta.Annotations = map[string]string{}
+		}
+		for key, value := range annotations {
+			tr.ObjectMeta.Annotations[key] = value
+		}
+	}
+}
+
 // TaskRunAnnotation adds an annotation with the specified key and value to the TaskRun.
 func TaskRunAnnotation(key, value string) TaskRunOp {
 	return func(tr *v1alpha1.TaskRun) {

--- a/internal/builder/v1alpha1/task_test.go
+++ b/internal/builder/v1alpha1/task_test.go
@@ -182,6 +182,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 		),
 		tb.TaskRunLabels(map[string]string{"label-2": "label-value-2", "label-3": "label-value-3"}),
 		tb.TaskRunLabel("label", "label-value"),
+		tb.TaskRunAnnotations(map[string]string{"annotation-1": "annotation-value-1", "annotation-2": "annotation-value-2"}),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task-output",
 				tb.TaskRefKind(v1alpha1.ClusterTaskKind),
@@ -236,7 +237,10 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 				"label-2": "label-value-2",
 				"label-3": "label-value-3",
 			},
-			Annotations: map[string]string{},
+			Annotations: map[string]string{
+				"annotation-1": "annotation-value-1",
+				"annotation-2": "annotation-value-2",
+			},
 		},
 		Spec: v1alpha1.TaskRunSpec{
 			Inputs: &v1alpha1.TaskRunInputs{

--- a/internal/builder/v1beta1/task.go
+++ b/internal/builder/v1beta1/task.go
@@ -576,6 +576,18 @@ func TaskRunLabel(key, value string) TaskRunOp {
 	}
 }
 
+// TaskRunAnnotations adds the specified annotations to the TaskRun.
+func TaskRunAnnotations(annotations map[string]string) TaskRunOp {
+	return func(tr *v1beta1.TaskRun) {
+		if tr.ObjectMeta.Annotations == nil {
+			tr.ObjectMeta.Annotations = map[string]string{}
+		}
+		for key, value := range annotations {
+			tr.ObjectMeta.Annotations[key] = value
+		}
+	}
+}
+
 // TaskRunAnnotation adds an annotation with the specified key and value to the TaskRun.
 func TaskRunAnnotation(key, value string) TaskRunOp {
 	return func(tr *v1beta1.TaskRun) {

--- a/internal/builder/v1beta1/task_test.go
+++ b/internal/builder/v1beta1/task_test.go
@@ -179,6 +179,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 		),
 		tb.TaskRunLabels(map[string]string{"label-2": "label-value-2", "label-3": "label-value-3"}),
 		tb.TaskRunLabel("label", "label-value"),
+		tb.TaskRunAnnotations(map[string]string{"annotation-1": "annotation-value-1", "annotation-2": "annotation-value-2"}),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("task-output",
 				tb.TaskRefKind(v1beta1.ClusterTaskKind),
@@ -231,7 +232,10 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 				"label-2": "label-value-2",
 				"label-3": "label-value-3",
 			},
-			Annotations: map[string]string{},
+			Annotations: map[string]string{
+				"annotation-1": "annotation-value-1",
+				"annotation-2": "annotation-value-2",
+			},
 		},
 		Spec: v1beta1.TaskRunSpec{
 			Params: []v1beta1.Param{{

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -899,6 +899,13 @@ func (c *Reconciler) makeConditionCheckContainer(rprt *resources.ResolvedPipelin
 		labels[key] = value
 	}
 
+	// Propagate annotations from PipelineRun to TaskRun.
+	annotations := getTaskrunAnnotations(pr)
+
+	for key, value := range rcc.Condition.ObjectMeta.Annotations {
+		annotations[key] = value
+	}
+
 	taskSpec, err := rcc.ConditionToTaskSpec()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get TaskSpec from Condition: %w", err)
@@ -910,7 +917,7 @@ func (c *Reconciler) makeConditionCheckContainer(rprt *resources.ResolvedPipelin
 			Namespace:       pr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
 			Labels:          labels,
-			Annotations:     getTaskrunAnnotations(pr), // Propagate annotations from PipelineRun to TaskRun.
+			Annotations:     annotations,
 		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskSpec:           taskSpec,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1537,6 +1537,10 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 					"label-1": "value-1",
 					"label-2": "value-2",
 				}),
+			tbv1alpha1.ConditionAnnotations(
+				map[string]string{
+					"annotation-1": "value-1",
+				}),
 			tbv1alpha1.ConditionSpec(
 				tbv1alpha1.ConditionSpecCheck("", "foo", tb.Args("bar")),
 			)),
@@ -1593,7 +1597,7 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 	}
 	expectedConditionChecks := make([]*v1beta1.TaskRun, len(conditions))
 	for index, condition := range conditions {
-		expectedConditionChecks[index] = makeExpectedTr(condition.Name, ccNames[condition.Name], condition.Labels)
+		expectedConditionChecks[index] = makeExpectedTr(condition.Name, ccNames[condition.Name], condition.Labels, condition.Annotations)
 	}
 
 	// Check that the expected TaskRun was created
@@ -1729,7 +1733,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 	}
 }
 
-func makeExpectedTr(condName, ccName string, labels map[string]string) *v1beta1.TaskRun {
+func makeExpectedTr(condName, ccName string, labels, annotations map[string]string) *v1beta1.TaskRun {
 	return tb.TaskRun(ccName,
 		tb.TaskRunNamespace("foo"),
 		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run",
@@ -1743,6 +1747,7 @@ func makeExpectedTr(condName, ccName string, labels map[string]string) *v1beta1.
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.ConditionNameKey, condName),
 		tb.TaskRunLabels(labels),
 		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
+		tb.TaskRunAnnotations(annotations),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskSpec(
 				tb.Step("foo", tb.StepName("condition-check-"+condName), tb.StepArgs("bar")),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change is a follow-up to #1787. It mirrors propagation for labels by also copying annotations, which is in line with how Tasks behave.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Copy annotations from metadata of Conditions to their corresponding TaskRuns and Pods
```
