### PR TITLE
Fix documentation about TaskRunSpecs within PipelineRun

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -13,8 +13,8 @@ weight: 4
   - [Speciying `Parameters`](#specifying-parameters)
   - [Specifying custom `ServiceAccount` credentials](#specifying-custom-serviceaccount-credentials)
   - [Mapping `ServiceAccount` credentials to `Tasks`](#mapping-serviceaccount-credentials-to-tasks)
-  - [Specifying `TaskRunSpecs`](#specifying-task-run-specs)
   - [Specifying a `Pod` template](#specifying-a-pod-template)
+  - [Specifying `TaskRunSpecs`](#specifying-taskrunspecs)
   - [Specifying `Workspaces`](#specifying-workspaces)
   - [Specifying `LimitRange` values](#specifying-limitrange-values)
   - [Configuring a failure timeout](#configuring-a-failure-timeout)
@@ -290,7 +290,32 @@ spec:
         claimName: my-volume-claim
 ```
 
-## Specifying `Workspaces`
+### Specifying taskRunSpecs
+
+Specifies a list of `PipelineTaskRunSpec` which contains `TaskServiceAccountName`, `TaskPodTemplate`
+and `PipelineTaskName`. Mapping the specs to the corresponding `Task` based upon the `TaskName` a PipelineTask
+will run with the configured  `TaskServiceAccountName` and `TaskPodTemplate` overwriting the pipeline
+wide `ServiceAccountName`  and [`podTemplate`](./podtemplates.md) configuration,
+for example:
+
+```yaml
+spec:
+   podTemplate:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 2000
+      fsGroup: 3000
+  taskRunSpecs:
+    - pipelineTaskName: build-task
+      taskServiceAccountName: sa-for-build
+      taskPodTemplate:
+        nodeSelector:
+          disktype: ssd
+```
+
+If used with this `Pipeline`,  `build-task` will use the task specific `PodTemplate` (where `nodeSelector` has `disktype` equal to `ssd`). 
+
+### Specifying `Workspaces`
 
 If your `Pipeline` specifies one or more `Workspaces`, you must map those `Workspaces` to
 the corresponding physical volumes in your `PipelineRun` definition. For example, you
@@ -352,27 +377,6 @@ spec:
   # […]
   status: "PipelineRunCancelled"
 ```
-
-## Specifying task run specs
-
-Specifies a list of  `PipelineRunTaskSpec` which contains `TaskServiceAccountName`,`TaskPodTemplate` and `TaskName`. Mapping the specs to the corresponding `Task` based upon the `TaskName` a PipelineTask will run with the configured  `TaskServiceAccountName` and `TaskPodTemplate` overwriting the pipeline wide [`ServiceAccountName`](#service-account)  and [`podTemplate`](#pod-template) configuration, for example:
-
-```yaml
-spec:
-   podTemplate:
-    securityContext:
-      runAsUser: 1000
-      runAsGroup: 2000
-      fsGroup: 3000
-  taskRunSpecs:
-    - taskName: build-task
-      taskServiceAccountName: sa-for-build
-      taskPodTemplate:
-        nodeSelector:
-          disktype: ssd
-```
-
-If used with this `Pipeline`,  `build-task` will use the task specific pod template (where `nodeSelector` has `disktype` equal to `ssd`). 
 
 ---
 


### PR DESCRIPTION
# Changes

- Name of `pipelineTaskName` is fixed so it corresponds with the implementation
- Other minor incorrectnesses are fixed as well
- Move the section to be in the same location in the document as in the menu
- Fix broken links

/kind documentation

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
- Fix documentation about TaskRunSpecs within PipelineRun
```
