### PR TITLE
Link the task results doc section to their usage in pipelines

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -419,6 +419,9 @@ spec:
         date | tee /tekton/results/current-date-human-readable
 ```
 
+The stored results can be used [at the `Task` level](./pipelines.md#configuring-execution-results-at-the-task-level)
+or [at the `Pipeline` level](./pipelines.md#configuring-execution-results-at-the-pipeline-level).
+
 **Note:** The maximum size of a `Task's` results is limited by the container termination log feature of Kubernetes,
 as results are passed back to the controller via this mechanism. At present, the limit is
 ["2048 bytes or 80 lines, whichever is smaller."](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#customizing-the-termination-message).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The documentation of the syntax for storing `Task` results is not linked to the
section where their usage is described in `Pipeline` resources.

# Submitter Checklist

N/A

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

