### PR TITLE
implementing pipeline level finally

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -1,0 +1,187 @@
+# Copied from https://github.com/tektoncd/catalog/blob/v1beta1/git/git-clone.yaml :(
+# This can be deleted after we add support to refer to the remote Task in a registry (Issue #1839) or
+# add support for referencing task in git directly (issue #2298)
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone-from-catalog
+spec:
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this workspace
+  params:
+    - name: url
+      description: git url to clone
+      type: string
+    - name: revision
+      description: git revision to checkout (branch, tag, sha, ref…)
+      type: string
+      default: master
+    - name: refspec
+      description: (optional) git refspec to fetch before checking out revision
+      default: ""
+    - name: submodules
+      description: defines if the resource should initialize and fetch the submodules
+      type: string
+      default: "true"
+    - name: depth
+      description: performs a shallow clone where only the most recent commit(s) will be fetched
+      type: string
+      default: "1"
+    - name: sslVerify
+      description: defines if http.sslVerify should be set to true or false in the global git config
+      type: string
+      default: "true"
+    - name: subdirectory
+      description: subdirectory inside the "output" workspace to clone the git repo into
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: clean out the contents of the repo's destination directory (if it already exists) before trying to clone the repo there
+      type: string
+      default: "false"
+    - name: httpProxy
+      description: git HTTP proxy server for non-SSL requests
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: git HTTPS proxy server for SSL requests
+      type: string
+      default: ""
+    - name: noProxy
+      description: git no proxy - opt out of proxying HTTP/HTTPS requests
+      type: string
+      default: ""
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task
+  steps:
+    - name: clone
+      image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.1
+      script: |
+        CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf $CHECKOUT_DIR" because $CHECKOUT_DIR might be "/"
+          # or the root of a mounted volume.
+          if [[ -d "$CHECKOUT_DIR" ]] ; then
+            # Delete non-hidden files and directories
+            rm -rf "$CHECKOUT_DIR"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "$CHECKOUT_DIR"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "$CHECKOUT_DIR"/..?*
+          fi
+        }
+
+        if [[ "$(params.deleteExisting)" == "true" ]] ; then
+          cleandir
+        fi
+
+        test -z "$(params.httpProxy)" || export HTTP_PROXY=$(params.httpProxy)
+        test -z "$(params.httpsProxy)" || export HTTPS_PROXY=$(params.httpsProxy)
+        test -z "$(params.noProxy)" || export NO_PROXY=$(params.noProxy)
+
+        /ko-app/git-init \
+          -url "$(params.url)" \
+          -revision "$(params.revision)" \
+          -refspec "$(params.refspec)" \
+          -path "$CHECKOUT_DIR" \
+          -sslVerify="$(params.sslVerify)" \
+          -submodules="$(params.submodules)" \
+          -depth "$(params.depth)"
+        cd "$CHECKOUT_DIR"
+        RESULT_SHA="$(git rev-parse HEAD | tr -d '\n')"
+        EXIT_CODE="$?"
+        if [ "$EXIT_CODE" != 0 ]
+        then
+          exit $EXIT_CODE
+        fi
+        # Make sure we don't add a trailing newline to the result!
+        echo -n "$RESULT_SHA" > $(results.commit.path)
+
+---
+
+# Task to cleanup shared workspace
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cleanup-workspace
+spec:
+  workspaces:
+    # Shared workspace where git repo is cloned
+    - name: source
+  steps:
+    - name: check-application-dir-has-source
+      image: ubuntu
+      script: |
+        if [ ! -d "$(workspaces.source.path)/application/" ]; then
+          echo "Something went wrong and could not find application source under $(workspaces.source.path)/application/"
+          exit 1
+        fi
+    - name: cleanup-workspace
+      image: ubuntu
+      script: |
+        rm -rf $(workspaces.source.path)/application/
+    - name: verify-application-dir-has-gone
+      image: ubuntu
+      script: |
+        if [ -d "$(workspaces.source.path)/application/" ]; then
+          echo "Something went wrong cleaning up and the application source still exists under $(workspaces.source.path)/application/"
+          exit 1
+        fi
+---
+
+# Pipeline to clone repo into shared workspace and cleanup the workspace after done
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: clone-cleanup-workspace
+spec:
+  workspaces:
+    # common workspace where git repo is cloned and needs to be cleanup after done
+    - name: git-source
+  tasks:
+    # Clone app repo to workspace
+    - name: clone-app-repo
+      taskRef:
+        name: git-clone-from-catalog
+      params:
+        - name: url
+          value: https://github.com/tektoncd/community.git
+        - name: subdirectory
+          value: application
+      workspaces:
+        - name: output
+          workspace: git-source
+  finally:
+    # Cleanup workspace
+    - name: cleanup
+      taskRef:
+        name: cleanup-workspace
+      workspaces:
+        - name: source
+          workspace: git-source
+---
+
+# PipelineRun to execute pipeline - clone-into-workspace-and-cleanup-workspace
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: write-and-cleanup-workspace
+spec:
+  pipelineRef:
+    name: clone-cleanup-workspace
+  serviceAccountName: 'default'
+  workspaces:
+    - name: git-source
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+---

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -153,6 +153,25 @@ func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
 	}
 }
 
