### PR TITLE
Improve Pod template documentation

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -243,7 +243,7 @@ then `test-task` will execute using the `sa-1` account while `build-task` will e
 
 You can specify a [`Pod` template](podtemplates.md) configuration that will serve as the configuration starting
 point for the `Pod` in which the container images specified in your `Tasks` will execute. This allows you to
-customize the `Pod` confguration specifically for each `TaskRun`.
+customize the `Pod` configuration specifically for each `TaskRun`.
 
 In the following example, the `Task` defines a `volumeMount` object named `my-cache`. The `PipelineRun`
 provisions this object for the `Task` using a `persistentVolumeClaim` and executes it as user 1001.

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -1,18 +1,18 @@
 <!--
 ---
-linkTitle: "Pod Templates"
+linkTitle: "Pod templates"
 weight: 12
 ---
 -->
-# PodTemplates
+# Pod templates
 
 A pod template specifies a subset of
 [`PodSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#pod-v1-core)
 configuration that will be used as the basis for the `Task` pod.
 
-This allows to customize some Pod specific field per `Task` execution, aka `TaskRun`.
+This allows for customizing some `Pod` specific field per `Task` execution, `TaskRun` or for all `Task` executions part of a `PipelineRun`.
 
-Alternatively, you can also define a default pod template in tekton config, see [here](https://github.com/tektoncd/pipeline/blob/master/docs/install.md)
+Alternatively, you can also define a default pod template in Tekton config, see [Customizing basic execution parameters](./install.md#customizing-basic-execution-parameters)
 When a pod template is specified for a `PipelineRun` or `TaskRun`, the default pod template is ignored, i.e.
 both templates are **NOT** merged, it's always one or the other.
 
@@ -21,7 +21,7 @@ both templates are **NOT** merged, it's always one or the other.
 The current fields supported are:
 
 - `nodeSelector`: a selector which must be true for the pod to fit on
-  a node, see [here](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/).
+  a node, see [Assigning pods to Nodes](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/).
 - `tolerations`: allow (but do not require) the pods to schedule onto
   nodes with matching taints.
 - `affinity`: allow to constrain which nodes your pod is eligible to
@@ -57,10 +57,13 @@ The current fields supported are:
   to use when dispatching the Pod. This can be used when workloads of specific types need specific schedulers,
   e.g.: If you are using volcano.sh for Machine Learning Workloads, you can pass the schedulerName and have Tasks be 
   dispatched by the volcano.sh scheduler.
+- `hostNetwork`: set this to `true` if the host network namespace should be used.
+  Defaults to `false`.
 
 
-A pod template can be specified for `TaskRun` or `PipelineRun` resources.
-See [here](./taskruns.md#pod-template) or [here](./pipelineruns.md#pod-template) for examples using pod templates.
+A `Pod` template can be specified for `TaskRun` or `PipelineRun` resources.
+See [Specifying a Pod template](./taskruns.md#specifying-a-pod-template) for a `TaskRun` example or
+[Specifying a Pod template](./pipelineruns.md#specifying-a-pod-template) for a `PipelineRun` example using Pod templates.
 
 ---
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -152,7 +152,7 @@ spec:
 
 You can specify a [`Pod` template](podtemplates.md) configuration that will serve as the configuration starting
 point for the `Pod` in which the container images specified in your `Task` will execute. This allows you to
-customize the `Pod` confguration specifically for that `TaskRun`.
+customize the `Pod` configuration specifically for that `TaskRun`.
 
 In the following example, the `Task` specifies a `volumeMount` (`my-cache`) object, also provided by the `TaskRun`,
 using a `PersistentVolumeClaim` volume. A specific scheduler is also configured in the  `SchedulerName` field. 
@@ -184,7 +184,6 @@ spec:
     name: mytask
   podTemplate:
     schedulerName: volcano
-    hostNetwork: true
     securityContext:
       runAsNonRoot: true
       runAsUser: 1001


### PR DESCRIPTION
# Changes

The `hostNetwork` field was added to Pod template in #2325 but not documented in the [Pod template](https://github.com/tektoncd/pipeline/blob/master/docs/podtemplates.md) documentation. It is added in this commit.

Also:
- Clarify that the Pod template is for both `TaskRun` and `PipelineRun`.
- Fixing broken links in the documentation
- Removing `hostNetwork` from the `TaskRun` example, since it is a special case, but document it in the Pod template documentation.

/kind documentation

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
