### PR TITLE
Add results linking to execution order docs 🔗

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -440,8 +440,9 @@ without getting stuck in an infinite loop.
 
 This is done using:
 
-- [`from`](#using-the-from-parameter) clauses on the [`PipelineResources`](resources.md) used by each `Task`, and
-- [`runAfter`](#using-the-runafter-parameter) clauses on the corresponding `Tasks`.
+- [`from`](#using-the-from-parameter) clauses on the [`PipelineResources`](resources.md) used by each `Task`
+- [`runAfter`](#using-the-runafter-parameter) clauses on the corresponding `Tasks`
+- By linking the [`results`](#configuring-execution-results-at-the-pipeline-level) of one `Task` to the params of another
 
 For example, the `Pipeline` defined as follows
 


### PR DESCRIPTION
# Changes

The docs on how to control ordering in pipelines were missing that you
can also express ordering by linking the results of one Task to the
params of another.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).