### PR TITLE
Update nop, gsutil and shell images

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -66,12 +66,13 @@ spec:
           "-pr-image", "github.com/tektoncd/pipeline/cmd/pullrequest-init",
           "-build-gcs-fetcher-image", "github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher",
 
-          # These images are pulled from Dockerhub, by digest, as of April 15, 2020.
-          "-nop-image", "tianon/true@sha256:009cce421096698832595ce039aa13fa44327d96beedb84282a69d3dbcf5a81b",
-          "-gsutil-image", "google/cloud-sdk@sha256:6e8676464c7581b2dc824956b112a61c95e4144642bec035e6db38e3384cae2e",
+          # These images are pulled from Dockerhub, by digest, as of May 19, 2020.
+          "-nop-image", "tianon/true@sha256:183cb5fd54142948ad88cc986a217465cfe8786cfdd89b1ed1fc49825da413a7",
+          # This is google/cloud-sdk:293.0.0-slim
+          "-gsutil-image", "google/cloud-sdk@sha256:37654ada9b7afbc32828b537030e85de672a9dd468ac5c92a36da1e203a98def",
           # The shell image must be root in order to create directories and copy files to PVCs.
-          # As of April 17, 2020
-          "-shell-image", "gcr.io/distroless/base:debug@sha256:dac57423f6d9210198e1ac25de9f6d48753196a112aa2deb22f54e984cfd462d",
+          # As of May 19, 2020
+          "-shell-image", "gcr.io/distroless/base:debug@sha256:f79e093f9ba639c957ee857b1ad57ae5046c328998bf8f72b30081db4d8edbe4",
         ]
         volumeMounts:
         - name: config-logging


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

- Bump to latest for tianon/true and gcr.io/distroless/base:debug
- Bump to 293.0.0 for google/cloud-sdk

This witch from debian based to alpine based for
`google/cloud-sdk` (`-slim` tag). This is mainly to be *on-par* with
the rest of the images (that are based on `distroless` which tends to
be based on apline (or `scratch`)

/cc @bobcatfish @sbwsg @mattmoor 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Bump gsutil image to google/cloud-sdk:293.0.0 with a alpine base image, tianon/true and distroless/base:debug to latest
```
