### PR TITLE
WIP - implementing pipeline level finally

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -21,6 +21,7 @@ weight: 3
   - [Configuring execution results at the `Pipeline` level](#configuring-execution-results-at-the-pipeline-level)
   - [Configuring the `Task` execution order](#configuring-the-task-execution-order)
   - [Adding a description](#adding-a-description)
+  - [Adding `Finally` to the `Pipeline`](#adding-finally-to-the-pipeline)
   - [Code examples](#code-examples)
 
 ## Overview
@@ -515,6 +516,196 @@ In particular:
 ## Adding a description
 
 The `description` field is an optional field and can be used to provide description of the `Pipeline`.
+
+## Adding `Finally` to the `Pipeline`
+
+You can specify a list of one or more final tasks under `finally` section. Final tasks are guaranteed to be executed
+after all `PipelineTasks` under `tasks` have completed regardless of success or error. Final tasks are very similar to
+`PipelineTasks` under `tasks` section and follow the same syntax. Each final task must have a
+[valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) `name` and a `taskRef` or
+`taskSpec`. For example:
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+  finally:
+    - name: cleanup-test
+      taskRef:
+        Name: cleanup
+```
+
+### Specifying `Workspaces` in Final Tasks
+
+It is possible that the final tasks might require access to the same workspaces which `PipelineTasks` might have utilized
+e.g. a mount point for credentials held in Secrets. To support that requirement, you can specify one or more
+`Workspaces` in the `workspaces` field for the final tasks similar to `tasks`.
+
+```yaml
+spec:
+  resources:
+    - name: app-git
+      type: git
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone-app-source
+      taskRef:
+        name: clone-app-repo-to-workspace
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+      resources:
+        inputs:
+          - name: app-git
+            resource: app-git
+  finally:
+    - name: cleanup-workspace
+      taskRef:
+        name: cleanup-workspace
+      workspaces:
+        - name: shared-workspace
+          workspace: shared-workspace
+```
+
+### Specifying `Parameters` in Final Tasks
+
+Again, similar to `tasks`, you can specify [`Parameters`](tasks.md#specifying-parameters):
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+  finally:
+    - name: report-results
+      taskRef:
+        Name: report-results
+      params:
+        - name: url
+          value: $(params.url)
+```
+
+### `PipelineRun` Status with `finally`
+
+With `finally`, `PipelineRun` status is calculated based on `PipelineTasks` under `tasks` section and final tasks.
+
+Without `finally`:
+
+| `PipelineTasks` under `tasks` | `PipelineRun` status | Reason |
+| ----------------------------- | -------------------- | ------ |
+| all `PipelineTasks` successful | `true` | `Succeeded` |
+| one or more `PipelineTasks` skipped and rest successful | `true` | `Completed` |
+| single failure of `PipelineTask` | `false` | `failed` |
+
+With `finally`:
+
+| `PipelineTasks` under `tasks` | Final Tasks | `PipelineRun` status | Reason |
+| ----------------------------- | ----------- | -------------------- | ------ |
+| all `PipelineTask` successful | all final tasks successful | `true` | `Succeeded` |
+| all `PipelineTask` successful | one or more failure of final tasks | `false` | `Failed` |
+| one or more `PipelineTask` skipped and rest successful | all final tasks successful | `true` | `Completed` |
+| one or more `PipelineTask` skipped and rest successful | one or more failure of final tasks | `false` | `Failed` |
+| single failure of `PipelineTask` | all final tasks successful | `false` | `failed` |
+| single failure of `PipelineTask` | one or more failure of final tasks | `false` | `failed` |
+
+### Known Limitations
+
+### Specifying `Resources` in Final Tasks
+
+Similar to `tasks`, you can use [PipelineResources](#specifying-resources) as inputs and outputs for
+final tasks in the Pipeline. The only difference here is, final tasks with an input resource can not have a `from` clause
+like a `PipelineTask` from `tasks` section. For example:
+
+```yaml
+spec:
+  tasks:
+    - name: tests
+      taskRef:
+        Name: integration-test
+      resources:
+        inputs:
+          - name: source
+            resource: tektoncd-pipeline-repo
+        outputs:
+          - name: workspace
+            resource: my-repo
+  finally:
+    - name: clear-workspace
+      taskRef:
+        Name: clear-workspace
+      resources:
+        inputs:
+          - name: workspace
+            resource: my-repo
+            from:
+              - tests
+```
+
+### Cannot configure the Final Task execution order
+
+It's not possible to configure or modify the execution order of the final tasks. Unlike `Tasks` in a `Pipeline`,
+all final tasks run simultaneously and starts executing once all `PipelineTasks` under `tasks` have settled which means
+no `runAfter` can be specified in final tasks.
+
+### Cannot specify execution `Conditions` in Final Tasks
+
+`Tasks` in a `Pipeline` can be configured to run only if some conditions are satisfied using `conditions`. But the
+final tasks are guaranteed to be executed after all `PipelineTasks` therefore no `conditions` can be specified in
+final tasks.
+
+#### Cannot configure `Task` execution results with `finally`
+
+Final tasks can not be configured to consume `Results` of `PipelineTask` from `tasks` section i.e. the following
+example is not supported right now but we are working on adding support for the same.
+
+```yaml
+spec:
+  tasks:
+    - name: count-comments-before
+      taskRef:
+        Name: count-comments
+    - name: add-comment
+      taskRef:
+        Name: add-comment
+    - name: count-comments-after
+      taskRef:
+        Name: count-comments
+  finally:
+    - name: check-count
+      taskRef:
+        Name: check-count
+      params:
+        - name: before-count
+          value: $(tasks.count-comments-before.results.count)
+        - name: after-count
+          value: $(tasks.count-comments-after.results.count)
+```
+
+#### Cannot configure `Pipeline` result with `finally`
+
+Final tasks can emit `Results` but results emitted from the final tasks can not be configured in the
+[Pipeline Results](#configuring-execution-results-at-the-pipeline-level). We are working on adding support for this.
+
+```yaml
+  results:
+    - name: comment-count-validate
+      value: $(finally.check-count.results.comment-count-validate)
+```
+
+In this example, `PipelineResults` is set to:
+
+```
+"pipelineResults": [
+  {
+    "name": "comment-count-validate",
+    "value": "$(finally.check-count.results.comment-count-validate)"
+  }
+],
+```
 
 ## Code examples
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -71,6 +71,10 @@ type PipelineSpec struct {
 	// Results are values that this pipeline can output once run
 	// +optional
 	Results []PipelineResult `json:"results,omitempty"`
+	// Finally declares the list of Tasks that execute just before leaving the Pipeline
+	// i.e. either after all Tasks are finished executing successfully
+	// or after a failure which would result in ending the Pipeline
+	Finally []PipelineTask `json:"finally,omitempty"`
 }
 
 // PipelineResult used to describe the results of a pipeline

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -785,6 +785,13 @@ func (in *PipelineSpec) DeepCopyInto(out *PipelineSpec) {
 		*out = make([]PipelineResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.Finally != nil {
+		in, out := &in.Finally, &out.Finally
+		*out = make([]PipelineTask, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -1,0 +1,350 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	knativetest "knative.dev/pkg/test"
+)
+
+// Pipeline results in failure since dag task fails but final tasks does get executed
+func TestPipelineLevelFinallyWhenOneDAGTaskFailed(t *testing.T) {
+	c, namespace := setup(t)
+
+	taskName := "dagtask"
+	finalTaskName := "finaltask"
+	pipelineName := "pipeline-with-failed-dag-tasks"
+	pipelineRunName := "pipelinerun-with-failed-dag-tasks"
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	task := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 1",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create non final Task: %s", err)
+	}
+
+	finalTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: finalTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name:    "dagtask1",
+				TaskRef: &v1beta1.TaskRef{Name: taskName},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name:    "finaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: finalTaskName},
+			}},
+		},
+	}
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: pipelineName},
+		},
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRunName, err)
+	}
+
+	if err := WaitForPipelineRunState(c, pipelineRunName, timeout, PipelineRunFailed(pipelineRunName), "PipelineRunFailed"); err != nil {
+		t.Fatalf("Waiting for PipelineRun %s to fail: %v", pipelineRunName, err)
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+	}
+
+	// verify non final task failed and final task executed and succeeded
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, pipelineRunName+"-"+finalTaskName):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have succedded", n)
+			}
+		case strings.HasPrefix(n, pipelineRunName+"-"+taskName):
+			if !isFailed(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for non final task should have failed", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and dag tasks")
+		}
+	}
+}
+
+// Pipeline exits with success even if final task execution fails
+func TestPipelineLevelFinallyWhenOneFinalTaskFailed(t *testing.T) {
+	c, namespace := setup(t)
+
+	taskName := "dagtask"
+	finalTaskName := "finaltask"
+	pipelineName := "pipeline-with-failed-final-tasks"
+	pipelineRunName := "pipelinerun-with-failed-final-tasks"
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	task := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create non final Task: %s", err)
+	}
+
+	finalTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: finalTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 1",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name:    "dagtask1",
+				TaskRef: &v1beta1.TaskRef{Name: taskName},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name:    "finaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: finalTaskName},
+			}},
+		},
+	}
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: pipelineName},
+		},
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRunName, err)
+	}
+
+	if err := WaitForPipelineRunState(c, pipelineRunName, timeout, PipelineRunFailed(pipelineRunName), "PipelineRunFailed"); err != nil {
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRunName, err)
+		t.Fatalf("PipelineRun execution failed")
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+	}
+
+	// verify non final task succeeded and final task failed
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, pipelineRunName+"-"+finalTaskName):
+			if !isFailed(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have failed", n)
+			}
+		case strings.HasPrefix(n, pipelineRunName+"-"+taskName):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for non final task should have succedded", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and dag tasks")
+		}
+	}
+}
+
+// The dag task is skipped due to condition failure, final tasks should still be executed
+func TestPipelineLevelFinallyWhenDAGTaskSkipped(t *testing.T) {
+	c, namespace := setup(t)
+
+	taskName := "dagtask"
+	finalTaskName := "finaltask"
+	pipelineName := "pipeline-with-skipped-dag-tasks"
+	pipelineRunName := "pipelinerun-with-skipped-dag-tasks"
+	condName := "failedcondition"
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	cond := &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{Name: condName, Namespace: namespace},
+		Spec: v1alpha1.ConditionSpec{
+			Check: v1alpha1.Step{
+				Container: corev1.Container{Image: "ubuntu"},
+				Script:    "exit 1",
+			},
+		},
+	}
+	if _, err := c.ConditionClient.Create(cond); err != nil {
+		t.Fatalf("Failed to create Condition `%s`: %s", cond1Name, err)
+	}
+
+	task := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: taskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create non final Task: %s", err)
+	}
+
+	finalTask := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: finalTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    "exit 0",
+			}},
+		},
+	}
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineName, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name:    "dagtask1",
+				TaskRef: &v1beta1.TaskRef{Name: taskName},
+				Conditions: []v1beta1.PipelineTaskCondition{{
+					ConditionRef: condName,
+				}},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name:    "finaltask1",
+				TaskRef: &v1beta1.TaskRef{Name: finalTaskName},
+			}},
+		},
+	}
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: pipelineName},
+		},
+	}
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", pipelineRunName, err)
+	}
+
+	if err := WaitForPipelineRunState(c, pipelineRunName, timeout, PipelineRunSucceed(pipelineRunName), "PipelineRunCompleted"); err != nil {
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRunName, err)
+		t.Fatalf("PipelineRun execution failed")
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+	}
+
+	// verify non final task skipped but final task executed and succeeded
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, pipelineRunName+"-"+finalTaskName):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have succeeded", n)
+			}
+		case strings.HasPrefix(n, pipelineRunName+"-"+taskName):
+			if !isSkipped(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for non final task should have skipped due to condition failure", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and dag tasks")
+		}
+	}
+}
+
+func isSuccessful(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
+	for _, c := range conds {
+		if c.Type == apis.ConditionSucceeded {
+			if c.Status != corev1.ConditionTrue {
+				t.Errorf("TaskRun status %q is not succeeded, got %q", taskRunName, c.Status)
+			}
+			return true
+		}
+	}
+	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
+	return false
+}
+
+func isSkipped(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
+	for _, c := range conds {
+		if c.Type == apis.ConditionSucceeded {
+			if c.Status != corev1.ConditionFalse && c.Reason != resources.ReasonConditionCheckFailed {
+				t.Errorf("TaskRun status %q is not skipped due to condition failure, got %q", taskRunName, c.Status)
+			}
+			return true
+		}
+	}
+	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
+	return false
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We can now specify a list of tasks needs to be executed just before
pipeline exits (either after finishing all non-final tasks successfully or after
a single failure)

Most useful for tasks such as report test results, cleanup cluster resources, etc

```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: pipeline-with-final-tasks
spec:
  tasks:
    - name: pre-work
      taskRef:
        Name: some-pre-work
    - name: unit-test
      taskRef:
        Name: run-unit-test
      runAfter:
        - pre-work
    - name: integration-test
      taskRef:
        Name: run-integration-test
      runAfter:
        - unit-test
  finally:
    - name: cleanup-test
      taskRef:
        Name: cleanup-cluster
    - name: report-results
      taskRef:
        Name: report-test-results
```

Design doc: https://docs.google.com/document/d/1lxpYQHppiWOxsn4arqbwAFDo4T0-LCqpNa6p-TJdHrw/edit#

Part of #1684
Fixes #2446

Depends on: #2650 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```Users can now specify Tasks within a Pipeline that will always execute, even if Tasks fail, via the new `finally` clause```