+// FinalTask adds a final PipelineTask, with specified name and task name, to the PipelineSpec.
+// Any number of PipelineTask modifier can be passed to transform it.
+func FinalPipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
+	return func(ps *v1beta1.PipelineSpec) {
+		pTask := &v1beta1.PipelineTask{
+			Name: name,
+		}
+		if taskName != "" {
+			pTask.TaskRef = &v1beta1.TaskRef{
+				Name: taskName,
+			}
+		}
+		for _, op := range ops {
+			op(pTask)
+		}
+		ps.Finally = append(ps.Finally, *pTask)
+	}
+}
+
 // PipelineResult adds a PipelineResult, with specified name, value and description, to the PipelineSpec.
 func PipelineResult(name, value, description string, ops ...PipelineOp) PipelineSpecOp {
 	return func(ps *v1beta1.PipelineSpec) {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -293,6 +293,19 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 		return controller.NewPermanentError(err)
 	}
 
+	// build DAG with a list of final tasks, this DAG is used later to identify
+	// if a task in PipelineRunState is final task or not
+	// the finally section is optional and might not exist
+	// dfinally holds an empty Graph in the absence of finally clause
+	dfinally, err := dag.Build(v1beta1.PipelineTaskList(pipelineSpec.Finally))
+	if err != nil {
+		// This Run has failed, so we need to mark it as failed and stop reconciling it
+		pr.Status.MarkFailed(ReasonInvalidGraph,
+			"PipelineRun %s's Pipeline DAG is invalid for finally clause: %s",
+			pr.Namespace, pr.Name, err)
+		return controller.NewPermanentError(err)
+	}
+
 	if err := pipelineSpec.Validate(ctx); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Status.MarkFailed(ReasonFailedValidation,
@@ -355,6 +368,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 	// Apply parameter substitution from the PipelineRun
 	pipelineSpec = resources.ApplyParameters(pipelineSpec, pr)
 
+	// pipelineState holds a list of pipeline tasks after resolving conditions and pipeline resources
+	// pipelineState also holds a taskRun for each pipeline task after the taskRun is created
+	// pipelineState is instantiated and updated on every reconcile cycle
 	pipelineState, err := resources.ResolvePipelineRun(ctx,
 		*pr,
 		func(name string) (v1beta1.TaskInterface, error) {
@@ -369,7 +385,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 		func(name string) (*v1alpha1.Condition, error) {
 			return c.conditionLister.Conditions(pr.Namespace).Get(name)
 		},
-		pipelineSpec.Tasks, providedResources,
+		append(pipelineSpec.Tasks, pipelineSpec.Finally...), providedResources,
 	)
 
 	if err != nil {
@@ -436,16 +452,11 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 		return controller.NewPermanentError(err)
 	}
 
-	// When the pipeline run is stopping, we don't schedule any new task and only
-	// wait for all running tasks to complete and report their status
-	if !pipelineState.IsStopping() {
-		err = c.runNextSchedulableTask(ctx, pr, d, pipelineState, as)
-		if err != nil {
-			return err
-		}
+	if err := c.runNextSchedulableTask(ctx, pr, d, dfinally, pipelineState, as); err != nil {
+		return err
 	}
 
-	after := resources.GetPipelineConditionStatus(pr, pipelineState, logger, d)
+	after := resources.GetPipelineConditionStatus(pr, pipelineState, logger, d, dfinally)
 	switch after.Status {
 	case corev1.ConditionTrue:
 		pr.Status.MarkSucceeded(after.Reason, after.Message)
@@ -463,18 +474,31 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 
 // runNextSchedulableTask gets the next schedulable Tasks from the dag based on the current
 // pipeline run state, and starts them
-func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.PipelineRun, d *dag.Graph, pipelineState resources.PipelineRunState, as artifacts.ArtifactStorageInterface) error {
+// after all DAG tasks are done, it's responsible for scheduling final tasks and start executing them
+func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.PipelineRun, d *dag.Graph, dfinally *dag.Graph, pipelineState resources.PipelineRunState, as artifacts.ArtifactStorageInterface) error {
 
 	logger := logging.FromContext(ctx)
 	recorder := controller.GetEventRecorder(ctx)
 
-	candidateTasks, err := dag.GetSchedulable(d, pipelineState.SuccessfulPipelineTaskNames()...)
-	if err != nil {
-		logger.Errorf("Error getting potential next tasks for valid pipelinerun %s: %v", pr.Name, err)
-		return controller.NewPermanentError(err)
+	var nextRprts []*resources.ResolvedPipelineRunTask
+
+	// when pipeline run is stopping, do not schedule any new task and only
+	// wait for all running tasks to complete and report their status
+	if !pipelineState.IsStopping(d) {
+		// candidateTasks is initialized to DAG root nodes to start pipeline execution
+		// candidateTasks is derived based on successfully finished tasks and/or skipped tasks
+		candidateTasks, err := dag.GetSchedulable(d, pipelineState.SuccessfulOrSkippedDAGTasks(d)...)
+		if err != nil {
+			logger.Errorf("Error getting potential next tasks for valid pipelinerun %s: %v", pr.Name, err)
+			return controller.NewPermanentError(err)
+		}
+		// nextRprts holds a list of pipeline tasks which should be executed next
+		nextRprts = pipelineState.GetNextTasks(candidateTasks)
 	}
 
-	nextRprts := pipelineState.GetNextTasks(candidateTasks)
+	// GetFinalTasks only returns tasks when a DAG is complete
+	nextRprts = append(nextRprts, pipelineState.GetFinalTasks(d, dfinally)...)
+
 	resolvedResultRefs, err := resources.ResolveResultRefs(pipelineState, nextRprts)
 	if err != nil {
 		logger.Infof("Failed to resolve all task params for %q with error %v", pr.Name, err)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -150,6 +150,8 @@ func (state PipelineRunState) ToMap() map[string]*ResolvedPipelineRunTask {
 	return m
 }
 
+// IsDone returns true when all pipeline tasks have respective taskRun created and
+// that taskRun has either succeeded or failed after all possible retry attempts
 func (state PipelineRunState) IsDone() (isDone bool) {
 	isDone = true
 	for _, t := range state {
@@ -175,21 +177,24 @@ func (state PipelineRunState) IsBeforeFirstTaskRun() bool {
 }
 
 // IsStopping returns true if the PipelineRun won't be scheduling any new Task because
-// at least one task already failed or was cancelled
-func (state PipelineRunState) IsStopping() bool {
+// at least one task already failed or was cancelled in the specified dag
+func (state PipelineRunState) IsStopping(d *dag.Graph) bool {
 	for _, t := range state {
-		if t.IsCancelled() {
-			return true
-		}
-		if t.IsFailure() {
-			return true
+		if _, ok := d.Nodes[t.PipelineTask.Name]; ok {
+			if t.IsCancelled() {
+				return true
+			}
+			if t.IsFailure() {
+				return true
+			}
 		}
 	}
 	return false
 }
 
-// GetNextTasks will return the next ResolvedPipelineRunTasks to execute, which are the ones in the
-// list of candidateTasks which aren't yet indicated in state to be running.
+// GetNextTasks returns a list of tasks which should be executed next i.e.
+// a list of tasks from candidateTasks which aren't yet indicated in state to be running and
+// a list of cancelled/failed tasks from candidateTasks which haven't exhausted their retries
 func (state PipelineRunState) GetNextTasks(candidateTasks map[string]struct{}) []*ResolvedPipelineRunTask {
 	tasks := []*ResolvedPipelineRunTask{}
 	for _, t := range state {
@@ -210,19 +215,81 @@ func (state PipelineRunState) GetNextTasks(candidateTasks map[string]struct{}) [
 	return tasks
 }
 
-// SuccessfulPipelineTaskNames returns a list of the names of all of the PipelineTasks in state
-// which have successfully completed.
-func (state PipelineRunState) SuccessfulPipelineTaskNames() []string {
-	done := []string{}
+// SuccessfulOrSkippedDAGTasks returns a list of the names of all of the PipelineTasks in state
+// which have successfully completed or skipped
+func (state PipelineRunState) SuccessfulOrSkippedDAGTasks(d *dag.Graph) []string {
+	tasks := []string{}
+	stateMap := state.ToMap()
 	for _, t := range state {
-		if t.TaskRun != nil {
-			c := t.TaskRun.Status.GetCondition(apis.ConditionSucceeded)
-			if c.IsTrue() {
-				done = append(done, t.PipelineTask.Name)
+		if _, ok := d.Nodes[t.PipelineTask.Name]; ok {
+			if t.IsSuccessful() || isSkipped(t, stateMap, d) {
+				tasks = append(tasks, t.PipelineTask.Name)
 			}
 		}
 	}
-	return done
+	return tasks
+}
+
+// isDAGTasksStopped returns true if any of the pipeline task has failed
+// and none of the pipeline task are still running
+func (state PipelineRunState) isDAGTasksStopped(d *dag.Graph) bool {
+	failed := false
+	for _, t := range state {
+		if t.IsFailure() {
+			failed = true
+			continue
+		}
+		if t.IsStarted() && !t.IsDone() {
+			failed = false
+			break
+		}
+	}
+	return failed
+}
+
+// checkTasksDone returns true if all tasks from the specified graph are finished executing
+// a task is considered done if it has failed/succeeded/skipped
+func (state PipelineRunState) checkTasksDone(d *dag.Graph) (isDone bool) {
+	isDone = true
+	stateMap := state.ToMap()
+	for _, t := range state {
+		if _, ok := d.Nodes[t.PipelineTask.Name]; ok {
+			if t.TaskRun == nil {
+				// this task might have skipped if taskRun is nil
+				// continue and ignore if this task was skipped
+				// skipped task is considered part of done
+				if isSkipped(t, stateMap, d) {
+					continue
+				}
+				return false
+			}
+			isDone = isDone && t.IsDone()
+			if !isDone {
+				return
+			}
+		}
+	}
+	return
+}
+
+// GetFinalTasks returns a list of final tasks without any taskRun associated with it
+// GetFinalTasks returns final tasks only when all DAG tasks have finished executing successfully or skipped or
+// any one DAG task resulted in failure
+func (state PipelineRunState) GetFinalTasks(d *dag.Graph, dfinally *dag.Graph) []*ResolvedPipelineRunTask {
+	tasks := []*ResolvedPipelineRunTask{}
+	finalCandidates := map[string]struct{}{}
+	// check either pipeline has finished executing all DAG pipelineTasks
+	// or any one of the DAG pipelineTask has failed
+	if state.isDAGTasksStopped(d) || state.checkTasksDone(d) {
+		// return list of tasks with all final tasks
+		for _, t := range state {
+			if _, ok := dfinally.Nodes[t.PipelineTask.Name]; ok && !t.IsSuccessful() {
+				finalCandidates[t.PipelineTask.Name] = struct{}{}
+			}
+		}
+		tasks = state.GetNextTasks(finalCandidates)
+	}
+	return tasks
 }
 
 // GetTaskRun is a function that will retrieve the TaskRun name.
@@ -414,7 +481,7 @@ func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus,
 
 // GetPipelineConditionStatus will return the Condition that the PipelineRun prName should be
 // updated with, based on the status of the TaskRuns in state.
-func GetPipelineConditionStatus(pr *v1beta1.PipelineRun, state PipelineRunState, logger *zap.SugaredLogger, dag *dag.Graph) *apis.Condition {
+func GetPipelineConditionStatus(pr *v1beta1.PipelineRun, state PipelineRunState, logger *zap.SugaredLogger, dag *dag.Graph, dfinally *dag.Graph) *apis.Condition {
 	// We have 4 different states here:
 	// 1. Timed out -> Failed
 	// 2. All tasks are done and at least one has failed or has been cancelled -> Failed
@@ -436,7 +503,7 @@ func GetPipelineConditionStatus(pr *v1beta1.PipelineRun, state PipelineRunState,
 	cancelledTasks := int(0)
 	reason := v1beta1.PipelineRunReasonSuccessful.String()
 	stateAsMap := state.ToMap()
-	isStopping := state.IsStopping()
+	isStopping := state.IsStopping(dag)
 
 	// Check to see if all tasks are success or skipped
 	//
@@ -457,8 +524,11 @@ func GetPipelineConditionStatus(pr *v1beta1.PipelineRun, state PipelineRunState,
 			// If the pipeline is in stopping mode, all tasks that are not running
 			// already will be skipped. Otherwise these tasks end up in the
 			// incomplete count.
-			skipTasks++
-			withStatusTasks = append(withStatusTasks, rprt.PipelineTask.Name)
+			// this should never be the case for final task
+			if _, ok := dag.Nodes[rprt.PipelineTask.Name]; ok {
+				skipTasks++
+				withStatusTasks = append(withStatusTasks, rprt.PipelineTask.Name)
+			}
 		case rprt.IsSuccessful():
 			withStatusTasks = append(withStatusTasks, rprt.PipelineTask.Name)
 		case isSkipped(rprt, stateAsMap, dag):
@@ -496,9 +566,11 @@ func GetPipelineConditionStatus(pr *v1beta1.PipelineRun, state PipelineRunState,
 		}
 	}
 
-	// Hasn't timed out; not all tasks have finished....
-	// Must keep running then....
-	if failedTasks > 0 || cancelledTasks > 0 {
+	// Hasn't timed out; not all tasks have finished.... Must keep running then....
+	// transition pipeline into stopping state when one of the tasks(dag/final) cancelled or one of the dag tasks failed
+	// for a pipeline with final tasks, single dag task failure does not transition to interim stopping state
+	// pipeline stays in running state until all final tasks are done before transitioning to failed state
+	if cancelledTasks > 0 || (failedTasks > 0 && state.checkTasksDone(dfinally)) {
 		reason = v1beta1.PipelineRunReasonStopping.String()
 	} else {
 		reason = v1beta1.PipelineRunReasonRunning.String()
@@ -531,11 +603,13 @@ func isSkipped(rprt *ResolvedPipelineRunTask, stateMap map[string]*ResolvedPipel
 
 	// Recursively look at parent tasks to see if they have been skipped,
 	// if any of the parents have been skipped, skip as well
-	node := d.Nodes[rprt.PipelineTask.Name]
-	for _, p := range node.Prev {
-		skip := isSkipped(stateMap[p.Task.HashKey()], stateMap, d)
-		if skip {
-			return true
+	// continue if the task does not belong to the specified Graph
+	if node, ok := d.Nodes[rprt.PipelineTask.Name]; ok {
+		for _, p := range node.Prev {
+			skip := isSkipped(stateMap[p.Task.HashKey()], stateMap, d)
+			if skip {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -161,7 +161,7 @@ func makeFailed(tr v1beta1.TaskRun) *v1beta1.TaskRun {
 }
 
 func withCancelled(tr *v1beta1.TaskRun) *v1beta1.TaskRun {
-	tr.Status.Conditions[0].Reason = "TaskRunCancelled"
+	tr.Status.Conditions[0].Reason = v1beta1.TaskRunSpecStatusCancelled
 	return tr
 }
 
@@ -1177,7 +1177,7 @@ func TestIsSkipped(t *testing.T) {
 	}
 }
 
-func TestSuccessfulPipelineTaskNames(t *testing.T) {
+func TestPipelineRunState_SuccessfulOrSkippedDAGTasks(t *testing.T) {
 	tcs := []struct {
 		name          string
 		state         PipelineRunState
@@ -1193,7 +1193,7 @@ func TestSuccessfulPipelineTaskNames(t *testing.T) {
 	}, {
 		name:          "one-task-finished",
 		state:         oneFinishedState,
-		expectedNames: []string{"mytask1"},
+		expectedNames: []string{pts[0].Name},
 	}, {
 		name:          "one-task-failed",
 		state:         oneFailedState,
@@ -1201,11 +1201,37 @@ func TestSuccessfulPipelineTaskNames(t *testing.T) {
 	}, {
 		name:          "all-finished",
 		state:         allFinishedState,
-		expectedNames: []string{"mytask1", "mytask2"},
+		expectedNames: []string{pts[0].Name, pts[1].Name},
+	}, {
+		name:          "conditional task not skipped as the condition execution was successful",
+		state:         conditionCheckSuccessNoTaskStartedState,
+		expectedNames: []string{},
+	}, {
+		name:          "conditional task not skipped as the condition has not started executing yet",
+		state:         conditionCheckStartedState,
+		expectedNames: []string{},
+	}, {
+		name:          "conditional task skipped as the condition execution resulted in failure",
+		state:         conditionCheckFailedWithNoOtherTasksState,
+		expectedNames: []string{pts[5].Name},
+	}, {
+		name: "conditional task skipped as the condition execution resulted in failure but the other pipeline task" +
+			"not skipped since it finished execution successfully",
+		state:         conditionCheckFailedWithOthersPassedState,
+		expectedNames: []string{pts[5].Name, pts[0].Name},
+	}, {
+		name: "conditional task skipped as the condition execution resulted in failure but the other pipeline task" +
+			"not skipped since it failed",
+		state:         conditionCheckFailedWithOthersFailedState,
+		expectedNames: []string{pts[5].Name},
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			names := tc.state.SuccessfulPipelineTaskNames()
+			dag, err := DagFromState(tc.state)
+			if err != nil {
+				t.Fatalf("Unexpected error while buildig DAG for state %v: %v", tc.state, err)
+			}
+			names := tc.state.SuccessfulOrSkippedDAGTasks(dag)
 			if d := cmp.Diff(names, tc.expectedNames); d != "" {
 				t.Errorf("Expected to get completed names %v but got something different %s", tc.expectedNames, diff.PrintWantGot(d))
 			}
@@ -1237,6 +1263,20 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 		PipelineTask: &pts[4],
 		TaskRunName:  "pipelinerun-mytask1",
 		TaskRun:      withCancelled(makeFailed(trs[0])),
+	}}
+
+	var cancelledTask = PipelineRunState{{
+		PipelineTask: &pts[3], // 1 retry needed
+		TaskRunName:  "pipelinerun-mytask1",
+		TaskRun: &v1beta1.TaskRun{
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
+					Reason: v1beta1.TaskRunSpecStatusCancelled,
+				}}},
+			},
+		},
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskSpec: &task.Spec,
 		},
@@ -1259,18 +1299,6 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 		TaskRunName:  "failedTaskRun", // this failed
 		PipelineTask: &pts[0],
 		TaskRun:      makeFailed(trs[0]),
-	}, {
-		TaskRunName:  "skippedTaskRun", // skipped because parent failed
-		PipelineTask: &pts[7],          // mytask8 runAfter mytask1 (failed), mytask6 (succeeded)
-		TaskRun:      nil,
-	}, {
-		TaskRunName:  "anothertaskrun", // this failed
-		PipelineTask: &pts[1],
-		TaskRun:      makeFailed(trs[1]),
-	}, {
-		TaskRunName:  "taskrun", // this was cancelled
-		PipelineTask: &pts[4],
-		TaskRun:      withCancelled(makeFailed(trs[0])),
 	}}
 
 	var taskNotRunningWithSuccesfulParentsOneFailed = PipelineRunState{{
@@ -1416,10 +1444,10 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 		expectedReason:     v1beta1.PipelineRunReasonStopping.String(),
 		expectedStatus:     corev1.ConditionUnknown,
 		expectedSucceeded:  1,
-		expectedFailed:     2,
+		expectedFailed:     1,
 		expectedIncomplete: 1,
-		expectedCancelled:  1,
-		expectedSkipped:    1,
+		expectedCancelled:  0,
+		expectedSkipped:    0,
 	}, {
 		name:              "task not started with passed parent; one failed",
 		state:             taskNotRunningWithSuccesfulParentsOneFailed,
@@ -1428,15 +1456,139 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 		expectedSucceeded: 1,
 		expectedFailed:    1,
 		expectedSkipped:   1,
+	}, {
+		name:               "task with grand parents; one not run yet",
+		state:              taskWithGrandParentsOneNotRunState,
+		expectedStatus:     corev1.ConditionUnknown,
+		expectedReason:     v1beta1.PipelineRunReasonRunning.String(),
+		expectedSucceeded:  1,
+		expectedIncomplete: 3,
+	}, {
+		name:              "cancelled task should result in cancelled pipeline",
+		state:             cancelledTask,
+		expectedStatus:    corev1.ConditionFalse,
+		expectedReason:    v1beta1.PipelineRunReasonCancelled.String(),
+		expectedCancelled: 1,
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := tb.PipelineRun("somepipelinerun")
-			dag, err := DagFromState(tc.state)
+			d, err := DagFromState(tc.state)
 			if err != nil {
 				t.Fatalf("Unexpected error while buildig DAG for state %v: %v", tc.state, err)
 			}
-			c := GetPipelineConditionStatus(pr, tc.state, zap.NewNop().Sugar(), dag)
+			c := GetPipelineConditionStatus(pr, tc.state, zap.NewNop().Sugar(), d, &dag.Graph{})
+			wantCondition := &apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: tc.expectedStatus,
+				Reason: tc.expectedReason,
+				Message: getExpectedMessage(tc.expectedStatus, tc.expectedSucceeded,
+					tc.expectedIncomplete, tc.expectedSkipped, tc.expectedFailed, tc.expectedCancelled),
+			}
+			if d := cmp.Diff(wantCondition, c); d != "" {
+				t.Fatalf("Mismatch in condition %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
+
+	// pipeline state with one DAG successful, one final task failed
+	dagSucceededFinalFailed := PipelineRunState{{
+		TaskRunName:  "task0taskrun",
+		PipelineTask: &pts[0],
+		TaskRun:      makeSucceeded(trs[0]),
+	}, {
+		TaskRunName:  "failedTaskRun",
+		PipelineTask: &pts[1],
+		TaskRun:      makeFailed(trs[0]),
+	}}
+
+	// pipeline state with one DAG failed, no final started
+	dagFailedFinalNotStarted := PipelineRunState{{
+		TaskRunName:  "task0taskrun",
+		PipelineTask: &pts[0],
+		TaskRun:      makeFailed(trs[0]),
+	}, {
+		TaskRunName:  "notRunningTaskRun",
+		PipelineTask: &pts[1],
+		TaskRun:      nil,
+	}}
+
+	// pipeline state with one DAG failed, one final task failed
+	dagFailedFinalFailed := PipelineRunState{{
+		TaskRunName:  "task0taskrun",
+		PipelineTask: &pts[0],
+		TaskRun:      makeFailed(trs[0]),
+	}, {
+		TaskRunName:  "failedTaskRun",
+		PipelineTask: &pts[1],
+		TaskRun:      makeFailed(trs[0]),
+	}}
+
+	tcs := []struct {
+		name               string
+		state              PipelineRunState
+		dagTasks           []v1beta1.PipelineTask
+		finalTasks         []v1beta1.PipelineTask
+		expectedStatus     corev1.ConditionStatus
+		expectedReason     string
+		expectedSucceeded  int
+		expectedIncomplete int
+		expectedSkipped    int
+		expectedFailed     int
+		expectedCancelled  int
+	}{{
+		name:               "pipeline with one successful DAG task and failed final task",
+		state:              dagSucceededFinalFailed,
+		dagTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedStatus:     corev1.ConditionFalse,
+		expectedReason:     v1beta1.PipelineRunReasonFailed.String(),
+		expectedSucceeded:  1,
+		expectedIncomplete: 0,
+		expectedSkipped:    0,
+		expectedFailed:     1,
+		expectedCancelled:  0,
+	}, {
+		name:               "pipeline with one failed DAG task and not started final task",
+		state:              dagFailedFinalNotStarted,
+		dagTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedStatus:     corev1.ConditionUnknown,
+		expectedReason:     v1beta1.PipelineRunReasonRunning.String(),
+		expectedSucceeded:  0,
+		expectedIncomplete: 1,
+		expectedSkipped:    0,
+		expectedFailed:     1,
+		expectedCancelled:  0,
+	}, {
+		name:               "pipeline with one failed DAG task and failed final task",
+		state:              dagFailedFinalFailed,
+		dagTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedStatus:     corev1.ConditionFalse,
+		expectedReason:     v1beta1.PipelineRunReasonFailed.String(),
+		expectedSucceeded:  0,
+		expectedIncomplete: 0,
+		expectedSkipped:    0,
+		expectedFailed:     2,
+		expectedCancelled:  0,
+	}}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := tb.PipelineRun("pipelinerun-final-tasks")
+			d, err := dag.Build(v1beta1.PipelineTaskList(tc.dagTasks))
+			if err != nil {
+				t.Fatalf("Unexpected error while buildig graph for DAG tasks %v: %v", tc.dagTasks, err)
+			}
+			df, err := dag.Build(v1beta1.PipelineTaskList(tc.finalTasks))
+			if err != nil {
+				t.Fatalf("Unexpected error while buildig graph for final tasks %v: %v", tc.finalTasks, err)
+			}
+			c := GetPipelineConditionStatus(pr, tc.state, zap.NewNop().Sugar(), d, df)
 			wantCondition := &apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: tc.expectedStatus,
@@ -1468,7 +1620,7 @@ func TestGetPipelineConditionStatus_PipelineTimeouts(t *testing.T) {
 			},
 		},
 	}
-	c := GetPipelineConditionStatus(pr, oneFinishedState, zap.NewNop().Sugar(), d)
+	c := GetPipelineConditionStatus(pr, oneFinishedState, zap.NewNop().Sugar(), d, &dag.Graph{})
 	if c.Status != corev1.ConditionFalse && c.Reason != v1beta1.PipelineRunReasonTimedOut.String() {
 		t.Fatalf("Expected to get status %s but got %s for state %v", corev1.ConditionFalse, c.Status, oneFinishedState)
 	}
@@ -2350,5 +2502,170 @@ func TestIsBeforeFirstTaskRun_WithNotStartedTask(t *testing.T) {
 func TestIsBeforeFirstTaskRun_WithStartedTask(t *testing.T) {
 	if oneStartedState.IsBeforeFirstTaskRun() {
 		t.Fatalf("Expected state to be after first taskrun")
+	}
+}
+
+func TestPipelineRunState_GetFinalTasks(t *testing.T) {
+	tcs := []struct {
+		name               string
+		desc               string
+		state              PipelineRunState
+		DAGTasks           []v1beta1.PipelineTask
+		finalTasks         []v1beta1.PipelineTask
+		expectedFinalTasks []*ResolvedPipelineRunTask
+	}{{
+		// tasks: [ mytask1, mytask2]
+		// none finally
+		name: "01 - DAG tasks done, no final tasks",
+		desc: "DAG tasks (mytask1 and mytask2) finished successfully -" +
+			" do not schedule final tasks since pipeline didnt have any",
+		state:              oneStartedState,
+		DAGTasks:           []v1beta1.PipelineTask{pts[0], pts[1]},
+		finalTasks:         []v1beta1.PipelineTask{},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{},
+	}, {
+		// tasks: [ mytask1]
+		// finally: [mytask2]
+		name:               "02 - DAG task not started, no final tasks",
+		desc:               "DAG tasks (mytask1) not started yet - do not schedule final tasks (mytask2)",
+		state:              noneStartedState,
+		DAGTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{},
+	}, {
+		// tasks: [ mytask1]
+		// finally: [mytask2]
+		name:               "03 - DAG task not finished, no final tasks",
+		desc:               "DAG tasks (mytask1) started but not finished - do not schedule final tasks (mytask2)",
+		state:              oneStartedState,
+		DAGTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{},
+	}, {
+		// tasks: [ mytask1]
+		// finally: [mytask2]
+		name:               "04 - DAG task done, return final tasks",
+		desc:               "DAG tasks (mytask1) done - schedule final tasks (mytask2)",
+		state:              oneFinishedState,
+		DAGTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+	}, {
+		// tasks: [ mytask1]
+		// finally: [mytask2]
+		name:               "05 - DAG task failed, return final tasks",
+		desc:               "DAG task (mytask1) failed - schedule final tasks (mytask2)",
+		state:              oneFailedState,
+		DAGTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+	}, {
+		// tasks: [ mytask6 with condition]
+		// finally: [mytask2]
+		name:               "06 - DAG task condition started, no final tasks",
+		desc:               "DAG task (mytask6) condition started - do not schedule final tasks (mytask1)",
+		state:              append(conditionCheckStartedState, noneStartedState[0]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[5]},
+		finalTasks:         []v1beta1.PipelineTask{pts[0]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{},
+	}, {
+		// tasks: [ mytask6 with condition]
+		// finally: [mytask2]
+		name:               "07 - DAG task condition done, no final tasks",
+		desc:               "DAG task (mytask6) condition finished, mytask6 not started - do not schedule final tasks (mytask2)",
+		state:              append(conditionCheckSuccessNoTaskStartedState, noneStartedState[0]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[5]},
+		finalTasks:         []v1beta1.PipelineTask{pts[0]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{},
+	}, {
+		// tasks: [ mytask6 with condition]
+		// finally: [mytask2]
+		name:               "08 - DAG task skipped, return final tasks",
+		desc:               "DAG task (mytask6) condition failed - schedule final tasks (mytask2) ",
+		state:              append(conditionCheckFailedWithNoOtherTasksState, noneStartedState[0]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[5]},
+		finalTasks:         []v1beta1.PipelineTask{pts[0]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[0]},
+	}, {
+		// tasks: [ mytask1, mytask6 with condition]
+		// finally: [mytask2]
+		name:               "09 - DAG task succeeded/skipped, return final tasks ",
+		desc:               "DAG task (mytask1) finished, mytask6 condition failed - schedule final tasks (mytask2)",
+		state:              append(conditionCheckFailedWithOthersPassedState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[5], pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		// tasks: [ mytask1, mytask6 with condition]
+		// finally: [mytask2]
+		name:               "10 - DAG task failed/skipped, return final tasks",
+		desc:               "DAG task (mytask1) failed, mytask6 condition failed - schedule final tasks (mytask2)",
+		state:              append(conditionCheckFailedWithOthersFailedState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[5], pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		// tasks: [ mytask6 with condition, mytask7 runAfter mytask6]
+		// finally: [mytask2]
+		name:               "11 - DAG task skipped, return final tasks",
+		desc:               "DAG task (mytask6) condition failed, mytask6 and mytask7 skipped - schedule final tasks (mytask2)",
+		state:              append(taskWithParentSkippedState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[5], pts[6]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		// tasks: [ mytask1, mytask6 with condition, mytask8 runAfter mytask6]
+		// finally: [mytask2]
+		name:               "12 - DAG task succeeded/skipped, return final tasks",
+		desc:               "DAG task (mytask1) finished - DAG task (mytask6) condition failed, mytask6 and mytask8 skipped - schedule final tasks (mytask2)",
+		state:              append(taskWithMultipleParentsSkippedState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[0], pts[5], pts[7]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		// tasks: [ mytask1, mytask6 with condition, mytask8 runAfter mytask6, mytask9 runAfter mytask1 and mytask6]
+		// finally: [mytask2]
+		name: "13 - DAG task succeeded/skipped - return final tasks",
+		desc: "DAG task (mytask1) finished - DAG task (mytask6) condition failed, mytask6, mytask8, and mytask9 skipped" +
+			"- schedule final tasks (mytask2)",
+		state:              append(taskWithGrandParentSkippedState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[0], pts[5], pts[7], pts[8]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		//tasks: [ mytask1, mytask6 with condition, mytask8 runAfter mytask6, mytask9 runAfter mytask1 and mytask6]
+		//finally: [mytask2]
+		name: "14 - DAG task succeeded, skipped - return final tasks",
+		desc: "DAG task (mytask1) finished - DAG task (mytask6) failed - mytask8 and mytask9 skipped" +
+			"- schedule final tasks (mytask2)",
+		state:              append(taskWithGrandParentsOneFailedState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[0], pts[5], pts[7], pts[8]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{noneStartedState[1]},
+	}, {
+		//tasks: [ mytask1, mytask6 with condition, mytask8 runAfter mytask6, mytask9 runAfter mytask1 and mytask6]
+		//finally: [mytask2]
+		name:               "15 - DAG task succeeded/started - no final tasks",
+		desc:               "DAG task (mytask1) finished - DAG task (mytask6) started - do no schedule final tasks",
+		state:              append(taskWithGrandParentsOneNotRunState, noneStartedState[1]),
+		DAGTasks:           []v1beta1.PipelineTask{pts[0], pts[5], pts[7], pts[8]},
+		finalTasks:         []v1beta1.PipelineTask{pts[1]},
+		expectedFinalTasks: []*ResolvedPipelineRunTask{},
+	}}
+	for _, tc := range tcs {
+		dagGraph, err := dag.Build(v1beta1.PipelineTaskList(tc.DAGTasks))
+		if err != nil {
+			t.Fatalf("Unexpected error while buildig DAG for pipelineTasks %v: %v", tc.DAGTasks, err)
+		}
+		finalGraph, err := dag.Build(v1beta1.PipelineTaskList(tc.finalTasks))
+		if err != nil {
+			t.Fatalf("Unexpected error while buildig DAG for final pipelineTasks %v: %v", tc.finalTasks, err)
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			next := tc.state.GetFinalTasks(dagGraph, finalGraph)
+			if d := cmp.Diff(tc.expectedFinalTasks, next); d != "" {
+				t.Errorf("Didn't get expected final Tasks for %s (%s): %s", tc.name, tc.desc, diff.PrintWantGot(d))
+			}
+		})
 	}
 }

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -1,0 +1,287 @@
+// +build e2e
+
+/*
+Copyright 2019 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	knativetest "knative.dev/pkg/test"
+)
+
+func TestPipelineLevelFinally_OneDAGTaskFailed_Failure(t *testing.T) {
+	c, namespace := setup(t)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	cond := getCondition("failedcondition", namespace)
+	if _, err := c.ConditionClient.Create(cond); err != nil {
+		t.Fatalf("Failed to create Condition `%s`: %s", cond1Name, err)
+	}
+
+	task := getFailTask("failtask", namespace)
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create dag Task: %s", err)
+	}
+
+	delayedTask := getDelaySuccessTask("delayed-task", namespace)
+	if _, err := c.TaskClient.Create(delayedTask); err != nil {
+		t.Fatalf("Failed to create dag Task: %s", err)
+	}
+
+	finalTask := getSuccessTask("successtask", namespace)
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := getPipeline(
+		namespace,
+		"pipeline-failed-dag-tasks",
+		map[string]string{
+			"dagtask1": "failtask",
+			"dagtask2": "delayed-task",
+			"dagtask3": "successtask",
+		},
+		map[string]string{
+			"dagtask3": "failedcondition",
+		},
+		map[string]string{
+			"finaltask1": "successtask",
+		},
+	)
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := getPipelineRun(namespace, "pipelinerun-failed-dag-tasks", "pipeline-failed-dag-tasks")
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", "pipelinerun-failed-dag-tasks", err)
+	}
+
+	if err := WaitForPipelineRunState(c, "pipelinerun-failed-dag-tasks", timeout, PipelineRunFailed("pipelinerun-failed-dag-tasks"), "PipelineRunFailed"); err != nil {
+		t.Fatalf("Waiting for PipelineRun %s to fail: %v", "pipelinerun-failed-dag-tasks", err)
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=pipelinerun-failed-dag-tasks"})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", "pipelinerun-failed-dag-tasks", err)
+	}
+
+	var dagTask1EndTime, dagTask2EndTime, finalTaskStartTime *metav1.Time
+	// verify dag task failed, parallel dag task succeeded, and final task succeeded
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, "pipelinerun-failed-dag-tasks-dagtask1"):
+			if !isFailed(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for dag task should have failed", n)
+			}
+			dagTask1EndTime = taskrunItem.Status.CompletionTime
+		case strings.HasPrefix(n, "pipelinerun-failed-dag-tasks-dagtask2"):
+			if err := WaitForTaskRunState(c, n, TaskRunSucceed(n), "TaskRunSuccess"); err != nil {
+				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
+			}
+			dagTask2EndTime = taskrunItem.Status.CompletionTime
+		case strings.HasPrefix(n, "pipelinerun-failed-dag-tasks-dagtask3"):
+			if !isSkipped(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for dag task should have skipped due to condition failure", n)
+			}
+		case strings.HasPrefix(n, "pipelinerun-failed-dag-tasks-finaltask1"):
+			if err := WaitForTaskRunState(c, n, TaskRunSucceed(n), "TaskRunSuccess"); err != nil {
+				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
+			}
+			finalTaskStartTime = taskrunItem.Status.StartTime
+		default:
+			t.Fatalf("TaskRuns were not found for both final and dag tasks")
+		}
+	}
+	// final task should start executing after dagtask1 fails and dagtask2 is done
+	if finalTaskStartTime.Before(dagTask1EndTime) || finalTaskStartTime.Before(dagTask2EndTime) {
+		t.Fatalf("Final Tasks should start getting executed after all DAG tasks finishes")
+	}
+}
+
+func TestPipelineLevelFinally_OneFinalTaskFailed_Failure(t *testing.T) {
+	c, namespace := setup(t)
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	task := getSuccessTask("successtask", namespace)
+	if _, err := c.TaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create dag Task: %s", err)
+	}
+
+	finalTask := getFailTask("failtask", namespace)
+	if _, err := c.TaskClient.Create(finalTask); err != nil {
+		t.Fatalf("Failed to create final Task: %s", err)
+	}
+
+	pipeline := getPipeline(
+		namespace,
+		"pipeline-failed-final-tasks",
+		map[string]string{
+			"dagtask1": "successtask",
+		},
+		map[string]string{},
+		map[string]string{
+			"finaltask1": "failtask",
+		},
+	)
+	if _, err := c.PipelineClient.Create(pipeline); err != nil {
+		t.Fatalf("Failed to create Pipeline: %s", err)
+	}
+
+	pipelineRun := getPipelineRun(namespace, "pipelinerun-failed-final-tasks", "pipeline-failed-final-tasks")
+	if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
+		t.Fatalf("Failed to create Pipeline Run `%s`: %s", "pipelinerun-failed-final-tasks", err)
+	}
+
+	if err := WaitForPipelineRunState(c, "pipelinerun-failed-final-tasks", timeout, PipelineRunFailed("pipelinerun-failed-final-tasks"), "PipelineRunFailed"); err != nil {
+		t.Errorf("Error waiting for PipelineRun %s to finish: %s", "pipelinerun-failed-final-tasks", err)
+		t.Fatalf("PipelineRun execution failed")
+	}
+
+	taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=pipelinerun-failed-final-tasks"})
+	if err != nil {
+		t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", "pipelinerun-failed-final-tasks", err)
+	}
+
+	// verify dag task succeeded and final task failed
+	for _, taskrunItem := range taskrunList.Items {
+		switch n := taskrunItem.Name; {
+		case strings.HasPrefix(n, "pipelinerun-failed-final-tasks-dagtask1"):
+			if !isSuccessful(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for dag task should have succedded", n)
+			}
+		case strings.HasPrefix(n, "pipelinerun-failed-final-tasks-finaltask1"):
+			if !isFailed(t, n, taskrunItem.Status.Conditions) {
+				t.Fatalf("TaskRun %s for final task should have failed", n)
+			}
+		default:
+			t.Fatalf("TaskRuns were not found for both final and dag tasks")
+		}
+	}
+}
+
+func isSuccessful(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
+	for _, c := range conds {
+		if c.Type == apis.ConditionSucceeded {
+			if c.Status != corev1.ConditionTrue {
+				t.Errorf("TaskRun status %q is not succeeded, got %q", taskRunName, c.Status)
+			}
+			return true
+		}
+	}
+	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
+	return false
+}
+
+func isSkipped(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
+	for _, c := range conds {
+		if c.Type == apis.ConditionSucceeded {
+			if c.Status != corev1.ConditionFalse && c.Reason != resources.ReasonConditionCheckFailed {
+				t.Errorf("TaskRun status %q is not skipped due to condition failure, got %q", taskRunName, c.Status)
+			}
+			return true
+		}
+	}
+	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
+	return false
+}
+
+func getTaskDef(n, namespace, script string) *v1beta1.Task {
+	return &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{Image: "alpine"},
+				Script:    script,
+			}},
+		},
+	}
+}
+
+func getSuccessTask(n, namespace string) *v1beta1.Task {
+	return getTaskDef(n, namespace, "exit 0")
+}
+
+func getFailTask(n, namespace string) *v1beta1.Task {
+	return getTaskDef(n, namespace, "exit 1")
+}
+
+func getDelaySuccessTask(n, namespace string) *v1beta1.Task {
+	return getTaskDef(n, namespace, "sleep 5; exit 0")
+}
+
+func getCondition(n, namespace string) *v1alpha1.Condition {
+	return &v1alpha1.Condition{
+		ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: namespace},
+		Spec: v1alpha1.ConditionSpec{
+			Check: v1alpha1.Step{
+				Container: corev1.Container{Image: "ubuntu"},
+				Script:    "exit 1",
+			},
+		},
+	}
+}
+
+func getPipeline(namespace, p string, t map[string]string, c map[string]string, f map[string]string) *v1beta1.Pipeline {
+	var pt []v1beta1.PipelineTask
+	var fpt []v1beta1.PipelineTask
+	for k, v := range t {
+		task := v1beta1.PipelineTask{
+			Name:    k,
+			TaskRef: &v1beta1.TaskRef{Name: v},
+		}
+		if _, ok := c[k]; ok {
+			task.Conditions = []v1beta1.PipelineTaskCondition{{
+				ConditionRef: c[k],
+			}}
+		}
+		pt = append(pt, task)
+	}
+	for k, v := range f {
+		fpt = append(fpt, v1beta1.PipelineTask{
+			Name:    k,
+			TaskRef: &v1beta1.TaskRef{Name: v},
+		})
+	}
+	pipeline := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: p, Namespace: namespace},
+		Spec: v1beta1.PipelineSpec{
+			Tasks:   pt,
+			Finally: fpt,
+		},
+	}
+	return pipeline
+}
+
+func getPipelineRun(namespace, pr, p string) *v1beta1.PipelineRun {
+	return &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: pr, Namespace: namespace},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: p},
+		},
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We can now specify a list of tasks needs to be executed just before
pipeline exits (either after finishing all non-final tasks successfully or after
a single failure)

Most useful for tasks such as report test results, cleanup cluster resources, etc

### Summary of Changes:

1) `pipelines.md`: Documented final tasks including how to specify `workspaces` and `params`, documenting updates to pipeline run status as a result of  finally clause, and known limitations (task results, `from` clause, pipeline results, `runAfter`, and `conditions`).
2)  `pipelinerun-with-final-tasks.yaml`: Example pipeline demonstrating cloning a repo into shared workspace and cleaning up the workspace.
3) `pipelinerun.go`: Building graph for `final` tasks, build `pipelineState` for both DAG tasks and final tasks, invoke final tasks once all DAG tasks are done (execution queue is empty)
4) `pipelinerun_test.go`: Test three major test pipelines, (1) pipeline when a DAG task fails but final task succeeds, (2) pipeline when all DAG task succeeds but a final task fails, (3) pipeline when one of the DAG tasks fail and a final task fails
5) `pipelinerunresolution.go`: Replace `SuccessfulPipelineTaskNames` with `SuccessfulOrSkippedDAGTasks` like explained here. Two helper functions `isDAGTasksDone`, `isDAGTaskFailed `. `GetFinalTasks` to return final tasks once they are eligible to execute.
6) `pipelinefinally_test.go`: Validate pipelineRun Status and taskRun Status along with competition time making sure (1) Final tasks are executed after all DAG tasks succeeds (2) Pipeline results in failure since a DAG task fails but final tasks does get executed successfully (3) Pipeline exits with failure when final task execution fails (4) The DAG task is skipped due to condition failure, final tasks is still executed.

### Example:

```
apiVersion: tekton.dev/v1beta1
kind: Pipeline
metadata:
  name: pipeline-with-final-tasks
spec:
  tasks:
    - name: pre-work
      taskRef:
        Name: some-pre-work
    - name: unit-test
      taskRef:
        Name: run-unit-test
      runAfter:
        - pre-work
    - name: integration-test
      taskRef:
        Name: run-integration-test
      runAfter:
        - unit-test
  finally:
    - name: cleanup-test
      taskRef:
        Name: cleanup-cluster
    - name: report-results
      taskRef:
        Name: report-test-results
```

Design doc: https://docs.google.com/document/d/1lxpYQHppiWOxsn4arqbwAFDo4T0-LCqpNa6p-TJdHrw/edit#

Part of #1684
Fixes #2446

Depends on: #2650

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Users can now specify Tasks within a Pipeline that will always execute, even if Tasks fail, via the new `finally` clause
```
