### PR TITLE
Invalid length of container termination message

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
+	"github.com/tektoncd/pipeline/pkg/termination"
 )
 
 var (
@@ -65,6 +66,9 @@ func main() {
 		switch t := err.(type) {
 		case skipError:
 			log.Print("Skipping step because a previous step failed")
+			os.Exit(1)
+		case termination.MessageLengthError:
+			log.Print(err.Error())
 			os.Exit(1)
 		case *exec.ExitError:
 			// Copied from https://stackoverflow.com/questions/10385551/get-exit-code-go

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -422,16 +422,16 @@ spec:
 The stored results can be used [at the `Task` level](./pipelines.md#configuring-execution-results-at-the-task-level)
 or [at the `Pipeline` level](./pipelines.md#configuring-execution-results-at-the-pipeline-level).
 
-**Note:** The maximum size of a `Task's` results is limited by the container termination log feature of Kubernetes,
+**Note:** The maximum size of a `Task's` results is limited by the container termination message feature of Kubernetes,
 as results are passed back to the controller via this mechanism. At present, the limit is
-["2048 bytes or 80 lines, whichever is smaller."](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message).
-Results are written to the termination log encoded as JSON objects and Tekton uses those objects
+["4096 bytes"](https://github.com/kubernetes/kubernetes/blob/96e13de777a9eb57f87889072b68ac40467209ac/pkg/kubelet/container/runtime.go#L632).
+Results are written to the termination message encoded as JSON objects and Tekton uses those objects
 to pass additional information to the controller. As such, `Task` results are best suited for holding
 small amounts of data, such as commit SHAs, branch names, ephemeral space names, and so on.
 
 If your `Task` writes a large number of small results, you can work around this limitation
-by writing each result from a separate `Step` so that each `Step` has its own termination log.
-However, for results larger than a kilobyte, use a [`Workspace`](#specifying-workspaces) to
+by writing each result from a separate `Step` so that each `Step` has its own termination message.
+About size limitation, there is validation for it, will raise exception: `Termination message is above max allowed size 4096, caused by large task result`. Since Tekton also uses the termination message for some internal information, so the real available size will less than 4096 bytes. For results larger than a kilobyte, use a [`Workspace`](#specifying-workspaces) to
 shuttle data between `Tasks` within a `Pipeline`.
 
 ### Specifying `Volumes`


### PR DESCRIPTION
Fix issue: #2617

`Tekton` use container termination message of kubenetes to pass additional information to the controller(by Tekton Result).

Kubenates use `MaxContainerTerminationMessageLength` which is 4096 to limit the read size from disk, the redundant content will be discard. See the below implements in `Kubenetes`:

https://github.com/kubernetes/kubernetes/blob/96e13de777a9eb57f87889072b68ac40467209ac/pkg/kubelet/kuberuntime/kuberuntime_container.go#L420

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
Tasks will now fail if they emit termination messages larger than Kubernetes' termination message size. At time of writing this is 4096 bytes. Since Task Results are returned JSON-encoded through a container's termination message please take care that they do not bloat the message over 4096 bytes.
