### PR TITLE
Add support for more cloud events

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -155,7 +155,7 @@ point for the `Pod` in which the container images specified in your `Task` will 
 customize the `Pod` configuration specifically for that `TaskRun`.
 
 In the following example, the `Task` specifies a `volumeMount` (`my-cache`) object, also provided by the `TaskRun`,
-using a `PersistentVolumeClaim` volume. A specific scheduler is also configured in the  `SchedulerName` field. 
+using a `PersistentVolumeClaim` volume. A specific scheduler is also configured in the  `SchedulerName` field.
 The `Pod` executes with regular (non-root) user permissions.
 
 ```yaml
@@ -281,7 +281,7 @@ For more information, see [`ServiceAccount`](auth.md).
 ## Monitoring execution status
 
 As your `TaskRun` executes, its `status` field accumulates information on the execution of each `Step`
-as well as the `TaskRun` as a whole. This information includes start and stop times, exit codes, the 
+as well as the `TaskRun` as a whole. This information includes start and stop times, exit codes, the
 fully-qualified name of the container image, and the corresponding digest.
 
 **Note:** If any `Pods` have been [`OOMKilled`](https://kubernetes.io/docs/tasks/administer-cluster/out-of-resource/)
@@ -310,6 +310,23 @@ steps:
     reason: Completed
     startedAt: "2019-08-12T18:22:54Z"
   ```
+
+The following tables shows how to read the overall status of a `TaskRun`:
+
+`status`|`reason`|`completionTime` is set|Description
+:-------|:-------|:---------------------:|--------------:
+Unknown|Started|No|The TaskRun has just been picked up by the controller.
+Unknown|Pending|No|The TaskRun is waiting on a Pod in status Pending.
+Unknown|Running|No|The TaskRun has been validate and started to perform its work.
+Unknown|TaskRunCancelled|No|The user requested the TaskRun to be cancelled. Cancellation has not be done yet.
+True|Succeeded|Yes|The TaskRun completed successfully.
+False|Failed|Yes|The TaskRun failed because one of the steps failed.
+False|\[Error message\]|No|The TaskRun encountered a non-permanent error, and it's still running. It may ultimately succeed.
+False|\[Error message\]|Yes|The TaskRun failed with a permanent error (usually validation).
+False|TaskRunCancelled|Yes|The TaskRun was cancelled successfully.
+False|TaskRunTimeout|Yes|The TaskRun timed out.
+
+When a `TaskRun` changes status, [events](events.md#taskruns) are triggered accordingly.
 
 ### Monitoring `Steps`
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -73,6 +73,21 @@ func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
 	}
 }
 
+// GetTypeMeta returns the task run type meta
+func (pr *PipelineRun) GetTypeMeta() *metav1.TypeMeta {
+	return &pr.TypeMeta
+}
+
+// GetObjectMeta returns the task run type meta
+func (pr *PipelineRun) GetObjectMeta() *metav1.ObjectMeta {
+	return &pr.ObjectMeta
+}
+
+// GetStatus returns the task run status as a RunsToCompletionStatus
+func (pr *PipelineRun) GetStatus() RunsToCompletionStatus {
+	return &pr.Status
+}
+
 // GetOwnerReference gets the pipeline run as owner reference for any related objects
 func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
 	return *metav1.NewControllerRef(pr, groupVersionKind)
