### PR TITLE
Propagate NodeSelector and Tolerations to Affinity Assistant

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -245,7 +245,7 @@ The example below customizes the following:
 - the default timeout from 60 minutes to 20 minutes.
 - the default `app.kubernetes.io/managed-by` label is applied to all Pods created to execute `TaskRuns`.
 - the default Pod template to include a node selector to select the node where the Pod will be scheduled by default.
-  For more information, see [`PodTemplate` in `TaskRuns`](./taskruns.md#pod-template) or [`PodTemplate` in `PipelineRuns`](./pipelineruns.md#pod-template).
+  For more information, see [`PodTemplate` in `TaskRuns`](./taskruns.md#specifying-a-pod-template) or [`PodTemplate` in `PipelineRuns`](./pipelineruns.md#specifying-a-pod-template).
 
 ```yaml
 apiVersion: v1
@@ -270,7 +270,7 @@ To customize the behavior of the Pipelines Controller, modify the ConfigMap `fea
 
 - `disable-affinity-assistant` - set this flag to disable the [Affinity Assistant](./workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline)
   that is used to provide Node Affinity for `TaskRun` pods that share workspace volume. 
-  The Affinity Assistant pods may be incompatible with NodeSelector and other affinity rules
+  The Affinity Assistant is incompatible with other affinity rules
   configured for `TaskRun` pods.
 
   **Note:** Affinity Assistant use [Inter-pod affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity)

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -209,13 +209,15 @@ The `subPath` specified in a `Pipeline` will be appended to any `subPath` specif
 
 Sharing a `Workspace` between `Tasks` requires you to define the order in which those `Tasks`
 write to or read from that `Workspace`. Use the `runAfter` field in your `Pipeline` definition
-to define when a `Task` should be executed. For more information, see the [`runAfter` documentation](pipelines.md#runAfter).
+to define when a `Task` should be executed. For more information, see the [`runAfter` documentation](pipelines.md#using-the-runafter-parameter).
 
 When a `PersistentVolumeClaim` is used as volume source for a `Workspace` in a `PipelineRun`,
 an Affinity Assistant will be created. The Affinity Assistant acts as a placeholder for `TaskRun` pods
 sharing the same `Workspace`. All `TaskRun` pods within the `PipelineRun` that share the `Workspace`
 will be scheduled to the same Node as the Affinity Assistant pod. This means that Affinity Assistant is incompatible
-with e.g. NodeSelectors or other affinity rules configured for the `TaskRun` pods. The Affinity Assistant
+with e.g. other affinity rules configured for the `TaskRun` pods. If the `PipepineRun` has a custom
+[PodTemplate](pipelineruns.md#specifying-a-pod-template) configured, the `NodeSelector` and `Tolerations` fields
+will also be set on the Affinity Assistant pod. The Affinity Assistant
 is deleted when the `PipelineRun` is completed. The Affinity Assistant can be disabled by setting the
 [disable-affinity-assistant](install.md#customizing-basic-execution-parameters) feature gate.
 

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -117,6 +117,18 @@ func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimNam
 	// We want a singleton pod
 	replicas := int32(1)
 
+	// use tolerations from default podTemplate if specified
+	var tolerations []corev1.Toleration
+	if pr.Spec.PodTemplate != nil {
+		tolerations = pr.Spec.PodTemplate.Tolerations
+	}
+
+	// use nodeSelector from default podTemplate if specified
+	var nodeSelector map[string]string
+	if pr.Spec.PodTemplate != nil {
+		nodeSelector = pr.Spec.PodTemplate.NodeSelector
+	}
+
 	containers := []corev1.Container{{
 		Name: "affinity-assistant",
 
@@ -171,7 +183,9 @@ func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimNam
 					Labels: getStatefulSetLabels(pr, name),
 				},
 				Spec: corev1.PodSpec{
-					Containers: containers,
+					Containers:   containers,
+					Tolerations:  tolerations,
+					NodeSelector: nodeSelector,
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{repelOtherAffinityAssistantsPodAffinityTerm},


### PR DESCRIPTION
# Changes

To be able to run Tekton workload on a subset of the Nodes in a cluster,
a NodeSelector or Tolerations can be set on the pods, e.g. by specifying a
custom PodTemplate.

When using the Affinity Assistant, this was not supported to customize.

This commit, also propagate NodeSelector and Tolerations to the Affinity Assistant pod,
so that Tekton workload can be kept to a subset of the Nodes in a cluster, also when
using the Affinity Assistant.

My original idea https://github.com/tektoncd/pipeline/pull/2630#issuecomment-629558587 was that it could be useful to specify a specific PodTemplate for the AffinityAssistant.
But I think it is better to inherit some values from the already specified custom PodTemplate.

Fixes #2742
Fixes #2679
/kind feature

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 --

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
