### PR TITLE
WIP: add SAR check on SA for TaskRun/PipelineRun reference to ClusterTask;…

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -43,6 +43,9 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["tekton-pipelines"]
     verbs: ["use"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -59,3 +59,31 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "update"]
     resourceNames: ["webhook-certs"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-view-clustertask
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["clustertasks"]
+    verbs: ["get", "list", "watch"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-view-clustertask
+  namespace: default
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["clustertasks"]
+    verbs: ["get", "list", "watch"]

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -47,3 +47,39 @@ roleRef:
   kind: Role
   name: tekton-pipelines-webhook
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-view-clustertask
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: tekton-view-clustertask
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-view-clustertask
+  namespace: default
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: Role
+  name: tekton-view-clustertask
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -143,6 +143,15 @@ spec:
       params: ....
 ```
 
+**Note:** Access to cluster scoped resources like `ClusterTask` is not assumed to exist for every
+namespace in a cluster.  The Tekton controller will make sure the `ServiceAccount` associated with
+every `TaskRun` or `PipelineRun` (if no `ServiceAccount` is specified, `default` is used) that references a `ClusterTask`
+has sufficient permissions as defined by Kubernetes "Rules Based Access Control" 
+or ["RBAC"](https://kubernetes.io/docs/reference/access-authn-authz/authorization/)
+to get the `ClusterTask`.  See the `Role` and `RoleBinding` named `tekton-view-clustertask` defined 
+in the `config` directory of this repository for an example of how the `default` `ServiceAccount`
+in the `tekton-pipelines` namespace is given this permission.
+
 ### Defining `Steps`
 
 A `Step` is a reference to a container image that executes a specific tool on a

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -153,6 +153,26 @@ func PipelineTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
 	}
 }
 
+// PipelineClusterTask adds a PipelineTask, with specified name and task name, with kind ClusterTask, to the PipelineSpec.
+// Any number of PipelineTask modifier can be passed to transform it.
+func PipelineClusterTask(name, taskName string, ops ...PipelineTaskOp) PipelineSpecOp {
+	return func(ps *v1beta1.PipelineSpec) {
+		pTask := &v1beta1.PipelineTask{
+			Name: name,
+		}
+		if taskName != "" {
+			pTask.TaskRef = &v1beta1.TaskRef{
+				Name: taskName,
+				Kind: v1beta1.ClusterTaskKind,
+			}
+		}
+		for _, op := range ops {
+			op(pTask)
+		}
+		ps.Tasks = append(ps.Tasks, *pTask)
+	}
+}
+
 // PipelineResult adds a PipelineResult, with specified name, value and description, to the PipelineSpec.
 func PipelineResult(name, value, description string, ops ...PipelineOp) PipelineSpecOp {
 	return func(ps *v1beta1.PipelineSpec) {

--- a/pkg/authorization/util.go
+++ b/pkg/authorization/util.go
@@ -1,0 +1,41 @@
+package authorization
+
+import (
+	"errors"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+// AddUserToSAR adds the requisite user information to a SubjectAccessReview.
+// It returns the modified SubjectAccessReview.
+func AddUserToSAR(saName, saNamespace string, sar *authorizationv1.SubjectAccessReview) *authorizationv1.SubjectAccessReview {
+	sar.Spec.User = fmt.Sprintf("system:serviceaccount:%s:%s", saNamespace, saName)
+
+	return sar
+}
+
+// Authorize verifies that a given user is permitted to carry out a given
+// action.  If this cannot be determined, or if the user is not permitted, an
+// error is returned.
+func AuthorizeSAR(sarClient authorizationclient.SubjectAccessReviewInterface, saName, saNamespace string,
+	resourceAttributes *authorizationv1.ResourceAttributes) error {
+	sar := AddUserToSAR(saName, saNamespace, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: resourceAttributes,
+		},
+	})
+
+	resp, err := sarClient.Create(sar)
+	if err == nil && resp != nil && resp.Status.Allowed {
+		return nil
+	}
+
+	if err == nil {
+		err = errors.New(resp.Status.Reason)
+	}
+	return kerrors.NewForbidden(schema.GroupResource{Group: resourceAttributes.Group, Resource: resourceAttributes.Resource}, resourceAttributes.Name, err)
+}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -105,6 +105,9 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 
 		go metrics.ReportRunningPipelineRuns(ctx, pipelineRunInformer.Lister())
 
+		c.Logger.Info("Setting up SAR client")
+		c.sarClient = c.KubeClientSet.AuthorizationV1()
+
 		return impl
 	}
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -117,6 +118,7 @@ type Reconciler struct {
 	timeoutHandler    *reconciler.TimeoutSet
 	metrics           *Recorder
 	pvcHandler        volumeclaim.PvcHandler
+	sarClient         authorizationclient.SubjectAccessReviewsGetter
 }
 
 var (
@@ -361,6 +363,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 			return c.conditionLister.Conditions(pr.Namespace).Get(name)
 		},
 		pipelineSpec.Tasks, providedResources,
+		c.sarClient,
 	)
 
 	if err != nil {

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -103,6 +103,9 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 
 		c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 
+		c.Logger.Info("Setting up SAR client")
+		c.sarClient = c.KubeClientSet.AuthorizationV1()
+
 		podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: controller.FilterGroupKind(v1beta1.Kind("TaskRun")),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -46,6 +46,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/configmap"
 	pkgreconciler "knative.dev/pkg/reconciler"
@@ -78,6 +79,7 @@ type Reconciler struct {
 	metrics           *Recorder
 	pvcHandler        volumeclaim.PvcHandler
 	configStore       configStore
+	sarClient         authorizationclient.SubjectAccessReviewsGetter
 }
 
 // Check that our Reconciler implements taskrunreconciler.Interface
@@ -207,6 +209,9 @@ func (c *Reconciler) getTaskResolver(tr *v1beta1.TaskRun) (*resources.LocalTaskR
 	resolver := &resources.LocalTaskRefResolver{
 		Namespace:    tr.Namespace,
 		Tektonclient: c.PipelineClientSet,
+		SarClient:    c.sarClient,
+		TaskRunSA:    tr.Spec.ServiceAccountName,
+		TaskRunName:  tr.Name,
 	}
 	kind := v1beta1.NamespacedTaskKind
 	if tr.Spec.TaskRef != nil && tr.Spec.TaskRef.Kind == v1beta1.ClusterTaskKind {

--- a/test/clients.go
+++ b/test/clients.go
@@ -59,6 +59,7 @@ type clients struct {
 	PipelineRunClient      v1beta1.PipelineRunInterface
 	PipelineResourceClient resourcev1alpha1.PipelineResourceInterface
 	ConditionClient        v1alpha1.ConditionInterface
+	ClusterTaskClient      v1beta1.ClusterTaskInterface
 }
 
 // newClients instantiates and returns several clientsets required for making requests to the
@@ -93,5 +94,6 @@ func newClients(t *testing.T, configPath, clusterName, namespace string) *client
 	c.PipelineRunClient = cs.TektonV1beta1().PipelineRuns(namespace)
 	c.PipelineResourceClient = rcs.TektonV1alpha1().PipelineResources(namespace)
 	c.ConditionClient = cs.TektonV1alpha1().Conditions(namespace)
+	c.ClusterTaskClient = cs.TektonV1beta1().ClusterTasks()
 	return c
 }

--- a/test/controller.go
+++ b/test/controller.go
@@ -41,6 +41,7 @@ import (
 	fakeresourceinformer "github.com/tektoncd/pipeline/pkg/client/resource/injection/informers/resource/v1alpha1/pipelineresource/fake"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"go.uber.org/zap"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -77,6 +78,7 @@ type Clients struct {
 	Resource    *fakeresourceclientset.Clientset
 	Kube        *fakekubeclientset.Clientset
 	CloudEvents cloudeventclient.CEClient
+	Sar         *fakekubeclientset.Clientset
 }
 
 // Informers holds references to informers which are useful for reconciler tests.
@@ -243,6 +245,9 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 	}
 	c.Pipeline.ClearActions()
 	c.Kube.ClearActions()
+	c.Kube.PrependReactor("create", "subjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+	})
 	return c, i
 }
 

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
 )
@@ -185,4 +187,179 @@ func TestTaskRunStatus(t *testing.T) {
 	if d := cmp.Diff(taskrun.Status.TaskSpec, &task.Spec); d != "" {
 		t.Fatalf("-got, +want: %v", d)
 	}
+}
+
+func TestTaskRunClusterTaskWithPermissions(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	taskRunName := "taskrun-to-clustertask"
+	clusterTaskName := "status-cluster-task"
+
+	fqImageName := "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := &v1beta1.ClusterTask{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			// This was the digest of the latest tag as of 8/12/2019
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Image:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "echo hello"},
+			}}},
+		},
+	}
+	if _, err := c.ClusterTaskClient.Get(clusterTaskName, metav1.GetOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		t.Fatalf("Unexpected error on get of clustertask: %s", err)
+	} else if _, err := c.ClusterTaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	defer c.ClusterTaskClient.Delete(task.Name, &metav1.DeleteOptions{})
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-to-clustertask", Namespace: namespace},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"tekton.dev"},
+			Resources: []string{"clustertasks"},
+			Verbs:     []string{"get", "list", "watch"},
+		}},
+	}
+	if _, err := c.KubeClient.Kube.RbacV1().Roles(namespace).Create(role); err != nil {
+		t.Fatalf("error creating clustertask role %s", err)
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-to-cluster-task", Namespace: namespace},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "taskrun-to-clustertask",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      "default",
+			Namespace: namespace,
+		}},
+	}
+	if _, err := c.KubeClient.Kube.RbacV1().RoleBindings(namespace).Create(roleBinding); err != nil {
+		t.Fatalf("error creating clustertask rolebinding %s", err)
+	}
+
+	taskRun := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: taskRunName, Namespace: namespace},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{Name: clusterTaskName, Kind: "ClusterTask"},
+		},
+	}
+	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
+	if err := WaitForTaskRunState(c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed"); err != nil {
+		t.Errorf("Error waiting for TaskRun to finish: %s", err)
+	}
+
+	taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	expectedStepState := []v1beta1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+		Name:          "unnamed-0",
+		ContainerName: "step-unnamed-0",
+	}}
+
+	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+	// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
+	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
+		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
+	}
+
+}
+
+func TestTaskRunClusterTaskWithoutPermissions(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	taskRunName := "taskrun-to-clustertask"
+	clusterTaskName := "status-cluster-task"
+
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := &v1beta1.ClusterTask{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			// This was the digest of the latest tag as of 8/12/2019
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Image:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "echo hello"},
+			}}},
+		},
+	}
+	if _, err := c.ClusterTaskClient.Get(clusterTaskName, metav1.GetOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		t.Fatalf("Unexpected error on get of clustertask: %s", err)
+	} else if _, err := c.ClusterTaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	defer c.ClusterTaskClient.Delete(task.Name, &metav1.DeleteOptions{})
+
+	taskRun := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: taskRunName, Namespace: namespace},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{Name: clusterTaskName, Kind: "ClusterTask"},
+		},
+	}
+	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
+	if err := WaitForTaskRunState(c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed"); err == nil {
+		taskrun, _ := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+		t.Fatalf("should have errored out: %#v", taskrun)
+	}
+
+	/*taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	expectedStepState := []v1beta1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+		Name:          "unnamed-0",
+		ContainerName: "step-unnamed-0",
+	}}
+
+	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+	// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
+	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
+		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
+	}*/
+
 }


### PR DESCRIPTION
… add Role/RoleBinding for default SA in project config; related test/doc changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is the first (and simplest) of the set of[ subject access review (SAR)](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#checking-api-access) checks that verify that the entity (the service account in this case) has permissions per the [role-based access control system (RBAC)](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) of k8s I brought up in recent WG sessions.

In particular, this change focuses on the read the cluster scoped `ClusterTask` references that can be done by either a namespace scoped `TaskRun` or namespaced scoped `PipelineRun`, and it verifies that the underlying Service Account (SA) of those namespaced scoped objects is allowed to access `ClusterTask` objects.

A new role and rolebinding so that the `default` service account in the `tekton-pipelines` namesapce can access `ClusterTask` is also defined, to preserve current behavior.  However, the permissions to do this are now explicitly declared, instead of inheriting the permissions of the Tekton Pipeline controller in a non-explicit fashion, which goes against recommendations and best practices around controllers manipulating API objects on behalf of other "users" (SAs most notably) in the system.

With these changes, cluster administrators can now control which namespaces have access to which `ClusterTasks` managed by a single Tekton Pipelines controller.

Also, as I indicated in the pipeline WG, I will be creating a design doc around the broader set of scenarios, but I thought it instructive to those unfamiliar with SAR/RBAC to have an actual example to cross reference.

And IMO, this change on its own *could* be merged independent of iterating over that doc and the more complicated scenarios.  But of course, let's see how the review and discussion goes, and decide on that.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [/] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [/] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [/] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