@@ -101,6 +116,11 @@ func (pr *PipelineRun) GetRunKey() string {
 
 // IsTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout
 func (pr *PipelineRun) IsTimedOut() bool {
+	return pr.HasTimedOut()
+}
+
+// HasTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout
+func (pr *PipelineRun) HasTimedOut() bool {
 	pipelineTimeout := pr.Spec.Timeout
 	startTime := pr.Status.StartTime
 

--- a/pkg/apis/pipeline/v1beta1/run_interface.go
+++ b/pkg/apis/pipeline/v1beta1/run_interface.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+// RunsToCompletionStatus is implemented by TaskRun.Status and PipelineRun.Status
+type RunsToCompletionStatus interface {
+	GetCondition(t apis.ConditionType) *apis.Condition
+	InitializeConditions()
+	SetCondition(newCond *apis.Condition)
+}
+
+// RunsToCompletion is implemented by TaskRun and PipelineRun
+type RunsToCompletion interface {
+	GetTypeMeta() *metav1.TypeMeta
+	GetObjectMeta() *metav1.ObjectMeta
+	GetOwnerReference() metav1.OwnerReference
+	GetStatus() RunsToCompletionStatus
+	IsDone() bool
+	HasStarted() bool
+	IsCancelled() bool
+	HasTimedOut() bool
+	GetRunKey() string
+}

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -180,9 +180,24 @@ type TaskRunResult struct {
 	Value string `json:"value"`
 }
 
+// GetTypeMeta returns the task run type meta
+func (tr *TaskRun) GetTypeMeta() *metav1.TypeMeta {
+	return &tr.TypeMeta
+}
+
+// GetObjectMeta returns the task run type meta
+func (tr *TaskRun) GetObjectMeta() *metav1.ObjectMeta {
+	return &tr.ObjectMeta
+}
+
 // GetOwnerReference gets the task run as owner reference for any related objects
 func (tr *TaskRun) GetOwnerReference() metav1.OwnerReference {
 	return *metav1.NewControllerRef(tr, taskRunGroupVersionKind)
+}
+
+// GetStatus returns the task run status as a RunsToCompletionStatus
+func (tr *TaskRun) GetStatus() RunsToCompletionStatus {
+	return &tr.Status
 }
 
 // GetCondition returns the Condition matching the given type.

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -36,7 +36,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 	conditionRunning := apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionUnknown,
-		Reason:  ReasonRunning,
+		Reason:  v1beta1.TaskRunReasonRunning.String(),
 		Message: "Not all Steps in the Task have finished executing",
 	}
 	for _, c := range []struct {
@@ -146,7 +146,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionTrue,
-					Reason:  ReasonSucceeded,
+					Reason:  v1beta1.TaskRunReasonSuccessful.String(),
 					Message: "All Steps have completed executing",
 				}},
 			},
@@ -214,7 +214,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
-					Reason:  ReasonFailed,
+					Reason:  v1beta1.TaskRunReasonFailed.String(),
 					Message: "\"step-failure\" exited with code 123 (image: \"image-id\"); for logs run: kubectl -n foo logs pod -c step-failure\n",
 				}},
 			},
@@ -245,7 +245,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
-					Reason:  ReasonFailed,
+					Reason:  v1beta1.TaskRunReasonFailed.String(),
 					Message: "boom",
 				}},
 			},
@@ -276,7 +276,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
-					Reason:  ReasonFailed,
+					Reason:  v1beta1.TaskRunReasonFailed.String(),
 					Message: "OOMKilled",
 				}},
 			},
@@ -304,7 +304,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
-					Reason:  ReasonFailed,
+					Reason:  v1beta1.TaskRunReasonFailed.String(),
 					Message: "build failed for unspecified reasons.",
 				}},
 			},
@@ -652,7 +652,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				Conditions: []apis.Condition{{
 					Type:    apis.ConditionSucceeded,
 					Status:  corev1.ConditionFalse,
-					Reason:  ReasonFailed,
+					Reason:  v1beta1.TaskRunReasonFailed.String(),
 					Message: "\"step-non-json\" exited with code 1 (image: \"image\"); for logs run: kubectl -n foo logs pod -c step-non-json\n",
 				}},
 			},

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -25,6 +25,8 @@ import (
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestCloudEventDeliveryFromTargets(t *testing.T) {
@@ -88,6 +90,11 @@ func TestSendCloudEvents(t *testing.T) {
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
 			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+					Reason: "somethingelse",
+				}),
 				tb.TaskRunCloudEvent("http//notattemptedunknown", "", 0, v1beta1.CloudEventConditionUnknown),
 				tb.TaskRunCloudEvent("http//notattemptedfailed", "somehow", 0, v1beta1.CloudEventConditionFailed),
 				tb.TaskRunCloudEvent("http//notattemptedsucceeded", "", 0, v1beta1.CloudEventConditionSent),
@@ -102,6 +109,11 @@ func TestSendCloudEvents(t *testing.T) {
 				tb.TaskRunTaskRef("fakeTaskName"),
 			),
 			tb.TaskRunStatus(
+				tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+					Reason: "somethingelse",
+				}),
 				tb.TaskRunCloudEvent("http//notattemptedunknown", "", 1, v1beta1.CloudEventConditionSent),
 				tb.TaskRunCloudEvent("http//notattemptedfailed", "somehow", 0, v1beta1.CloudEventConditionFailed),
 				tb.TaskRunCloudEvent("http//notattemptedsucceeded", "", 0, v1beta1.CloudEventConditionSent),
