### PR TITLE
Improve TaskRun workspaces documentation

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -11,13 +11,13 @@ weight: 5
   - [`Workspaces` in `Pipelines` and `PipelineRuns`](#workspaces-in-pipelines-and-pipelineruns)
 - [Configuring `Workspaces`](#configuring-workspaces)
   - [Using `Workspaces` in `Tasks`](#using-workspaces-in-tasks)
-    - [Using `Workspace` variables in `TaskRuns`](#using-workspace-variables-in-taskruns)
+    - [Using `Workspace` variables in `Tasks`](#using-workspace-variables-in-tasks)
     - [Mapping `Workspaces` in `Tasks` to `TaskRuns`](#mapping-workspaces-in-tasks-to-taskruns)
-    - [Examples of `TaskRun` definitions using `Workspaces`](#examples-of-taskrun-definitions-using-workspaces)
+    - [Examples of `TaskRun` definition using `Workspaces`](#examples-of-taskrun-definition-using-workspaces)
   - [Using `Workspaces` in `Pipelines`](#using-workspaces-in-pipelines)
     - [Specifying `Workspace` order in a `Pipeline`](#specifying-workspace-order-in-a-pipeline)
     - [Specifying `Workspaces` in `PipelineRuns`](#specifying-workspaces-in-pipelineruns)
-    - [Example `PipelineRun` definition using `Workspaces`](#example-pipelinerun-definitions-using-workspaces)
+    - [Example `PipelineRun` definition using `Workspaces`](#example-pipelinerun-definition-using-workspaces)
   - [Specifying `VolumeSources` in `Workspaces`](#specifying-volumesources-in-workspaces)
     - [Using `PersistentVolumeClaims` as `VolumeSource`](#using-persistentvolumeclaims-as-volumesource)
     - [Using other types of `VolumeSources`](#using-other-types-of-volumesources)
@@ -141,66 +141,26 @@ The entry must also include one `VolumeSource`. See [Using `VolumeSources` with 
 - The `Workspaces` declared in a `Task` must be available when executing the associated `TaskRun`.
   Otherwise, the `TaskRun` will fail.
 
-#### Examples of `TaskRun` definitions using `Workspaces`
+#### Examples of `TaskRun` definition using `Workspaces`
 
-The following examples illustrate how to specify `Workspaces` in your `TaskRun` definition.
-For a more in-depth example, see [`Workspaces` in a `TaskRun`](../examples/v1beta1/taskruns/workspace.yaml).
-
-In the example below, a template is provided for how a `PersistentVolumeClaim` should be created for a Task's workspace named `myworkspace`. When using `volumeClaimTemplate` a new `PersistentVolumeClaim` is created for each `TaskRun` and it allows the user to specify e.g. size and StorageClass for the volume.
-
-```yaml
-workspaces:
-- name: myworkspace
-  volumeClaimTemplate:
-    spec:
-      accessModes: 
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi
-```
-
-In the example below, an existing `PersistentVolumeClaim` called `mypvc` is used for a Task's `workspace`
-called `myworkspace`. It exposes only the subdirectory `my-subdir` from that `PersistentVolumeClaim`:
-
-```yaml
-workspaces:
-- name: myworkspace
-  persistentVolumeClaim:
-    claimName: mypvc
-  subPath: my-subdir
-```
-
-In the example below, an [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
+The following example illustrate how to specify `Workspaces` in your `TaskRun` definition,
+an [`emptyDir`](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir)
 is provided for a Task's `workspace` called `myworkspace`:
 
 ```yaml
-workspaces:
-- name: myworkspace
-  emptyDir: {}
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: example-taskrun-
+spec:
+  taskRef:
+    name: example-task
+  workspaces:
+    - name: myworkspace # this workspace name must be declared in the Task
+      emptyDir: {}      # emptyDir volumes can be used for TaskRuns, but consider using a PersistentVolumeClaim for PipelineRuns
 ```
-
-In the example below, a `ConfigMap` named `my-configmap` is used for a `Workspace` 
-named `myworkspace` declared inside a `Task`:
-
-```yaml
-workspaces:
-- name: myworkspace
-  configmap:
-    name: my-configmap
-```
-
-In this example, a `Secret` named `my-secret` is used for a `Workspace` 
-named `myworkspace` declared inside a `Task`:
-
-```yaml
-workspaces:
-- name: myworkspace
-  secret:
-    secretName: my-secret
-```
-
-For a more in-depth example, see [workspace.yaml](../examples/v1beta1/taskruns/workspace.yaml).
+For examples of using other types of volume sources, see [Specifying `VolumeSources` in `Workspaces`](#specifying-volumesources-in-workspaces).
+For a more in-depth example, see [`Workspaces` in a `TaskRun`](../examples/v1beta1/taskruns/workspace.yaml).
 
 ### Using `Workspaces` in `Pipelines`
 
@@ -290,7 +250,7 @@ each `PipelineRun` and it allows the user to specify e.g. size and StorageClass 
 apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
-  generateName: pr-
+  generateName: example-pipelinerun-
 spec:
   pipelineRef:
     name: example-pipeline


### PR DESCRIPTION
# Changes

This commit contains similar changes for the TaskRun section as what was done for the PipelineRun section in https://github.com/tektoncd/pipeline/pull/2521

- We did not provide a full example of a TaskRun definition under "Examples of `TaskRun` definition using `Workspaces`". This commit add a full example of a TaskRun definition.

- Examples of how to use different volume sources already exists under "Specifying `VolumeSources` in `Workspaces`", add a link to that section instead of having the same examples under the TaskRun section.

- A few broken links in the table-of-contents are fixed.

/kind documentation

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

