### PR TITLE
Remove creds-init initContainer

### DIFF
--- a/cmd/creds-init/main.go
+++ b/cmd/creds-init/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"flag"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
 	"github.com/tektoncd/pipeline/pkg/credentials/gitcreds"
@@ -37,7 +38,7 @@ func main() {
 
 	builders := []credentials.Builder{dockercreds.NewBuilder(), gitcreds.NewBuilder()}
 	for _, c := range builders {
-		if err := c.Write(); err != nil {
+		if err := c.Write(pipeline.CredsDir); err != nil {
 			logger.Fatalf("Error initializing credentials: %v", err)
 		}
 	}

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -121,9 +121,13 @@ This is required because while Tekton does set the $HOME environment variable
 to `/tekton/home` by default, `ssh` ignores that environment variable and only
 considers the user's home as that described in `/etc/passwd`.
 
-**Note:** This additional symlink is not required if you are using the
+**Note:** The additional symlink is not required if you are using the
 [`git-clone` catalog Task](https://github.com/tektoncd/catalog/tree/v1beta1/git)
 or Git PipelineResource.
+
+For an example of vanilla git commands using the SSH credentials described
+above, see the
+[authenticating-git-commands example](../examples/v1beta1/taskruns/authenticating-git-commands.yaml).
 
 ## Basic authentication (Git)
 
@@ -374,6 +378,28 @@ github.com only.
 Credential annotation keys must begin with `tekton.dev/docker-` or
 `tekton.dev/git-`, and the value describes the URL of the host with which to use
 the credential.
+
+## Using credentials as non-root user
+
+For a number of reasons you may need to use the credentials described in this
+doc in non-root contexts:
+
+- Your platform may randomize the user and/or groups that your containers run as.
+- The Steps of Tasks that you use may define a non-root `securityContext`.
+- Tasks themselves may specify non-root `securityContext`s applied to all `Steps`.
+
+Running as a non-root user has several effects that need to be accounted for
+when using the credentials mounted with the process described above:
+
+1. Certain credential types (SSH/git) require that the user have a valid home
+directory defined in `/etc/passwd`. Just having a random UID but no home directory
+will result in SSH erroring out.
+2. Credentials may need to be moved or symlinked from the `$HOME` directory that
+Tekton defines (`/tekton/home`) to the correct `home` directory for your user.
+This is true for SSH, which ignores the `$HOME` environment variable completely.
+
+For an example of using SSH credentials in a non-root `securityContext`, see the
+[authenticating-git-commands example](../examples/v1beta1/taskruns/authenticating-git-commands.yaml).
 
 ## Implementation details
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -29,7 +29,7 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. |
 | `workspaces.<workspaceName>.claim` | The name of the `PersistentVolumeClaim` specified as a volume source for the `Workspace`. Empty string for other volume types. |
 | `workspaces.<workspaceName>.volume` | The name of the volume populating the `Workspace`. |
-| `credentials.path` | The path to the credentials written by the `creds-init` init container. |
+| `credentials.path` | The path to credentials injected from Secrets with matching annotations. |
 | `context.taskRun.name` | The name of the `TaskRun` that this `Task` is running in. |
 | `context.task.name` | The name of this `Task`. |
 

--- a/examples/v1beta1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1beta1/taskruns/authenticating-git-commands.yaml
@@ -1,0 +1,204 @@
+# This example demonstrates usage of creds-init credentials to issue
+# git commands without a Git PipelineResource or git-clone catalog task.
+#
+# In order to exercise creds-init a sidecar is used to run a
+# git server fronted by SSH. The sidecar does the following things:
+# - Generates a host key pair, providing the public key to Steps for their known_hosts file
+# - Accepts a public key generated from creds-init credentials and uses that for an authorized_keys file
+# - Creates a bare git repo for the test git commands to run against
+# - Starts sshd and tails its log, waiting for the git commands to come in over SSH
+#
+# Two separate Steps then perform authenticated git actions against the sidecar
+# git server using the credentials mounted by creds-init:
+
+# The first step makes a git clone of the bare repository and populates it
+# with a file.
+#
+# The second step makes a git clone of the populated repository and checks
+# the contents of the repo match expectations. This step runs as a non-root
+# user in order to exercise creds-init credentials when a securityContext
+# is set.
+#
+# Notice that in each Step there is different code for handling creds-init
+# credentials when the disable-home-env-overwrite flag is "false" and when
+# it's "true".
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/ssh-auth
+metadata:
+  name: ssh-key-for-git
+  annotations:
+    tekton.dev/git-0: localhost
+data:
+  # This key was generated for this test and isn't used for anything else.
+  ssh-privatekey: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUJsd0FBQUFkemMyZ3RjbgpOaEFBQUFBd0VBQVFBQUFZRUF5T1g3ZG5OWlFBZVk4cHNMOXlaUnp3NXNDVG1yWGh6Zld1YTZuZ2VDQ0VRRTY4YjVUSThTCkNlbEhlNG9oTUtBdXZ0ZTE4YXJMK2EvVldpeFN6a2tBMmFIZVhkdUJ1bStkS2R2TlVVSUhNc1dOUythcENQYmE4R3ZGaHYKdG81Tkx0bWpxT2M0WjJkK1RPS3AvakMrS3pvUDFHQWdRL25QMitMTldabzlvTTc4TzQ3Z1dSem9FNlFKeGJqbFlPMHRMbwp4YXUxdTNrbUtsNSthbUxsNHpGN25wdmV1dGlSWDhmY2hGam5Ka2dqK3BVeFJvTGF4SDdDN0NTcDExWUkyMEhKRVFXeEk3CllaekNTYml5KzZ1a2l0Tk1MZ29qMnpSTGl2ZTVvZm9nenpYbkdWUUpZdUIzOFhQM0ZIQWMvOXhzUXdzd3dQS2hkQ3g4T0QKbjErYXpLOHp5SGhXK0dxckJhS1R4cDlrcVRpKzZSMWk4ZjVxOEt6NXpGVTZmd05qQXZ3STFBZ3IwS2FzU1JxWTVMcGxnTgpZcW1DY01JODZKUnRGWHRWWVQrT05tdWFhYUQ1QUErbnpkNW81R0haZTlFSlNqUThZMHZwbjhmNjNjeEw2RTdzVmxpMnpzCnNhN1RST2JMK3YyVnFuSlpEY2pIZXMzS1M5Mld0V3RJbXdXOG81VkRBQUFGaU04K0NUL1BQZ2svQUFBQUIzTnphQzF5YzIKRUFBQUdCQU1qbCszWnpXVUFIbVBLYkMvY21VYzhPYkFrNXExNGMzMXJtdXA0SGdnaEVCT3ZHK1V5UEVnbnBSM3VLSVRDZwpMcjdYdGZHcXkvbXYxVm9zVXM1SkFObWgzbDNiZ2Jwdm5TbmJ6VkZDQnpMRmpVdm1xUWoyMnZCcnhZYjdhT1RTN1pvNmpuCk9HZG5ma3ppcWY0d3ZpczZEOVJnSUVQNXo5dml6Vm1hUGFETy9EdU80RmtjNkJPa0NjVzQ1V0R0TFM2TVdydGJ0NUppcGUKZm1waTVlTXhlNTZiM3JyWWtWL0gzSVJZNXlaSUkvcVZNVWFDMnNSK3d1d2txZGRXQ050QnlSRUZzU08yR2N3a200c3Z1cgpwSXJUVEM0S0k5czBTNHIzdWFINklNODE1eGxVQ1dMZ2QvRno5eFJ3SFAvY2JFTUxNTUR5b1hRc2ZEZzU5Zm1zeXZNOGg0ClZ2aHFxd1dpazhhZlpLazR2dWtkWXZIK2F2Q3MrY3hWT244RFl3TDhDTlFJSzlDbXJFa2FtT1M2WllEV0twZ25EQ1BPaVUKYlJWN1ZXRS9qalpybW1tZytRQVBwODNlYU9SaDJYdlJDVW8wUEdOTDZaL0grdDNNUytoTzdGWll0czdMR3UwMFRteS9yOQpsYXB5V1EzSXgzck55a3ZkbHJWclNKc0Z2S09WUXdBQUFBTUJBQUVBQUFHQUNQSGtmbU9vWjZkdThlNWhYQUhDeHJ0WHFCCmwvUGROL1JtYmJqRW05U216czR5cWEwd1BUdzhrMU81VHM0V05nY1hMZFVRTlB6YkE4aWFWTGtvL0JqKzhiSFlhMmdmeVMKUE5qaWpXbXBOR09EWlF2Q0h2b095WUdpNjkycHovWnNTZCt0bEFzNm54LzY1ZjcwZHdVREJub0FjZnFLY28wQnVMRlNBKworamY5RnhISGYzQkFEUS9TdDVFQjlZelo1Q2F2cTRQcjZvS2w3R3RpbnRIbTZIbUlwTUlubWVEMnV3cjl2ZGZ1RGJhVDdYClVOSm10elVGck1uOUhlOWd1WkoyTXd3a015S09ScnRhVFA3VjFZK3FOM3ZncStmRkNtU0VkekxBU3BWTHMyL1hQTCtwTnAKTTVZUVRRMFJSZWdKTEdtTHZ0ZmpkK1RRMFQ0bjBucnBJVGRXRTRsL05sTG9taTVhUndzQXFtY2hZSGxhN0g3YlNyS2lKawpyWTg1RTliZm8wSXJqUDNQNzFYNmxjcTB0VDhDTklUQUNleWJQT3kwcDVDc3JwZTdhZEJBOXF4MTZjR2tkZ0NPWk9GMnRpCktoWWJHeTc4ei9YNEh2OEptVmhaSHF3RlFQQzVleWljbE1PTFJXNDJOcUJhNEVFc3RHT3l4MHZwa0lVS3VhRlJuQkFBQUEKd1FESytXYzU1WHVpWjgySXM5NnN2bWIrR0Y5c2pBRWVaWHpHSWpDL1NHVEhIWTZSQmc1TnlQOUdZNmtoWnBjd0cyTU52dQpZUjhuN0psRWlVanU2cjY2Smh0WGtvdTR4WlU1dDkvMlJvdHRmeWpKODJmYm8yTHZmNERUOVNvSURxZnk5VmlMSjhSWUNkCkt6NnpYSHFTZ1RBRU1vaUhjbFpIZzRqTitrOW1ma2tPMDBQbEJJaE1YU0ZMLzUrZUhGdStQTmxaU1g5NUlMRjJvZ0Y1RG0KWTFuaTRUOGJjdzY2dmFzamthcjFZekptM1VidEVnSzQ2VVllNGJac2NXbWt4dngwMEFBQURCQVA4UysyTmtheWkvb3NzVApTQXpJMi9QU2tJMDVEY1lTYnNOQjZ4a3pobzdKaDlHeUNvbW5xZ1IxR2ZBOTBqV3AxVks0TG43TmtYYWJaVmJPc0xoT21DCkdBbVRZTHRjaTB0bkhhYk5HTEZ3ZmdiUitqRzZNQ2p4cEh5anM5MDlKSHhtYmswbElpczdPN1N3VThERGcrSEVxc0EvNUoKQ1VMTWU3em9mNERhUnZXdFhTRks2ZW5LNnpGaHBINjVQY29TN0o0NjJhNzdUMDVGQXhMemNaRkc5VWZ5WUdMa1ZmdHRTTApNVDhudW9LaW5XTGNLSlVQeis1MjJlM3lIcis4c3pVUUFBQU1FQXlhQ28xSnRBcjRpczY0YTBuZTFUV0o0dXcyT3FDdUlDCm9acG1QN2UyRnh3bVRCSWMrbzZkSEVNVHo2c2ZZSkFxU2l4ZzYydXYzWlRTc25STWljaDZ0b1k0SVI4cWFMa1prLzU5cmEKQWFONFlvTkdpQTZxY0Jzc3NLMmZuM2YxRFJhckxPbWZHTnpTMU41S1RvSFVlUkVGWDExdHVNM1pqOGxTelFBOWZSakk1OQpFWmFnOWJaOXRJOEg5dmEvTGRMK3U3dTZZWkVRSEJCS1MxMW1tOVVXd1pDMkdUV3ZnNzRlTnRmemtZeDQxdlhIeTZBbW9ECmxuOHo2N3lvWEZzbEpUQUFBQURuTmpiM1IwUUcxbFkyZ3ViR0Z1QVFJREJBPT0KLS0tLS1FTkQgT1BFTlNTSCBQUklWQVRFIEtFWS0tLS0tCg==
+  # This known_hosts file doesn't actually get used; we overwrite it with the public key
+  # of our temporary test git server. But it's required here because otherwise creds-init
+  # calls ssh-keyscan which in turn tries to reach out over the network, will fail to make
+  # contact with the localhost SSH server because it isn't running yet, and the TaskRun
+  # will end in failure.
+  known_hosts: Cg==
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ssh-key-service-account
+secrets:
+- name: ssh-key-for-git
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: authenticating-git-commands
+spec:
+  serviceAccountName: ssh-key-service-account
+  taskSpec:
+    volumes:
+    - name: messages
+      emptyDir: {}
+    sidecars:
+    - name: server
+      image: alpine/git:v2.24.3
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+      - name: messages
+        mountPath: /messages
+      script: |
+        #!/usr/bin/env ash
+
+        # Generate a private host key and give the Steps access to its public
+        # key for their known_hosts file.
+        ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
+        chmod 0600 /etc/ssh/ssh_host_rsa_key*
+        HOST_PUBLIC_KEY=$(cat /etc/ssh/ssh_host_rsa_key.pub | awk '{ print $2 }')
+        echo "localhost ssh-rsa $HOST_PUBLIC_KEY" > /messages/known_hosts
+
+        # Wait for a Step to supply the server a public key generated from creds-init
+        # credentials.
+        while [ ! -f /messages/authorized_keys ] ; do
+          sleep 1
+        done
+
+        # Allow Steps to SSH login as root to this server.
+        mkdir /root/.ssh
+        cp /messages/authorized_keys /root/.ssh/
+
+        # "Unlock" the root account, allowing SSH login to succeed.
+        sed -i s/root:!/"root:*"/g /etc/shadow
+
+        # Create the git repo we're going to test against.
+        cd /root/
+        mkdir repo
+        cd repo
+        git init . --bare
+
+        # Start the sshd server.
+        /usr/sbin/sshd -E /var/log/sshd
+        touch /messages/sshd-ready
+        tail -f /var/log/sshd
+    steps:
+    - name: setup
+      # This Step is only necessary as part of the test, it's not something you'll
+      # ever need in a real-world scenario involving an external git repo.
+      image: alpine/git:v2.24.3
+      securityContext:
+        runAsUser: 0
+      volumeMounts:
+      - name: messages
+        mountPath: /messages
+      script: |
+        #!/usr/bin/env ash
+
+        # Generate authorized_keys file from the creds-init private key and give
+        # it to the sidecar server so that Steps can successfully SSH login
+        # using creds-init credentials.
+        ssh-keygen -y -f $(credentials.path)/.ssh/id_ssh-key-for-git > /messages/authorized_keys
+
+        # Wait for sshd to start on the git server.
+        while [ ! -f /messages/sshd-ready ] ; do
+          sleep 1
+        done
+    - name: git-clone-and-push
+      image: alpine/git:v2.24.3
+      securityContext:
+        runAsUser: 0
+      workingDir: /root
+      volumeMounts:
+      - name: messages
+        mountPath: /messages
+      script: |
+        #!/usr/bin/env ash
+        set -xe
+
+        if [ -d /tekton/home/.ssh ] ; then
+          # When disable-home-env-overwrite is "false", creds-init credentials
+          # will be copied to /tekton/home/.ssh by the entrypoint. But we need
+          # them in /root/.ssh.
+
+          # Overwrite the creds-init known_hosts file with that of our test
+          # git server. You wouldn't need to do this in any kind of real-world
+          # scenario involving an external git repo.
+          cp /messages/known_hosts $(credentials.path)/.ssh/
+
+          # Symlink /tekton/creds/.ssh to /root/.ssh because this script issues
+          # vanilla git commands of its own. Git PipelineResources and the git-clone
+          # catalog task handle this for you.
+          ln -s $(credentials.path)/.ssh /root/.ssh
+        else
+          # When disable-home-env-overwrite is "true", creds-init credentials
+          # will be copied to /root/.ssh by the entrypoint. We just need to
+          # overwrite the known_hosts file with that of our test git server.
+          cp /messages/known_hosts /root/.ssh/known_hosts
+        fi
+
+        git clone root@localhost:/root/repo ./repo
+        cd repo
+        git config user.email "example@example.com"
+        git config user.name "Example"
+        echo "Hello, world!" > README
+        git add README
+        git commit -m "Test commit!"
+        git push origin master
+    - name: git-clone-and-check
+      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:mario
+      # Because this Step runs with a non-root security context, the creds-init
+      # credentials will fail to copy into /tekton/home. This happens because
+      # our previous step _already_ wrote to /tekton/home and ran as a root
+      # user. So there will be warning messages reporting "unsuccessful cred
+      # copy". These can be safely ignored and instead this Step will copy
+      # the credentials out of /tekton/creds to nonroot's HOME directory.
+      securityContext:
+        runAsUser: 1000
+      workingDir: /home/nonroot
+      volumeMounts:
+      - name: messages
+        mountPath: /messages
+      script: |
+        #!/usr/bin/env ash
+        set -xe
+
+        if [ -d /tekton/home/.ssh ] ; then
+          # When disable-home-env-overwrite is "false", creds-init credentials
+          # will be copied to /tekton/home/.ssh by the entrypoint. But we need
+          # them in /home/nonroot/.ssh.
+
+          # Overwrite the creds-init known_hosts file with that of our test
+          # git server. You wouldn't need to do this in any kind of real-world
+          # scenario involving an external git repo.
+          cp /messages/known_hosts $(credentials.path)/.ssh/
+
+          # Symlink /tekton/creds/.ssh to /home/nonroot/.ssh because this script issues
+          # vanilla git commands of its own and we're running as a non-root user.
+          # Git PipelineResources and the git-clone catalog task handle this for you.
+          ln -s $(credentials.path)/.ssh /home/nonroot/.ssh
+        else
+          # When disable-home-env-overwrite is "true", creds-init credentials
+          # will be copied to /home/nonroot/.ssh by the entrypoint. We just need to
+          # overwrite the known_hosts file with that of our test git server.
+          cp /messages/known_hosts /home/nonroot/ssh/known_hosts
+        fi
+
+        git clone root@localhost:/root/repo ./repo
+        cd repo
+        cat README | grep "Hello, world!"

--- a/pkg/apis/pipeline/paths.go
+++ b/pkg/apis/pipeline/paths.go
@@ -23,4 +23,6 @@ const (
 	DefaultResultPath = "/tekton/results"
 	// HomeDir is the HOME directory of PipelineResources
 	HomeDir = "/tekton/home"
+	// CredsDir is the directory where credentials are placed to meet the creds-init contract
+	CredsDir = "/tekton/creds"
 )

--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -37,15 +37,16 @@ var config basicDocker
 var dockerConfig string
 var dockerCfg string
 
+// AddFlags adds CLI flags that dockercreds supports to a given flag.FlagSet.
+func AddFlags(flagSet *flag.FlagSet) {
+	flags(flagSet)
+}
+
 func flags(fs *flag.FlagSet) {
 	config = basicDocker{make(map[string]entry)}
 	fs.Var(&config, "basic-docker", "List of secret=url pairs.")
 	fs.StringVar(&dockerConfig, "docker-config", "", "Docker config.json secret file.")
 	fs.StringVar(&dockerCfg, "docker-cfg", "", "Docker .dockercfg secret file.")
-}
-
-func init() {
-	flags(flag.CommandLine)
 }
 
 // As the flag is read, this status is populated.
@@ -148,8 +149,8 @@ func (*basicDockerBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 	return flags
 }
 
-func (*basicDockerBuilder) Write() error {
-	dockerDir := filepath.Join(os.Getenv("HOME"), ".docker")
+func (*basicDockerBuilder) Write(directory string) error {
+	dockerDir := filepath.Join(directory, ".docker")
 	basicDocker := filepath.Join(dockerDir, "config.json")
 	if err := os.MkdirAll(dockerDir, os.ModePerm); err != nil {
 		return err

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -45,7 +45,7 @@ func TestFlagHandling(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		"-basic-docker=foo=https://us.gcr.io",
 	})
@@ -54,7 +54,7 @@ func TestFlagHandling(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
@@ -94,7 +94,7 @@ func TestFlagHandlingTwice(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		"-basic-docker=foo=https://us.gcr.io",
 		"-basic-docker=bar=https://eu.gcr.io",
@@ -104,7 +104,7 @@ func TestFlagHandlingTwice(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
@@ -253,7 +253,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		"-basic-docker=foo=https://us.gcr.io",
 		"-docker-config=bar",
@@ -264,7 +264,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 

--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -71,8 +70,8 @@ func (dc *basicGitConfig) Set(value string) error {
 	return nil
 }
 
-func (dc *basicGitConfig) Write() error {
-	gitConfigPath := filepath.Join(os.Getenv("HOME"), ".gitconfig")
+func (dc *basicGitConfig) Write(directory string) error {
+	gitConfigPath := filepath.Join(directory, ".gitconfig")
 	gitConfigs := []string{
 		"[credential]\n	helper = store\n",
 	}
@@ -85,7 +84,7 @@ func (dc *basicGitConfig) Write() error {
 		return err
 	}
 
-	gitCredentialsPath := filepath.Join(os.Getenv("HOME"), ".git-credentials")
+	gitCredentialsPath := filepath.Join(directory, ".git-credentials")
 	var gitCredentials []string
 	for _, k := range dc.order {
 		v := dc.entries[k]

--- a/pkg/credentials/gitcreds/creds.go
+++ b/pkg/credentials/gitcreds/creds.go
@@ -36,16 +36,17 @@ var (
 	sshConfig   sshGitConfig
 )
 
+// AddFlags adds CLI flags that gitcreds supports to a given flag.FlagSet.
+func AddFlags(flagSet *flag.FlagSet) {
+	flags(flagSet)
+}
+
 func flags(fs *flag.FlagSet) {
 	basicConfig = basicGitConfig{entries: make(map[string]basicEntry)}
 	fs.Var(&basicConfig, basicAuthFlag, "List of secret=url pairs.")
 
 	sshConfig = sshGitConfig{entries: make(map[string][]sshEntry)}
 	fs.Var(&sshConfig, sshFlag, "List of secret=url pairs.")
-}
-
-func init() {
-	flags(flag.CommandLine)
 }
 
 type gitConfigBuilder struct{}
@@ -76,9 +77,9 @@ func (*gitConfigBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 	return flags
 }
 
-func (*gitConfigBuilder) Write() error {
-	if err := basicConfig.Write(); err != nil {
+func (*gitConfigBuilder) Write(directory string) error {
+	if err := basicConfig.Write(directory); err != nil {
 		return err
 	}
-	return sshConfig.Write()
+	return sshConfig.Write(directory)
 }

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -45,7 +45,7 @@ func TestBasicFlagHandling(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		"-basic-git=foo=https://github.com",
 	})
@@ -54,7 +54,7 @@ func TestBasicFlagHandling(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
@@ -108,7 +108,7 @@ func TestBasicFlagHandlingTwice(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		"-basic-git=foo=https://github.com",
 		"-basic-git=bar=https://gitlab.com",
@@ -118,7 +118,7 @@ func TestBasicFlagHandlingTwice(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
@@ -201,7 +201,7 @@ func TestSSHFlagHandling(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		"-ssh-git=foo=github.com",
 	})
@@ -210,7 +210,7 @@ func TestSSHFlagHandling(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 
@@ -282,7 +282,7 @@ func TestSSHFlagHandlingThrice(t *testing.T) {
 	}
 
 	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	flags(fs)
+	AddFlags(fs)
 	err := fs.Parse([]string{
 		// Two secrets target github.com, and both will end up in the
 		// ssh config.
@@ -295,7 +295,7 @@ func TestSSHFlagHandlingThrice(t *testing.T) {
 	}
 
 	os.Setenv("HOME", credentials.VolumePath)
-	if err := NewBuilder().Write(); err != nil {
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
 

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -73,8 +73,8 @@ func (dc *sshGitConfig) Set(value string) error {
 	return nil
 }
 
-func (dc *sshGitConfig) Write() error {
-	sshDir := filepath.Join(os.Getenv("HOME"), ".ssh")
+func (dc *sshGitConfig) Write(directory string) error {
+	sshDir := filepath.Join(directory, ".ssh")
 	if err := os.MkdirAll(sshDir, os.ModePerm); err != nil {
 		return err
 	}

--- a/pkg/pod/creds_init_test.go
+++ b/pkg/pod/creds_init_test.go
@@ -34,33 +34,24 @@ const (
 )
 
 func TestCredsInit(t *testing.T) {
-	volumeMounts := []corev1.VolumeMount{{
-		Name: "implicit-volume-mount",
-	}}
-	fooEnvVar := corev1.EnvVar{
-		Name:  "FOO",
-		Value: "bar",
-	}
-	credsInitHomeEnvVar := corev1.EnvVar{
-		Name:  "HOME",
-		Value: credsInitHomeDir,
-	}
 	customHomeEnvVar := corev1.EnvVar{
 		Name:  "HOME",
 		Value: "/users/home/my-test-user",
 	}
 
 	for _, c := range []struct {
-		desc    string
-		want    *corev1.Container
-		objs    []runtime.Object
-		envVars []corev1.EnvVar
+		desc             string
+		wantArgs         []string
+		wantVolumeMounts []corev1.VolumeMount
+		objs             []runtime.Object
+		envVars          []corev1.EnvVar
 	}{{
 		desc: "service account exists with no secrets; nothing to initialize",
 		objs: []runtime.Object{
 			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: serviceAccountName, Namespace: namespace}},
 		},
-		want: nil,
+		wantArgs:         nil,
+		wantVolumeMounts: nil,
 	}, {
 		desc: "service account has no annotated secrets; nothing to initialize",
 		objs: []runtime.Object{
@@ -80,7 +71,8 @@ func TestCredsInit(t *testing.T) {
 				},
 			},
 		},
-		want: nil,
+		wantArgs:         nil,
+		wantVolumeMounts: nil,
 	}, {
 		desc: "service account has annotated secret and no HOME env var passed in; initialize creds in /tekton/creds",
 		objs: []runtime.Object{
@@ -108,23 +100,17 @@ func TestCredsInit(t *testing.T) {
 				},
 			},
 		},
-		envVars: []corev1.EnvVar{fooEnvVar},
-		want: &corev1.Container{
-			Name:    "credential-initializer",
-			Image:   images.CredsImage,
-			Command: []string{"/ko-app/creds-init"},
-			Args: []string{
-				"-basic-docker=my-creds=https://docker.io",
-				"-basic-docker=my-creds=https://us.gcr.io",
-				"-basic-git=my-creds=github.com",
-				"-basic-git=my-creds=gitlab.com",
-			},
-			Env: []corev1.EnvVar{fooEnvVar, credsInitHomeEnvVar},
-			VolumeMounts: append(volumeMounts, corev1.VolumeMount{
-				Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
-				MountPath: "/tekton/creds-secrets/my-creds",
-			}),
+		envVars: []corev1.EnvVar{},
+		wantArgs: []string{
+			"-basic-docker=my-creds=https://docker.io",
+			"-basic-docker=my-creds=https://us.gcr.io",
+			"-basic-git=my-creds=github.com",
+			"-basic-git=my-creds=gitlab.com",
 		},
+		wantVolumeMounts: []corev1.VolumeMount{{
+			Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
+			MountPath: "/tekton/creds-secrets/my-creds",
+		}},
 	}, {
 		desc: "service account with secret and HOME env var passed in",
 		objs: []runtime.Object{
@@ -153,34 +139,31 @@ func TestCredsInit(t *testing.T) {
 			},
 		},
 		envVars: []corev1.EnvVar{customHomeEnvVar},
-		want: &corev1.Container{
-			Name:    "credential-initializer",
-			Image:   images.CredsImage,
-			Command: []string{"/ko-app/creds-init"},
-			Args: []string{
-				"-basic-docker=my-creds=https://docker.io",
-				"-basic-docker=my-creds=https://us.gcr.io",
-				"-basic-git=my-creds=github.com",
-				"-basic-git=my-creds=gitlab.com",
-			},
-			Env: []corev1.EnvVar{customHomeEnvVar},
-			VolumeMounts: append(volumeMounts, corev1.VolumeMount{
-				Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
-				MountPath: "/tekton/creds-secrets/my-creds",
-			}),
+		wantArgs: []string{
+			"-basic-docker=my-creds=https://docker.io",
+			"-basic-docker=my-creds=https://us.gcr.io",
+			"-basic-git=my-creds=github.com",
+			"-basic-git=my-creds=gitlab.com",
 		},
+		wantVolumeMounts: []corev1.VolumeMount{{
+			Name:      "tekton-internal-secret-volume-my-creds-9l9zj",
+			MountPath: "/tekton/creds-secrets/my-creds",
+		}},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
 			kubeclient := fakek8s.NewSimpleClientset(c.objs...)
-			got, volumes, err := credsInit(images.CredsImage, serviceAccountName, namespace, kubeclient, volumeMounts, c.envVars)
+			args, volumes, volumeMounts, err := credsInit(serviceAccountName, namespace, kubeclient)
 			if err != nil {
 				t.Fatalf("credsInit: %v", err)
 			}
-			if got == nil && len(volumes) > 0 {
-				t.Errorf("Got nil creds-init container, with non-empty volumes: %v", volumes)
+			if len(args) == 0 && len(volumes) != 0 {
+				t.Fatalf("credsInit returned secret volumes but no arguments")
 			}
-			if d := cmp.Diff(c.want, got); d != "" {
+			if d := cmp.Diff(c.wantArgs, args); d != "" {
+				t.Fatalf("Diff %s", diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(c.wantVolumeMounts, volumeMounts); d != "" {
 				t.Fatalf("Diff %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -86,7 +86,7 @@ var (
 // method, using entrypoint_lookup.go.
 //
 // TODO(#1605): Also use entrypoint injection to order sidecar start/stop.
-func orderContainers(entrypointImage string, steps []corev1.Container, results []v1beta1.TaskResult) (corev1.Container, []corev1.Container, error) {
+func orderContainers(entrypointImage string, extraEntrypointArgs []string, steps []corev1.Container, results []v1beta1.TaskResult) (corev1.Container, []corev1.Container, error) {
 	initContainer := corev1.Container{
 		Name:         "place-tools",
 		Image:        entrypointImage,
@@ -118,6 +118,7 @@ func orderContainers(entrypointImage string, steps []corev1.Container, results [
 				"-termination_path", terminationPath,
 			}
 		}
+		argsForEntrypoint = append(argsForEntrypoint, extraEntrypointArgs...)
 		argsForEntrypoint = append(argsForEntrypoint, resultArgument(steps, results)...)
 
 		cmd, args := s.Command, s.Args

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -87,7 +87,7 @@ func TestOrderContainers(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	gotInit, got, err := orderContainers(images.EntrypointImage, steps, nil)
+	gotInit, got, err := orderContainers(images.EntrypointImage, []string{}, steps, nil)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestEntryPointResults(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -34,6 +34,8 @@ import (
 )
 
 const (
+	homeDir = "/tekton/home"
+
 	// ResultsDir is the folder used by default to create the results file
 	ResultsDir = "/tekton/results"
 
@@ -56,7 +58,7 @@ var (
 		MountPath: pipeline.WorkspaceDir,
 	}, {
 		Name:      "tekton-internal-home",
-		MountPath: pipeline.HomeDir,
+		MountPath: homeDir,
 	}, {
 		Name:      "tekton-internal-results",
 		MountPath: ResultsDir,
@@ -88,23 +90,19 @@ func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskR
 	if overrideHomeEnv {
 		implicitEnvVars = append(implicitEnvVars, corev1.EnvVar{
 			Name:  "HOME",
-			Value: pipeline.HomeDir,
+			Value: homeDir,
 		})
-	} else {
-		// Add the volume that creds-init will write to when
-		// there's no consistent $HOME for Steps.
-		v, vm := getCredsInitVolume(volumes)
-		volumes = append(volumes, v)
-		volumeMounts = append(volumeMounts, vm)
 	}
 
-	// Inititalize any credentials found in annotated Secrets.
-	if credsInitContainer, secretsVolumes, err := credsInit(images.CredsImage, taskRun.Spec.ServiceAccountName, taskRun.Namespace, kubeclient, volumeMounts, implicitEnvVars); err != nil {
+	// Create Volumes and VolumeMounts for any credentials found in annotated
+	// Secrets, along with any arguments needed by Step entrypoints to process
+	// those secrets.
+	credEntrypointArgs, credVolumes, credVolumeMounts, err := credsInit(taskRun.Spec.ServiceAccountName, taskRun.Namespace, kubeclient)
+	if err != nil {
 		return nil, err
-	} else if credsInitContainer != nil {
-		initContainers = append(initContainers, *credsInitContainer)
-		volumes = append(volumes, secretsVolumes...)
 	}
+	volumes = append(volumes, credVolumes...)
+	volumeMounts = append(volumeMounts, credVolumeMounts...)
 
 	// Merge step template with steps.
 	// TODO(#1605): Move MergeSteps to pkg/pod
@@ -134,7 +132,7 @@ func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskR
 
 	// Rewrite steps with entrypoint binary. Append the entrypoint init
 	// container to place the entrypoint binary.
-	entrypointInit, stepContainers, err := orderContainers(images.EntrypointImage, stepContainers, taskSpec.Results)
+	entrypointInit, stepContainers, err := orderContainers(images.EntrypointImage, credEntrypointArgs, stepContainers, taskSpec.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +158,13 @@ func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskR
 	// Add implicit volume mounts to each step, unless the step specifies
 	// its own volume mount at that path.
 	for i, s := range stepContainers {
+		// Mount /tekton/creds with a fresh volume for each Step. It needs to
+		// be world-writeable and empty so creds can be initialized in there. Cant
+		// guarantee what UID container runs with.
+		v, vm := getCredsInitVolume()
+		volumes = append(volumes, v)
+		s.VolumeMounts = append(s.VolumeMounts, vm)
+
 		requestedVolumeMounts := map[string]bool{}
 		for _, vm := range s.VolumeMounts {
 			requestedVolumeMounts[filepath.Clean(vm.MountPath)] = true

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -142,8 +142,8 @@ func ApplyTaskResults(spec *v1beta1.TaskSpec) *v1beta1.TaskSpec {
 	return ApplyReplacements(spec, stringReplacements, map[string][]string{})
 }
 
-// ApplyCredentialsPath applies a substitution of the key $(credentials.path) with the path that the creds-init
-// helper will write its credentials to.
+// ApplyCredentialsPath applies a substitution of the key $(credentials.path) with the path that credentials
+// from annotated secrets are written to.
 func ApplyCredentialsPath(spec *v1beta1.TaskSpec, path string) *v1beta1.TaskSpec {
 	stringReplacements := map[string]string{
 		"credentials.path": path,

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -543,7 +543,7 @@ func (c *Reconciler) createPod(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	shouldOverrideHomeEnv := podconvert.ShouldOverrideHomeEnv(ctx)
 
 	// Apply creds-init path substitutions.
-	ts = resources.ApplyCredentialsPath(ts, podconvert.CredentialsPath(shouldOverrideHomeEnv))
+	ts = resources.ApplyCredentialsPath(ts, pipeline.CredsDir)
 
 	pod, err := podconvert.MakePod(ctx, c.Images, tr, *ts, c.KubeClientSet, c.entrypointCache, shouldOverrideHomeEnv)
 	if err != nil {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -222,36 +222,6 @@ var (
 		},
 	}
 
-	getMkdirResourceContainer = func(name, dir, suffix string, ops ...tb.ContainerOp) tb.PodSpecOp {
-		actualOps := []tb.ContainerOp{
-			tb.Command("/tekton/tools/entrypoint"),
-			tb.Args("-wait_file",
-				"/tekton/downward/ready",
-				"-wait_file_content",
-				"-post_file",
-				"/tekton/tools/0",
-				"-termination_path",
-				"/tekton/termination",
-				"-entrypoint",
-				"mkdir",
-				"--",
-				"-p",
-				dir),
-			tb.WorkingDir(workspaceDir),
-			tb.EnvVar("HOME", "/tekton/home"),
-			tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-			tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-			tb.VolumeMount("tekton-internal-workspace", workspaceDir),
-			tb.VolumeMount("tekton-internal-home", "/tekton/home"),
-			tb.VolumeMount("tekton-internal-results", "/tekton/results"),
-			tb.TerminationMessagePath("/tekton/termination"),
-		}
-
-		actualOps = append(actualOps, ops...)
-
-		return tb.PodContainer(fmt.Sprintf("step-create-dir-%s-%s", name, suffix), "busybox", actualOps...)
-	}
-
 	getPlaceToolsInitContainer = func(ops ...tb.ContainerOp) tb.PodSpecOp {
 		actualOps := []tb.ContainerOp{
 			tb.Command("cp", "/ko-app/entrypoint", entrypointLocation),
@@ -387,7 +357,10 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
 				tb.PodServiceAccountName(defaultSAName),
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
@@ -407,6 +380,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -427,7 +401,10 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
 				tb.PodServiceAccountName("test-sa"),
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-sa-step", "foo",
@@ -447,6 +424,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -557,7 +535,10 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-home-env",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, credsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
@@ -577,10 +558,10 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 					tb.EnvVar("foo", "bar"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
-					tb.VolumeMount("tekton-creds-init-home", "/tekton/creds"),
 					tb.TerminationMessagePath("/tekton/termination"),
 				),
 			),
@@ -598,7 +579,10 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-working-dir",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
@@ -617,6 +601,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -835,7 +820,10 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
@@ -855,6 +843,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -879,7 +868,10 @@ func TestReconcile(t *testing.T) {
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
 				tb.PodServiceAccountName("test-sa"),
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-sa-step", "foo",
@@ -899,6 +891,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -923,7 +916,26 @@ func TestReconcile(t *testing.T) {
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
 				tb.PodVolumes(
-					workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume,
+					workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+						Name:         "tekton-creds-init-home-78c5n",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+					},
+					corev1.Volume{
+						Name:         "tekton-creds-init-home-6nl7g",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+					},
+					corev1.Volume{
+						Name:         "tekton-creds-init-home-j2tds",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+					},
+					corev1.Volume{
+						Name:         "tekton-creds-init-home-vr6ds",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+					},
+					corev1.Volume{
+						Name:         "tekton-creds-init-home-l22wn",
+						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+					},
 					corev1.Volume{
 						Name: "volume-configmap",
 						VolumeSource: corev1.VolumeSource{
@@ -937,7 +949,30 @@ func TestReconcile(t *testing.T) {
 				),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
-				getMkdirResourceContainer("myimage", "/workspace/output/myimage", "mssqb"),
+				tb.PodContainer("step-create-dir-myimage-mssqb", "busybox",
+					tb.Command("/tekton/tools/entrypoint"),
+					tb.Args("-wait_file",
+						"/tekton/downward/ready",
+						"-wait_file_content",
+						"-post_file",
+						"/tekton/tools/0",
+						"-termination_path",
+						"/tekton/termination",
+						"-entrypoint",
+						"mkdir",
+						"--",
+						"-p",
+						"/workspace/output/myimage"),
+					tb.WorkingDir(workspaceDir),
+					tb.EnvVar("HOME", "/tekton/home"),
+					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-78c5n", "/tekton/creds"),
+					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
+					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
+					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
+					tb.TerminationMessagePath("/tekton/termination"),
+				),
 				tb.PodContainer("step-git-source-workspace-mz4c7", "override-with-git:latest",
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/tekton/tools/0", "-post_file", "/tekton/tools/1", "-termination_path",
@@ -948,6 +983,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("TEKTON_RESOURCE_NAME", "workspace"),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-creds-init-home-6nl7g", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -962,6 +998,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-creds-init-home-j2tds", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -974,6 +1011,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-creds-init-home-vr6ds", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -987,6 +1025,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-creds-init-home-l22wn", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1009,7 +1048,13 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-taskspec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-mz4c7",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}, corev1.Volume{
+					Name:         "tekton-creds-init-home-mssqb",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-git-source-workspace-9l9zj", "override-with-git:latest",
@@ -1038,6 +1083,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-mz4c7", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1050,6 +1096,7 @@ func TestReconcile(t *testing.T) {
 						"/tekton/termination", "-entrypoint", "/mycmd", "--", "--my-arg=foo"),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-creds-init-home-mssqb", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1074,7 +1121,10 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-cluster-task",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
@@ -1094,6 +1144,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1116,7 +1167,13 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-resource-spec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-mz4c7",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}, corev1.Volume{
+					Name:         "tekton-creds-init-home-mssqb",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-git-source-workspace-9l9zj", "override-with-git:latest",
@@ -1146,6 +1203,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-mz4c7", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1158,6 +1216,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
+					tb.VolumeMount("tekton-creds-init-home-mssqb", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1181,7 +1240,10 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-pod",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-simple-step", "foo",
@@ -1200,6 +1262,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1208,7 +1271,7 @@ func TestReconcile(t *testing.T) {
 			),
 		),
 	}, {
-		name:    "taskrun-with-credentials-variable-default-tekton-home",
+		name:    "taskrun-with-credentials-variable-default-tekton-creds",
 		taskRun: taskRunWithCredentialsVariable,
 		wantEvents: []string{
 			"Normal Started ",
@@ -1222,7 +1285,10 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-credentials-variable",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
-				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume),
+				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
+					Name:         "tekton-creds-init-home-9l9zj",
+					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
 				getPlaceToolsInitContainer(),
 				tb.PodContainer("step-mycontainer", "myimage",
@@ -1235,13 +1301,14 @@ func TestReconcile(t *testing.T) {
 						"-termination_path",
 						"/tekton/termination",
 						"-entrypoint",
-						// Important bit here: /tekton/home
-						"/mycmd /tekton/home",
+						// Important bit here: /tekton/creds
+						"/mycmd /tekton/creds",
 						"--"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
+					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/2524 and puts us in a better position to flip the `disable-home-env-overwrite` feature flag with less fallout for users.

Fixes https://github.com/tektoncd/pipeline/issues/1271 when the feature-flag is flipped.  Also we have documentation on how to use SSH creds without the feature flag flip [in auth.md](https://github.com/tektoncd/pipeline/blob/master/docs/auth.md#using-ssh-authentication-in-your-own-git-tasks) now too.

**TLDR; The behaviour that used to be implemented by creds-init is now performed by
the entrypointer.**

Creds-init is an initContainer that writes credential files (like .ssh) to
/tekton/home. One side-effect of relying on an initContainer to write these
files is that they receive the UID / Group ID of the initContainer's process.
This side-effect breaks any Step in the Task that relies on these credentials
but runs with a different UID. An example of where this can happen is on
OpenShift, where the UID of the user is randomized for each container in
order to limit the fallout of malicious process breaking out.

This commit removes the creds-init initContainer from all TaskRun Pods. I
haven't removed the creds-init binary from our build process in this
changeset. Doing so generates a lot of extra line noise which distracts
from the core modification being presented here.

Further fallout from this change:

- Credential volume mounts from annotated Secrets used to be mounted only once,
in the `creds-init` initContainer, at `/tekcon/creds-secrets/...`. These volume mounts
are now given to every Step container so that they can be copied out by the entrypointer.
- Credentials used to be copied from `/tekton/creds-secrets/...` to `/tekton/home`
or `/tekton/creds`, depending on whether the `disable-home-env-overwrite` feature flag
was set. Now those credentials are always copied into `/tekton/creds`.
- The `$(credentials.path)` variable is now always `/tekton/creds` regardless of whether
the `disable-home-env-overwrite` feature flag is set or not.
- When the  `disable-home-env-overwrite` feature flag is set, credentials will be placed at
the actual home directory of the current user in the Step container, instead of being placed
in `/tekton/home`. If the container or Step explicitly sets a `$HOME` then credentials will
end up in there.
- Every single Step gets its own empty `/tekton/creds` volume. This allows `/tekton/creds` to be world-writable and empty for every Step to copy in to.  The directory needs to be world-writable so it's accessible even if the user's UID wouldn't normally have permissions to create a directory under `/tekton`. This is also why there are so many lines changed in the various `pkg/pod` tests.

I've put a hold on this while I add better testing and examples that exercise the cases that this PR deals with.

~~Need to figure out a safe way to introduce a credential that can be used for testing. Possibly a `read-only` Github Deploy Secret for a private test Github repo in the tektoncd org?~~

Edit: It took me way too long but I finally figured out how to spin up a git/ssh sidecar that works as an authenticated remote repo for testing creds-init.

- [x] Example that shows credentials being used in conjunction with different `securityContext`s per Step.
- [x] Example that shows using these credentials with vanilla `git` commands, not git-init or Git PipelineResource.
- [x] Documentation that describes the behaviour of credentials in the face of different `securityContext`s.

I think there also needs to be a bit of discussion about some of the more questionable design decisions.  Maybe next API WG.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).  

# Release Notes

```release-note
Tekton's creds-init initContainer has been removed and will no longer show up in TaskRun Pods. Credentials from annotated Secrets will continue to be mounted and placed in Step containers' home directory.
```

/kind bug
/hold