@@ -145,6 +157,11 @@ func TestSendCloudEventsErrors(t *testing.T) {
 			tb.TaskRunStatus(
 				tb.TaskRunCloudEvent("http//sink1", "", 0, v1beta1.CloudEventConditionUnknown),
 				tb.TaskRunCloudEvent("http//sink2", "", 0, v1beta1.CloudEventConditionUnknown),
+				tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+					Reason: "somethingelse",
+				}),
 			),
 		),
 		wantTaskRun: tb.TaskRun("test-taskrun-multiple-cloudeventdelivery",
@@ -156,6 +173,11 @@ func TestSendCloudEventsErrors(t *testing.T) {
 				// Error message is not checked in the Diff below
 				tb.TaskRunCloudEvent("http//sink1", "", 1, v1beta1.CloudEventConditionFailed),
 				tb.TaskRunCloudEvent("http//sink2", "", 1, v1beta1.CloudEventConditionFailed),
+				tb.StatusCondition(apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+					Reason: "somethingelse",
+				}),
 			),
 		),
 	}}

--- a/pkg/reconciler/events/cloudevent/interface.go
+++ b/pkg/reconciler/events/cloudevent/interface.go
@@ -14,29 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package cloudevent
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
-// RunsToCompletionStatus is implemented by TaskRun.Status and PipelineRun.Status
-type RunsToCompletionStatus interface {
-	GetCondition(t apis.ConditionType) *apis.Condition
-	InitializeConditions()
-	SetCondition(newCond *apis.Condition)
-}
+// objectWithCondition is implemented by TaskRun and PipelineRun
+type objectWithCondition interface {
 
-// RunsToCompletion is implemented by TaskRun and PipelineRun
-type RunsToCompletion interface {
-	GetTypeMeta() *metav1.TypeMeta
-	GetObjectMeta() *metav1.ObjectMeta
-	GetOwnerReference() metav1.OwnerReference
-	GetStatus() RunsToCompletionStatus
-	IsDone() bool
-	HasStarted() bool
-	IsCancelled() bool
-	HasTimedOut() bool
-	GetRunKey() string
+	// ObjectMetaAccessor requires a GetObjectMeta that returns the ObjectMeta
+	metav1.ObjectMetaAccessor
+
+	// GetStatusCondition returns a ConditionAccessor for the status of the RunsToCompletion
+	GetStatusCondition() apis.ConditionAccessor
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -279,8 +279,8 @@ func TestReconcile(t *testing.T) {
 	if condition == nil || condition.Status != corev1.ConditionUnknown {
 		t.Errorf("Expected PipelineRun status to be in progress, but was %v", condition)
 	}
-	if condition != nil && condition.Reason != resources.ReasonRunning {
-		t.Errorf("Expected reason %q but was %s", resources.ReasonRunning, condition.Reason)
+	if condition != nil && condition.Reason != v1beta1.PipelineRunReasonRunning.String() {
+		t.Errorf("Expected reason %q but was %s", v1beta1.PipelineRunReasonRunning.String(), condition.Reason)
 	}
 
 	if len(reconciledRun.Status.TaskRuns) != 2 {
@@ -786,7 +786,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionTrue,
-			Reason:  resources.ReasonSucceeded,
+			Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
 			Message: "All Tasks have completed executing",
 		}),
 			tb.PipelineRunTaskRunsStatus(taskRunName, &v1beta1.PipelineRunTaskRunStatus{
@@ -971,7 +971,7 @@ func TestReconcileWithTimeout(t *testing.T) {
 	}
 
 	// The PipelineRun should be timed out.
-	if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != resources.ReasonTimedOut {
+	if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != "PipelineRunTimeout" {
 		t.Errorf("Expected PipelineRun to be timed out, but condition reason is %s", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
 	}
 
@@ -1733,7 +1733,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionUnknown,
-			Reason:  resources.ReasonRunning,
+			Reason:  v1beta1.PipelineRunReasonRunning.String(),
 			Message: "Not all Tasks in the Pipeline have finished executing",
 		}), tb.PipelineRunTaskRunsStatus(pipelineRunName+"task-1", &v1beta1.PipelineRunTaskRunStatus{
 			PipelineTaskName: "task-1",
@@ -2394,7 +2394,7 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 			tb.PipelineRunStatusCondition(apis.Condition{
 				Type:    apis.ConditionSucceeded,
 				Status:  corev1.ConditionTrue,
-				Reason:  resources.ReasonSucceeded,
+				Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
 				Message: "All Tasks have completed executing",
 			}),
 			tb.PipelineRunTaskRunsStatus(trs[0].Name, &v1beta1.PipelineRunTaskRunStatus{

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -25,7 +25,6 @@ import (
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	test "github.com/tektoncd/pipeline/test"
 	"go.uber.org/zap"
@@ -43,7 +42,7 @@ func TestRecorderOptions(t *testing.T) {
 		tb.PipelineRunStatus(tb.PipelineRunStatusCondition(apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionTrue,
-			Reason:  resources.ReasonSucceeded,
+			Reason:  v1beta1.PipelineRunReasonSuccessful.String(),
 			Message: "All Tasks have completed executing",
 		})),
 	)}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -192,7 +192,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 	if tr.HasTimedOut() {
 		before := tr.Status.GetCondition(apis.ConditionSucceeded)
 		message := fmt.Sprintf("TaskRun %q failed to finish within %q", tr.Name, tr.GetTimeout())
-		err := c.failTaskRun(tr, podconvert.ReasonTimedOut, message)
+		err := c.failTaskRun(tr, v1beta1.TaskRunReasonTimedOut, message)
 		return c.finishReconcileUpdateEmitEvents(tr, original, before, err)
 	}
 
@@ -513,9 +513,9 @@ func (c *Reconciler) handlePodCreationError(tr *v1beta1.TaskRun, err error) {
 // If a pod is associated to the TaskRun, it stops it
 // failTaskRun function may return an error in case the pod could not be deleted
 // failTaskRun may update the local TaskRun status, but it won't push the updates to etcd
-func (c *Reconciler) failTaskRun(tr *v1beta1.TaskRun, reason, message string) error {
+func (c *Reconciler) failTaskRun(tr *v1beta1.TaskRun, reason v1beta1.TaskRunReason, message string) error {
 
-	c.Logger.Warn("stopping task run %q because of %q", tr.Name, reason)
+	c.Logger.Warn("stopping task run %q because of %q", tr.Name, reason.String())
 	tr.Status.MarkResourceFailed(reason, errors.New(message))
 
 	// update tr completed time

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -495,8 +495,8 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			if condition == nil || condition.Status != corev1.ConditionUnknown {
 				t.Errorf("Expected invalid TaskRun to have in progress status, but had %v", condition)
 			}
-			if condition != nil && condition.Reason != podconvert.ReasonRunning {
-				t.Errorf("Expected reason %q but was %s", podconvert.ReasonRunning, condition.Reason)
+			if condition != nil && condition.Reason != v1beta1.TaskRunReasonRunning.String() {
+				t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
 			}
 
 			if tr.Status.PodName == "" {
@@ -676,8 +676,8 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			if condition == nil || condition.Status != corev1.ConditionUnknown {
 				t.Errorf("Expected invalid TaskRun to have in progress status, but had %v", condition)
 			}
-			if condition != nil && condition.Reason != podconvert.ReasonRunning {
-				t.Errorf("Expected reason %q but was %s", podconvert.ReasonRunning, condition.Reason)
+			if condition != nil && condition.Reason != v1beta1.TaskRunReasonRunning.String() {
+				t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
 			}
 
 			if tr.Status.PodName == "" {
@@ -1303,8 +1303,8 @@ func TestReconcile(t *testing.T) {
 			if condition == nil || condition.Status != corev1.ConditionUnknown {
 				t.Errorf("Expected invalid TaskRun to have in progress status, but had %v", condition)
 			}
-			if condition != nil && condition.Reason != podconvert.ReasonRunning {
-				t.Errorf("Expected reason %q but was %s", podconvert.ReasonRunning, condition.Reason)
+			if condition != nil && condition.Reason != v1beta1.TaskRunReasonRunning.String() {
+				t.Errorf("Expected reason %q but was %s", v1beta1.TaskRunReasonRunning.String(), condition.Reason)
 			}
 
 			if tr.Status.PodName == "" {
@@ -1637,7 +1637,7 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 	if d := cmp.Diff(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionUnknown,
-		Reason:  "Running",
+		Reason:  v1beta1.TaskRunReasonRunning.String(),
 		Message: "Not all Steps in the Task have finished executing",
 	}, newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
@@ -1666,7 +1666,7 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 	if d := cmp.Diff(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionTrue,
-		Reason:  podconvert.ReasonSucceeded,
+		Reason:  v1beta1.TaskRunReasonSuccessful.String(),
 		Message: "All Steps have completed executing",
 	}, newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
 		t.Errorf("Did not get expected condition %s", diff.PrintWantGot(d))
@@ -2685,7 +2685,7 @@ func TestFailTaskRun(t *testing.T) {
 		name           string
 		taskRun        *v1beta1.TaskRun
 		pod            *corev1.Pod
-		reason         string
+		reason         v1beta1.TaskRunReason
 		message        string
 		expectedStatus apis.Condition
 	}{{

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -112,7 +111,7 @@ func TestPipelineRunTimeout(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(resources.ReasonTimedOut, pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonTimedOut.String(), pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -301,7 +300,7 @@ func TestPipelineTaskTimeout(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s with PipelineTask timeout in namespace %s to fail", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(resources.ReasonFailed, pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(v1beta1.PipelineRunReasonFailed.String(), pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 

--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
@@ -141,6 +142,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			wg.Wait()
 
 			matchKinds := map[string][]string{"PipelineRun": {"pear"}, "TaskRun": trName}
+			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
 			expectedNumberOfEvents := 1 + len(trName)
 			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)
 			events, err := collectMatchingEvents(c.KubeClient, namespace, matchKinds, "Failed")
@@ -148,7 +150,14 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				t.Fatalf("Failed to collect matching events: %q", err)
 			}
 			if len(events) != expectedNumberOfEvents {
-				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of receieved events : %#v", expectedNumberOfEvents, len(events), events)
+				collectedEvents := ""
+				for i, event := range events {
+					collectedEvents += fmt.Sprintf("%#v", event)
+					if i < (len(events) - 1) {
+						collectedEvents += ", "
+					}
+				}
+				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of received events : %#v", expectedNumberOfEvents, len(events), collectedEvents)
 			}
 		})
 	}

--- a/test/v1alpha1/timeout_test.go
+++ b/test/v1alpha1/timeout_test.go
@@ -26,7 +26,6 @@ import (
 
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -95,7 +94,7 @@ func TestPipelineRunTimeout(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(resources.ReasonTimedOut, pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason("PipelineRunTimeout", pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -230,7 +229,7 @@ func TestPipelineTaskTimeout(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s with PipelineTask timeout in namespace %s to fail", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason(resources.ReasonFailed, pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRun.Name, timeout, FailedWithReason("Failed", pipelineRun.Name), "PipelineRunTimedOut"); err != nil {
 		t.Errorf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 


### PR DESCRIPTION
# Changes

This PR is split into two commits, to help with the review. 

Add support for more cloud events

Change the event type string for taskruns from dev.tekton.event.task.*
to dev.tekton.event.taskrun.*. Since cloud events are only sent by
pipeline resources - which are alpha - we don't need to comply with
the beta deprecation policy for this.

Extend the cloudevents module to include more event types for TaskRuns
and event types for PipelineRuns, with unit test coverage.
This is achieved by introducing the RunsToCompletion and
RunsToCompletionStatus interface which are met by TaskRun, PipelineRun
and their respective status types.

At this stage there is no event producer that generates these new
events. This is preparing the stage for the next changes where
we will start to emit cloud events in addition to the k8s events
we emit today.

No extra docs yet since the new events are not produced by anything yet.

Partially addresses #2082
Partially addresses #2684

The second:

Make phase condition reasons part of the API

TaskRuns and PipelineRuns use the "Reason" field to complement the
value of the "Succeeded" condition. Those values are not part of
the API and are even owned by the underlying resource (pod) in
case of TaskRuns. This makes it difficult to rely on them to
understand that the state of the resource is.

In case of corev1.ConditionTrue, the reason can be used to
distinguish between:
- Successful
- Successful, some parts were skipped (pipelinerun only)

In case of corev1.ConditionFalse, the reason can be used to
distinguish between:
- Failed
- Failed because of timeout
- Failed because of cancelled by the user

In case of corev1.ConditionUnknown, the reason can be used to
distinguish between:
- Just started reconciling
- Validation done, running (or still running)
- Cancellation requested

This is implemented through the following changes:
- Bubble up reasons for taskrun and pipelinerun to the
  v1beta1 API, except for reason that are defined by the
  underlying resource
- Enforce the start reason to be set during condition init

This allows for an additional change in the eventing module: the
condition before and after can be used to decide whether to send
an event at all. If they are different, the after condition now
contains enough information to send the event.

The cloudevent module is extended with ability to send the correct
event based on both status and reason.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The cloudevent message type strings change from "dev.tekton.event.task.*" to "dev.tekton.event.taskrun.*" for events produced by the `CloudEventPipelineResource`.
```
