### PR TITLE
Allow variable substitution inside csi volumes parameters

### DIFF
--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -179,6 +179,16 @@ func ApplyReplacements(spec *v1beta1.TaskSpec, stringReplacements map[string]str
 				}
 			}
 		}
+		if v.CSI != nil {
+			if v.CSI.NodePublishSecretRef != nil {
+				spec.Volumes[i].CSI.NodePublishSecretRef.Name = substitution.ApplyReplacements(v.CSI.NodePublishSecretRef.Name, stringReplacements)
+			}
+			if v.CSI.VolumeAttributes != nil {
+				for key, value := range v.CSI.VolumeAttributes {
+					spec.Volumes[i].CSI.VolumeAttributes[key] = substitution.ApplyReplacements(value, stringReplacements)
+				}
+			}
+		}
 	}
 
 	// Apply variable substitution to the sidecar definitions

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -180,6 +180,18 @@ var (
 					}},
 				},
 			},
+		}, {
+			Name: "some-csi",
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					VolumeAttributes: map[string]string{
+						"secretProviderClass": "$(inputs.params.FOO)",
+					},
+					NodePublishSecretRef: &corev1.LocalObjectReference{
+						Name: "$(inputs.params.FOO)",
+					},
+				},
+			},
 		}},
 		Resources: &v1beta1.TaskResources{
 			Inputs: []v1beta1.TaskResource{{
@@ -539,6 +551,8 @@ func TestApplyParameters(t *testing.T) {
 		spec.Volumes[3].VolumeSource.Projected.Sources[0].ConfigMap.Name = "world"
 		spec.Volumes[3].VolumeSource.Projected.Sources[0].Secret.Name = "world"
 		spec.Volumes[3].VolumeSource.Projected.Sources[0].ServiceAccountToken.Audience = "world"
+		spec.Volumes[4].VolumeSource.CSI.VolumeAttributes["secretProviderClass"] = "world"
+		spec.Volumes[4].VolumeSource.CSI.NodePublishSecretRef.Name = "world"
 
 		spec.Sidecars[0].Container.Image = "bar"
 		spec.Sidecars[0].Container.Env[0].Value = "world"


### PR DESCRIPTION
# Changes

This change allow variable subsitution inside csi volumes parameters. You can have a look at the following location to have a better understanding of the problem: https://github.com/tektoncd/pipeline/issues/2642

For the moment it's just a WIP to have feedbacks or advices.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
This PR allow to use parameters in CSI volume parameters.
```
