### PR TITLE
Validate PipelineRun Parameters

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -186,6 +186,9 @@ to all `persistentVolumeClaims` generated internally.
 You can specify `Parameters` that you want to pass to the `Pipeline` during execution,
 including different values of the same parameter for different `Tasks` in the `Pipeline`.
 
+**Note:** You must specify all the `Parameters` that the `Pipeline` expects. Parameters 
+that have default values specified in Pipeline are not required to be provided by PipelineRun.
+
 For example:
 
 ```yaml
@@ -196,6 +199,10 @@ spec:
   - name: pl-param-y
     value: "500"
 ```
+You can pass in extra `Parameters` if needed depending on your use cases. An example use 
+case is when your CI system autogenerates `PipelineRuns` and it has `Parameters` it wants to 
+provide to all `PipelineRuns`. Because you can pass in extra `Parameters`, you don't have to 
+go through the complexity of checking each `Pipeline` and providing only the required params.
 
 ### Specifying custom `ServiceAccount` credentials
 

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-extra-params.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-extra-params.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: pipeline-with-extra-params
+spec:
+  params:
+  - name: pl-param-x
+    type: string
+  - name: pl-param-y
+    type: string
+  tasks:
+  - name: add-params
+    taskRef:
+      name: add-params
+    params:
+    - name: a
+      value: "$(params.pl-param-x)"
+    - name: b
+      value: "$(params.pl-param-y)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: add-params
+  annotations:
+    description: |
+      A simple task that sums the two provided integers
+spec:
+  params:
+  - name: a
+    type: string
+    description: The first integer
+  - name: b
+    type: string
+    description: The second integer
+  steps:
+  - name: sum
+    image: bash:latest
+    script: |
+      #!/usr/bin/env bash
+      echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" ))
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-with-extra-params
+spec:
+  params:
+  - name: pl-param-x
+    value: "100"
+  - name: pl-param-y
+    value: "200"
+  - name: pl-param-z # the extra parameter
+    value: "300"
+  pipelineRef:
+    name: pipeline-with-extra-params

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -434,6 +434,10 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			tb.PipelineTask("some-task", "a-task-that-needs-array-params")),
 			tb.PipelineRunParam("some-param", "stringval"),
 		)),
+		tb.PipelineRun("pipelinerun-missing-params", tb.PipelineRunNamespace("foo"), tb.PipelineRunSpec("", tb.PipelineRunPipelineSpec(
+			tb.PipelineParamSpec("some-param", v1beta1.ParamTypeString),
+			tb.PipelineTask("some-task", "a-task-that-needs-params")),
+		)),
 	}
 	d := test.Data{
 		Tasks:        ts,
@@ -491,6 +495,10 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			name:        "invalid-embedded-pipeline-mismatching-parameter-types",
 			pipelineRun: prs[10],
 			reason:      ReasonParameterTypeMismatch,
+		}, {
+			name:        "invalid-pipeline-run-missing-params-shd-stop-reconciling",
+			pipelineRun: prs[11],
+			reason:      ReasonParameterMissing,
 		},
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -121,3 +121,104 @@ func TestValidateParamTypesMatching_Invalid(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRequiredParametersProvided_Valid(t *testing.T) {
+	tcs := []struct {
+		name string
+		pp   []v1beta1.ParamSpec
+		prp  []v1beta1.Param
+	}{{
+		name: "required string params provided",
+		pp: []v1beta1.ParamSpec{
+			{
+				Name: "required-string-param",
+				Type: v1beta1.ParamTypeString,
+			},
+		},
+		prp: []v1beta1.Param{
+			{
+				Name:  "required-string-param",
+				Value: *tb.ArrayOrString("somestring"),
+			},
+		},
+	}, {
+		name: "required array params provided",
+		pp: []v1beta1.ParamSpec{
+			{
+				Name: "required-array-param",
+				Type: v1beta1.ParamTypeArray,
+			},
+		},
+		prp: []v1beta1.Param{
+			{
+				Name:  "required-array-param",
+				Value: *tb.ArrayOrString("another", "array"),
+			},
+		},
+	}, {
+		name: "string params provided in default",
+		pp: []v1beta1.ParamSpec{
+			{
+				Name:    "string-param",
+				Type:    v1beta1.ParamTypeString,
+				Default: tb.ArrayOrString("somedefault"),
+			},
+		},
+		prp: []v1beta1.Param{
+			{
+				Name:  "another-string-param",
+				Value: *tb.ArrayOrString("somestring"),
+			},
+		},
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateRequiredParametersProvided(&tc.pp, &tc.prp); err != nil {
+				t.Errorf("Didn't expect to see error when validating valid PipelineRun parameters but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateRequiredParametersProvided_Invalid(t *testing.T) {
+	tcs := []struct {
+		name string
+		pp   []v1beta1.ParamSpec
+		prp  []v1beta1.Param
+	}{{
+		name: "required string param missing",
+		pp: []v1beta1.ParamSpec{
+			{
+				Name: "required-string-param",
+				Type: v1beta1.ParamTypeString,
+			},
+		},
+		prp: []v1beta1.Param{
+			{
+				Name:  "another-string-param",
+				Value: *tb.ArrayOrString("anotherstring"),
+			},
+		},
+	}, {
+		name: "required array param missing",
+		pp: []v1beta1.ParamSpec{
+			{
+				Name: "required-array-param",
+				Type: v1beta1.ParamTypeArray,
+			},
+		},
+		prp: []v1beta1.Param{
+			{
+				Name:  "another-array-param",
+				Value: *tb.ArrayOrString("anotherstring"),
+			},
+		},
+	}}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateRequiredParametersProvided(&tc.pp, &tc.prp); err == nil {
+				t.Errorf("Expected to see error when validating invalid PipelineRun parameters but saw none")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

While working on allowing PipelineRuns to provide extra parameters (#2513), we found that providing extra parameters was unintentionally allowed. That's because, currently, there's no validation that all parameters expected by the Pipeline is provided by the PipelineRun.

In this PR, we add validation for PipelineRun parameters by generating a list of provided parameters then iterating through the expected parameters to ensure they are in the list of provided parameters. Note that parameters which have default values specified in Pipeline are not required to be provided by PipelineRun.

In the validation, we still allow PipelineRuns to provide extra parameters. If we disallow PipelineRuns from providing extra parameters, the Pipelines would fail. As a result, systems that autogenerate PipelineRuns would need to look at each pipeline to see what parameters they need so it can provide only the required parameters. That means users would have to resort to more complex designs to solve this issue, as further described in (#2513). 

By allowing PipelineRuns to provide extra parameters, we make the process of autogenerating of PipelineRuns simpler.

Fixes #2708.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
- PipelineRun parameters are validated to ensure that all the parameters required by the Pipeline are provided by the PipelineRun.

- PipelineRun parameters validation allows PipelineRuns to provide extra parameters in addition to the required parameters.

- Warning: backwards incompatible change that will force users to pass in default parameter values or provide the required parameters. 
```
