### PR TITLE
Disentangle metric reporting from the actual reconciler.

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -40,10 +40,6 @@ import (
 	"knative.dev/pkg/tracker"
 )
 
-const (
-	resyncPeriod = 10 * time.Hour
-)
-
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
 func NewController(namespace string, images pipeline.Images) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -102,6 +98,8 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 		c.Logger.Info("Setting up ConfigMap receivers")
 		c.configStore = config.NewStore(images, c.Logger.Named("config-store"))
 		c.configStore.WatchConfigs(cmw)
+
+		go metrics.ReportRunningPipelineRuns(ctx, pipelineRunInformer.Lister())
 
 		return impl
 	}

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -106,6 +106,9 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 
 		c.configStore = config.NewStore(c.Logger.Named("config-store"))
 		c.configStore.WatchConfigs(cmw)
+
+		go metrics.ReportRunningTaskRuns(ctx, taskRunInformer.Lister())
+
 		return impl
 	}
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -421,8 +421,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun,
 // Push changes (if any) to the TaskRun status, labels and annotations to
 // TaskRun definition in ectd
 func (c *Reconciler) updateStatusLabelsAndAnnotations(tr, original *v1beta1.TaskRun) error {
-	var updated bool
-
 	if !equality.Semantic.DeepEqual(original.Status, tr.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
@@ -432,7 +430,6 @@ func (c *Reconciler) updateStatusLabelsAndAnnotations(tr, original *v1beta1.Task
 			c.Logger.Warn("Failed to update taskRun status", zap.Error(err))
 			return err
 		}
-		updated = true
 	}
 
 	// When we update the status only, we use updateStatus to minimize the chances of
@@ -444,16 +441,6 @@ func (c *Reconciler) updateStatusLabelsAndAnnotations(tr, original *v1beta1.Task
 			c.Logger.Warn("Failed to update TaskRun labels/annotations", zap.Error(err))
 			return err
 		}
-		updated = true
-	}
-
-	if updated {
-		go func(metrics *Recorder) {
-			err := metrics.RunningTaskRuns(c.taskRunLister)
-			if err != nil {
-				c.Logger.Warnf("Failed to log the metrics : %v", err)
-			}
-		}(c.metrics)
 	}
 
 	return nil


### PR DESCRIPTION
This changes the metric reporting to happen periodically vs. being
triggered by reconciliation.  The previous method was prone to stale
data because it was driven by the informer cache immediately following
writes through the client, and might not fix itself since the status
may not change (even on resync every 10h).  With this change it should
exhibit the correct value within 30s + {informer delay}, where the 30s
is configurable on the Recorders.

Fixes: #2729
