### PR TITLE
events: rename EmitEvent and EmitErrorEvent 🌲

### DIFF
--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -34,7 +34,7 @@ const (
 	EventReasonError = "Error"
 )
 
-// EmitEvent emits an event for object if afterCondition is different from beforeCondition
+// Emit emits an event for object if afterCondition is different from beforeCondition
 //
 // Status "ConditionUnknown":
 //   beforeCondition == nil, emit EventReasonStarted
@@ -43,7 +43,7 @@ const (
 //  Status "ConditionTrue": emit EventReasonSucceded
 //  Status "ConditionFalse": emit EventReasonFailed
 //
-func EmitEvent(c record.EventRecorder, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
+func Emit(c record.EventRecorder, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
 	if !equality.Semantic.DeepEqual(beforeCondition, afterCondition) && afterCondition != nil {
 		// If the condition changed, and the target condition is not empty, we send an event
 		switch afterCondition.Status {
@@ -66,9 +66,28 @@ func EmitEvent(c record.EventRecorder, beforeCondition *apis.Condition, afterCon
 	}
 }
 
-// EmitErrorEvent emits a failure associated to an error
-func EmitErrorEvent(c record.EventRecorder, err error, object runtime.Object) {
+// EmitError emits a failure associated to an error
+func EmitError(c record.EventRecorder, err error, object runtime.Object) {
 	if err != nil {
 		c.Event(object, corev1.EventTypeWarning, EventReasonError, err.Error())
 	}
+}
+
+// EmitEvent emits an event for object if afterCondition is different from beforeCondition
+//
+// Status "ConditionUnknown":
+//   beforeCondition == nil, emit EventReasonStarted
+//   beforeCondition != nil, emit afterCondition.Reason
+//
+//  Status "ConditionTrue": emit EventReasonSucceded
+//  Status "ConditionFalse": emit EventReasonFailed
+// Deprecated: use Emit
+func EmitEvent(c record.EventRecorder, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
+	Emit(c, beforeCondition, afterCondition, object)
+}
+
+// EmitErrorEvent emits a failure associated to an error
+// Deprecated: use EmitError instead
+func EmitErrorEvent(c record.EventRecorder, err error, object runtime.Object) {
+	EmitError(c, err, object)
 }

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func TestEmitEvent(t *testing.T) {
+func TestEmit(t *testing.T) {
 	testcases := []struct {
 		name      string
 		before    *apis.Condition
@@ -136,7 +136,7 @@ func TestEmitEvent(t *testing.T) {
 	for _, ts := range testcases {
 		fr := record.NewFakeRecorder(1)
 		tr := &corev1.Pod{}
-		EmitEvent(fr, ts.before, ts.after, tr)
+		Emit(fr, ts.before, ts.after, tr)
 
 		err := checkEvents(t, fr, ts.name, ts.wantEvent)
 		if err != nil {
@@ -145,7 +145,7 @@ func TestEmitEvent(t *testing.T) {
 	}
 }
 
-func TestEmitErrorEvent(t *testing.T) {
+func TestEmitError(t *testing.T) {
 	testcases := []struct {
 		name      string
 		err       error
@@ -163,7 +163,7 @@ func TestEmitErrorEvent(t *testing.T) {
 	for _, ts := range testcases {
 		fr := record.NewFakeRecorder(1)
 		tr := &corev1.Pod{}
-		EmitErrorEvent(fr, ts.err, tr)
+		EmitError(fr, ts.err, tr)
 
 		err := checkEvents(t, fr, ts.name, ts.wantEvent)
 		if err != nil {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -204,7 +204,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		before := pr.Status.GetCondition(apis.ConditionSucceeded)
 		merr = multierror.Append(merr, cancelPipelineRun(c.Logger, pr, c.PipelineClientSet))
 		after := pr.Status.GetCondition(apis.ConditionSucceeded)
-		events.EmitEvent(c.Recorder, before, after, pr)
+		events.Emit(c.Recorder, before, after, pr)
 	default:
 		if err := c.tracker.Track(pr.GetTaskRunRef(), pr); err != nil {
 			c.Logger.Errorf("Failed to create tracker for TaskRuns for PipelineRun %s: %v", pr.Name, err)
@@ -638,7 +638,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 	before := pr.Status.GetCondition(apis.ConditionSucceeded)
 	after := resources.GetPipelineConditionStatus(pr, pipelineState, c.Logger, d)
 	pr.Status.SetCondition(after)
-	events.EmitEvent(c.Recorder, before, after, pr)
+	events.Emit(c.Recorder, before, after, pr)
 
 	pr.Status.TaskRuns = getTaskRunsStatus(pr, pipelineState)
 	c.Logger.Infof("PipelineRun %s status is being set to %s", pr.Name, pr.Status.GetCondition(apis.ConditionSucceeded))

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -117,7 +117,7 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 		// We also want to send the "Started" event as soon as possible for anyone who may be waiting
 		// on the event to perform user facing initialisations, such has reset a CI check status
 		afterCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
-		events.EmitEvent(c.Recorder, nil, afterCondition, tr)
+		events.Emit(c.Recorder, nil, afterCondition, tr)
 	}
 
 	// If the TaskRun is complete, run some post run fixtures when applicable
@@ -210,9 +210,9 @@ func (c *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 func (c *Reconciler) finishReconcileUpdateEmitEvents(tr, original *v1beta1.TaskRun, beforeCondition *apis.Condition, previousError error) error {
 	afterCondition := tr.Status.GetCondition(apis.ConditionSucceeded)
-	events.EmitEvent(c.Recorder, beforeCondition, afterCondition, tr)
+	events.Emit(c.Recorder, beforeCondition, afterCondition, tr)
 	err := c.updateStatusLabelsAndAnnotations(tr, original)
-	events.EmitErrorEvent(c.Recorder, err, tr)
+	events.EmitError(c.Recorder, err, tr)
 	return multierror.Append(previousError, err).ErrorOrNil()
 }
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This renames two methods:

events.EmitEvent -> events.Emit
events.EmitErrorEvent -> events.EmitError

It keeps the old name and mark them as Deprecated (so that external
user of those function are not broken).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

This is a small follow-up to #2655 

/cc @afrittoli @bobcatfish @dibyom 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Renaming events.EmitEvent and events.EmitErrorEvent to, respectively, events.Emit and events.EmitError
```
