### PR TITLE
Revert "config: prefixes image names with ko:// scheme"

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
       - name: tekton-pipelines-controller
-        image: ko://github.com/tektoncd/pipeline/cmd/controller
+        image: github.com/tektoncd/pipeline/cmd/controller
         args: [
           # These images are built on-demand by `ko resolve` and are replaced
           # by image references by digest.

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -48,7 +48,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: ko://github.com/tektoncd/pipeline/cmd/webhook
+        image: github.com/tektoncd/pipeline/cmd/webhook
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This reverts commit c903e5d661beb941dd3a861c4ceef62958ff8d05.
The change is require to be able to release until the issue is fixed on `ko` side.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Do not use the ko:// scheme in manifests
```
