### PR TITLE
Add Node Affinity for TaskRuns that share PVC workspace

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -60,7 +60,7 @@ rules:
     # Unclear if this access is actually required.  Simply a hold-over from the previous
     # incarnation of the controller's ClusterRole.
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments/finalizers"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -268,6 +268,19 @@ file lists the keys you can customize along with their default values.
 
 To customize the behavior of the Pipelines Controller, modify the ConfigMap `feature-flags` as follows:
 
+- `disable-affinity-assistant` - set this flag to disable the [Affinity Assistant](./workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline)
+  that is used to provide Node Affinity for `TaskRun` pods that share workspace volume. 
+  The Affinity Assistant pods may be incompatible with NodeSelector and other affinity rules
+  configured for `TaskRun` pods.
+
+  **Note:** Affinity Assistant use [Inter-pod affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)
+  that require substantial amount of processing which can slow down scheduling in large clusters
+  significantly. We do not recommend using them in clusters larger than several hundred nodes
+
+  **Note:** Pod anti-affinity requires nodes to be consistently labelled, in other words every
+  node in the cluster must have an appropriate label matching `topologyKey`. If some or all nodes
+  are missing the specified `topologyKey` label, it can lead to unintended behavior.
+
 - `disable-home-env-overwrite` - set this flag to `true` to prevent Tekton
 from overriding the `$HOME` environment variable for the containers executing your `Steps`.
 The default is `false`. For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/2013).

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -58,6 +58,8 @@ The following labels are added to resources automatically:
   reference a `ClusterTask` will also receive `tekton.dev/task`.
 - `tekton.dev/taskRun` is added to `Pods`, and contains the name of the
   `TaskRun` that created the `Pod`.
