### PR TITLE
adding finally type (without implementation) at the pipeline level

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -21,6 +21,7 @@ weight: 3
   - [Configuring execution results at the `Pipeline` level](#configuring-execution-results-at-the-pipeline-level)
   - [Configuring the `Task` execution order](#configuring-the-task-execution-order)
   - [Adding a description](#adding-a-description)
+  - [Adding `Finally` to the `Pipeline` (Preview)](#adding-finally-to-the-pipeline-preview)
   - [Code examples](#code-examples)
 
 ## Overview
@@ -528,6 +529,34 @@ In particular:
 ## Adding a description
 
 The `description` field is an optional field and can be used to provide description of the `Pipeline`.
+
+## Adding `Finally` to the `Pipeline` (Preview)
+
+_Finally type is available in the `Pipeline` but functionality is in progress. Final tasks are can be specified and
+are validated but not executed yet._
+
+You can specify a list of one or more final tasks under `finally` section. Final tasks are guaranteed to be executed
+in parallel after all `PipelineTasks` under `tasks` have completed regardless of success or error. Final tasks are very
+similar to `PipelineTasks` under `tasks` section and follow the same syntax. Each final task must have a
+[valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) `name` and a [taskRef or
+taskSpec](taskruns.md#specifying-the-target-task). For example:
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+  finally:
+    - name: cleanup-test
+      taskRef:
+        Name: cleanup
+```
+
+_[PR #2661](https://github.com/tektoncd/pipeline/pull/2661) is implementing this new functionality by adding support to enable
+final tasks along with workspaces and parameters. `PipelineRun` status is being updated to include execution status of
+final tasks i.e. `PipelineRun` status is set to success or failure depending on execution of `PipelineTasks`, this status
+remains same when all final tasks finishes successfully but is set to failure if any of the final tasks fail._
 
 ## Code examples
 

--- a/pkg/apis/pipeline/v1alpha1/conversion_error.go
+++ b/pkg/apis/pipeline/v1alpha1/conversion_error.go
@@ -26,6 +26,8 @@ const (
 	// resources when they cannot be converted to warn of a forthcoming
 	// breakage.
 	ConditionTypeConvertible apis.ConditionType = v1beta1.ConditionTypeConvertible
+	// Conversion Error message for a field not available in v1alpha1
+	ConversionErrorFieldNotAvailableMsg = "the specified field/section is not available in v1alpha1"
 )
 
 // CannotConvertError is returned when a field cannot be converted.

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -25,6 +25,8 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+const FinallyFieldName = "finally"
+
 var _ apis.Convertible = (*Pipeline)(nil)
 
 // ConvertTo implements api.Convertible
@@ -51,6 +53,7 @@ func (source *PipelineSpec) ConvertTo(ctx context.Context, sink *v1beta1.Pipelin
 			}
 		}
 	}
+	sink.Finally = nil
 	return nil
 }
 
@@ -96,6 +99,10 @@ func (sink *PipelineSpec) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 				return err
 			}
 		}
+	}
+	// finally clause was introduced in v1beta1 and not available in v1alpha1
+	if len(source.Finally) > 0 {
+		return ConvertErrorf(FinallyFieldName, ConversionErrorFieldNotAvailableMsg)
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -42,4 +42,14 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)
 	}
+	for _, ft := range ps.Finally {
+		if ft.TaskRef != nil {
+			if ft.TaskRef.Kind == "" {
+				ft.TaskRef.Kind = NamespacedTaskKind
+			}
+		}
+		if ft.TaskSpec != nil {
+			ft.TaskSpec.SetDefaults(ctx)
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/test/diff"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+)
+
+func TestPipeline_SetDefaults(t *testing.T) {
+	p := &v1beta1.Pipeline{}
+	want := &v1beta1.Pipeline{}
+	ctx := context.Background()
+	p.SetDefaults(ctx)
+	if d := cmp.Diff(want, p); d != "" {
+		t.Errorf("Mismatch of Pipeline: empty pipeline must not change after setting defaults: %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestPipelineSpec_SetDefaults(t *testing.T) {
+	cases := []struct {
+		desc string
+		ps   *v1beta1.PipelineSpec
+		want *v1beta1.PipelineSpec
+	}{{
+		desc: "empty pipelineSpec must not change after setting defaults",
+		ps:   &v1beta1.PipelineSpec{},
+		want: &v1beta1.PipelineSpec{},
+	}, {
+		desc: "pipeline task - default task kind must be " + string(v1beta1.NamespacedTaskKind),
+		ps: &v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name: "foo", TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+			}},
+		},
+		want: &v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name: "foo", TaskRef: &v1beta1.TaskRef{Name: "foo-task", Kind: v1beta1.NamespacedTaskKind},
+			}},
+		},
+	}, {
+		desc: "final pipeline task - default task kind must be " + string(v1beta1.NamespacedTaskKind),
+		ps: &v1beta1.PipelineSpec{
+			Finally: []v1beta1.PipelineTask{{
+				Name: "final-task", TaskRef: &v1beta1.TaskRef{Name: "foo-task"},
+			}},
+		},
+		want: &v1beta1.PipelineSpec{
+			Finally: []v1beta1.PipelineTask{{
+				Name: "final-task", TaskRef: &v1beta1.TaskRef{Name: "foo-task", Kind: v1beta1.NamespacedTaskKind},
+			}},
+		},
+	}, {
+		desc: "param type - default param type must be " + string(v1beta1.ParamTypeString),
+		ps: &v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name: "string-param",
+			}},
+		},
+		want: &v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name: "string-param", Type: v1beta1.ParamTypeString,
+			}},
+		},
+	}, {
+		desc: "pipeline task with taskSpec - default param type must be " + string(v1beta1.ParamTypeString),
+		ps: &v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name: "foo", TaskSpec: &v1beta1.TaskSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "string-param",
+					}},
+				},
+			}},
+		},
+		want: &v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name: "foo", TaskSpec: &v1beta1.TaskSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "string-param",
+						Type: v1beta1.ParamTypeString,
+					}},
+				},
+			}},
+		},
+	}, {
+		desc: "final pipeline task with taskSpec - default param type must be " + string(v1beta1.ParamTypeString),
+		ps: &v1beta1.PipelineSpec{
+			Finally: []v1beta1.PipelineTask{{
+				Name: "foo", TaskSpec: &v1beta1.TaskSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "string-param",
+					}},
+				},
+			}},
+		},
+		want: &v1beta1.PipelineSpec{
+			Finally: []v1beta1.PipelineTask{{
+				Name: "foo", TaskSpec: &v1beta1.TaskSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "string-param",
+						Type: v1beta1.ParamTypeString,
+					}},
+				},
+			}},
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctx := context.Background()
+			tc.ps.SetDefaults(ctx)
+			if d := cmp.Diff(tc.want, tc.ps); d != "" {
+				t.Errorf("Mismatch of pipelineSpec after setting defaults: %s: %s", tc.desc, diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -71,6 +71,10 @@ type PipelineSpec struct {
 	// Results are values that this pipeline can output once run
 	// +optional
 	Results []PipelineResult `json:"results,omitempty"`
+	// Finally declares the list of Tasks that execute just before leaving the Pipeline
+	// i.e. either after all Tasks are finished executing successfully
+	// or after a failure which would result in ending the Pipeline
+	Finally []PipelineTask `json:"finally,omitempty"`
 }
 
 // PipelineResult used to describe the results of a pipeline

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -101,7 +101,7 @@ func TestPipeline_Validate_Success(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.p.Validate(context.Background())
 			if err != nil {
-				t.Errorf("Pipeline.Validate() returned error: %v", err)
+				t.Errorf("Pipeline.Validate() returned error for valid Pipeline: %s: %v", tt.name, err)
 			}
 		})
 	}
@@ -134,7 +134,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.p.Validate(context.Background())
 			if err == nil {
-				t.Error("Pipeline.Validate() did not return error, wanted error")
+				t.Errorf("Pipeline.Validate() did not return error for invalid pipeline: %s", tt.name)
 			}
 		})
 	}
@@ -231,7 +231,7 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.ps.Validate(context.Background())
 			if err == nil {
-				t.Error("PipelineSpec.Validate() did not return error, wanted error")
+				t.Errorf("PipelineSpec.Validate() did not return error for invalid pipelineSpec: %s", tt.name)
 			}
 		})
 	}
@@ -260,9 +260,9 @@ func TestValidatePipelineTasks_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelineTasks(context.Background(), tt.tasks)
+			err := validatePipelineTasks(context.Background(), tt.tasks, []PipelineTask{})
 			if err != nil {
-				t.Errorf("Pipeline.validatePipelineTasks() returned error: %v", err)
+				t.Errorf("Pipeline.validatePipelineTasks() returned error for valid pipeline tasks: %s: %v", tt.name, err)
 			}
 		})
 	}
@@ -315,49 +315,42 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelineTasks(context.Background(), tt.tasks)
+			err := validatePipelineTasks(context.Background(), tt.tasks, []PipelineTask{})
 			if err == nil {
-				t.Error("Pipeline.validatePipelineTasks() did not return error, wanted error")
+				t.Error("Pipeline.validatePipelineTasks() did not return error for invalid pipeline tasks:", tt.name)
 			}
 		})
 	}
 }
 
 func TestValidateFrom_Success(t *testing.T) {
-	tests := []struct {
-		name  string
-		tasks []PipelineTask
-	}{{
-		name: "valid pipeline task - from resource referring to valid output resource of the pipeline task",
-		tasks: []PipelineTask{{
-			Name:    "bar",
-			TaskRef: &TaskRef{Name: "bar-task"},
-			Resources: &PipelineTaskResources{
-				Inputs: []PipelineTaskInputResource{{
-					Name: "some-resource", Resource: "some-resource",
-				}},
-				Outputs: []PipelineTaskOutputResource{{
-					Name: "output-resource", Resource: "output-resource",
-				}},
-			},
-		}, {
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-			Resources: &PipelineTaskResources{
-				Inputs: []PipelineTaskInputResource{{
-					Name: "wow-image", Resource: "output-resource", From: []string{"bar"},
-				}},
-			},
-		}},
+	desc := "valid pipeline task - from resource referring to valid output resource of the pipeline task"
+	tasks := []PipelineTask{{
+		Name:    "bar",
+		TaskRef: &TaskRef{Name: "bar-task"},
+		Resources: &PipelineTaskResources{
+			Inputs: []PipelineTaskInputResource{{
+				Name: "some-resource", Resource: "some-resource",
+			}},
+			Outputs: []PipelineTaskOutputResource{{
+				Name: "output-resource", Resource: "output-resource",
+			}},
+		},
+	}, {
+		Name:    "foo",
+		TaskRef: &TaskRef{Name: "foo-task"},
+		Resources: &PipelineTaskResources{
+			Inputs: []PipelineTaskInputResource{{
+				Name: "wow-image", Resource: "output-resource", From: []string{"bar"},
+			}},
+		},
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateFrom(tt.tasks)
-			if err != nil {
-				t.Errorf("Pipeline.validateFrom() returned error: %v", err)
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validateFrom(tasks)
+		if err != nil {
+			t.Errorf("Pipeline.validateFrom() returned error for: %s: %v", desc, err)
+		}
+	})
 }
 
 func TestValidateFrom_Failure(t *testing.T) {
@@ -449,7 +442,7 @@ func TestValidateFrom_Failure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateFrom(tt.tasks)
 			if err == nil {
-				t.Error("Pipeline.validateFrom() did not return error, wanted error")
+				t.Error("Pipeline.validateFrom() did not return error for invalid pipeline task resources: ", tt.name)
 			}
 		})
 	}
@@ -540,9 +533,9 @@ func TestValidateDeclaredResources_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateDeclaredResources(tt.resources, tt.tasks)
+			err := validateDeclaredResources(tt.resources, tt.tasks, []PipelineTask{})
 			if err != nil {
-				t.Errorf("Pipeline.validateDeclaredResources() returned error: %v", err)
+				t.Errorf("Pipeline.validateDeclaredResources() returned error for valid resource declarations: %s: %v", tt.name, err)
 			}
 		})
 	}
@@ -619,164 +612,123 @@ func TestValidateDeclaredResources_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateDeclaredResources(tt.resources, tt.tasks)
+			err := validateDeclaredResources(tt.resources, tt.tasks, []PipelineTask{})
 			if err == nil {
-				t.Error("Pipeline.validateDeclaredResources() did not return error, wanted error")
+				t.Errorf("Pipeline.validateDeclaredResources() did not return error for invalid resource declarations: %s", tt.name)
 			}
 		})
 	}
 }
 
 func TestValidateGraph_Success(t *testing.T) {
-	tests := []struct {
-		name  string
-		tasks []PipelineTask
-	}{{
-		name: "valid dependency graph with multiple tasks",
-		tasks: []PipelineTask{{
-			Name: "foo", TaskRef: &TaskRef{Name: "foo-task"},
-		}, {
-			Name: "bar", TaskRef: &TaskRef{Name: "bar-task"},
-		}, {
-			Name: "foo1", TaskRef: &TaskRef{Name: "foo-task"}, RunAfter: []string{"foo"},
-		}, {
-			Name: "bar1", TaskRef: &TaskRef{Name: "bar-task"}, RunAfter: []string{"bar"},
-		}, {
-			Name: "foo-bar", TaskRef: &TaskRef{Name: "bar-task"}, RunAfter: []string{"foo1", "bar1"},
-		}},
+	desc := "valid dependency graph with multiple tasks"
+	tasks := []PipelineTask{{
+		Name: "foo", TaskRef: &TaskRef{Name: "foo-task"},
+	}, {
+		Name: "bar", TaskRef: &TaskRef{Name: "bar-task"},
+	}, {
+		Name: "foo1", TaskRef: &TaskRef{Name: "foo-task"}, RunAfter: []string{"foo"},
+	}, {
+		Name: "bar1", TaskRef: &TaskRef{Name: "bar-task"}, RunAfter: []string{"bar"},
+	}, {
+		Name: "foo-bar", TaskRef: &TaskRef{Name: "bar-task"}, RunAfter: []string{"foo1", "bar1"},
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateGraph(tt.tasks)
-			if err != nil {
-				t.Errorf("Pipeline.validateGraph() returned error: %v", err)
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validateGraph(tasks)
+		if err != nil {
+			t.Errorf("Pipeline.validateGraph() returned error for valid DAG of pipeline tasks: %s: %v", desc, err)
+		}
+	})
 }
 
 func TestValidateGraph_Failure(t *testing.T) {
-	tests := []struct {
-		name  string
-		tasks []PipelineTask
-	}{{
-		name: "invalid dependency graph between the tasks with cyclic dependency",
-		tasks: []PipelineTask{{
-			Name: "foo", TaskRef: &TaskRef{Name: "foo-task"}, RunAfter: []string{"bar"},
-		}, {
-			Name: "bar", TaskRef: &TaskRef{Name: "bar-task"}, RunAfter: []string{"foo"},
-		}},
+	desc := "invalid dependency graph between the tasks with cyclic dependency"
+	tasks := []PipelineTask{{
+		Name: "foo", TaskRef: &TaskRef{Name: "foo-task"}, RunAfter: []string{"bar"},
+	}, {
+		Name: "bar", TaskRef: &TaskRef{Name: "bar-task"}, RunAfter: []string{"foo"},
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateGraph(tt.tasks)
-			if err == nil {
-				t.Error("Pipeline.validateGraph() did not return error, wanted error")
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validateGraph(tasks)
+		if err == nil {
+			t.Error("Pipeline.validateGraph() did not return error for invalid DAG of pipeline tasks:", desc)
+
+		}
+	})
 }
 
 func TestValidateParamResults_Success(t *testing.T) {
-	tests := []struct {
-		name  string
-		tasks []PipelineTask
-	}{{
-		name: "invalid pipeline task referencing task result along with parameter variable",
-		tasks: []PipelineTask{{
-			TaskSpec: &TaskSpec{
-				Results: []TaskResult{{
-					Name: "output",
-				}},
-				Steps: []Step{{
-					Container: corev1.Container{Name: "foo", Image: "bar"},
-				}},
-			},
-			Name: "a-task",
-		}, {
-			Name:    "foo",
-			TaskRef: &TaskRef{Name: "foo-task"},
-			Params: []Param{{
-				Name: "a-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.foo) and $(tasks.a-task.results.output)"},
+	desc := "valid pipeline task referencing task result along with parameter variable"
+	tasks := []PipelineTask{{
+		TaskSpec: &TaskSpec{
+			Results: []TaskResult{{
+				Name: "output",
 			}},
+			Steps: []Step{{
+				Container: corev1.Container{Name: "foo", Image: "bar"},
+			}},
+		},
+		Name: "a-task",
+	}, {
+		Name:    "foo",
+		TaskRef: &TaskRef{Name: "foo-task"},
+		Params: []Param{{
+			Name: "a-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.foo) and $(tasks.a-task.results.output)"},
 		}},
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateParamResults(tt.tasks)
-			if err != nil {
-				t.Errorf("Pipeline.validateParamResults() returned error: %v", err)
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validateParamResults(tasks)
+		if err != nil {
+			t.Errorf("Pipeline.validateParamResults() returned error for valid pipeline: %s: %v", desc, err)
+		}
+	})
 }
 
 func TestValidateParamResults_Failure(t *testing.T) {
-	tests := []struct {
-		name  string
-		tasks []PipelineTask
-	}{{
-		name: "invalid pipeline task referencing task results with malformed variable substitution expression",
-		tasks: []PipelineTask{{
-			Name: "a-task", TaskRef: &TaskRef{Name: "a-task"},
-		}, {
-			Name: "b-task", TaskRef: &TaskRef{Name: "b-task"},
-			Params: []Param{{
-				Name: "a-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(tasks.a-task.resultTypo.bResult)"}}},
-		}},
+	desc := "invalid pipeline task referencing task results with malformed variable substitution expression"
+	tasks := []PipelineTask{{
+		Name: "a-task", TaskRef: &TaskRef{Name: "a-task"},
+	}, {
+		Name: "b-task", TaskRef: &TaskRef{Name: "b-task"},
+		Params: []Param{{
+			Name: "a-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(tasks.a-task.resultTypo.bResult)"}}},
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateParamResults(tt.tasks)
-			if err == nil {
-				t.Error("Pipeline.validateParamResults() did not return error, wanted error")
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validateParamResults(tasks)
+		if err == nil {
+			t.Errorf("Pipeline.validateParamResults() did not return error for invalid pipeline: %s", desc)
+		}
+	})
 }
 
 func TestValidatePipelineResults_Success(t *testing.T) {
-	tests := []struct {
-		name    string
-		results []PipelineResult
-	}{{
-		name: "valid pipeline result",
-		results: []PipelineResult{{
-			Name:        "my-pipeline-result",
-			Description: "this is my pipeline result",
-			Value:       "$(tasks.a-task.results.output)",
-		}},
+	desc := "valid pipeline with valid pipeline results syntax"
+	results := []PipelineResult{{
+		Name:        "my-pipeline-result",
+		Description: "this is my pipeline result",
+		Value:       "$(tasks.a-task.results.output)",
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelineResults(tt.results)
-			if err != nil {
-				t.Errorf("Pipeline.validatePipelineResults() returned error: %v", err)
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validatePipelineResults(results)
+		if err != nil {
+			t.Errorf("Pipeline.validatePipelineResults() returned error for valid pipeline: %s: %v", desc, err)
+		}
+	})
 }
 
 func TestValidatePipelineResults_Failure(t *testing.T) {
-	tests := []struct {
-		name    string
-		results []PipelineResult
-	}{{
-		name: "invalid pipeline result reference",
-		results: []PipelineResult{{
-			Name:        "my-pipeline-result",
-			Description: "this is my pipeline result",
-			Value:       "$(tasks.a-task.results.output.output)",
-		}},
+	desc := "invalid pipeline result reference"
+	results := []PipelineResult{{
+		Name:        "my-pipeline-result",
+		Description: "this is my pipeline result",
+		Value:       "$(tasks.a-task.results.output.output)",
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelineResults(tt.results)
-			if err == nil {
-				t.Error("Pipeline.validatePipelineResults() did not return error, wanted error")
-			}
-		})
-	}
+	t.Run(desc, func(t *testing.T) {
+		err := validatePipelineResults(results)
+		if err == nil {
+			t.Errorf("Pipeline.validatePipelineResults() did not return for invalid pipeline: %s", desc)
+		}
+	})
 }
 
 func TestValidatePipelineParameterVariables_Success(t *testing.T) {
@@ -843,7 +795,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validatePipelineParameterVariables(tt.tasks, tt.params)
 			if err != nil {
-				t.Errorf("Pipeline.validatePipelineParameterVariables() returned error: %v", err)
+				t.Errorf("Pipeline.validatePipelineParameterVariables() returned error for valid pipeline parameters: %s: %v", tt.name, err)
 			}
 		})
 	}
@@ -969,36 +921,28 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validatePipelineParameterVariables(tt.tasks, tt.params)
 			if err == nil {
-				t.Error("Pipeline.validatePipelineParameterVariables() did not return error, wanted error")
+				t.Errorf("Pipeline.validatePipelineParameterVariables() did not return error for invalid pipeline parameters: %s", tt.name)
 			}
 		})
 	}
 }
 
 func TestValidatePipelineWorkspaces_Success(t *testing.T) {
-	tests := []struct {
-		name       string
-		workspaces []PipelineWorkspaceDeclaration
-		tasks      []PipelineTask
-	}{{
-		name: "unused pipeline spec workspaces do not cause an error",
-		workspaces: []PipelineWorkspaceDeclaration{{
-			Name: "foo",
-		}, {
-			Name: "bar",
-		}},
-		tasks: []PipelineTask{{
-			Name: "foo", TaskRef: &TaskRef{Name: "foo"},
-		}},
+	desc := "unused pipeline spec workspaces do not cause an error"
+	workspaces := []PipelineWorkspaceDeclaration{{
+		Name: "foo",
+	}, {
+		Name: "bar",
 	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelineWorkspaces(tt.workspaces, tt.tasks)
-			if err != nil {
-				t.Errorf("Pipeline.validatePipelineWorkspaces() returned error: %v", err)
-			}
-		})
-	}
+	tasks := []PipelineTask{{
+		Name: "foo", TaskRef: &TaskRef{Name: "foo"},
+	}}
+	t.Run(desc, func(t *testing.T) {
+		err := validatePipelineWorkspaces(workspaces, tasks, []PipelineTask{})
+		if err != nil {
+			t.Errorf("Pipeline.validatePipelineWorkspaces() returned error for valid pipeline workspaces: %s: %v", desc, err)
+		}
+	})
 }
 
 func TestValidatePipelineWorkspaces_Failure(t *testing.T) {
@@ -1039,9 +983,377 @@ func TestValidatePipelineWorkspaces_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatePipelineWorkspaces(tt.workspaces, tt.tasks)
+			err := validatePipelineWorkspaces(tt.workspaces, tt.tasks, []PipelineTask{})
 			if err == nil {
-				t.Error("Pipeline.validatePipelineWorkspaces() did not return error, wanted error")
+				t.Errorf("Pipeline.validatePipelineWorkspaces() did not return error for invalid pipeline workspaces: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidatePipelineWithFinalTasks_Success(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *Pipeline
+	}{{
+		name: "valid pipeline with final tasks",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:    "final-task-1",
+					TaskRef: &TaskRef{Name: "final-task"},
+				}, {
+					Name: "final-task-2",
+					TaskSpec: &TaskSpec{
+						Steps: []Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
+		name: "valid pipeline with resource declarations and their valid usage",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Resources: []PipelineDeclaredResource{{
+					Name: "great-resource", Type: PipelineResourceTypeGit,
+				}, {
+					Name: "wonderful-resource", Type: PipelineResourceTypeImage,
+				}},
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "bar-task"},
+					Resources: &PipelineTaskResources{
+						Inputs: []PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+						Outputs: []PipelineTaskOutputResource{{
+							Name: "some-image", Resource: "wonderful-resource",
+						}},
+					},
+					Conditions: []PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+						Resources: []PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+					}},
+				}},
+				Finally: []PipelineTask{{
+					Name:    "foo",
+					TaskRef: &TaskRef{Name: "foo-task"},
+					Resources: &PipelineTaskResources{
+						Inputs: []PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+						Outputs: []PipelineTaskOutputResource{{
+							Name: "some-image", Resource: "wonderful-resource",
+						}},
+					},
+				}},
+			},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.p.Validate(context.Background())
+			if err != nil {
+				t.Errorf("Pipeline.Validate() returned error for valid pipeline with finally: %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *Pipeline
+	}{{
+		name: "invalid pipeline without any non-final task (tasks set to nil) but at least one final task",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: nil,
+				Finally: []PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &TaskRef{Name: "final-task"},
+				}},
+			},
+		},
+	}, {
+		name: "invalid pipeline without any non-final task (tasks set to empty list of pipeline task) but at least one final task",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{}},
+				Finally: []PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &TaskRef{Name: "final-task"},
+				}},
+			},
+		},
+	}, {
+		name: "invalid pipeline with valid non-final tasks but empty finally section",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{}},
+			},
+		},
+	}, {
+		name: "invalid pipeline with duplicate final tasks",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &TaskRef{Name: "final-task"},
+				}, {
+					Name:    "final-task",
+					TaskRef: &TaskRef{Name: "final-task"},
+				}},
+			},
+		},
+	}, {
+		name: "invalid pipeline with same task name for final and non final task",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "common-task-name",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:    "common-task-name",
+					TaskRef: &TaskRef{Name: "final-task"},
+				}},
+			},
+		},
+	}, {
+		name: "final task missing tasfref and taskspec",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name: "final-task",
+				}},
+			},
+		},
+	}, {
+		name: "final task with both tasfref and taskspec",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+					TaskSpec: &TaskSpec{
+						Steps: []Step{{
+							Container: corev1.Container{Name: "foo", Image: "bar"},
+						}},
+					},
+				}},
+			},
+		},
+	}, {
+		name: "extra parameter called final-param provided to final task which is not specified in the Pipeline",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Params: []ParamSpec{{
+					Name: "foo", Type: ParamTypeString,
+				}},
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:    "final-task",
+					TaskRef: &TaskRef{Name: "final-task"},
+					Params: []Param{{
+						Name: "final-param", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.foo) and $(params.does-not-exist)"},
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "invalid pipeline with invalid final tasks with runAfter and conditions",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name:    "non-final-task",
+					TaskRef: &TaskRef{Name: "non-final-task"},
+				}},
+				Finally: []PipelineTask{{
+					Name:     "final-task-1",
+					TaskRef:  &TaskRef{Name: "final-task"},
+					RunAfter: []string{"non-final-task"},
+				}, {
+					Name:    "final-task-2",
+					TaskRef: &TaskRef{Name: "final-task"},
+					Conditions: []PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+					}},
+				}},
+			},
+		},
+	}, {
+		name: "invalid pipeline - workspace bindings in final task relying on a non-existent pipeline workspace",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Tasks: []PipelineTask{{
+					Name: "non-final-task", TaskRef: &TaskRef{Name: "foo"},
+				}},
+				Finally: []PipelineTask{{
+					Name: "final-task", TaskRef: &TaskRef{Name: "foo"},
+					Workspaces: []WorkspacePipelineTaskBinding{{
+						Name:      "shared-workspace",
+						Workspace: "pipeline-shared-workspace",
+					}},
+				}},
+				Workspaces: []WorkspacePipelineDeclaration{{
+					Name: "foo",
+				}},
+			},
+		},
+	}, {
+		name: "invalid pipeline with no tasks under tasks section and empty finally section",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: PipelineSpec{
+				Finally: []PipelineTask{{}},
+			},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.p.Validate(context.Background())
+			if err == nil {
+				t.Errorf("Pipeline.Validate() did not return error for invalid pipeline with finally: %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateTasksAndFinallySection_Success(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   *PipelineSpec
+	}{{
+		name: "pipeline with tasks and final tasks",
+		ps: &PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name: "non-final-task", TaskRef: &TaskRef{Name: "foo"},
+			}},
+			Finally: []PipelineTask{{
+				Name: "final-task", TaskRef: &TaskRef{Name: "foo"},
+			}},
+		},
+	}, {
+		name: "valid pipeline with tasks and finally section without any tasks",
+		ps: &PipelineSpec{
+			Tasks: []PipelineTask{{
+				Name: "my-task", TaskRef: &TaskRef{Name: "foo"},
+			}},
+			Finally: nil,
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTasksAndFinallySection(tt.ps)
+			if err != nil {
+				t.Errorf("Pipeline.ValidateTasksAndFinallySection() returned error for valid pipeline with finally: %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestValidateTasksAndFinallySection_Failure(t *testing.T) {
+	desc := "invalid pipeline with empty tasks and a few final tasks"
+	ps := &PipelineSpec{
+		Tasks: nil,
+		Finally: []PipelineTask{{
+			Name: "final-task", TaskRef: &TaskRef{Name: "foo"},
+		}},
+	}
+	t.Run(desc, func(t *testing.T) {
+		err := validateTasksAndFinallySection(ps)
+		if err == nil {
+			t.Errorf("Pipeline.ValidateTasksAndFinallySection() did not return error for invalid pipeline with finally: %s", desc)
+		}
+	})
+}
+
+func TestValidateFinalTasks_Failure(t *testing.T) {
+	tests := []struct {
+		name       string
+		finalTasks []PipelineTask
+	}{{
+		name: "invalid pipeline with final task specifying runAfter",
+		finalTasks: []PipelineTask{{
+			Name:     "final-task",
+			TaskRef:  &TaskRef{Name: "final-task"},
+			RunAfter: []string{"non-final-task"},
+		}},
+	}, {
+		name: "invalid pipeline with final task specifying conditions",
+		finalTasks: []PipelineTask{{
+			Name:    "final-task",
+			TaskRef: &TaskRef{Name: "final-task"},
+			Conditions: []PipelineTaskCondition{{
+				ConditionRef: "some-condition",
+			}},
+		}},
+	}, {
+		name: "invalid pipeline with final task output resources referring to other task input",
+		finalTasks: []PipelineTask{{
+			Name:    "final-task",
+			TaskRef: &TaskRef{Name: "final-task"},
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					Name: "final-input-2", Resource: "great-resource", From: []string{"task"},
+				}},
+			},
+		}},
+	}, {
+		name: "invalid pipeline with final tasks having reference to task results",
+		finalTasks: []PipelineTask{{
+			Name:    "final-task",
+			TaskRef: &TaskRef{Name: "final-task"},
+			Params: []Param{{
+				Name: "param1", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(tasks.a-task.results.output)"},
+			}},
+		}},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateFinalTasks(tt.finalTasks)
+			if err == nil {
+				t.Errorf("Pipeline.ValidateFinalTasks() did not return error for invalid pipeline: %s", tt.name)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -785,6 +785,13 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 		*out = make([]PipelineResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.Finally != nil {
+		in, out := &in.Finally, &out.Finally
+		*out = make([]PipelineTask, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Updating pipeline type to support finally. These changes are adding a new type and validation, does not implement this new functionality.

Design doc: https://docs.google.com/document/d/1lxpYQHppiWOxsn4arqbwAFDo4T0-LCqpNa6p-TJdHrw/edit#

Part of #1684

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

``` 
Introducing a new clause under `pipeline` named `finally` where users can specify a list of tasks that will always execute, even if pipeline tasks fail. Adding a new type and its validation here, stay tuned for this functionality. Without implementing the functionality, a list of tasks under `finally` are validated but not executed at all.
```
