### PR TITLE
Add helper function ErrorIfWantNotGot & FatalIfWantNotGot to wrap cmp.Diff

### DIFF
--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -19,7 +19,6 @@ package config_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	test "github.com/tektoncd/pipeline/pkg/reconciler/testing"
@@ -187,9 +186,7 @@ func TestEquals(t *testing.T) {
 func verifyConfigFileWithExpectedConfig(t *testing.T, fileName string, expectedConfig *config.Defaults) {
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if Defaults, err := config.NewDefaultsFromConfigMap(cm); err == nil {
-		if d := cmp.Diff(Defaults, expectedConfig); d != "" {
-			t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, Defaults, expectedConfig, "Diff:\n%s")
 	} else {
 		t.Errorf("NewDefaultsFromConfigMap(actual) = %v", err)
 	}

--- a/pkg/apis/config/store_test.go
+++ b/pkg/apis/config/store_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	test "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -45,7 +44,5 @@ func TestStoreLoadWithContext(t *testing.T) {
 
 	cfg := config.FromContext(store.ToContext(context.Background()))
 
-	if d := cmp.Diff(cfg, expected); d != "" {
-		t.Errorf("Unexpected config %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, cfg, expected, "Unexpected config %s")
 }

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_conversion_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -176,9 +175,7 @@ func TestClusterTaskConversion(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.in, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.in, got, "roundtrip %s")
 			})
 		}
 	}
@@ -313,9 +310,7 @@ func TestClusterTaskConversionFromDeprecated(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.want, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.want, got, "roundtrip %s")
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1alpha1/condition_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_defaults_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -91,9 +90,7 @@ func TestConditionSpec_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.input.SetDefaults(ctx)
-			if d := cmp.Diff(tc.output, tc.input); d != "" {
-				t.Errorf("Mismatch of PipelineRunSpec: %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.output, tc.input, "Mismatch of PipelineRunSpec: %s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -92,9 +91,7 @@ func TestCondition_Invalidate(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Expected an Error, got nothing for %v", tc)
 			}
-			if d := cmp.Diff(tc.expectedError, *err, cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
-				t.Errorf("Condition.Validate() errors diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.expectedError, *err, "Condition.Validate() errors diff %s", cmpopts.IgnoreUnexported(apis.FieldError{}))
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/container_replacements_test.go
+++ b/pkg/apis/pipeline/v1alpha1/container_replacements_test.go
@@ -19,7 +19,6 @@ package v1alpha1_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -121,9 +120,7 @@ func TestApplyContainerReplacements(t *testing.T) {
 	}
 
 	v1alpha1.ApplyContainerReplacements(&s, replacements, arrayReplacements)
-	if d := cmp.Diff(s, expected); d != "" {
-		t.Errorf("Container replacements failed: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, s, expected, "Container replacements failed: %s")
 }
 
 func TestApplyContainerReplacements_NotDefined(t *testing.T) {
@@ -142,7 +139,5 @@ func TestApplyContainerReplacements_NotDefined(t *testing.T) {
 		Name: "$(params.not.defined)",
 	}
 	v1alpha1.ApplyContainerReplacements(&s, replacements, arrayReplacements)
-	if d := cmp.Diff(s, expected); d != "" {
-		t.Errorf("Unexpected container replacement: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, s, expected, "Unexpected container replacement: %s")
 }

--- a/pkg/apis/pipeline/v1alpha1/merge_test.go
+++ b/pkg/apis/pipeline/v1alpha1/merge_test.go
@@ -129,10 +129,7 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 			if err != nil {
 				t.Errorf("expected no error. Got error %v", err)
 			}
-
-			if d := cmp.Diff(tc.expected, result, resourceQuantityCmp); d != "" {
-				t.Errorf("merged steps don't match, diff: %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.expected, result, "merged steps don't match, diff: %s", resourceQuantityCmp)
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/param_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/param_types_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -72,9 +71,7 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.before.SetDefaults(ctx)
-			if d := cmp.Diff(tc.before, tc.defaultsApplied); d != "" {
-				t.Errorf("ParamSpec.SetDefaults/%s %s", tc.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.before, tc.defaultsApplied, "ParamSpec.SetDefaults/%s %s")
 		})
 	}
 }
@@ -133,9 +130,7 @@ func TestArrayOrString_ApplyReplacements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.input.ApplyReplacements(tt.args.stringReplacements, tt.args.arrayReplacements)
-			if d := cmp.Diff(tt.expectedOutput, tt.args.input); d != "" {
-				t.Errorf("ApplyReplacements() output did not match expected value %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.expectedOutput, tt.args.input, "ApplyReplacements() output did not match expected value %s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -130,9 +129,7 @@ func TestPipelineConversion_Success(t *testing.T) {
 				}
 				// compare origin input and roundtrip Pipeline i.e. v1alpha1 pipeline converted to v1beta1 and then converted back to v1alpha1
 				// this check is making sure that we do not end up with different object than what we started with
-				if d := cmp.Diff(test.in, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.in, got, "roundtrip %s")
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -173,9 +172,7 @@ func TestPipelineRunConversion(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.in, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.in, got, "roundtrip %s")
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
@@ -88,10 +88,7 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
 			tc.prs.SetDefaults(ctx)
-
-			if d := cmp.Diff(tc.want, tc.prs); d != "" {
-				t.Errorf("Mismatch of PipelineRunSpec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.want, tc.prs, "Mismatch of PipelineRunSpec %s")
 		})
 	}
 
@@ -258,8 +255,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			}
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
-				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+				diff.ErrorWantGot(t, got, tc.want, "SetDefaults %s", ignoreUnexportedResources)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -49,18 +49,14 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 	p.Status.SetCondition(foo)
 
 	fooStatus := p.Status.GetCondition(foo.Type)
-	if d := cmp.Diff(fooStatus, foo, ignoreVolatileTime); d != "" {
-		t.Errorf("Unexpected pipeline run condition type; diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, fooStatus, foo, "Unexpected pipeline run condition type; diff %s", ignoreVolatileTime)
 
 	// Add a second condition.
 	p.Status.SetCondition(bar)
 
 	barStatus := p.Status.GetCondition(bar.Type)
+	diff.FatalWantGot(t, barStatus, bar, "Unexpected pipeline run condition type; diff %s", ignoreVolatileTime)
 
-	if d := cmp.Diff(barStatus, bar, ignoreVolatileTime); d != "" {
-		t.Fatalf("Unexpected pipeline run condition type; diff %s", diff.PrintWantGot(d))
-	}
 }
 
 func TestPipelineRun_TaskRunref(t *testing.T) {
@@ -77,10 +73,7 @@ func TestPipelineRun_TaskRunref(t *testing.T) {
 		Namespace:  p.Namespace,
 		Name:       p.Name,
 	}
-
-	if d := cmp.Diff(p.GetTaskRunRef(), expectTaskRunRef); d != "" {
-		t.Fatalf("Taskrun reference mismatch; diff %s", diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, p.GetTaskRunRef(), expectTaskRunRef, "Taskrun reference mismatch; diff %s")
 }
 
 func TestInitializeConditions(t *testing.T) {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
@@ -18,10 +18,10 @@ package v1alpha1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -86,9 +86,7 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
 			err := ps.pr.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), ps.want.Error()); d != "" {
-				t.Errorf("PipelineRun.Validate/%s %s", ps.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ps.want.Error(), fmt.Sprintf("PipelineRun.Validate/%s ", ps.name)+"%s")
 		})
 	}
 }
@@ -187,9 +185,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
 			err := ps.spec.Validate(context.Background())
-			if d := cmp.Diff(ps.wantErr.Error(), err.Error()); d != "" {
-				t.Errorf("PipelineRunSpec.Validate/%s %s", ps.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, ps.wantErr.Error(), err.Error(), fmt.Sprintf("PipelineRunSpec.Validate/%s ", ps.name)+"%s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/resource_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_types_test.go
@@ -16,7 +16,6 @@ package v1alpha1_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -94,9 +93,7 @@ func TestApplyTaskModifier(t *testing.T) {
 				},
 			}}
 
-			if d := cmp.Diff(expectedTaskSpec, tc.ts); d != "" {
-				t.Errorf("TaskSpec was not modified as expected %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, expectedTaskSpec, tc.ts, "TaskSpec was not modified as expected %s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/step_replacements_test.go
+++ b/pkg/apis/pipeline/v1alpha1/step_replacements_test.go
@@ -19,7 +19,6 @@ package v1alpha1_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -126,7 +125,5 @@ func TestApplyStepReplacements(t *testing.T) {
 		},
 	}
 	v1alpha1.ApplyStepReplacements(&s, replacements, arrayReplacements)
-	if d := cmp.Diff(s, expected); d != "" {
-		t.Errorf("Container replacements failed: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, s, expected, "Container replacements failed: %s")
 }

--- a/pkg/apis/pipeline/v1alpha1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_conversion_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -177,9 +176,7 @@ func TestTaskConversion(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.in, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.in, got, "roundtrip %s")
 			})
 		}
 	}
@@ -314,9 +311,7 @@ func TestTaskConversionFromDeprecated(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.want, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.want, got, "roundtrip %s")
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1alpha1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -1015,9 +1014,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}
-			if d := cmp.Diff(tt.expectedError, *err, cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
-				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.expectedError, *err, "TaskSpec.Validate() errors diff %s", cmpopts.IgnoreUnexported(apis.FieldError{}))
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_conversion_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -291,9 +290,7 @@ func TestTaskRunConversion(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.in, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.in, got, "roundtrip %s")
 			})
 		}
 	}
@@ -432,9 +429,7 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
-				if d := cmp.Diff(test.want, got); d != "" {
-					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, test.want, got, "roundtrip %s")
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/contexts"
@@ -116,9 +115,7 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			ctx := context.Background()
 			tc.trs.SetDefaults(ctx)
 
-			if d := cmp.Diff(tc.want, tc.trs); d != "" {
-				t.Errorf("Mismatch of TaskRunSpec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.want, tc.trs, "Mismatch of TaskRunSpec %s")
 		})
 	}
 }
@@ -378,9 +375,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 				ctx = tc.wc(ctx)
 			}
 			got.SetDefaults(ctx)
