### PR TITLE
Document git ssh symlink requirement

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -108,6 +108,21 @@ When the `Run` executes, before steps execute, a `~/.ssh/config` will be
 generated containing the key configured in the `Secret`. This key is then used
 to authenticate when retrieving any `PipelineResources`.
 
+### Using SSH authentication in your own `git` `Tasks`
+
+The SSH credentials described above can be used when invoking `git` commands
+directly in your own Task's Steps. However, a Step will first need to symlink
+`/tekton/home/.ssh` to its user home directory (e.g. `/root/.ssh` when the
+Step's container runs as `root`).
+
+This is required because while Tekton does set the $HOME environment variable
+to `/tekton/home` by default, `ssh` ignores that environment variable and only
+considers the user's home as that described in `/etc/passwd`.
+
+**Note:** This additional symlink is not required if you are using the
+[`git-clone` catalog Task](https://github.com/tektoncd/catalog/tree/v1beta1/git)
+or Git PipelineResource.
+
 ## Basic authentication (Git)
 
 1. Define a `Secret` containing the username and password that the `Run` should


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds documentation around https://github.com/tektoncd/pipeline/issues/2638

When relying on creds-init to generate git ssh credentials
a user will need to symlink from /tekton/home/.ssh to /root/.ssh
if they're issuing `git` commands in a Step's script or image.

This commit documents the need to symlink in auth.md.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
