### PR TITLE
Google/ko 5.0+ requires images to be prefixed by ko:// .

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -54,17 +54,17 @@ spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
       - name: tekton-pipelines-controller
-        image: github.com/tektoncd/pipeline/cmd/controller
+        image: ko://github.com/tektoncd/pipeline/cmd/controller
         args: [
           # These images are built on-demand by `ko resolve` and are replaced
           # by image references by digest.
-          "-kubeconfig-writer-image", "github.com/tektoncd/pipeline/cmd/kubeconfigwriter",
-          "-creds-image", "github.com/tektoncd/pipeline/cmd/creds-init",
-          "-git-image", "github.com/tektoncd/pipeline/cmd/git-init",
-          "-entrypoint-image", "github.com/tektoncd/pipeline/cmd/entrypoint",
-          "-imagedigest-exporter-image", "github.com/tektoncd/pipeline/cmd/imagedigestexporter",
-          "-pr-image", "github.com/tektoncd/pipeline/cmd/pullrequest-init",
-          "-build-gcs-fetcher-image", "github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher",
+          "-kubeconfig-writer-image", "ko://github.com/tektoncd/pipeline/cmd/kubeconfigwriter",
+          "-creds-image", "ko://github.com/tektoncd/pipeline/cmd/creds-init",
+          "-git-image", "ko://github.com/tektoncd/pipeline/cmd/git-init",
+          "-entrypoint-image", "ko://github.com/tektoncd/pipeline/cmd/entrypoint",
+          "-imagedigest-exporter-image", "ko://github.com/tektoncd/pipeline/cmd/imagedigestexporter",
+          "-pr-image", "ko://github.com/tektoncd/pipeline/cmd/pullrequest-init",
+          "-build-gcs-fetcher-image", "ko://github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher",
 
           # This image is used as a placeholder pod, the Affinity Assistant
           # TODO(#2640) We may want to create a custom, minimal binary

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -59,7 +59,7 @@ spec:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: github.com/tektoncd/pipeline/cmd/webhook
+        image: ko://github.com/tektoncd/pipeline/cmd/webhook
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
# Changes

Adds ko:// scheme to images used by ko

See https://github.com/google/ko/issues/158


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Adds ko:// scheme to images used by ko (dev only)
```
