### PR TITLE
Update development guide to recommend ko v0.5.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,7 +77,7 @@ You must install these tools:
 1.  [`go`](https://golang.org/doc/install): The language Tekton Pipelines is
     built in
 1.  [`git`](https://help.github.com/articles/set-up-git/): For source control
-1.  [`ko`](https://github.com/google/ko): For development. `ko` version v0.1 or
+1.  [`ko`](https://github.com/google/ko): For development. `ko` version v0.5.1 or
     higher is required for `pipeline` to work correctly.
 1.  [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
     interacting with your kube cluster


### PR DESCRIPTION
I recently tried to deploy pipelines at head with ko v0.4.0, and it failed to deploy. Instead, it preserved the "github.com/tektoncd/..." import paths, which when deployed failed to start.

Upgrading ko to the latest version (in my case v0.5.1) fixed the problem. Earlier versions of ko may work, but users will likely install at least this version on update.

/kind documentation

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