-			if d := cmp.Diff(tc.want, got, ignoreUnexportedResources); d != "" {
-				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.want, got, "SetDefaults %s", ignoreUnexportedResources)
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -247,9 +247,7 @@ func TestHasTimedOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.taskRun.HasTimedOut()
-			if d := cmp.Diff(result, tc.expectedStatus); d != "" {
-				t.Fatalf(diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, result, tc.expectedStatus, "%s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -18,10 +18,10 @@ package v1alpha1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -51,9 +51,7 @@ func TestTaskRun_Invalid(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.task.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), ts.want.Error()); d != "" {
-				t.Errorf("TaskRun.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ts.want.Error(), fmt.Sprintf("TaskRun.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }
@@ -95,9 +93,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 			if err == nil {
 				t.Errorf("Expected error for invalid TaskRun but got none")
 			}
-			if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {
-				t.Errorf("TaskRunSpec.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, ts.wantErr.Error(), err.Error(), fmt.Sprintf("TaskRunSpec.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }
@@ -159,9 +155,7 @@ func TestTaskRunSpec_Invalid(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.spec.Validate(context.Background())
-			if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {
-				t.Errorf("TaskRunSpec.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, ts.wantErr.Error(), err.Error(), fmt.Sprintf("TaskRunSpec.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }
@@ -322,9 +316,7 @@ func TestInput_Invalid(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.inputs.Validate(context.Background(), "spec.Inputs")
-			if d := cmp.Diff(err.Error(), ts.wantErr.Error()); d != "" {
-				t.Errorf("TaskRunInputs.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ts.wantErr.Error(), fmt.Sprintf("TaskRunInputs.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }
@@ -383,9 +375,7 @@ func TestOutput_Invalid(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.outputs.Validate(context.Background(), "spec.Outputs")
-			if d := cmp.Diff(err.Error(), ts.wantErr.Error()); d != "" {
-				t.Errorf("TaskRunOutputs.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ts.wantErr.Error(), fmt.Sprintf("TaskRunOutputs.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/merge_test.go
+++ b/pkg/apis/pipeline/v1beta1/merge_test.go
@@ -108,9 +108,7 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 				t.Errorf("expected no error. Got error %v", err)
 			}
 
-			if d := cmp.Diff(tc.expected, result, resourceQuantityCmp); d != "" {
-				t.Errorf("merged steps don't match, diff: %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.expected, result, "merged steps don't match, diff: %s", resourceQuantityCmp)
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -19,10 +19,10 @@ package v1beta1_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -72,9 +72,7 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			tc.before.SetDefaults(ctx)
-			if d := cmp.Diff(tc.before, tc.defaultsApplied); d != "" {
-				t.Errorf("ParamSpec.SetDefaults/%s %s", tc.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.before, tc.defaultsApplied, fmt.Sprintf("ParamSpec.SetDefaults/%s ", tc.name)+"%s")
 		})
 	}
 }
@@ -133,9 +131,7 @@ func TestArrayOrString_ApplyReplacements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.args.input.ApplyReplacements(tt.args.stringReplacements, tt.args.arrayReplacements)
-			if d := cmp.Diff(tt.expectedOutput, tt.args.input); d != "" {
-				t.Errorf("ApplyReplacements() output did not match expected value %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.expectedOutput, tt.args.input, "ApplyReplacements() output did not match expected value %s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -84,9 +84,7 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			ctx := context.Background()
 			tc.prs.SetDefaults(ctx)
 
-			if d := cmp.Diff(tc.want, tc.prs); d != "" {
-				t.Errorf("Mismatch of PipelineRunSpec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.want, tc.prs, "Mismatch of PipelineRunSpec %s")
 		})
 	}
 
@@ -276,8 +274,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 			}
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
-				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+				diff.ErrorWantGot(t, got, tc.want, "SetDefaults %s", ignoreUnexportedResources)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -49,18 +49,14 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 	p.Status.SetCondition(foo)
 
 	fooStatus := p.Status.GetCondition(foo.Type)
-	if d := cmp.Diff(fooStatus, foo, ignoreVolatileTime); d != "" {
-		t.Errorf("Unexpected pipeline run condition type; diff %v", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, fooStatus, foo, "Unexpected pipeline run condition type; diff %v", ignoreVolatileTime)
 
 	// Add a second condition.
 	p.Status.SetCondition(bar)
 
 	barStatus := p.Status.GetCondition(bar.Type)
 
-	if d := cmp.Diff(barStatus, bar, ignoreVolatileTime); d != "" {
-		t.Fatalf("Unexpected pipeline run condition type; diff %s", diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, barStatus, bar, "Unexpected pipeline run condition type; diff %s", ignoreVolatileTime)
 }
 
 func TestPipelineRun_TaskRunref(t *testing.T) {
@@ -77,10 +73,7 @@ func TestPipelineRun_TaskRunref(t *testing.T) {
 		Namespace:  p.Namespace,
 		Name:       p.Name,
 	}
-
-	if d := cmp.Diff(p.GetTaskRunRef(), expectTaskRunRef); d != "" {
-		t.Fatalf("Taskrun reference mismatch; diff %s", diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, p.GetTaskRunRef(), expectTaskRunRef, "Taskrun reference mismatch; diff %s")
 }
 
 func TestInitializePipelineRunConditions(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -18,10 +18,10 @@ package v1beta1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -100,9 +100,7 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
 			err := ps.pr.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), ps.want.Error()); d != "" {
-				t.Errorf("PipelineRun.Validate/%s %s", ps.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ps.want.Error(), fmt.Sprintf("PipelineRun.Validate/%s ", ps.name)+"%s")
 		})
 	}
 }
@@ -201,9 +199,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {
 			err := ps.spec.Validate(context.Background())
-			if d := cmp.Diff(ps.wantErr.Error(), err.Error()); d != "" {
-				t.Errorf("PipelineRunSpec.Validate/%s (-want, +got) = %v", ps.name, d)
-			}
+			diff.ErrorWantGot(t, ps.wantErr.Error(), err.Error(), fmt.Sprintf("PipelineRunSpec.Validate/%s ", ps.name)+"%s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/resource_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_test.go
@@ -16,7 +16,6 @@ package v1beta1_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -93,9 +92,7 @@ func TestApplyTaskModifier(t *testing.T) {
 				},
 			}
 
-			if d := cmp.Diff(expectedTaskSpec, tc.ts); d != "" {
-				t.Errorf("TaskSpec was not modified as expected %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, expectedTaskSpec, tc.ts, "TaskSpec was not modified as expected %s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/resultref_test.go
+++ b/pkg/apis/pipeline/v1beta1/resultref_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1_test
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -170,9 +170,7 @@ func TestNewResultReference(t *testing.T) {
 				t.Fatalf("expected to find expressions but didn't find any")
 			} else {
 				got := v1beta1.NewResultRefs(expressions)
-				if d := cmp.Diff(tt.want, got); d != "" {
-					t.Errorf("TestNewResultReference/%s %s", tt.name, diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, tt.want, got, fmt.Sprintf("TestNewResultReference/%s ", tt.name)+"%s")
 			}
 		})
 	}
@@ -306,9 +304,7 @@ func TestHasResultReference(t *testing.T) {
 				}
 				return true
 			})
-			if d := cmp.Diff(tt.wantRef, got); d != "" {
-				t.Errorf("TestHasResultReference/%s %s", tt.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.wantRef, got, fmt.Sprintf("TestHasResultReference/%s ", tt.name)+"%s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -870,9 +869,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}
-			if d := cmp.Diff(tt.expectedError, *err, cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
-				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.expectedError, *err, "TaskSpec.Validate() errors diff %s", cmpopts.IgnoreUnexported(apis.FieldError{}))
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -116,9 +116,7 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			ctx := context.Background()
 			tc.trs.SetDefaults(ctx)
 
-			if d := cmp.Diff(tc.want, tc.trs); d != "" {
-				t.Errorf("Mismatch of TaskRunSpec: %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.want, tc.trs, "Mismatch of TaskRunSpec: %s")
 		})
 	}
 }
@@ -379,8 +377,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 			}
 			got.SetDefaults(ctx)
 			if !cmp.Equal(got, tc.want, ignoreUnexportedResources) {
-				d := cmp.Diff(got, tc.want, ignoreUnexportedResources)
-				t.Errorf("SetDefaults %s", diff.PrintWantGot(d))
+				diff.ErrorWantGot(t, got, tc.want, "SetDefaults %s", ignoreUnexportedResources)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -38,14 +37,12 @@ func TestTaskRun_GetBuildPodRef(t *testing.T) {
 			Name:      "taskrunname",
 		},
 	}
-	if d := cmp.Diff(tr.GetBuildPodRef(), corev1.ObjectReference{
+	diff.FatalWantGot(t, tr.GetBuildPodRef(), corev1.ObjectReference{
 		APIVersion: "v1",
 		Kind:       "Pod",
 		Namespace:  "testns",
 		Name:       "taskrunname",
-	}); d != "" {
-		t.Fatalf("taskrun build pod ref mismatch: %s", diff.PrintWantGot(d))
-	}
+	}, "taskrun build pod ref mismatch: %s")
 }
 
 func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
@@ -334,9 +331,7 @@ func TestHasTimedOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.taskRun.HasTimedOut()
-			if d := cmp.Diff(result, tc.expectedStatus); d != "" {
-				t.Fatalf(diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, result, tc.expectedStatus, "%s")
 		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -18,10 +18,10 @@ package v1beta1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -56,9 +56,7 @@ func TestTaskRun_Invalidate(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.task.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), ts.want.Error()); d != "" {
-				t.Errorf("TaskRun.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ts.want.Error(), fmt.Sprintf("TaskRun.Validate/%s", ts.name)+"%s")
 		})
 	}
 }
@@ -118,9 +116,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 			if err == nil {
 				t.Errorf("Expected error for invalid TaskRun but got none")
 			}
-			if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {
-				t.Errorf("TaskRunSpec.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, ts.wantErr.Error(), err.Error(), fmt.Sprintf("TaskRunSpec.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }
@@ -204,9 +200,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.spec.Validate(context.Background())
-			if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {
-				t.Errorf("TaskRunSpec.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, ts.wantErr.Error(), err.Error(), fmt.Sprintf("TaskRunSpec.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }
@@ -500,9 +494,7 @@ func TestResources_Invalidate(t *testing.T) {
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
 			err := ts.resources.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), ts.wantErr.Error()); d != "" {
-				t.Errorf("TaskRunInputs.Validate/%s %s", ts.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, err.Error(), ts.wantErr.Error(), fmt.Sprintf("TaskRunInputs.Validate/%s ", ts.name)+"%s")
 		})
 	}
 }

--- a/pkg/apis/resource/v1alpha1/cloudevent/cloud_event_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/cloudevent/cloud_event_resource_test.go
@@ -19,7 +19,6 @@ package cloudevent_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -69,9 +68,7 @@ func TestNewResource_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error creating CloudEvent resource: %s", err)
 	}
