### PR TITLE
Lower the CPU request for the Affinity Assistant

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -128,11 +128,11 @@ func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimNam
 		// Affinity Assistant pod is a placeholder; request minimal resources
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
-				"cpu":    resource.MustParse("100m"),
+				"cpu":    resource.MustParse("50m"),
 				"memory": resource.MustParse("100Mi"),
 			},
 			Requests: corev1.ResourceList{
-				"cpu":    resource.MustParse("100m"),
+				"cpu":    resource.MustParse("50m"),
 				"memory": resource.MustParse("100Mi"),
 			},
 		},


### PR DESCRIPTION
# Changes

1/10th of a core may be too much to request. This may affect how much
TaskRun pods can request, especially on single-core Nodes.

This commit lower the CPU request to 1/20th of a core.

/kind misc

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.