### PR TITLE
Add replacement for cluster resource in v1alpha1 to v1beta1 migration docs

### DIFF
--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -178,3 +178,7 @@ For examples of replacing an `image` resource, see the following Catalog `Tasks`
   illustrates how to write the digest of an image to a result.
 - The [Buildah Catalog `Task`](https://github.com/tektoncd/catalog/blob/v1beta1/buildah/)
   illustrates how to accept an image digest as a parameter.
+
+### Replacing a `cluster` resource
+
+You can replace a `cluster` resource with the [`kubeconfig-creator` Catalog `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/kubeconfig-creator).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is part of providing documentation for alternative to pipeline resource.
As we have now [kubeconfig-creator](https://github.com/tektoncd/catalog/tree/v1beta1/kubeconfig-creator) task in the catalog as the replacement for cluster resource,
Added the same in the "v1alpha1 to v1beta1 migration" docs.
Ref: #1369

Signed-off-by: Divyansh42 <diagrawa@redhat.com>


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

/kind documentation