-	if d := cmp.Diff(expectedResource, r); d != "" {
-		t.Errorf("Mismatch of CloudEvent resource %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expectedResource, r, "Mismatch of CloudEvent resource %s")
 }
 
 func TestCloudEvent_GetReplacements(t *testing.T) {
@@ -85,9 +82,7 @@ func TestCloudEvent_GetReplacements(t *testing.T) {
 		"type":       "cloudEvent",
 		"target-uri": "http://fake-uri",
 	}
-	if d := cmp.Diff(r.Replacements(), expectedReplacementMap); d != "" {
-		t.Errorf("CloudEvent Replacement map mismatch: %s", d)
-	}
+	diff.ErrorWantGot(t, r.Replacements(), expectedReplacementMap, "CloudEvent Replacement map mismatch: %s")
 }
 
 func TestCloudEvent_InputContainerSpec(t *testing.T) {

--- a/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
@@ -19,7 +19,6 @@ package cluster_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -151,9 +150,7 @@ func TestNewClusterResource(t *testing.T) {
 				t.Errorf("Test: %q; TestNewClusterResource() error = %v", c.desc, err)
 			}
 			c.want.ShellImage = "override-with-shell-image:latest"
-			if d := cmp.Diff(got, c.want); d != "" {
-				t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, got, c.want, "Diff:\n%s")
 		})
 	}
 }
@@ -199,7 +196,5 @@ func TestClusterResource_GetInputTaskModifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetDownloadSteps: %v", err)
 	}
-	if d := cmp.Diff(got.GetStepsToPrepend(), wantSteps); d != "" {
-		t.Errorf("Error mismatch between download steps: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got.GetStepsToPrepend(), wantSteps, "Error mismatch between download steps: %s")
 }

--- a/pkg/apis/resource/v1alpha1/git/git_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/git/git_resource_test.go
@@ -19,7 +19,6 @@ package git_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -321,9 +320,7 @@ func TestNewGitResource_Valid(t *testing.T) {
 				t.Fatalf("Unexpected error creating Git resource: %s", err)
 			}
 
-			if d := cmp.Diff(tc.want, got); d != "" {
-				t.Errorf("Mismatch of Git resource %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.want, got, "Mismatch of Git resource %s")
 		})
 	}
 }
@@ -359,9 +356,7 @@ func TestGitResource_Replacements(t *testing.T) {
 
 	got := r.Replacements()
 
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Mismatch of GitResource Replacements %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Mismatch of GitResource Replacements %s")
 }
 
 func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
@@ -719,9 +714,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				t.Fatalf("Unexpected error getting GetDownloadTaskModifier: %s", err)
 			}
 
-			if d := cmp.Diff([]v1beta1.Step{{Container: tc.want}}, modifier.GetStepsToPrepend()); d != "" {
-				t.Errorf("Mismatch of GitResource DownloadContainerSpec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, []v1beta1.Step{{Container: tc.want}}, modifier.GetStepsToPrepend(), "Mismatch of GitResource DownloadContainerSpec %s")
 		})
 	}
 }

--- a/pkg/apis/resource/v1alpha1/image/image_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/image/image_resource_test.go
@@ -19,8 +19,6 @@ package image_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1/image"
@@ -58,9 +56,7 @@ func TestNewImageResource_Valid(t *testing.T) {
 		t.Fatalf("Unexpected error creating Image resource: %s", err)
 	}
 
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Mismatch of Image resource: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Mismatch of Image resource: %s")
 }
 
 func TestImageResource_Replacements(t *testing.T) {
@@ -80,7 +76,5 @@ func TestImageResource_Replacements(t *testing.T) {
 
 	got := ir.Replacements()
 
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Mismatch of ImageResource Replacements %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Mismatch of ImageResource Replacements %s")
 }

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -18,9 +18,9 @@ package v1alpha1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"knative.dev/pkg/apis"
@@ -160,9 +160,7 @@ func TestResourceValidation_Invalid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.res.Validate(context.Background())
-			if d := cmp.Diff(tt.want.Error(), err.Error()); d != "" {
-				t.Errorf("Didn't get expected error for %s %s", tt.name, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.want.Error(), err.Error(), fmt.Sprintf("Didn't get expected error for %s ", tt.name)+"%s")
 		})
 	}
 }

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
@@ -19,7 +19,6 @@ package pullrequest_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -54,9 +53,7 @@ func TestPullRequest_NewResource(t *testing.T) {
 		InsecureSkipTLSVerify:     false,
 		DisableStrictJSONComments: true,
 	}
-	if d := cmp.Diff(want, got); d != "" {
-		t.Error(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "%s")
 }
 
 func TestPullRequest_NewResource_error(t *testing.T) {
@@ -163,9 +160,7 @@ func TestPullRequest_GetDownloadSteps(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if d := cmp.Diff(tc.out, got.GetStepsToPrepend()); d != "" {
-				t.Error(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.out, got.GetStepsToPrepend(), "%s")
 		})
 	}
 }
@@ -180,9 +175,7 @@ func TestPullRequest_GetOutputSteps(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if d := cmp.Diff(tc.out, got.GetStepsToAppend()); d != "" {
-				t.Error(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.out, got.GetStepsToAppend(), "%s")
 		})
 	}
 }

--- a/pkg/apis/resource/v1alpha1/storage/artifact_bucket_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/artifact_bucket_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1/storage"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -64,9 +63,7 @@ func TestBucketGetCopyFromContainerSpec(t *testing.T) {
 	}}}
 
 	got := bucket.GetCopyFromStorageToSteps("workspace", "src-path", "/workspace/destination")
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }
 
 func TestBucketGetCopyToContainerSpec(t *testing.T) {
@@ -81,9 +78,7 @@ func TestBucketGetCopyToContainerSpec(t *testing.T) {
 	}}}
 
 	got := bucket.GetCopyToStorageFromSteps("workspace", "src-path", "workspace/destination")
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }
 
 func TestGetSecretsVolumes(t *testing.T) {
@@ -97,7 +92,5 @@ func TestGetSecretsVolumes(t *testing.T) {
 		},
 	}}
 	got := bucket.GetSecretsVolumes()
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }

--- a/pkg/apis/resource/v1alpha1/storage/artifact_pvc_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/artifact_pvc_test.go
@@ -19,7 +19,6 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1/storage"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -43,9 +42,7 @@ func TestPVCGetCopyFromContainerSpec(t *testing.T) {
 	}}}
 
 	got := pvc.GetCopyFromStorageToSteps("workspace", "src-path", "/workspace/destination")
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }
 
 func TestPVCGetCopyToContainerSpec(t *testing.T) {
@@ -68,9 +65,7 @@ func TestPVCGetCopyToContainerSpec(t *testing.T) {
 	}}}
 
 	got := pvc.GetCopyToStorageFromSteps("workspace", "src-path", "/workspace/destination")
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }
 
 func TestPVCGetPvcMount(t *testing.T) {
@@ -83,9 +78,7 @@ func TestPVCGetPvcMount(t *testing.T) {
 		MountPath: pvcDir,
 	}
 	got := storage.GetPvcMount(name)
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }
 
 func TestPVCGetMakeStep(t *testing.T) {
@@ -97,9 +90,7 @@ func TestPVCGetMakeStep(t *testing.T) {
 		Command: []string{"mkdir", "-p", "/workspace/destination"},
 	}}
 	got := storage.CreateDirStep("busybox", "workspace", "/workspace/destination")
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff:\n%s")
 }
 
 func TestStorageBasePath(t *testing.T) {
@@ -113,7 +104,5 @@ func TestStorageBasePath(t *testing.T) {
 		},
 	}
 	got := pvc.StorageBasePath(pipelinerun)
-	if d := cmp.Diff(got, "/pvc"); d != "" {
-		t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, "/pvc", "Diff:\n%s")
 }

--- a/pkg/apis/resource/v1alpha1/storage/build_gcs_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/build_gcs_test.go
@@ -19,7 +19,6 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -123,9 +122,7 @@ func TestNewBuildGCSResource_Valid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error creating BuildGCS resource: %s", err)
 	}
-	if d := cmp.Diff(expectedGCSResource, r); d != "" {
-		t.Errorf("Mismatch of BuildGCS resource: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expectedGCSResource, r, "Mismatch of BuildGCS resource: %s")
 }
 
 func TestBuildGCS_GetReplacements(t *testing.T) {
@@ -139,9 +136,7 @@ func TestBuildGCS_GetReplacements(t *testing.T) {
 		"type":     "build-gcs",
 		"location": "gs://fake-bucket",
 	}
-	if d := cmp.Diff(r.Replacements(), expectedReplacementMap); d != "" {
-		t.Errorf("BuildGCS Replacement map mismatch: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.Replacements(), expectedReplacementMap, "BuildGCS Replacement map mismatch: %s")
 }
 
 func TestBuildGCS_GetInputSteps(t *testing.T) {
@@ -176,9 +171,7 @@ func TestBuildGCS_GetInputSteps(t *testing.T) {
 			if err != nil {
 				t.Fatalf("GetDownloadSteps: %v", err)
 			}
-			if d := cmp.Diff(got.GetStepsToPrepend(), wantSteps); d != "" {
-				t.Errorf("Error mismatch between download steps: %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, got.GetStepsToPrepend(), wantSteps, "Error mismatch between download steps: %s")
 		})
 	}
 }

--- a/pkg/apis/resource/v1alpha1/storage/gcs_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/gcs_test.go
@@ -19,7 +19,6 @@ package storage_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -105,9 +104,7 @@ func TestValidNewGCSResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error creating GCS resource: %s", err)
 	}
-	if d := cmp.Diff(expectedGCSResource, gcsRes); d != "" {
-		t.Errorf("Mismatch of GCS resource %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expectedGCSResource, gcsRes, "Mismatch of GCS resource %s")
 }
 
 func TestGCSGetReplacements(t *testing.T) {
@@ -121,9 +118,7 @@ func TestGCSGetReplacements(t *testing.T) {
 		"type":     "gcs",
 		"location": "gs://fake-bucket",
 	}
-	if d := cmp.Diff(gcsResource.Replacements(), expectedReplacementMap); d != "" {
-		t.Errorf("GCS Replacement map mismatch %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, gcsResource.Replacements(), expectedReplacementMap, "GCS Replacement map mismatch %s")
 }
 
 func TestGetParams(t *testing.T) {
@@ -142,9 +137,7 @@ func TestGetParams(t *testing.T) {
 		SecretName: "test-secret-name",
 		FieldName:  "test-field-name",
 	}}
-	if d := cmp.Diff(gcsResource.GetSecretParams(), expectedSp); d != "" {
-		t.Errorf("Error mismatch on storage secret params %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, gcsResource.GetSecretParams(), expectedSp, "Error mismatch on storage secret params %s")
 }
 
 func TestGetInputSteps(t *testing.T) {
@@ -243,9 +236,7 @@ gsutil cp gs://some-bucket /workspace
 			if tc.wantErr && err == nil {
 				t.Fatalf("Expected error to be %t but got %v:", tc.wantErr, err)
 			}
-			if d := cmp.Diff(tc.wantSteps, gotSpec.GetStepsToPrepend()); d != "" {
-				t.Errorf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.wantSteps, gotSpec.GetStepsToPrepend(), "Diff %s")
 		})
 	}
 }
@@ -333,9 +324,7 @@ func TestGetOutputTaskModifier(t *testing.T) {
 				t.Fatalf("Expected error to be %t but got %v:", tc.wantErr, err)
 			}
 
-			if d := cmp.Diff(got.GetStepsToAppend(), tc.wantSteps); d != "" {
-				t.Errorf("Error mismatch between upload containers spec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, got.GetStepsToAppend(), tc.wantSteps, "Error mismatch between upload containers spec %s")
 		})
 	}
 }

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -375,12 +375,8 @@ func TestInitializeArtifactStorageWithConfigMap(t *testing.T) {
 			if err := CleanupArtifactStorage(pipelinerun, fakekubeclient, logger); err != nil {
 				t.Fatalf("Error cleaning up artifact storage: %s", err)
 			}
-			if d := cmp.Diff(artifactStorage.GetType(), c.storagetype); d != "" {
-				t.Fatalf(diff.PrintWantGot(d))
-			}
-			if d := cmp.Diff(artifactStorage, c.expectedArtifactStorage, quantityComparer); d != "" {
-				t.Fatalf(diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, artifactStorage.GetType(), c.storagetype, "%s")
+			diff.FatalWantGot(t, artifactStorage, c.expectedArtifactStorage, "%s", quantityComparer)
 		})
 	}
 }
