### PR TITLE
Various documentation fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,12 +37,12 @@ Tekton Pipelines defines the following entities:
     <td>Defines a series of <code>Tasks</code> that accomplish a specific build or delivery goal. Can be triggered by an event or invoked from a <code>PipelineRun</code>.</td>
   </tr>
   <tr>
-    <td><code>PipelineResource</code></td>
-    <td>Defines locations for inputs ingested and outputs produced by the steps in <code>Tasks</code>.</td>
-  </tr>
-  <tr>
     <td><code>PipelineRun</code></td>
     <td>Instantiates a <code>Pipeline</code> for execution with specific inputs, outputs, and execution parameters.</td>
+  </tr>
+  <tr>
+    <td><code>PipelineResource</code></td>
+    <td>Defines locations for inputs ingested and outputs produced by the steps in <code>Tasks</code>.</td>
   </tr>
 </table>
 

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -8,8 +8,6 @@ weight: 11
 
 This document defines `Conditions` and their capabilities.
 
----
-
 - [Syntax](#syntax)
   - [Check](#check)
   - [Parameters](#parameters)

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -353,13 +353,6 @@ spec:
   status: "PipelineRunCancelled"
 ```
 
----
-
-Except as otherwise noted, the content of this page is licensed under the
-[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
-and code samples are licensed under the
-[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
-
 ## Specifying task run specs
 
 Specifies a list of  `PipelineRunTaskSpec` which contains `TaskServiceAccountName`,`TaskPodTemplate` and `TaskName`. Mapping the specs to the corresponding `Task` based upon the `TaskName` a PipelineTask will run with the configured  `TaskServiceAccountName` and `TaskPodTemplate` overwriting the pipeline wide [`ServiceAccountName`](#service-account)  and [`podTemplate`](#pod-template) configuration, for example:
@@ -380,3 +373,10 @@ spec:
 ```
 
 If used with this `Pipeline`,  `build-task` will use the task specific pod template (where `nodeSelector` has `disktype` equal to `ssd`). 
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -937,6 +937,8 @@ More information about Pod and Container Security Contexts can be found via the 
 
 The example Task/TaskRun above can be found as a [TaskRun example](../examples/v1beta1/taskruns/run-steps-as-non-root.yaml).
 
+---
+
 Except as otherwise noted, the contents of this page are licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/).
 Code samples are licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
# Changes

I see `Task` - `TaskRun`, and `Pipeline` - `PipelineRun` as _pairs_, so I move `PipelineResource` to the bottom of the table.

/kind misc

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