+- `app.kubernetes.io/instance` and `app.kubernetes.io/component` is added to 
+  Affinity Assistant `StatefulSets` and `Pods`. These are used for Pod Affinity for TaskRuns.
 
 ## Examples
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -363,7 +363,8 @@ steps:
 ### Specifying `Workspaces`
 
 [`Workspaces`](workspaces.md#using-workspaces-in-tasks) allow you to specify
-one or more volumes that your `Task` requires during execution. For example:
+one or more volumes that your `Task` requires during execution. It is recommended that `Tasks` uses **at most**
+one writeable `Workspace`. For example:
 
 ```yaml
 spec:

--- a/examples/v1beta1/pipelineruns/pipeline-run-with-parallel-tasks-using-pvc.yaml
+++ b/examples/v1beta1/pipelineruns/pipeline-run-with-parallel-tasks-using-pvc.yaml
@@ -1,0 +1,205 @@
+# This example shows how both sequential and parallel Tasks can share data
+# using a PersistentVolumeClaim as a workspace. The TaskRun pods that share
+# workspace will be scheduled to the same Node in your cluster with an
+# Affinity Assistant (unless it is disabled). The REPORTER task does not
+# use a workspace so it does not get affinity to the Affinity Assistant
+# and can be scheduled to any Node. If multiple concurrent PipelineRuns are
+# executed, their Affinity Assistant pods will repel eachother to different
+# Nodes in a Best Effort fashion.
+#
+# A PipelineRun will pass a message parameter to the Pipeline in this example.
+# The STARTER task will write the message to a file in the workspace. The UPPER
+# and LOWER tasks will execute in parallel and process the message written by
+# the STARTER, and transform it to upper case and lower case. The REPORTER task
+# is will use the Task Result from the UPPER task and print it - it is intended
+# to mimic a Task that sends data to an external service and shows a Task that
+# doesn't use a workspace. The VALIDATOR task will validate the result from
+# UPPER and LOWER.
+#
+# Use the runAfter property in a Pipeline to configure that a task depend on
+# another task. Output can be shared both via Task Result (e.g. like REPORTER task)
+# or via files in a workspace.
+#
+#             -- (upper) -- (reporter)
+#           /                         \
+#  (starter)                           (validator)
+#           \                         /
+#             -- (lower) ------------
+
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: parallel-pipeline
+spec:
+  params:
+    - name: message
+      type: string
+
+  workspaces:
+    - name: ws
+
+  tasks:
+    - name: starter          # Tasks that does not declare a runAfter property
+      taskRef:               # will start execution immediately
+        name: persist-param
+      params:
+        - name: message
+          value: $(params.message)
+      workspaces:
+        - name: task-ws
+          workspace: ws
+          subPath: init
+
+    - name: upper
+      runAfter:               # Note the use of runAfter here to declare that this task
+        - starter             # depends on a previous task
+      taskRef:
+        name: to-upper
+      params:
+        - name: input-path
+          value: init/message
+      workspaces:
+        - name: w
+          workspace: ws
+
+    - name: lower
+      runAfter:
+        - starter
+      taskRef:
+        name: to-lower
+      params:
+        - name: input-path
+          value: init/message
+      workspaces:
+        - name: w
+          workspace: ws
+
+    - name: reporter          # This task does not use workspace and may be scheduled to
+      runAfter:               # any Node in the cluster.
+        - upper
+      taskRef:
+        name: result-reporter
+      params:
+        - name: result-to-report
+          value: $(tasks.upper.results.message)  # A result from a previous task is used as param
+
+    - name: validator         # This task validate the output from upper and lower Task
+      runAfter:               # It does not strictly depend on the reporter Task
+        - reporter            # But you may want to skip this task if the reporter Task fail
+        - lower
+      taskRef:
+        name: validator
+      workspaces:
+        - name: files
+          workspace: ws
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: persist-param
+spec:
+  params:
+    - name: message
+      type: string
+  results:
+    - name: message
+      description: A result message
+  steps:
+    - name: write
+      image: ubuntu
+      script: echo $(params.message) | tee $(workspaces.task-ws.path)/message $(results.message.path)
+  workspaces:
+    - name: task-ws
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: to-upper
+spec:
+  description: |
+    This task read and process a file from the workspace and write the result
+    both to a file in the workspace and as a Task Result.
+  params:
+    - name: input-path
+      type: string
+  results:
+    - name: message
+      description: Input message in upper case
+  steps:
+    - name: to-upper
+      image: ubuntu
+      script: cat $(workspaces.w.path)/$(params.input-path) | tr '[:lower:]' '[:upper:]' | tee $(workspaces.w.path)/upper $(results.message.path)
+  workspaces:
+    - name: w
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: to-lower
+spec:
+  description: |
+    This task read and process a file from the workspace and write the result
+    both to a file in the workspace and as a Task Result
+  params:
+    - name: input-path
+      type: string
+  results:
+    - name: message
+      description: Input message in lower case
+  steps:
+    - name: to-lower
+      image: ubuntu
+      script: cat $(workspaces.w.path)/$(params.input-path) | tr '[:upper:]' '[:lower:]' | tee $(workspaces.w.path)/lower $(results.message.path)
+  workspaces:
+    - name: w
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: result-reporter
+spec:
+  description: |
+    This task is supposed to mimic a service that post data from the Pipeline,
+    e.g. to an remote HTTP service or a Slack notification.
+  params:
+    - name: result-to-report
+      type: string
+  steps:
+    - name: report-result
+      image: ubuntu
+      script: echo $(params.result-to-report)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: validator
+spec:
+  steps:
+    - name: validate-upper
+      image: ubuntu
+      script: cat $(workspaces.files.path)/upper | grep HELLO\ TEKTON
+    - name: validate-lower
+      image: ubuntu
+      script: cat $(workspaces.files.path)/lower | grep hello\ tekton
+  workspaces:
+    - name: files
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: parallel-pipelinerun-
+spec:
+  params:
+    - name: message
+      value: Hello Tekton
+  pipelineRef:
+    name: parallel-pipeline
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/pod"
+	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
+	"github.com/tektoncd/pipeline/pkg/system"
+	"github.com/tektoncd/pipeline/pkg/workspace"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	errorutils "k8s.io/apimachinery/pkg/util/errors"
+)
+
+const (
+	// ReasonCouldntCreateAffinityAssistantStatefulSet indicates that a PipelineRun uses workspaces with PersistentVolumeClaim
+	// as a volume source and expect an Assistant StatefulSet, but couldn't create a StatefulSet.
+	ReasonCouldntCreateAffinityAssistantStatefulSet = "CouldntCreateAffinityAssistantStatefulSet"
+
+	featureFlagDisableAffinityAssistantKey = "disable-affinity-assistant"
+	affinityAssistantStatefulSetNamePrefix = "affinity-assistant-"
+)
+
+// createAffinityAssistants creates an Affinity Assistant StatefulSet for every workspace in the PipelineRun that
+// use a PersistentVolumeClaim volume. This is done to achieve Node Affinity for all TaskRuns that
+// share the workspace volume and make it possible for the tasks to execute parallel while sharing volume.
+func (c *Reconciler) createAffinityAssistants(wb []v1alpha1.WorkspaceBinding, pr *v1beta1.PipelineRun, namespace string) error {
+	var errs []error
+	for _, w := range wb {
+		if w.PersistentVolumeClaim != nil || w.VolumeClaimTemplate != nil {
+			affinityAssistantName := getAffinityAssistantName(w.Name, pr.GetOwnerReference())
+			affinityAssistantStatefulSetName := affinityAssistantStatefulSetNamePrefix + affinityAssistantName
+			_, err := c.KubeClientSet.AppsV1().StatefulSets(namespace).Get(affinityAssistantStatefulSetName, metav1.GetOptions{})
+			claimName := getClaimName(w, pr.GetOwnerReference())
+			switch {
+			case apierrors.IsNotFound(err):
+				_, err := c.KubeClientSet.AppsV1().StatefulSets(namespace).Create(affinityAssistantStatefulSet(affinityAssistantName, pr, claimName))
+				if err != nil {
+					errs = append(errs, fmt.Errorf("failed to create StatefulSet %s: %s", affinityAssistantName, err))
+				}
+				if err == nil {
+					c.Logger.Infof("Created StatefulSet %s in namespace %s", affinityAssistantName, namespace)
+				}
+			case err != nil:
+				errs = append(errs, fmt.Errorf("failed to retrieve StatefulSet %s: %s", affinityAssistantName, err))
+			}
+		}
+	}
+	return errorutils.NewAggregate(errs)
+}
+
+func getClaimName(w v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReference) string {
+	if w.PersistentVolumeClaim != nil {
+		return w.PersistentVolumeClaim.ClaimName
+	} else if w.VolumeClaimTemplate != nil {
+		return volumeclaim.GetPersistentVolumeClaimName(w.VolumeClaimTemplate, w, ownerReference)
+	}
+
+	return ""
+}
+
+func (c *Reconciler) cleanupAffinityAssistants(pr *v1beta1.PipelineRun) error {
+	var errs []error
+	for _, w := range pr.Spec.Workspaces {
+		if w.PersistentVolumeClaim != nil || w.VolumeClaimTemplate != nil {
+			affinityAssistantStsName := affinityAssistantStatefulSetNamePrefix + getAffinityAssistantName(w.Name, pr.GetOwnerReference())
+			if err := c.KubeClientSet.AppsV1().StatefulSets(pr.Namespace).Delete(affinityAssistantStsName, &metav1.DeleteOptions{}); err != nil {
+				errs = append(errs, fmt.Errorf("failed to delete StatefulSet %s: %s", affinityAssistantStsName, err))
+			}
+		}
+	}
+	return errorutils.NewAggregate(errs)
+}
+
+func getAffinityAssistantName(pipelineWorkspaceName string, owner metav1.OwnerReference) string {
+	return fmt.Sprintf("%s-%s", pipelineWorkspaceName, owner.Name)
+}
+
+func getStatefulSetLabels(pr *v1beta1.PipelineRun, affinityAssistantName string) map[string]string {
+	// Propagate labels from PipelineRun to StatefulSet.
+	labels := make(map[string]string, len(pr.ObjectMeta.Labels)+1)
+	for key, val := range pr.ObjectMeta.Labels {
+		labels[key] = val
+	}
+	labels[pipeline.GroupName+pipeline.PipelineRunLabelKey] = pr.Name
+
+	// LabelInstance is used to configure PodAffinity for all TaskRuns belonging to this Affinity Assistant
+	// LabelComponent is used to configure PodAntiAffinity to other Affinity Assistants
+	labels[workspace.LabelInstance] = affinityAssistantName
+	labels[workspace.LabelComponent] = workspace.ComponentNameAffinityAssistant
+	return labels
+}
+
+func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimName string) *appsv1.StatefulSet {
+	// We want a singleton pod
+	replicas := int32(1)
+
+	containers := []corev1.Container{{
+		Name: "affinity-assistant",
+
+		//TODO(#2640) We may want to create a custom, minimal binary
+		Image: "nginx",
+
+		// Set requests == limits to get QoS class _Guaranteed_.
+		// See https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed
+		// Affinity Assistant pod is a placeholder; request minimal resources
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("100Mi"),
+			},
+			Requests: corev1.ResourceList{
+				"cpu":    resource.MustParse("100m"),
+				"memory": resource.MustParse("100Mi"),
+			},
+		},
+	}}
+
+	// use podAntiAffinity to repel other affinity assistants
+	repelOtherAffinityAssistantsPodAffinityTerm := corev1.WeightedPodAffinityTerm{
+		Weight: 100,
+		PodAffinityTerm: corev1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					workspace.LabelComponent: workspace.ComponentNameAffinityAssistant,
+				},
+			},
+			TopologyKey: "kubernetes.io/hostname",
+		},
+	}
+
+	return &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            affinityAssistantStatefulSetNamePrefix + name,
+			Labels:          getStatefulSetLabels(pr, name),
+			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: getStatefulSetLabels(pr, name),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: getStatefulSetLabels(pr, name),
+				},
+				Spec: corev1.PodSpec{
+					Containers: containers,
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{repelOtherAffinityAssistantsPodAffinityTerm},
+						},
+					},
+					Volumes: []corev1.Volume{{
+						Name: "workspace",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+
+								// A Pod mounting a PersistentVolumeClaim that has a StorageClass with
+								// volumeBindingMode: Immediate
+								// the PV is allocated on a Node first, and then the pod need to be
+								// scheduled to that node.
+								// To support those PVCs, the Affinity Assistant must also mount the
+								// same PersistentVolumeClaim - to be sure that the Affinity Assistant
+								// pod is scheduled to the same Availability Zone as the PV, when using
+								// a regional cluster. This is called VolumeScheduling.
+								ClaimName: claimName,
+							}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+// isAffinityAssistantDisabled returns a bool indicating whether an Affinity Assistant should
+// be created for each PipelineRun that use workspaces with PersistentVolumeClaims
+// as volume source. The default behaviour is to enable the Affinity Assistant to
+// provide Node Affinity for TaskRuns that share a PVC workspace.
+func (c *Reconciler) isAffinityAssistantDisabled() bool {
+	configMap, err := c.KubeClientSet.CoreV1().ConfigMaps(system.GetNamespace()).Get(pod.GetFeatureFlagsConfigName(), metav1.GetOptions{})
+	if err == nil && configMap != nil && configMap.Data != nil && configMap.Data[featureFlagDisableAffinityAssistantKey] == "true" {
+		return true
+	}
+	return false
+}

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/pod"
+	"github.com/tektoncd/pipeline/pkg/reconciler"
+	"github.com/tektoncd/pipeline/pkg/system"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
+)
+
+// TestCreateAndDeleteOfAffinityAssistant tests to create and delete an Affinity Assistant
+// for a given PipelineRun with a PVC workspace
+func TestCreateAndDeleteOfAffinityAssistant(t *testing.T) {
+	c := Reconciler{
+		Base: &reconciler.Base{
+			KubeClientSet: fakek8s.NewSimpleClientset(),
+			Images:        pipeline.Images{},
+			Logger:        zap.NewExample().Sugar(),
+		},
+	}
+
+	workspaceName := "testws"
+	pipelineRunName := "pipelinerun-1"
+	testPipelineRun := &v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pipelineRunName,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			Workspaces: []v1beta1.WorkspaceBinding{{
+				Name: workspaceName,
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "myclaim",
+				},
+			}},
+		},
+	}
+
+	err := c.createAffinityAssistants(testPipelineRun.Spec.Workspaces, testPipelineRun, testPipelineRun.Namespace)
+	if err != nil {
+		t.Errorf("unexpected error from createAffinityAssistants: %v", err)
+	}
+
+	expectedAffinityAssistantName := affinityAssistantStatefulSetNamePrefix + fmt.Sprintf("%s-%s", workspaceName, pipelineRunName)
+	_, err = c.KubeClientSet.AppsV1().StatefulSets(testPipelineRun.Namespace).Get(expectedAffinityAssistantName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("unexpected error when retrieving StatefulSet: %v", err)
+	}
+
+	err = c.cleanupAffinityAssistants(testPipelineRun)
+	if err != nil {
+		t.Errorf("unexpected error from cleanupAffinityAssistants: %v", err)
+	}
+
+	_, err = c.KubeClientSet.AppsV1().StatefulSets(testPipelineRun.Namespace).Get(expectedAffinityAssistantName, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected a NotFound response, got: %v", err)
+	}
+}
+
+func TestDisableAffinityAssistant(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		configMap   *corev1.ConfigMap
+		expected    bool
+	}{{
+		description: "Default behaviour: A missing disable-affinity-assistant flag should result in false",
+		configMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: pod.GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
+			Data:       map[string]string{},
+		},
+		expected: false,
+	}, {
+		description: "Setting disable-affinity-assistant to false should result in false",
+		configMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: pod.GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
+			Data: map[string]string{
+				featureFlagDisableAffinityAssistantKey: "false",
+			},
+		},
+		expected: false,
+	}, {
+		description: "Setting disable-affinity-assistant to true should result in true",
+		configMap: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: pod.GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
+			Data: map[string]string{
+				featureFlagDisableAffinityAssistantKey: "true",
+			},
+		},
+		expected: true,
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			c := Reconciler{
+				Base: &reconciler.Base{
+					KubeClientSet: fakek8s.NewSimpleClientset(
+						tc.configMap,
+					),
+					Images: pipeline.Images{},
+					Logger: zap.NewExample().Sugar(),
+				},
+			}
+			if result := c.isAffinityAssistantDisabled(); result != tc.expected {
+				t.Errorf("Expected %t Received %t", tc.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/workspace/affinity_assistant_names.go
+++ b/pkg/workspace/affinity_assistant_names.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workspace
+
+const (
+	// LabelInstance is used in combination with LabelComponent to configure PodAffinity for TaskRun pods
+	LabelInstance = "app.kubernetes.io/instance"
+
+	// LabelComponent is used to configure PodAntiAffinity to other Affinity Assistants
+	LabelComponent                 = "app.kubernetes.io/component"
+	ComponentNameAffinityAssistant = "affinity-assistant"
+
+	// AnnotationAffinityAssistantName is used to pass the instance name of an Affinity Assistant to TaskRun pods
+	AnnotationAffinityAssistantName = "pipeline.tekton.dev/affinity-assistant"
+)


### PR DESCRIPTION
# Changes

TaskRuns within a PipelineRun may share files using a workspace volume.
The typical case is files from a git-clone operation. Tasks in a CI-pipeline often
perform operations on the filesystem, e.g. generate files or analyze files,
so the workspace abstraction is very useful.

The Kubernetes way of using file volumes is by using [PersistentVolumeClaims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims).
PersistentVolumeClaims use PersistentVolumes with different [access modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes).
The most commonly available PV access mode is ReadWriteOnce, volumes with this
access mode can only be mounted on one Node at a time.

When using parallel Tasks in a Pipeline, the pods for the TaskRuns is
scheduled to any Node, most likely not to the same Node in a cluster.
Since volumes with the commonly available ReadWriteOnce access mode cannot
be use by multiple nodes at a time, these "parallel" pods is forced to
execute sequentially, since the volume only is available on one node at a time.
This may make that your TaskRuns time out.

Clusters are often _regional_, e.g. they are deployed across 3 Availability
Zones, but Persistent Volumes are often _zonal_, e.g. they are only available
for the Nodes within a single zone. Some cloud providers offer regional PVs,
but sometimes regional PVs is only replicated to one additional zone, e.g. not
all 3 zones within a region. This works fine for most typical stateful application,
but Tekton uses storage in a different way - it is designed so that multiple pods
access the same volume, in a sequece or parallel.

This makes it difficult to design a Pipeline that starts with parallel tasks using
its own PVC and then have a common tasks that mount the volume from the earlier
tasks - since - what happens if those tasks were scheduled to different zones -
the common task can not mount the PVCs that now is located in different zones, so
the PipelineRun is deadlocked.

There are a few technical solutions that offer parallel executions of Tasks
even when sharing PVC workspace:

- Using PVC access mode ReadWriteMany. But this access mode is not widely available,
  and is typically a NFS server or another not so "cloud native" solution.

- An alternative is to use a storage that is tied to a specific node, e.g. local volume
  and then configure so pods are scheduled to this node, but this is not commonly
  available and it has drawbacks, e.g. the pod may need to consume and mount a whole
  disk e.g. several hundreds GB.

Consequently, it would be good to find a way so that TaskRun pods that share
workspace are scheduled to the same Node - and thereby make it easy to use parallel
tasks with workspace - while executing concurrently - on widely available Kubernetes
cluster and storage configurations.

A few alternative solutions have been considered, as documented in #2586.
However, they all have major drawbacks, e.g. major API and contract changes.

This commit introduces an "Affinity Assistant" - a minimal placeholder-pod,
so that it is possible to use [Kubernetes inter-pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) for TaskRun pods that need to be scheduled to the same Node.

This solution has several benefits: it does not introduce any API changes,
it does not break or change any existing Tekton concepts and it is
implemented with very few changes. Additionally it can be disabled with a feature-flag.

**How it works:** When a PipelineRun is initiated, an "Affinity Assistant" is
created for each PVC workspace volume. TaskRun pods that share workspace
volume is configured with podAffinity to the "Affinity Assisant" pod that
was created for the volume. The "Affinity Assistant" lives until the
PipelineRun is completed, or deleted. "Affinity Assistant" pods are
configured with podAntiAffinity to repel other "Affinity Assistants" -
in a Best Effort fashion.

The Affinity Assistant is _singleton_ workload, since it acts as a
placeholder pod and TaskRun pods with affinity must be scheduled to the
same Node. It is implemented with [QoS class Guaranteed](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed) but with minimal resource requests -
since it does not provide any work other than beeing a placeholder.

Singleton workloads can be implemented in multiple ways, and they differ
in behavior when the Node becomes unreachable:

- as a Pod - the Pod is not managed, so it will not be recreated.
- as a Deployment - the Pod will be recreated and puts Availability before
  the singleton property
- as a StatefulSet - the Pod will be recreated but puds the singleton
  property before Availability

Therefor the Affinity Assistant is implemented as a StatefulSet.

Essentialy this commit provides an effortless way to use a functional
task parallelism with any Kubernetes cluster that has any PVC based
storage.

**Example output from example:**
First a Task graph:

```
#             -- (upper) -- (reporter)
#           /                         \
#  (starter)                           (validator)
#           \                         /
#             -- (lower) ------------
```

Logs:
```
$ tkn pr logs parallel-pipelinerun-2wf8d -n pe
Pipeline still running ...
[starter : write] Hello Tekton
[starter : write] + tee /workspace/task-ws/message /tekton/results/message
[starter : write] + echo Hello Tekton

[upper : to-upper] + tee /workspace/w/upper /tekton/results/message
[upper : to-upper] + tr [:lower:] [:upper:]
[upper : to-upper] + cat /workspace/w/init/message
[upper : to-upper] HELLO TEKTON

[lower : to-lower] + tee /workspace/w/lower /tekton/results/message
[lower : to-lower] + tr [:upper:] [:lower:]
[lower : to-lower] + cat /workspace/w/init/message
[lower : to-lower] hello tekton

[reporter : report-result] + echo HELLO TEKTON
[reporter : report-result] HELLO TEKTON

[validator : validate-upper] + grep HELLO TEKTON
[validator : validate-upper] + cat /workspace/files/upper
[validator : validate-upper] HELLO TEKTON

[validator : validate-lower] + cat /workspace/files/lower
[validator : validate-lower] + grep hello tekton
[validator : validate-lower] hello tekton
```

A listing of the pods, shows that all pods that share PVC workspace, is scheduled to the same Node. The "reporter" task does not use a workspace and hence can be scheduled to any Node (this was a 4 Node cluster).

```
$ kubectl get po -n pe -o wide
NAME                                                   READY              NODE                          
parallel-pipelinerun-2wf8d-lower-8fv5x-pod-kc9pw       0/1 gke-c4-pool-2-6ce2d103-m28z
parallel-pipelinerun-2wf8d-reporter-qwhc2-pod-572qc    0/1 gke-c4-pool-2-6ce2d103-nwpt
parallel-pipelinerun-2wf8d-starter-456l4-pod-rb4rs     0/1 gke-c4-pool-2-6ce2d103-m28z
parallel-pipelinerun-2wf8d-upper-h24gm-pod-7q67h       0/1 gke-c4-pool-2-6ce2d103-m28z
parallel-pipelinerun-2wf8d-validator-8qwws-pod-nxjhz   0/2 gke-c4-pool-2-6ce2d103-m28z

```

Fixes #2586
/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
- Add Node Affinity for TaskRuns that share PVC workspace
```