@@ -581,9 +577,7 @@ func TestInitializeArtifactStorageWithoutConfigMap(t *testing.T) {
 		ShellImage:            "busybox",
 	}
 
-	if d := cmp.Diff(pvc, expectedArtifactPVC, cmpopts.IgnoreUnexported(resource.Quantity{})); d != "" {
-		t.Fatalf(diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, pvc, expectedArtifactPVC, "%s", cmpopts.IgnoreUnexported(resource.Quantity{}))
 }
 
 func TestGetArtifactStorageWithConfigMap(t *testing.T) {
@@ -675,9 +669,7 @@ func TestGetArtifactStorageWithConfigMap(t *testing.T) {
 				t.Fatalf("Somehow had error initializing artifact storage run out of fake client: %s", err)
 			}
 
-			if d := cmp.Diff(artifactStorage, c.expectedArtifactStorage); d != "" {
-				t.Fatalf(diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, artifactStorage, c.expectedArtifactStorage, "%s")
 		})
 	}
 }
@@ -695,9 +687,7 @@ func TestGetArtifactStorageWithoutConfigMap(t *testing.T) {
 		ShellImage: "busybox",
 	}
 
-	if d := cmp.Diff(pvc, expectedArtifactPVC); d != "" {
-		t.Fatalf(diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, pvc, expectedArtifactPVC, "%s")
 }
 
 func TestGetArtifactStorageWithPVCConfigMap(t *testing.T) {
@@ -731,9 +721,7 @@ func TestGetArtifactStorageWithPVCConfigMap(t *testing.T) {
 				t.Fatalf("Somehow had error initializing artifact storage run out of fake client: %s", err)
 			}
 
-			if d := cmp.Diff(artifactStorage, c.expectedArtifactStorage); d != "" {
-				t.Fatalf(diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, artifactStorage, c.expectedArtifactStorage, "%s")
 		})
 	}
 }

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -224,9 +224,7 @@ func TestSSHFlagHandling(t *testing.T) {
     Port 22
     IdentityFile %s/.ssh/id_foo
 `, credentials.VolumePath)
-	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
-		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expectedSSHConfig, string(b), "ssh_config diff %s")
 
 	b, err = ioutil.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "known_hosts"))
 	if err != nil {
@@ -314,9 +312,7 @@ Host gitlab.example.com
     Port 2222
     IdentityFile %s/.ssh/id_baz
 `, credentials.VolumePath, credentials.VolumePath, credentials.VolumePath)
-	if d := cmp.Diff(expectedSSHConfig, string(b)); d != "" {
-		t.Errorf("ssh_config diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expectedSSHConfig, string(b), "ssh_config diff %s")
 
 	b, err = ioutil.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "known_hosts"))
 	if err != nil {
@@ -325,9 +321,7 @@ Host gitlab.example.com
 	expectedSSHKnownHosts := `ssh-rsa aaaa
 ssh-rsa bbbb
 ssh-rsa cccc`
-	if d := cmp.Diff(expectedSSHKnownHosts, string(b)); d != "" {
-		t.Errorf("known_hosts diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expectedSSHKnownHosts, string(b), "known_hosts diff %s")
 
 	b, err = ioutil.ReadFile(filepath.Join(credentials.VolumePath, ".ssh", "id_foo"))
 	if err != nil {

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -24,7 +24,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -80,9 +79,7 @@ func TestEntrypointerFailures(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Entrypointer didn't fail")
 			}
-			if d := cmp.Diff(c.expectedError, err.Error()); d != "" {
-				t.Errorf("Entrypointer error diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.expectedError, err.Error(), "Entrypointer error diff %s")
 
 			if c.postFile != "" {
 				if fpw.wrote == nil {

--- a/pkg/pod/creds_init_test.go
+++ b/pkg/pod/creds_init_test.go
@@ -19,7 +19,6 @@ package pod
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
@@ -160,12 +159,8 @@ func TestCredsInit(t *testing.T) {
 			if len(args) == 0 && len(volumes) != 0 {
 				t.Fatalf("credsInit returned secret volumes but no arguments")
 			}
-			if d := cmp.Diff(c.wantArgs, args); d != "" {
-				t.Fatalf("Diff %s", diff.PrintWantGot(d))
-			}
-			if d := cmp.Diff(c.wantVolumeMounts, volumeMounts); d != "" {
-				t.Fatalf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, c.wantArgs, args, "Diff %s")
+			diff.FatalWantGot(t, c.wantVolumeMounts, volumeMounts, "Diff %s")
 		})
 	}
 }

--- a/pkg/pod/entrypoint_lookup_test.go
+++ b/pkg/pod/entrypoint_lookup_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -99,9 +98,7 @@ func TestResolveEntrypoints(t *testing.T) {
 		Image:   "gcr.io/my/image@" + dig.String(),
 		Command: []string{"my", "entrypoint"},
 	}}
-	if d := cmp.Diff(want, got); d != "" {
-		t.Fatalf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, want, got, "Diff %s")
 }
 
 type fakeCache map[string]*data

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -101,9 +101,7 @@ func TestOrderContainers(t *testing.T) {
 		Command:      []string{"cp", "/ko-app/entrypoint", entrypointBinary},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
-	if d := cmp.Diff(wantInit, gotInit); d != "" {
-		t.Errorf("Init Container Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, wantInit, gotInit, "Init Container Diff %s")
 }
 
 func TestEntryPointResults(t *testing.T) {
@@ -175,9 +173,7 @@ func TestEntryPointResults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Diff %s")
 }
 
 func TestEntryPointResultsSingleStep(t *testing.T) {
@@ -213,9 +209,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Diff %s")
 }
 func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 	results := []v1alpha1.TaskResult{{
@@ -247,9 +241,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Diff %s")
 }
 func TestUpdateReady(t *testing.T) {
 	for _, c := range []struct {
@@ -304,8 +296,8 @@ func TestUpdateReady(t *testing.T) {
 			got, err := kubeclient.CoreV1().Pods(c.pod.Namespace).Get(c.pod.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Getting pod %q after update: %v", c.pod.Name, err)
-			} else if d := cmp.Diff(c.wantAnnotations, got.Annotations); d != "" {
-				t.Errorf("Annotations Diff %s", diff.PrintWantGot(d))
+			} else {
+				diff.ErrorWantGot(t, c.wantAnnotations, got.Annotations, "Annotations Diff %s")
 			}
 		})
 	}
@@ -419,8 +411,8 @@ func TestStopSidecars(t *testing.T) {
 			got, err := kubeclient.CoreV1().Pods(c.pod.Namespace).Get(c.pod.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Getting pod %q after update: %v", c.pod.Name, err)
-			} else if d := cmp.Diff(c.wantContainers, got.Spec.Containers); d != "" {
-				t.Errorf("Containers Diff %s", diff.PrintWantGot(d))
+			} else {
+				diff.ErrorWantGot(t, c.wantContainers, got.Spec.Containers, "Containers Diff %s")
 			}
 		})
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -1157,14 +1156,10 @@ script-heredoc-randomly-generated-78c5n
 				t.Errorf("Pod name %q should have prefix 'taskrun-name-pod-'", got.Name)
 			}
 
-			if d := cmp.Diff(c.want, &got.Spec, resourceQuantityCmp); d != "" {
-				t.Errorf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.want, &got.Spec, "Diff %s", resourceQuantityCmp)
 
 			if c.wantAnnotations != nil {
-				if d := cmp.Diff(c.wantAnnotations, got.ObjectMeta.Annotations, cmpopts.IgnoreMapEntries(ignoreReleaseAnnotation)); d != "" {
-					t.Errorf("Annotation Diff(-want, +got):\n%s", d)
-				}
+				diff.ErrorWantGot(t, c.wantAnnotations, got.ObjectMeta.Annotations, "Diff %s", cmpopts.IgnoreMapEntries(ignoreReleaseAnnotation))
 			}
 		})
 	}
@@ -1186,9 +1181,7 @@ func TestMakeLabels(t *testing.T) {
 			},
 		},
 	})
-	if d := cmp.Diff(got, want); d != "" {
-		t.Errorf("Diff labels %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, got, want, "Diff labels %s")
 }
 
 func TestShouldOverrideHomeEnv(t *testing.T) {

--- a/pkg/pod/resource_request_test.go
+++ b/pkg/pod/resource_request_test.go
@@ -208,9 +208,7 @@ func TestResolveResourceRequests_No_LimitRange(t *testing.T) {
 	} {
 		t.Run(c.desc, func(t *testing.T) {
 			got := resolveResourceRequests(c.in, allZeroQty())
-			if d := cmp.Diff(c.want, got, resourceQuantityCmp); d != "" {
-				t.Errorf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.want, got, "Diff %s", resourceQuantityCmp)
 		})
 	}
 }
@@ -338,9 +336,7 @@ func TestResolveResourceRequests_LimitRange(t *testing.T) {
 				corev1.ResourceEphemeralStorage: resource.MustParse("100m"),
 			},
 			)
-			if d := cmp.Diff(c.want, got, resourceQuantityCmp); d != "" {
-				t.Errorf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.want, got, "Diff %s", resourceQuantityCmp)
 		})
 	}
 }

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -19,7 +19,6 @@ package pod
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
@@ -41,9 +40,7 @@ func TestConvertScripts_NothingToConvert_EmptySidecars(t *testing.T) {
 	}, {
 		Image: "step-2",
 	}}
-	if d := cmp.Diff(want, gotScripts); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, gotScripts, "Diff %s")
 	if gotInit != nil {
 		t.Errorf("Wanted nil init container, got %v", gotInit)
 	}
@@ -68,9 +65,7 @@ func TestConvertScripts_NothingToConvert_NilSidecars(t *testing.T) {
 	}, {
 		Image: "step-2",
 	}}
-	if d := cmp.Diff(want, gotScripts); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, gotScripts, "Diff %s")
 	if gotInit != nil {
 		t.Errorf("Wanted nil init container, got %v", gotInit)
 	}
@@ -102,13 +97,8 @@ func TestConvertScripts_NothingToConvert_WithSidecar(t *testing.T) {
 	wantSidecar := []corev1.Container{{
 		Image: "sidecar-1",
 	}}
-	if d := cmp.Diff(want, gotScripts); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
-
-	if d := cmp.Diff(wantSidecar, gotSidecars); d != "" {
-		t.Errorf("Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, gotScripts, "Diff %s")
+	diff.ErrorWantGot(t, wantSidecar, gotSidecars, "Diff %s")
 
 	if gotInit != nil {
 		t.Errorf("Wanted nil init container, got %v", gotInit)
@@ -203,12 +193,8 @@ script-heredoc-randomly-generated-j2tds
 			scriptsVolumeMount,
 		},
 	}}
-	if d := cmp.Diff(wantInit, gotInit); d != "" {
-		t.Errorf("Init Container Diff %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(want, gotSteps); d != "" {
-		t.Errorf("Containers Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, wantInit, gotInit, "Init Container Diff %s")
+	diff.ErrorWantGot(t, want, gotSteps, "Init Container Diff %s")
 
 	if len(gotSidecars) != 0 {
 		t.Errorf("Expected zero sidecars, got %v", len(gotSidecars))
@@ -294,15 +280,9 @@ sidecar-script-heredoc-randomly-generated-j2tds
 		Command:      []string{"/tekton/scripts/sidecar-script-0-6nl7g"},
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 	}}
-	if d := cmp.Diff(wantInit, gotInit); d != "" {
-		t.Errorf("Init Container Diff %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(want, gotSteps); d != "" {
-		t.Errorf("Step Containers Diff %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(wantSidecars, gotSidecars); d != "" {
-		t.Errorf("Sidecar Containers Diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, wantInit, gotInit, "Init Container Diff %s")
+	diff.ErrorWantGot(t, want, gotSteps, "Step Containers Diff %s")
+	diff.ErrorWantGot(t, wantSidecars, gotSidecars, "Sidecar Containers Diff %s")
 
 	if len(gotSidecars) != 1 {
 		t.Errorf("Wanted 1 sidecar, got %v", len(gotSidecars))

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -729,9 +729,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 				}
 				return y != nil
 			})
-			if d := cmp.Diff(c.want, got, ignoreVolatileTime, ensureTimeNotNil); d != "" {
-				t.Errorf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.want, got, "Diff %s", ignoreVolatileTime, ensureTimeNotNil)
 			if tr.Status.StartTime.Time != c.want.StartTime.Time {
 				t.Errorf("Expected TaskRun startTime to be unchanged but was %s", tr.Status.StartTime)
 			}
@@ -879,9 +877,7 @@ func TestSortTaskRunStepOrder(t *testing.T) {
 	}
 
 	want := []string{"hello", "exit", "world", "nop"}
-	if d := cmp.Diff(want, gotNames); d != "" {
-		t.Errorf("Unexpected step order %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, gotNames, "Unexpected step order %s")
 }
 
 func TestSortContainerStatuses(t *testing.T) {
@@ -918,9 +914,7 @@ func TestSortContainerStatuses(t *testing.T) {
 	}
 
 	want := []string{"my", "world", "hello"}
-	if d := cmp.Diff(want, gotNames); d != "" {
-		t.Errorf("Unexpected step order %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, gotNames, "Unexpected step order %s")
 
 }
 
@@ -935,9 +929,7 @@ func TestMarkStatusRunning(t *testing.T) {
 		Message: "Not all Steps in the Task have finished executing",
 	}
 
-	if d := cmp.Diff(expected, trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
-		t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expected, trs.GetCondition(apis.ConditionSucceeded), "Unexpected status: %s", cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time))
 }
 
 func TestMarkStatusFailure(t *testing.T) {
@@ -950,10 +942,7 @@ func TestMarkStatusFailure(t *testing.T) {
 		Reason:  v1beta1.TaskRunReasonFailed.String(),
 		Message: "failure message",
 	}
-
-	if d := cmp.Diff(expected, trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
-		t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expected, trs.GetCondition(apis.ConditionSucceeded), "Unexpected status: %s", cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time))
 }
 
 func TestMarkStatusSuccess(t *testing.T) {
@@ -967,7 +956,5 @@ func TestMarkStatusSuccess(t *testing.T) {
 		Message: "All Steps have completed executing",
 	}
 
-	if d := cmp.Diff(expected, trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
-		t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expected, trs.GetCondition(apis.ConditionSucceeded), "Unexpected status: %s", cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time))
 }

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -19,7 +19,6 @@ package pod
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
@@ -66,9 +65,7 @@ func TestWorkingDirInit(t *testing.T) {
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			got := workingDirInit(images.ShellImage, c.stepContainers)
-			if d := cmp.Diff(c.want, got); d != "" {
-				t.Fatalf("Diff %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, c.want, got, "Diff %s")
 		})
 	}
 }

--- a/pkg/pullrequest/api_test.go
+++ b/pkg/pullrequest/api_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/tektoncd/pipeline/test/diff"
 
-	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -113,9 +112,7 @@ func TestDownload(t *testing.T) {
 	}
 	populateManifest(want)
 
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("Get PullRequest: %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "Get PullRequest: %s")
 }
 
 func TestUploadFromDisk(t *testing.T) {
@@ -164,9 +161,7 @@ func TestUpload_NewComment(t *testing.T) {
 
 	// Only compare comments since the resource manifest will change between
 	// downloads.
-	if d := cmp.Diff(r.Comments, got.Comments); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.Comments, got.Comments, "%s")
 }
 
 func TestUpload_DeleteComment(t *testing.T) {
@@ -185,9 +180,7 @@ func TestUpload_DeleteComment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(r.Comments, got.Comments); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.Comments, got.Comments, "%s")
 }
 
 func TestUpload_ManifestComment(t *testing.T) {
@@ -218,10 +211,7 @@ func TestUpload_ManifestComment(t *testing.T) {
 		Body:   "hello world!",
 		Author: scm.User{Login: "k8s-ci-robot"},
 	}}
-
-	if d := cmp.Diff(r.Comments, got.Comments); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.Comments, got.Comments, "%s")
 }
 
 func TestUpload_NewStatus(t *testing.T) {
@@ -244,9 +234,7 @@ func TestUpload_NewStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(r, got); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r, got, "%s")
 }
 
 func TestUpload_UpdateStatus(t *testing.T) {
@@ -265,9 +253,7 @@ func TestUpload_UpdateStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(r, got); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r, got, "%s")
 }
 
 func TestUpload_Invalid_Status(t *testing.T) {
@@ -304,9 +290,8 @@ func TestUpload_Invalid_Status(t *testing.T) {
 		t.Fatalf("expected 2 errors, got %d", len(merr.Errors))
 	}
 	for i, err := range merr.Errors {
-		if d := cmp.Diff(expectedErrors[i], err.Error()); d != "" {
-			t.Errorf("Upload status error diff %s", diff.PrintWantGot(d))
-		}
+
+		diff.ErrorWantGot(t, expectedErrors[i], err.Error(), "Upload status error diff %s")
 	}
 }
 
@@ -326,9 +311,7 @@ func TestUpload_NewLabel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(r.PR, got.PR); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.PR, got.PR, "%s")
 }
 
 func TestUpload_DeleteLabel(t *testing.T) {
@@ -347,9 +330,7 @@ func TestUpload_DeleteLabel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if d := cmp.Diff(r.PR, got.PR); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.PR, got.PR, "%s")
 }
 
 func TestUpload_ManifestLabel(t *testing.T) {
@@ -374,7 +355,5 @@ func TestUpload_ManifestLabel(t *testing.T) {
 	}
 	r.PR.Labels = append(r.PR.Labels, &scm.Label{Name: "z"})
 
-	if d := cmp.Diff(r.PR, got.PR); d != "" {
-		t.Errorf(diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, r.PR, got.PR, "%s")
 }

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -27,7 +27,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -87,17 +86,13 @@ func TestToDisk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d := cmp.Diff(pr, rsrc.PR); d != "" {
-		t.Errorf("PullRequest %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, pr, rsrc.PR, "PullRequest %s")
 
 	// Check the refs
 	checkRef := func(name string, r scm.PullRequestBranch) {
 		actualRef := scm.PullRequestBranch{}
 		readAndUnmarshal(t, filepath.Join(d, name), &actualRef)
-		if d := cmp.Diff(actualRef, r); d != "" {
-			t.Errorf("Get PullRequest %s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, actualRef, r, "Get PullRequest %s")
 	}
 	checkRef("head.json", rsrc.PR.Head)
 	checkRef("base.json", rsrc.PR.Base)
@@ -119,9 +114,7 @@ func TestToDisk(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected status with ID: %s, not found: %v", s.Target, statuses)
 		}
-		if d := cmp.Diff(actualStatus, *s); d != "" {
-			t.Errorf("Get Status %s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, actualStatus, *s, "Get Status %s")
 	}
 	// Check the labels
 	fis, err = ioutil.ReadDir(filepath.Join(d, "labels"))
@@ -183,9 +176,7 @@ func TestToDisk(t *testing.T) {
 		if !ok {
 			t.Errorf("Expected comment with ID: %d, not found: %v", c.ID, comments)
 		}
-		if d := cmp.Diff(actualComment, *c); d != "" {
-			t.Errorf("Get Comment %s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, actualComment, *c, "Get Comment %s")
 	}
 	gotManifest, err = manifestFromDisk(filepath.Join(d, "comments", manifestPath))
 	if err != nil {
@@ -238,13 +229,8 @@ func TestFromDiskWithoutComments(t *testing.T) {
 	}
 
 	// Check the refs
-	if d := cmp.Diff(rsrc.PR.Base, base); d != "" {
-		t.Errorf("Get Base %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(rsrc.PR.Head, head); d != "" {
-		t.Errorf("Get Head %s", diff.PrintWantGot(d))
-	}
-
+	diff.ErrorWantGot(t, rsrc.PR.Base, base, "Get Base %s")
+	diff.ErrorWantGot(t, rsrc.PR.Head, head, "Get Head %s")
 }
 
 func TestFromDisk(t *testing.T) {
@@ -347,15 +333,9 @@ func TestFromDisk(t *testing.T) {
 	}
 
 	// Check the refs
-	if d := cmp.Diff(rsrc.PR.Base, base); d != "" {
-		t.Errorf("Get Base %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(rsrc.PR.Head, head); d != "" {
-		t.Errorf("Get Head %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(rsrc.PR.Sha, head.Sha); d != "" {
-		t.Errorf("Get Sha %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, rsrc.PR.Base, base, "Get Base %s")
+	diff.ErrorWantGot(t, rsrc.PR.Head, head, "Get Head %s")
+	diff.ErrorWantGot(t, rsrc.PR.Sha, head.Sha, "Get Sha %s")
 
 	// Check the comments
 	commentMap := map[int]scm.Comment{}
@@ -366,17 +346,13 @@ func TestFromDisk(t *testing.T) {
 		Body: "plaincomment",
 	}
 	for _, c := range rsrc.Comments {
-		if d := cmp.Diff(commentMap[c.ID], *c); d != "" {
-			t.Errorf("Get comments %s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, commentMap[c.ID], *c, "Get comments %s")
 	}
 	commentManifest := Manifest{}
 	for _, c := range comments {
 		commentManifest[strconv.Itoa(c.ID)] = true
 	}
-	if d := cmp.Diff(commentManifest, rsrc.Manifests["comments"]); d != "" {
-		t.Errorf("Comment manifest %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, commentManifest, rsrc.Manifests["comments"], "Comment manifest %s")
 
 	// Check the labels
 	labelsMap := map[string]struct{}{}
@@ -385,17 +361,13 @@ func TestFromDisk(t *testing.T) {
 	}
 	for _, l := range rsrc.PR.Labels {
 		key := url.QueryEscape(l.Name)
-		if d := cmp.Diff(labelsMap[key], &l); d != "" {
-			t.Errorf("Get labels %s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, labelsMap[key], &l, "Get labels %s")
 	}
 	labelManifest := Manifest{}
 	for _, l := range labels {
 		labelManifest[l] = true
 	}
-	if d := cmp.Diff(labelManifest, rsrc.Manifests["labels"]); d != "" {
-		t.Errorf("Label manifest %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, labelManifest, rsrc.Manifests["labels"], "Label manifest %s")
 
 	// Check the statuses
 	statusMap := map[string]scm.Status{}
@@ -403,9 +375,7 @@ func TestFromDisk(t *testing.T) {
 		statusMap[s.Label] = s
 	}
 	for _, s := range rsrc.Statuses {
-		if d := cmp.Diff(statusMap[s.Label], *s); d != "" {
-			t.Errorf("Get status %s", diff.PrintWantGot(d))
-		}
+		diff.ErrorWantGot(t, statusMap[s.Label], *s, "Get status %s")
 	}
 }
 
@@ -537,9 +507,7 @@ func TestCommentsFromDisk(t *testing.T) {
 				t.Fatalf("Comments length does not match expected length. expected %d, got %d: %+v", len(tt.expectedComments), len(comments), comments)
 			}
 			for i, c := range tt.expectedComments {
-				if d := cmp.Diff(c, comments[i]); d != "" {
-					t.Errorf("Get comments: %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, c, comments[i], "Get comments: %s")
 			}
 		})
 	}

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -78,9 +77,7 @@ func TestCloudEventDeliveryFromTargets(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			gotCloudEvents := cloudEventDeliveryFromTargets(tc.targets)
-			if d := cmp.Diff(tc.wantCloudEvents, gotCloudEvents); d != "" {
-				t.Errorf("Wrong Cloud Events %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.wantCloudEvents, gotCloudEvents, "Wrong Cloud Events %s")
 		})
 	}
 }
@@ -143,9 +140,7 @@ func TestSendCloudEvents(t *testing.T) {
 				t.Fatalf("Unexpected error sending cloud events: %v", err)
 			}
 			opts := GetCloudEventDeliveryCompareOptions()
-			if d := cmp.Diff(tc.wantTaskRun.Status, tc.taskRun.Status, opts...); d != "" {
-				t.Errorf("Wrong Cloud Events Status %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.wantTaskRun.Status, tc.taskRun.Status, "Wrong Cloud Events Status %s", opts...)
 		})
 	}
 }
@@ -201,9 +196,7 @@ func TestSendCloudEventsErrors(t *testing.T) {
 				t.Fatalf("Unexpected success sending cloud events: %v", err)
 			}
 			opts := GetCloudEventDeliveryCompareOptions()
-			if d := cmp.Diff(tc.wantTaskRun.Status, tc.taskRun.Status, opts...); d != "" {
-				t.Errorf("Wrong Cloud Events Status %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.wantTaskRun.Status, tc.taskRun.Status, "Wrong Cloud Events Status %s", opts...)
 		})
 	}
 }
@@ -286,9 +279,7 @@ func TestInitializeCloudEvents(t *testing.T) {
 			}
 			InitializeCloudEvents(tc.taskRun, prMap)
 			opts := GetCloudEventDeliveryCompareOptions()
-			if d := cmp.Diff(tc.wantTaskRun.Status, tc.taskRun.Status, opts...); d != "" {
-				t.Errorf("Wrong Cloud Events Status %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.wantTaskRun.Status, tc.taskRun.Status, "Wrong Cloud Events Status %s", opts...)
 		})
 	}
 }
@@ -412,9 +403,7 @@ func TestSendCloudEventWithRetriesNoClient(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected an error sending cloud events with no client in the context, got none")
 	}
-	if d := cmp.Diff("No cloud events client found in the context", err.Error()); d != "" {
-		t.Fatalf("Unexpected error message %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, "No cloud events client found in the context", err.Error(), "Unexpected error message %s")
 }
 
 func setupFakeContext(t *testing.T, behaviour FakeClientBehaviour, withClient bool) context.Context {

--- a/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -19,7 +19,6 @@ package cloudevent
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
@@ -117,20 +116,15 @@ func TestEventForTaskRun(t *testing.T) {
 				t.Fatalf("I did not expect an error but I got %s", err)
 			} else {
 				wantSubject := taskRunName
-				if d := cmp.Diff(wantSubject, got.Subject()); d != "" {
-					t.Errorf("Wrong Event ID %s", diff.PrintWantGot(d))
-				}
-				if d := cmp.Diff(string(c.wantEventType), got.Type()); d != "" {
-					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, wantSubject, got.Subject(), "Wrong Event ID %s")
+				diff.ErrorWantGot(t, string(c.wantEventType), got.Type(), "Wrong Event Type %s")
+
 				wantData := NewTektonCloudEventData(c.taskRun)
 				gotData := TektonCloudEventData{}
 				if err := got.DataAs(&gotData); err != nil {
 					t.Errorf("Unexpected error from DataAsl; %s", err)
 				}
-				if d := cmp.Diff(wantData, gotData); d != "" {
-					t.Errorf("Wrong Event data %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, wantData, gotData, "Wrong Event data %s")
 
 				if err := got.Validate(); err != nil {
 					t.Errorf("Expected event to be valid; %s", err)
@@ -174,20 +168,15 @@ func TestEventForPipelineRun(t *testing.T) {
 				t.Fatalf("I did not expect an error but I got %s", err)
 			} else {
 				wantSubject := pipelineRunName
-				if d := cmp.Diff(wantSubject, got.Subject()); d != "" {
-					t.Errorf("Wrong Event ID %s", diff.PrintWantGot(d))
-				}
-				if d := cmp.Diff(string(c.wantEventType), got.Type()); d != "" {
-					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, wantSubject, got.Subject(), "Wrong Event ID %s")
+				diff.ErrorWantGot(t, string(c.wantEventType), got.Type(), "Wrong Event Type %s")
+
 				wantData := NewTektonCloudEventData(c.pipelineRun)
 				gotData := TektonCloudEventData{}
 				if err := got.DataAs(&gotData); err != nil {
 					t.Errorf("Unexpected error from DataAsl; %s", err)
 				}
-				if d := cmp.Diff(wantData, gotData); d != "" {
-					t.Errorf("Wrong Event data %s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, wantData, gotData, "Wrong Event data %s")
 
 				if err := got.Validate(); err != nil {
 					t.Errorf("Expected event to be valid; %s", err)

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package dag_test
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -119,9 +119,7 @@ func TestGetSchedulable(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Didn't expect error when getting next tasks for %v but got %v", tc.finished, err)
 			}
-			if d := cmp.Diff(tasks, tc.expectedTasks, cmpopts.IgnoreFields(v1alpha1.PipelineTask{}, "RunAfter")); d != "" {
-				t.Errorf("expected that with %v done, %v would be ready to schedule but was different: %s", tc.finished, tc.expectedTasks, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tasks, tc.expectedTasks, fmt.Sprintf("expected that with %v done, %v would be ready to schedule but was different: ", tc.finished, tc.expectedTasks)+"%s", cmpopts.IgnoreFields(v1alpha1.PipelineTask{}, "RunAfter"))
 		})
 	}
 }

--- a/pkg/reconciler/pipeline/dag/dagv1beta1_test.go
+++ b/pkg/reconciler/pipeline/dag/dagv1beta1_test.go
@@ -22,9 +22,9 @@ package dag_test
 // dealing with v1beta1 in our code and we won't need 2 sets of tests.
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
@@ -122,9 +122,7 @@ func TestGetSchedulable_v1beta1(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Didn't expect error when getting next tasks for %v but got %v", tc.finished, err)
 			}
-			if d := cmp.Diff(tasks, tc.expectedTasks, cmpopts.IgnoreFields(v1beta1.PipelineTask{}, "RunAfter")); d != "" {
-				t.Errorf("expected that with %v done, %v would be ready to schedule but was different: %s", tc.finished, tc.expectedTasks, diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tasks, tc.expectedTasks, fmt.Sprintf("expected that with %v done, %v would be ready to schedule but was different: ", tc.finished, tc.expectedTasks)+"%s", cmpopts.IgnoreFields(v1beta1.PipelineTask{}, "RunAfter"))
 		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -159,9 +158,7 @@ func TestApplyParameters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ApplyParameters(&tt.original.Spec, tt.run)
-			if d := cmp.Diff(&tt.expected.Spec, got); d != "" {
-				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, &tt.expected.Spec, got, "ApplyParameters() got diff %s")
 		})
 	}
 }
@@ -232,9 +229,7 @@ func TestApplyTaskResults_MinimalExpression(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ApplyTaskResults(tt.args.targets, tt.args.resolvedResultRefs)
-			if d := cmp.Diff(tt.want, tt.args.targets); d != "" {
-				t.Fatalf("ApplyTaskResults() %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, tt.want, tt.args.targets, "ApplyTaskResults() %s")
 		})
 	}
 }
@@ -305,9 +300,7 @@ func TestApplyTaskResults_EmbeddedExpression(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ApplyTaskResults(tt.args.targets, tt.args.resolvedResultRefs)
-			if d := cmp.Diff(tt.want, tt.args.targets); d != "" {
-				t.Fatalf("ApplyTaskResults() %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, tt.want, tt.args.targets, "ApplyTaskResults() %s")
 		})
 	}
 }
@@ -399,9 +392,7 @@ func TestApplyTaskResults_Conditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ApplyTaskResults(tt.args.targets, tt.args.resolvedResultRefs)
-			if d := cmp.Diff(tt.want[0].ResolvedConditionChecks, tt.args.targets[0].ResolvedConditionChecks, cmpopts.IgnoreUnexported(v1beta1.TaskRunSpec{}, ResolvedConditionCheck{})); d != "" {
-				t.Fatalf("ApplyTaskResults() %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, tt.want[0].ResolvedConditionChecks, tt.args.targets[0].ResolvedConditionChecks, "ApplyTaskResults() %s", cmpopts.IgnoreUnexported(v1beta1.TaskRunSpec{}, ResolvedConditionCheck{}))
 		})
 	}
 }
@@ -493,9 +484,7 @@ func TestContext(t *testing.T) {
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := ApplyContexts(&tc.original.Spec, tc.original.Name, tc.pr)
-			if d := cmp.Diff(tc.expected.Spec, *got); d != "" {
-				t.Errorf(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.expected.Spec, *got, "%s")
 		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
@@ -20,7 +20,6 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tbv1alpha1 "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -274,9 +273,7 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 				t.Errorf("Unexpected error when converting condition to task spec: %v", err)
 			}
 
-			if d := cmp.Diff(&tc.want, got); d != "" {
-				t.Errorf("TaskSpec generated from Condition is unexpected %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, &tc.want, got, "TaskSpec generated from Condition is unexpected %s")
 		})
 	}
 }
@@ -294,7 +291,5 @@ func TestResolvedConditionCheck_ToTaskResourceBindings(t *testing.T) {
 		},
 	}}
 
-	if d := cmp.Diff(expected, rcc.ToTaskResourceBindings()); d != "" {
-		t.Errorf("Did not get expected task resource binding from condition %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, expected, rcc.ToTaskResourceBindings(), "Did not get expected task resource binding from condition %s")
 }

--- a/pkg/reconciler/pipelinerun/resources/input_output_steps_test.go
+++ b/pkg/reconciler/pipelinerun/resources/input_output_steps_test.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -125,9 +124,7 @@ func TestGetOutputSteps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			postTasks := resources.GetOutputSteps(tc.outputs, tc.pipelineTaskName, pvcDir)
 			sort.SliceStable(postTasks, func(i, j int) bool { return postTasks[i].Name < postTasks[j].Name })
-			if d := cmp.Diff(postTasks, tc.expectedtaskOuputResources); d != "" {
-				t.Errorf("error comparing post steps %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, postTasks, tc.expectedtaskOuputResources, "error comparing post steps %s")
 		})
 	}
 }
@@ -267,10 +264,7 @@ func TestGetInputSteps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			taskInputResources := resources.GetInputSteps(tc.inputs, tc.pipelineTask.Resources.Inputs, pvcDir)
 			sort.SliceStable(taskInputResources, func(i, j int) bool { return taskInputResources[i].Name < taskInputResources[j].Name })
-			if d := cmp.Diff(tc.expectedtaskInputResources, taskInputResources); d != "" {
-				t.Errorf("error comparing task resource inputs %s", diff.PrintWantGot(d))
-			}
-
+			diff.ErrorWantGot(t, tc.expectedtaskInputResources, taskInputResources, "error comparing task resource inputs %s")
 		})
 	}
 }
@@ -349,10 +343,6 @@ func TestWrapSteps(t *testing.T) {
 	sort.SliceStable(expectedtaskInputResources, func(i, j int) bool { return expectedtaskInputResources[i].Name < expectedtaskInputResources[j].Name })
 	sort.SliceStable(expectedtaskOuputResources, func(i, j int) bool { return expectedtaskOuputResources[i].Name < expectedtaskOuputResources[j].Name })
 
-	if d := cmp.Diff(taskRunSpec.Resources.Inputs, expectedtaskInputResources, cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name })); d != "" {
-		t.Errorf("error comparing input resources %s", diff.PrintWantGot(d))
-	}
-	if d := cmp.Diff(taskRunSpec.Resources.Outputs, expectedtaskOuputResources, cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name })); d != "" {
-		t.Errorf("error comparing output resources %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, taskRunSpec.Resources.Inputs, expectedtaskInputResources, "error comparing input resources %s", cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name }))
+	diff.ErrorWantGot(t, taskRunSpec.Resources.Outputs, expectedtaskOuputResources, "error comparing output resources %s", cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name }))
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -19,7 +19,6 @@ package resources_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
@@ -75,9 +74,7 @@ func TestPipelineRef(t *testing.T) {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
 
-			if d := cmp.Diff(task, tc.expected); tc.expected != nil && d != "" {
-				t.Error(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, task, tc.expected, "%s")
 		})
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -377,9 +377,7 @@ func TestResolveResultRefs(t *testing.T) {
 				t.Errorf("ResolveResultRefs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if d := cmp.Diff(tt.want, got); d != "" {
-				t.Fatalf("ResolveResultRef %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, tt.want, got, "ResolveResultRef %s")
 		})
 	}
 }
@@ -511,9 +509,7 @@ func TestResolvePipelineResultRefs(t *testing.T) {
 			sort.SliceStable(got, func(i, j int) bool {
 				return strings.Compare(got[i].FromTaskRun, got[j].FromTaskRun) < 0
 			})
-			if d := cmp.Diff(tt.want, got); d != "" {
-				t.Fatalf("ResolveResultRef %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, tt.want, got, "ResolveResultRef %s")
 		})
 	}
 }

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -19,7 +19,6 @@ package resources_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -492,9 +491,7 @@ func TestApplyArrayParameters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resources.ApplyParameters(tt.args.ts, tt.args.tr, tt.args.dp...)
-			if d := cmp.Diff(tt.want, got); d != "" {
-				t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.want, got, "ApplyParameters() got diff %s")
 		})
 	}
 }
@@ -558,9 +555,7 @@ func TestApplyParameters(t *testing.T) {
 		spec.Sidecars[0].Container.Env[0].Value = "world"
 	})
 	got := resources.ApplyParameters(simpleTaskSpec, tr, dp...)
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("ApplyParameters() got diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "ApplyParameters() got diff %s")
 }
 
 func TestApplyResources(t *testing.T) {
@@ -630,9 +625,7 @@ func TestApplyResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := resources.ApplyResources(tt.args.ts, tt.args.r, tt.args.rStr)
-			if d := cmp.Diff(tt.want, got); d != "" {
-				t.Errorf("ApplyResources() %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tt.want, got, "ApplyResources() %s")
 		})
 	}
 }
@@ -751,9 +744,7 @@ func TestApplyWorkspaces(t *testing.T) {
 		EmptyDir: &corev1.EmptyDirVolumeSource{},
 	}}
 	got := resources.ApplyWorkspaces(ts, w, wb)
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("TestApplyWorkspaces() got diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "TestApplyWorkspaces() got diff %s")
 }
 
 func TestContext(t *testing.T) {
@@ -931,9 +922,7 @@ func TestContext(t *testing.T) {
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := resources.ApplyContexts(&tc.spec, &tc.rtr, &tc.tr)
-			if d := cmp.Diff(&tc.want, got); d != "" {
-				t.Errorf(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, &tc.want, got, "%s")
 		})
 	}
 }
@@ -969,9 +958,7 @@ func TestTaskResults(t *testing.T) {
 		spec.Steps[1].Script = "#!/usr/bin/env bash\ndate | tee /tekton/results/current-date-human-readable"
 	})
 	got := resources.ApplyTaskResults(ts)
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("ApplyTaskResults() got diff %s", diff.PrintWantGot(d))
-	}
+	diff.ErrorWantGot(t, want, got, "ApplyTaskResults() got diff %s")
 }
 
 func TestApplyCredentialsPath(t *testing.T) {
@@ -1015,9 +1002,7 @@ func TestApplyCredentialsPath(t *testing.T) {
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := resources.ApplyCredentialsPath(&tc.spec, tc.path)
-			if d := cmp.Diff(&tc.want, got); d != "" {
-				t.Errorf(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, &tc.want, got, " %s")
 		})
 	}
 }

--- a/pkg/reconciler/taskrun/resources/image_exporter_test.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter_test.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -189,9 +188,7 @@ func TestAddOutputImageDigestExporter(t *testing.T) {
 				t.Fatalf("Failed to declare output resources for test %q: error %v", c.desc, err)
 			}
 
-			if d := cmp.Diff(c.task.Spec.Steps, c.wantSteps); d != "" {
-				t.Fatalf("post build steps mismatch %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, c.task.Spec.Steps, c.wantSteps, "post build steps mismatch %s")
 		})
 	}
 }

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource"
@@ -970,9 +969,7 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 				t.Errorf("Test: %q; AddInputResource() error = %v, WantErr %v", c.desc, err, c.wantErr)
 			}
 			if got != nil {
-				if d := cmp.Diff(got, c.want); d != "" {
-					t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, got, c.want, "Diff:\n%s")
 			}
 		})
 	}
@@ -1205,9 +1202,7 @@ gsutil rsync -d -r gs://fake-bucket/rules.zip /workspace/gcs-input-resource
 			if (err != nil) != c.wantErr {
 				t.Errorf("Test: %q; AddInputResource() error = %v, WantErr %v", c.desc, err, c.wantErr)
 			}
-			if d := cmp.Diff(c.want, got); d != "" {
-				t.Errorf("Didn't get expected Task spec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.want, got, "Didn't get expected Task spec %s")
 		})
 	}
 }
@@ -1441,9 +1436,7 @@ func TestAddStepsToTaskWithBucketFromConfigMap(t *testing.T) {
 			if err != nil {
 				t.Errorf("Test: %q; AddInputResource() error = %v", c.desc, err)
 			}
-			if d := cmp.Diff(c.want, got); d != "" {
-				t.Errorf("Didn't get expected TaskSpec %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, c.want, got, "Didn't get expected TaskSpec %s")
 		})
 	}
 }

--- a/pkg/reconciler/taskrun/resources/output_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/output_resource_test.go
@@ -19,7 +19,6 @@ package resources
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -923,12 +922,8 @@ func TestValidOutputResources(t *testing.T) {
 			}
 
 			if got != nil {
-				if d := cmp.Diff(c.wantSteps, got.Steps); d != "" {
-					t.Fatalf("post build steps mismatch %s", diff.PrintWantGot(d))
-				}
-				if d := cmp.Diff(c.wantVolumes, got.Volumes); d != "" {
-					t.Fatalf("post build steps volumes mismatch %s", diff.PrintWantGot(d))
-				}
+				diff.FatalWantGot(t, c.wantSteps, got.Steps, "post build steps mismatch %s")
+				diff.FatalWantGot(t, c.wantVolumes, got.Volumes, "post build steps volumes mismatch %s")
 			}
 		})
 	}
@@ -1117,9 +1112,7 @@ func TestValidOutputResourcesWithBucketStorage(t *testing.T) {
 				t.Fatalf("Failed to declare output resources for test name %q ; test description %q: error %v", c.name, c.desc, err)
 			}
 			if got != nil {
-				if d := cmp.Diff(c.wantSteps, got.Steps); d != "" {
-					t.Fatalf("post build steps mismatch %s", diff.PrintWantGot(d))
-				}
+				diff.FatalWantGot(t, c.wantSteps, got.Steps, "post build steps mismatch %s")
 			}
 		})
 	}
@@ -1733,12 +1726,8 @@ func TestInputOutputBucketResources(t *testing.T) {
 			}
 
 			if got != nil {
-				if d := cmp.Diff(c.wantSteps, got.Steps); d != "" {
-					t.Fatalf("post build steps mismatch %s", diff.PrintWantGot(d))
-				}
-				if d := cmp.Diff(c.wantVolumes, got.Volumes); d != "" {
-					t.Fatalf("post build steps volumes mismatch %s", diff.PrintWantGot(d))
-				}
+				diff.FatalWantGot(t, c.wantSteps, got.Steps, "post build steps mismatch %s")
+				diff.FatalWantGot(t, c.wantVolumes, got.Volumes, "post build steps volumes mismatch %s")
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -19,7 +19,6 @@ package resources_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
@@ -90,9 +89,7 @@ func TestTaskRef(t *testing.T) {
 				t.Fatalf("Received unexpected error ( %#v )", err)
 			}
 
-			if d := cmp.Diff(task, tc.expected); tc.expected != nil && d != "" {
-				t.Error(diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, task, tc.expected, "%s")
 		})
 	}
 }

--- a/pkg/reconciler/taskrun/resources/volume_test.go
+++ b/pkg/reconciler/taskrun/resources/volume_test.go
@@ -19,7 +19,6 @@ package resources_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -32,7 +31,5 @@ func TestGetPVCVolume(t *testing.T) {
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
 		},
 	}
-	if d := cmp.Diff(expectedVolume, resources.GetPVCVolume("test-pvc")); d != "" {
-		t.Fatalf("PVC volume mismatch: %s", diff.PrintWantGot(d))
-	}
+	diff.FatalWantGot(t, expectedVolume, resources.GetPVCVolume("test-pvc"), "PVC volume mismatch: %s")
 }

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/registry"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
@@ -95,9 +94,7 @@ func TestOCIResolver(t *testing.T) {
 
 			// The contents of the image are in a specific order so we can expect this iteration to be consistent.
 			for idx, actual := range listActual {
-				if d := cmp.Diff(actual, tc.listExpected[idx]); d != "" {
-					t.Error(diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, actual, tc.listExpected[idx], "%s")
 			}
 
 			for _, obj := range tc.objs {
@@ -106,9 +103,7 @@ func TestOCIResolver(t *testing.T) {
 					t.Fatalf("could not retrieve object from image: %#v", err)
 				}
 
-				if d := cmp.Diff(actual, obj); d != "" {
-					t.Error(diff.PrintWantGot(d))
-				}
+				diff.ErrorWantGot(t, actual, obj, "%s")
 			}
 		})
 	}

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -99,9 +99,7 @@ func TestValidateVariables(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := substitution.ValidateVariable("somefield", tc.args.input, tc.args.prefix, tc.args.locationName, tc.args.path, tc.args.vars)
 
-			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
-				t.Errorf("ValidateVariable() error did not match expected error %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, got, tc.expectedError, "ValidateVariable() error did not match expected error %s", cmp.AllowUnexported(apis.FieldError{}))
 		})
 	}
 }
@@ -160,9 +158,7 @@ func TestApplyReplacements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualOutput := substitution.ApplyReplacements(tt.args.input, tt.args.replacements)
-			if d := cmp.Diff(actualOutput, tt.expectedOutput); d != "" {
-				t.Errorf("ApplyReplacements() output did not match expected value %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, actualOutput, tt.expectedOutput, "ApplyReplacements() output did not match expected value %s")
 		})
 	}
 }
@@ -220,9 +216,7 @@ func TestApplyArrayReplacements(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOutput := substitution.ApplyArrayReplacements(tc.args.input, tc.args.stringReplacements, tc.args.arrayReplacements)
-			if d := cmp.Diff(actualOutput, tc.expectedOutput); d != "" {
-				t.Errorf("ApplyArrayReplacements() output did not match expected value %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, actualOutput, tc.expectedOutput, "ApplyArrayReplacements() output did not match expected value %s")
 		})
 	}
 }

--- a/pkg/termination/parse_test.go
+++ b/pkg/termination/parse_test.go
@@ -18,7 +18,6 @@ package termination
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -73,9 +72,7 @@ func TestParseMessage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseMessage: %v", err)
 			}
-			if d := cmp.Diff(c.want, got); d != "" {
-				t.Fatalf("ParseMessage %s", diff.PrintWantGot(d))
-			}
+			diff.FatalWantGot(t, c.want, got, "ParseMessage %s")
 		})
 	}
 }

--- a/pkg/termination/write_test.go
+++ b/pkg/termination/write_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/logging"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -63,9 +62,7 @@ func TestExistingFile(t *testing.T) {
 		logger.Fatalf("Unexpected error reading %v: %v", tmpFile.Name(), err)
 	} else {
 		want := `[{"key":"key1","value":"hello","resourceRef":{}},{"key":"key2","value":"world","resourceRef":{}}]`
-		if d := cmp.Diff(want, string(fileContents)); d != "" {
-			t.Fatalf("Diff %s", diff.PrintWantGot(d))
-		}
+		diff.FatalWantGot(t, want, string(fileContents), "Diff %s")
 	}
 }
 

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -3,7 +3,6 @@ package workspace_test
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -186,9 +185,7 @@ func TestGetVolumes(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			v := workspace.GetVolumes(tc.workspaces)
-			if d := cmp.Diff(tc.expectedVolumes, v); d != "" {
-				t.Errorf("Didn't get expected volumes from bindings %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.expectedVolumes, v, "Didn't get expected volumes from bindings %s")
 		})
 	}
 }
@@ -515,9 +512,7 @@ func TestApply(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Did not expect error but got %v", err)
 			}
-			if d := cmp.Diff(tc.expectedTaskSpec, *ts); d != "" {
-				t.Errorf("Didn't get expected TaskSpec modifications %s", diff.PrintWantGot(d))
-			}
+			diff.ErrorWantGot(t, tc.expectedTaskSpec, *ts, "Didn't get expected TaskSpec modifications %s")
 		})
 	}
 }

--- a/test/diff/helper.go
+++ b/test/diff/helper.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// ErrorWantGot Wrap cmp.Diff with a t.Helper(). It takes the testing.T
+// want,got, format message and cmp.option as an argument. Therefore, if diff was found
+// it will call t.Error of format and diff that wrapped by PrintWantGot func
+func ErrorWantGot(t *testing.T, want interface{}, got interface{}, format string, opts ...cmp.Option) {
+	t.Helper()
+	if d := cmp.Diff(want, got, opts...); d != "" {
+		t.Errorf(fmt.Sprintf("%s %s", format, PrintWantGot(d)))
+	}
+}
+
+// FatalWantGot Wrap cmp.Diff with a t.Helper(). It takes the testing.T
+// want,got, format message and cmp.option as an argument. Therefore, if diff was found
+// it will call t.Fatalf of format and diff that wrapped by PrintWantGot func
+func FatalWantGot(t *testing.T, want interface{}, got interface{}, format string, opts ...cmp.Option) {
+	t.Helper()
+	if d := cmp.Diff(want, got, opts...); d != "" {
+		t.Fatalf(fmt.Sprintf("%s %s", format, PrintWantGot(d)))
+	}
+}

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
@@ -111,9 +111,7 @@ func TestTaskRunFailure(t *testing.T) {
 	}}
 	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
-	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
-		t.Fatalf("-got, +want: %v", d)
-	}
+	diff.FatalWantGot(t, taskrun.Status.Steps, expectedStepState, "-got, +want: %v", ignoreTerminatedFields, ignoreStepFields)
 }
 
 func TestTaskRunStatus(t *testing.T) {
@@ -174,15 +172,10 @@ func TestTaskRunStatus(t *testing.T) {
 
 	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
 	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
-	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
-		t.Fatalf("-got, +want: %v", d)
-	}
+	diff.FatalWantGot(t, taskrun.Status.Steps, expectedStepState, "-got, +want: %v", ignoreTerminatedFields, ignoreStepFields)
 	// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
 	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
 		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
 	}
-
-	if d := cmp.Diff(taskrun.Status.TaskSpec, &task.Spec); d != "" {
-		t.Fatalf("-got, +want: %v", d)
-	}
+	diff.FatalWantGot(t, taskrun.Status.TaskSpec, &task.Spec, "-got, +want: %v")
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR is trying to follow up #2587 
Including : 
- Adding a helper function called `FatalIfWantNotGot` & `ErrorIfWantNotGot` to wrap the cmp.Diff()
- Replace varying cmp.diff by using `FatalIfWantNotGot` & `ErrorIfWantNotGot` 

The implementation will be updated after the helper function is approved
 
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)


