### PR TITLE
WIP:  add sar lib; webhook for sar on SA -> clustertask

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -98,7 +98,7 @@ rules:
     resources: ["validatingwebhookconfigurations"]
     # validation.webhook.pipeline.tekton.dev performs schema validation when you, for example, create TaskRuns.
     # config.webhook.pipeline.tekton.dev validates the logging configuration against knative's logging structure
-    resourceNames: ["validation.webhook.pipeline.tekton.dev", "config.webhook.pipeline.tekton.dev"]
+    resourceNames: ["validation.webhook.pipeline.tekton.dev", "config.webhook.pipeline.tekton.dev", "uservalidation.webhook.pipeline.tekton.dev"]
     # When there are changes to the configs or secrets, knative updates the validatingwebhook config
     # with the updated certificates or the refreshed set of rules.
     verbs: ["get", "update"]
@@ -106,6 +106,12 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["tekton-pipelines"]
     verbs: ["use"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelines"]
+    verbs: ["get"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -59,31 +59,3 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "update"]
     resourceNames: ["webhook-certs"]
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: tekton-view-clustertask
-  namespace: tekton-pipelines
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipelines
-rules:
-  - apiGroups: ["tekton.dev"]
-    resources: ["clustertasks"]
-    verbs: ["get", "list", "watch"]
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: tekton-view-clustertask
-  namespace: default
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipelines
-rules:
-  - apiGroups: ["tekton.dev"]
-    resources: ["clustertasks"]
-    verbs: ["get", "list", "watch"]

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -59,3 +59,31 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "update"]
     resourceNames: ["webhook-certs"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-view-clustertask
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["clustertasks"]
+    verbs: ["get", "list", "watch"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-view-clustertask
+  namespace: default
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["clustertasks"]
+    verbs: ["get", "list", "watch"]

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -47,3 +47,39 @@ roleRef:
   kind: Role
   name: tekton-pipelines-webhook
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-view-clustertask
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: tekton-view-clustertask
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-view-clustertask
+  namespace: default
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+roleRef:
+  kind: Role
+  name: tekton-view-clustertask
+  apiGroup: rbac.authorization.k8s.io

--- a/config/201-rolebinding.yaml
+++ b/config/201-rolebinding.yaml
@@ -47,39 +47,3 @@ roleRef:
   kind: Role
   name: tekton-pipelines-webhook
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: tekton-view-clustertask
-  namespace: tekton-pipelines
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipelines
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: tekton-pipelines
-roleRef:
-  kind: Role
-  name: tekton-view-clustertask
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: tekton-view-clustertask
-  namespace: default
-  labels:
-    app.kubernetes.io/component: controller
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/part-of: tekton-pipelines
-subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: default
-roleRef:
-  kind: Role
-  name: tekton-view-clustertask
-  apiGroup: rbac.authorization.k8s.io

--- a/config/500-webhooks.yaml
+++ b/config/500-webhooks.yaml
@@ -89,3 +89,22 @@ webhooks:
   objectSelector:
     matchLabels:
       app.kubernetes.io/part-of: tekton-pipelines
+
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: uservalidation.webhook.pipeline.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: devel
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines
+    failurePolicy: Fail
+    sideEffects: None
+    name: uservalidation.webhook.pipeline.tekton.dev
+

--- a/config/clusterrole-aggregate-view.yaml
+++ b/config/clusterrole-aggregate-view.yaml
@@ -20,6 +20,8 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
     rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:
   - tekton.dev
@@ -30,6 +32,7 @@ rules:
   - pipelineruns
   - pipelineresources
   - conditions
+  - clustertasks
   verbs:
   - get
   - list

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -61,11 +61,13 @@ spec:
         # and substituted here.
         image: ko://github.com/tektoncd/pipeline/cmd/webhook
         env:
+        - name: DISABLE_CLUSTER_TASK_ACCESS_VALIDATION
+          value: "true"
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # If you are changing these names, you will also need to update
+          # If you are changing these names, you will also need to update
         # the webhook's Role in 200-role.yaml to include the new
         # values in the "configmaps" "get" rule.
         - name: CONFIG_LOGGING_NAME

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -1,0 +1,94 @@
+<!--
+---
+linkTitle: "Authorization"
+weight: 1
+---
+-->
+
+# Authorization
+
+This document explains use of Kubernetes "Rules Based Access Control" 
+or ["RBAC"](https://kubernetes.io/docs/reference/access-authn-authz/authorization/), beyond the 
+definition of various RBAC objects in the `config` folder of this project.
+
+## Controller Access to ClusterTasks from PipelineRuns and TaskRuns
+
+By default, Tekton allows any `PipelineRun` or `TaskRun` to access any ClusterTask because the 
+controller(s) has access to any ClusterTask.  However, if you happened to log into the cluster
+using the credentials of the `ServiceAccount` associated with the `PipelineRun` or `TaskRun` and ran
+
+```bash
+kubectl  auth can-i get clustertask <cluster task name>
+``` 
+
+you will get `false` because by default the `ServiceAccounts` used in `PipelineRuns` and `TaskRuns` are
+not granted permission to access the cluster scoped resource `ClusterTask`.  And remember, if no `ServiceAccount` is 
+set on the `PipelineRun` or `TaskRun`, the `default` `ServiceAccount` is used by Kubernetes when running the underlying
+`Pod`.
+
+If as an administrator, you want to control which `PipelineRun` and `TaskRun` instances, via their `ServiceAccounts`, 
+have access to given `ClusterTasks`, consider these steps:
+
+- First, as a convenience, Tekton adds viewing of `ClusterTask` as part of its aggregation of permissions to the default
+`view` / `edit` / `admin` `ClusterRoles` present with any Kubernetes cluster.  You can then assign one of those default
+`ClusterRoles` to any `ServiceAccount` that should have access to `ClusterTasks`
+- If one of those default `ClusterRoles` is too broad, then create more precise `Role` / `RoleBinding` or `ClusterRole` 
+/ `ClusterRoleBinding` and assign those to the `ServiceAccounts` in questions.
+- Then, an update to the Tekton webhook `Deployment` named `tekton-pipelines-webhook` in the `tekton-pipelines` namespace 
+is needed to enable the validating admission webhook that will ensure that the `ServiceAccount` associated with a 
+`PipelineRun` or `TaskRun` can read its referenced `ClusterTask`.
+- The specific update needed is setting the environment variable `ENABLE_CLUSTER_TASK_ACCESS_VALIDATION` to "true" on
+the webhook's underlying `Container`.
+- Once set, enforcement that the necessary permissions exist for `ClusterTask` access should start. 
+
+## Pod Security Policy
+
+### Background
+
+From Kubernetes documentation, [using Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) 
+introduces the pluggable authorization facility of Kubernetes. The concept of admission webhooks, with mutating and validating 
+specific types, are the substance of admission controllers. 
+
+There is a set of default admission controller “plugins” available for opt-in/opt-out, listed [here](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#what-does-each-admission-controller-do),
+that provide a slew of validations.  Of that list, the PodSecurityPolicy, which is introduced [here](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy)
+and detailed [here](https://kubernetes.io/docs/concepts/policy/pod-security-policy/), is perhaps the fundamental, 
+and controversial, of those default plugins. 
+
+
+Some key points regarding the PodSecurityPolicy plugin:
+
+- It regulates whether a `Pod` can be created
+- It has to be enabled.  It is off by default with Kubernetes out of the box.
+- It considers the permissions of **EITHER** the `ServiceAccount` associated with the `Pod`, or the user that invokes
+the HTTP requests against the API Server's `Pod` endpoint to create the `Pod` (this user is commonly referred to as 
+the "requesting user")
+- It maps both the "requesting user" and `ServiceAccount` to whatever `PodSecurityPolicy` objects that exist in 
+the Cluster (where RBAC can be defined such that a user can `use` a given `PodSecuirtyPolicy`).
+- `PodSecurityPolicy` defines whether certain fields in the `Pod` or underlying `Containers` can be set in certain ways
+
+### Best Practice Recommendations with Tekton
+
+So an exploration of the default configuration provide with Tekton discovers that an example `PodSecurityPolicy` is 
+provided [here](https://github.com/tektoncd/pipeline/blob/master/config/101-podsecuritypolicy.yaml).  And it is assigned 
+to the Tekton controller [here](https://github.com/tektoncd/pipeline/blob/master/config/200-clusterrole.yaml)
+
+An examination of the `PodSecurityPolicy` shows that it is fairly restrictive:
+
+- It does not allow privileged or escalation to privileged
+- It restricts volumes to emptyDir, `ConfigMap`, and `Secret`
+- it restricts access to the host networks and namespaces
+
+Now, if you run in a cluster with PodSecurityPolicy or similar plugin enabled, and want to allow escalated permissions
+for `Pods` for **SOME, BUT NOT ALL,** users, it is important that you create escalated `PodSecurityPolicy` 
+instances and assign them to the `ServiceAccounts` assigned to the `PipelineRun` or `TaskRun`, and **NOT** the Tekton
+controllers.
+
+Why?
+
+Because of the whose permissions the PodSecurityPolicy plugin considered when deciding if a `Pod` can be created.  Only
+1 of the users considered, either the "requesting user" or `ServiceAccount`, need to have permission.  The Tekton 
+controllers are the "requesting user" when a `PipelineRun` or `TaskRun` are converted into a `Pod`.  It is the Tekton
+controllers that issue the HTTP request to create the `Pod`.  If it has escalated permissions, that means **ANY** user
+in the system that can create `PipelineRun` or `TaskRun` objects can create `Pods` with escalated permissions. 
+
+

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -143,6 +143,12 @@ spec:
       params: ....
 ```
 
+**Note:** Access to cluster scoped resources like `ClusterTask` by any user (`ServiceAccounts` in specific namespace(s)
+or a human user) is not a given to exist for every Kubernetes based cluster, though Tekton allows
+`PipelineRuns` and `TaskRuns` to access any `ClusterTask` by default.  If an administrator wants to restrict
+access to `ClusterTasks` from certain `PipelineRuns` or `TaskRuns`, read about Tekton's use of the Kubernetes
+authorization features [here](authorization.md).
+
 ### Defining `Steps`
 
 A `Step` is a reference to a container image that executes a specific tool on a

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jenkins-x/go-scm v1.5.117
 	github.com/mailru/easyjson v0.7.1-0.20191009090205-6c0755d89d1e // indirect
+	github.com/markbates/inflect v1.0.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/tektoncd/plumbing v0.0.0-20200430135134-e53521e1d887

--- a/pkg/authorization/util.go
+++ b/pkg/authorization/util.go
@@ -1,0 +1,41 @@
+package authorization
+
+import (
+	"errors"
+	"fmt"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1"
+)
+
+// AddUserToSAR adds the requisite user information to a SubjectAccessReview.
+// It returns the modified SubjectAccessReview.
+func AddUserToSAR(saName, saNamespace string, sar *authorizationv1.SubjectAccessReview) *authorizationv1.SubjectAccessReview {
+	sar.Spec.User = fmt.Sprintf("system:serviceaccount:%s:%s", saNamespace, saName)
+
+	return sar
+}
+
+// Authorize verifies that a given user is permitted to carry out a given
+// action.  If this cannot be determined, or if the user is not permitted, an
+// error is returned.
+func AuthorizeSAR(sarClient authorizationclient.SubjectAccessReviewInterface, saName, saNamespace string,
+	resourceAttributes *authorizationv1.ResourceAttributes) error {
+	sar := AddUserToSAR(saName, saNamespace, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			ResourceAttributes: resourceAttributes,
+		},
+	})
+
+	resp, err := sarClient.Create(sar)
+	if err == nil && resp != nil && resp.Status.Allowed {
+		return nil
+	}
+
+	if err == nil {
+		err = errors.New(resp.Status.Reason)
+	}
+	return kerrors.NewForbidden(schema.GroupResource{Group: resourceAttributes.Group, Resource: resourceAttributes.Resource}, resourceAttributes.Name, err)
+}

--- a/pkg/webhook/authorization/validation/controller.go
+++ b/pkg/webhook/authorization/validation/controller.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+
+	// Injection stuff
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	vwhinformer "knative.dev/pkg/client/injection/kube/informers/admissionregistration/v1/validatingwebhookconfiguration"
+	secretinformer "knative.dev/pkg/injection/clients/namespacedkube/informers/core/v1/secret"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/resourcesemantics"
+)
+
+// NewAdmissionController constructs a reconciler
+func NewAdmissionController(
+	ctx context.Context,
+	name, path string,
+	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD,
+	wc func(context.Context) context.Context,
+	disallowUnknownFields bool,
+) *controller.Impl {
+
+	client := kubeclient.Get(ctx)
+	vwhInformer := vwhinformer.Get(ctx)
+	secretInformer := secretinformer.Get(ctx)
+	options := webhook.GetOptions(ctx)
+	tektonClient := pipelineclient.Get(ctx)
+
+	wh := &reconciler{
+		name:     name,
+		path:     path,
+		handlers: handlers,
+
+		withContext:           wc,
+		disallowUnknownFields: disallowUnknownFields,
+		secretName:            options.SecretName,
+
+		client:       client,
+		vwhlister:    vwhInformer.Lister(),
+		secretlister: secretInformer.Lister(),
+		tektonClient: tektonClient,
+	}
+
+	logger := logging.FromContext(ctx)
+	c := controller.NewImpl(wh, logger, "ConfigMapWebhook")
+
+	// Reconcile when the named ValidatingWebhookConfiguration changes.
+	vwhInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithName(name),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named VWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	// Reconcile when the cert bundle changes.
+	secretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterWithNameAndNamespace(system.Namespace(), wh.secretName),
+		// It doesn't matter what we enqueue because we will always Reconcile
+		// the named VWH resource.
+		Handler: controller.HandleAll(c.Enqueue),
+	})
+
+	return c
+}

--- a/pkg/webhook/authorization/validation/validation.go
+++ b/pkg/webhook/authorization/validation/validation.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/authorization"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+
+	"github.com/markbates/inflect"
+	"go.uber.org/zap"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	admissionlisters "k8s.io/client-go/listers/admissionregistration/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmp"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/webhook"
+	certresources "knative.dev/pkg/webhook/certificates/resources"
+	"knative.dev/pkg/webhook/resourcesemantics"
+)
+
+var errMissingNewObject = errors.New("the new object may not be nil")
+
+// reconciler implements the AdmissionController for resources
+type reconciler struct {
+	name     string
+	path     string
+	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD
+
+	withContext func(context.Context) context.Context
+
+	client       kubernetes.Interface
+	vwhlister    admissionlisters.ValidatingWebhookConfigurationLister
+	secretlister corelisters.SecretLister
+	tektonClient clientset.Interface
+
+	disallowUnknownFields bool
+	secretName            string
+}
+
+var _ controller.Reconciler = (*reconciler)(nil)
+var _ webhook.AdmissionController = (*reconciler)(nil)
+
+// Reconcile implements controller.Reconciler
+func (ac *reconciler) Reconcile(ctx context.Context, key string) error {
+	logger := logging.FromContext(ctx)
+
+	// Look up the webhook secret, and fetch the CA cert bundle.
+	secret, err := ac.secretlister.Secrets(system.Namespace()).Get(ac.secretName)
+	if err != nil {
+		logger.Errorw("Error fetching secret", zap.Error(err))
+		return err
+	}
+	caCert, ok := secret.Data[certresources.CACert]
+	if !ok {
+		return fmt.Errorf("secret %q is missing %q key", ac.secretName, certresources.CACert)
+	}
+
+	// Reconcile the webhook configuration.
+	return ac.reconcileValidatingWebhook(ctx, caCert)
+}
+
+// Path implements AdmissionController
+func (ac *reconciler) Path() string {
+	return ac.path
+}
+
+// Admit implements AdmissionController
+func (ac *reconciler) Admit(ctx context.Context, request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+	if ac.withContext != nil {
+		ctx = ac.withContext(ctx)
+	}
+
+	logger := logging.FromContext(ctx)
+	switch request.Operation {
+	case admissionv1.Create, admissionv1.Update:
+	default:
+		logger.Infof("Unhandled webhook operation, letting it through %v", request.Operation)
+		return &admissionv1.AdmissionResponse{Allowed: true}
+	}
+
+	if err := ac.validate(ctx, request); err != nil {
+		return webhook.MakeErrorStatus("validation failed: %v", err)
+	}
+
+	return &admissionv1.AdmissionResponse{Allowed: true}
+}
+
+func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []byte) error {
+	logger := logging.FromContext(ctx)
+
+	var rules []admissionregistrationv1.RuleWithOperations
+	for gvk := range ac.handlers {
+		plural := strings.ToLower(inflect.Pluralize(gvk.Kind))
+
+		rules = append(rules, admissionregistrationv1.RuleWithOperations{
+			Operations: []admissionregistrationv1.OperationType{
+				admissionregistrationv1.Create,
+				admissionregistrationv1.Update,
+			},
+			Rule: admissionregistrationv1.Rule{
+				APIGroups:   []string{gvk.Group},
+				APIVersions: []string{gvk.Version},
+				Resources:   []string{plural + "/*"},
+			},
+		})
+	}
+
+	// Sort the rules by Group, Version, Kind so that things are deterministically ordered.
+	sort.Slice(rules, func(i, j int) bool {
+		lhs, rhs := rules[i], rules[j]
+		if lhs.APIGroups[0] != rhs.APIGroups[0] {
+			return lhs.APIGroups[0] < rhs.APIGroups[0]
+		}
+		if lhs.APIVersions[0] != rhs.APIVersions[0] {
+			return lhs.APIVersions[0] < rhs.APIVersions[0]
+		}
+		return lhs.Resources[0] < rhs.Resources[0]
+	})
+
+	configuredWebhook, err := ac.vwhlister.Get(ac.name)
+	if err != nil {
+		return fmt.Errorf("error retrieving webhook: %v", err)
+	}
+
+	webhook := configuredWebhook.DeepCopy()
+
+	// Clear out any previous (bad) OwnerReferences.
+	// See: https://github.com/knative/serving/issues/5845
+	webhook.OwnerReferences = nil
+
+	for i, wh := range webhook.Webhooks {
+		if wh.Name != webhook.Name {
+			continue
+		}
+		webhook.Webhooks[i].Rules = rules
+		webhook.Webhooks[i].ClientConfig.CABundle = caCert
+		if webhook.Webhooks[i].ClientConfig.Service == nil {
+			return fmt.Errorf("missing service reference for webhook: %s", wh.Name)
+		}
+		webhook.Webhooks[i].ClientConfig.Service.Path = ptr.String(ac.Path())
+	}
+
+	ok, err := kmp.SafeEqual(configuredWebhook, webhook)
+	switch {
+	case err != nil:
+		return fmt.Errorf("error diffing webhooks: %v", err)
+	case !ok:
+		logger.Info("Updating webhook")
+		vwhclient := ac.client.AdmissionregistrationV1().ValidatingWebhookConfigurations()
+		if _, err := vwhclient.Update(webhook); err != nil {
+			return fmt.Errorf("failed to update webhook: %v", err)
+		}
+	default:
+		logger.Info("Webhook is valid")
+	}
+	return nil
+}
+
+func (ac *reconciler) validate(ctx context.Context, req *admissionv1.AdmissionRequest) error {
+	logger := logging.FromContext(ctx)
+
+	kind := req.Kind
+	newBytes := req.Object.Raw
+	oldBytes := req.OldObject.Raw
+	// Why, oh why are these different types...
+	gvk := schema.GroupVersionKind{
+		Group:   kind.Group,
+		Version: kind.Version,
+		Kind:    kind.Kind,
+	}
+
+	handler, ok := ac.handlers[gvk]
+	if !ok {
+		logger.Errorf("Unhandled kind: %v", gvk)
+		return fmt.Errorf("unhandled kind: %v", gvk)
+	}
+	if !strings.EqualFold(strings.TrimSpace(req.Kind.Kind), "PipelineRun") &&
+		!strings.EqualFold(strings.TrimSpace(req.Kind.Kind), "TaskRun") {
+		return nil
+	}
+
+	// nil values denote absence of `old` (create) or `new` (delete) objects.
+	var oldObj, newObj resourcesemantics.GenericCRD
+
+	if len(newBytes) != 0 {
+		newObj = handler.DeepCopyObject().(resourcesemantics.GenericCRD)
+		newDecoder := json.NewDecoder(bytes.NewBuffer(newBytes))
+		if ac.disallowUnknownFields {
+			newDecoder.DisallowUnknownFields()
+		}
+		if err := newDecoder.Decode(&newObj); err != nil {
+			return fmt.Errorf("cannot decode incoming new object: %v", err)
+		}
+	}
+	if len(oldBytes) != 0 {
+		oldObj = handler.DeepCopyObject().(resourcesemantics.GenericCRD)
+		oldDecoder := json.NewDecoder(bytes.NewBuffer(oldBytes))
+		if ac.disallowUnknownFields {
+			oldDecoder.DisallowUnknownFields()
+		}
+		if err := oldDecoder.Decode(&oldObj); err != nil {
+			return fmt.Errorf("cannot decode incoming old object: %v", err)
+		}
+	}
+
+	// Set up the context for defaulting and validation
+	if oldObj != nil {
+		if req.SubResource == "" {
+			ctx = apis.WithinUpdate(ctx, oldObj)
+		} else {
+			ctx = apis.WithinSubResourceUpdate(ctx, oldObj, req.SubResource)
+		}
+	} else {
+		ctx = apis.WithinCreate(ctx)
+	}
+	ctx = apis.WithUserInfo(ctx, &req.UserInfo)
+
+	// None of the validators will accept a nil value for newObj.
+	if newObj == nil {
+		return errMissingNewObject
+	}
+
+	if err := validate(ctx, newObj); err != nil {
+		logger.Errorw("Failed the resource specific validation", zap.Error(err))
+		// Return the error message as-is to give the validation callback
+		// discretion over (our portion of) the message that the user sees.
+		return err
+	}
+
+	switch v := newObj.(type) {
+	case *v1alpha1.PipelineRun:
+		pipelineTasks := []v1alpha1.PipelineTask{}
+		switch {
+		case v.Spec.PipelineRef != nil && v.Spec.PipelineRef.Name != "":
+			pipeline, err := ac.tektonClient.TektonV1alpha1().Pipelines(v.Namespace).Get(v.Spec.PipelineRef.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			pipelineTasks = pipeline.Spec.Tasks
+		case v.Spec.PipelineSpec != nil:
+			pipelineTasks = v.Spec.PipelineSpec.Tasks
+		}
+		for _, pt := range pipelineTasks {
+			if pt.TaskRef == nil || pt.TaskRef.Kind == v1beta1.NamespacedTaskKind {
+				continue
+			}
+			err := ac.runSar(v.Name, v.Namespace, v.Spec.ServiceAccountName, pt.TaskRef.Name)
+			if err != nil {
+				return err
+			}
+		}
+
+	case *v1alpha1.TaskRun:
+		if v.Spec.TaskRef != nil && v.Spec.TaskRef.Kind == v1alpha1.ClusterTaskKind {
+			return ac.runSar(v.Name, v.Namespace, v.Spec.ServiceAccountName, v.Spec.TaskRef.Name)
+		}
+
+	case *v1beta1.PipelineRun:
+		pipelineTasks := []v1beta1.PipelineTask{}
+		switch {
+		case v.Spec.PipelineRef != nil && v.Spec.PipelineRef.Name != "":
+			pipeline, err := ac.tektonClient.TektonV1beta1().Pipelines(v.Namespace).Get(v.Spec.PipelineRef.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			pipelineTasks = pipeline.Spec.Tasks
+		case v.Spec.PipelineSpec != nil:
+			pipelineTasks = v.Spec.PipelineSpec.Tasks
+		}
+		for _, pt := range pipelineTasks {
+			if pt.TaskRef == nil || pt.TaskRef.Kind == v1beta1.NamespacedTaskKind {
+				continue
+			}
+			err := ac.runSar(v.Name, v.Namespace, v.Spec.ServiceAccountName, pt.TaskRef.Name)
+			if err != nil {
+				return err
+			}
+		}
+
+	case *v1beta1.TaskRun:
+		tr := newObj.(*v1beta1.TaskRun)
+		if tr.Spec.TaskRef != nil && tr.Spec.TaskRef.Kind == v1beta1.ClusterTaskKind {
+			return ac.runSar(tr.Name, tr.Namespace, tr.Spec.ServiceAccountName, tr.Spec.TaskRef.Name)
+		}
+
+	}
+
+	return nil
+}
+
+var cannotReadClusterTaskString = "%s/%s service account cannot access clustertask %s"
+
+func (ac *reconciler) runSar(name, namespace, sa, clusterTaskName string) error {
+	saToUse := "default"
+	if len(sa) > 0 {
+		saToUse = sa
+	}
+	if err := authorization.AuthorizeSAR(ac.client.AuthorizationV1().SubjectAccessReviews(),
+		saToUse,
+		namespace,
+		&authorizationv1.ResourceAttributes{
+			Verb:      "get",
+			Group:     "tekton.dev",
+			Namespace: namespace,
+			Name:      clusterTaskName,
+			Resource:  "clustertasks",
+		}); err != nil {
+		return fmt.Errorf(cannotReadClusterTaskString, namespace, saToUse, clusterTaskName)
+	}
+	return nil
+}
+
+// validate performs validation on the provided "new" CRD.
+func validate(ctx context.Context, new apis.Validatable) error {
+	// Can't just `return new.Validate()` because it doesn't properly nil-check.
+	if err := new.Validate(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/webhook/authorization/validation/validation.go
+++ b/pkg/webhook/authorization/validation/validation.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -193,6 +194,15 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 
 func (ac *reconciler) validate(ctx context.Context, req *admissionv1.AdmissionRequest) error {
 	logger := logging.FromContext(ctx)
+
+	if os.Getenv("ENABLE_CLUSTER_TASK_ACCESS_VALIDATION") != "true" {
+		logger.Debug("ENABLE_CLUSTER_TASK_ACCESS_VALIDATION != true so returning")
+		return nil
+	}
+	if os.Getenv("DISABLE_CLUSTER_TASK_ACCESS_VALIDATION") == "true" {
+		logger.Debug("DISABLE_CLUSTER_TASK_ACCESS_VALIDATION == true so returning")
+		return nil
+	}
 
 	kind := req.Kind
 	newBytes := req.Object.Raw

--- a/test/controller.go
+++ b/test/controller.go
@@ -41,6 +41,7 @@ import (
 	fakeresourceinformer "github.com/tektoncd/pipeline/pkg/client/resource/injection/informers/resource/v1alpha1/pipelineresource/fake"
 	cloudeventclient "github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"go.uber.org/zap"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -77,6 +78,7 @@ type Clients struct {
 	Resource    *fakeresourceclientset.Clientset
 	Kube        *fakekubeclientset.Clientset
 	CloudEvents cloudeventclient.CEClient
+	Sar         *fakekubeclientset.Clientset
 }
 
 // Informers holds references to informers which are useful for reconciler tests.
@@ -243,6 +245,9 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 	}
 	c.Pipeline.ClearActions()
 	c.Kube.ClearActions()
+	c.Kube.PrependReactor("create", "subjectaccessreviews", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+	})
 	return c, i
 }
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -20,12 +20,20 @@ source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scri
 
 function install_pipeline_crd() {
   echo ">> Deploying Tekton Pipelines"
-  ko resolve -f config/ \
+  if [ "$TEST_CLUSTER_TASK_ACCESS_VALIDATION" == "true" ] ; then
+    ko resolve -f config/ \
       | sed -e 's%"level": "info"%"level": "debug"%' \
       | sed -e 's%loglevel.controller: "info"%loglevel.controller: "debug"%' \
       | sed -e 's%loglevel.webhook: "info"%loglevel.webhook: "debug"%' \
       | sed -e 's%DISABLE_CLUSTER_TASK_ACCESS_VALIDATION%ENABLE_CLUSTER_TASK_ACCESS_VALIDATION%' \
       | kubectl apply -f - || fail_test "Build pipeline installation failed"
+  else
+    ko resolve -f config/ \
+      | sed -e 's%"level": "info"%"level": "debug"%' \
+      | sed -e 's%loglevel.controller: "info"%loglevel.controller: "debug"%' \
+      | sed -e 's%loglevel.webhook: "info"%loglevel.webhook: "debug"%' \
+      | kubectl apply -f - || fail_test "Build pipeline installation failed"
+  fi
   verify_pipeline_installation
 }
 

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -24,6 +24,7 @@ function install_pipeline_crd() {
       | sed -e 's%"level": "info"%"level": "debug"%' \
       | sed -e 's%loglevel.controller: "info"%loglevel.controller: "debug"%' \
       | sed -e 's%loglevel.webhook: "info"%loglevel.webhook: "debug"%' \
+      | sed -e 's%DISABLE_CLUSTER_TASK_ACCESS_VALIDATION%ENABLE_CLUSTER_TASK_ACCESS_VALIDATION%' \
       | kubectl apply -f - || fail_test "Build pipeline installation failed"
   verify_pipeline_installation
 }

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
 )
@@ -185,4 +187,179 @@ func TestTaskRunStatus(t *testing.T) {
 	if d := cmp.Diff(taskrun.Status.TaskSpec, &task.Spec); d != "" {
 		t.Fatalf("-got, +want: %v", d)
 	}
+}
+
+func TestTaskRunClusterTaskWithPermissions(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	taskRunName := "taskrun-to-clustertask-with-perms"
+	clusterTaskName := "status-cluster-task-with-perms"
+
+	fqImageName := "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := &v1beta1.ClusterTask{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			// This was the digest of the latest tag as of 8/12/2019
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Image:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "echo hello"},
+			}}},
+		},
+	}
+	if _, err := c.ClusterTaskClient.Get(clusterTaskName, metav1.GetOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		t.Fatalf("Unexpected error on get of clustertask: %s", err)
+	} else if _, err := c.ClusterTaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	defer c.ClusterTaskClient.Delete(task.Name, &metav1.DeleteOptions{})
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-to-clustertask", Namespace: namespace},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"tekton.dev"},
+			Resources: []string{"clustertasks"},
+			Verbs:     []string{"get", "list", "watch"},
+		}},
+	}
+	if _, err := c.KubeClient.Kube.RbacV1().Roles(namespace).Create(role); err != nil {
+		t.Fatalf("error creating clustertask role %s", err)
+	}
+
+	roleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-to-cluster-task", Namespace: namespace},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "taskrun-to-clustertask",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      "default",
+			Namespace: namespace,
+		}},
+	}
+	if _, err := c.KubeClient.Kube.RbacV1().RoleBindings(namespace).Create(roleBinding); err != nil {
+		t.Fatalf("error creating clustertask rolebinding %s", err)
+	}
+
+	taskRun := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: taskRunName, Namespace: namespace},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{Name: clusterTaskName, Kind: "ClusterTask"},
+		},
+	}
+	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
+		t.Fatalf("Failed to create TaskRun: %s", err)
+	}
+
+	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
+	if err := WaitForTaskRunState(c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed"); err != nil {
+		t.Errorf("Error waiting for TaskRun to finish: %s", err)
+	}
+
+	taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	expectedStepState := []v1beta1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+		Name:          "unnamed-0",
+		ContainerName: "step-unnamed-0",
+	}}
+
+	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+	// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
+	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
+		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
+	}
+
+}
+
+func TestTaskRunClusterTaskWithoutPermissions(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	taskRunName := "taskrun-to-clustertask-without-perms"
+	clusterTaskName := "status-cluster-task-without-perms"
+
+	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
+	task := &v1beta1.ClusterTask{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterTaskName, Namespace: namespace},
+		Spec: v1beta1.TaskSpec{
+			// This was the digest of the latest tag as of 8/12/2019
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Image:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
+				Command: []string{"/bin/sh"},
+				Args:    []string{"-c", "echo hello"},
+			}}},
+		},
+	}
+	if _, err := c.ClusterTaskClient.Get(clusterTaskName, metav1.GetOptions{}); err != nil && !kerrors.IsNotFound(err) {
+		t.Fatalf("Unexpected error on get of clustertask: %s", err)
+	} else if _, err := c.ClusterTaskClient.Create(task); err != nil {
+		t.Fatalf("Failed to create Task: %s", err)
+	}
+	defer c.ClusterTaskClient.Delete(task.Name, &metav1.DeleteOptions{})
+
+	taskRun := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: taskRunName, Namespace: namespace},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{Name: clusterTaskName, Kind: "ClusterTask"},
+		},
+	}
+	if _, err := c.TaskRunClient.Create(taskRun); err == nil {
+		t.Fatalf("Should have failed to create TaskRun: %s", err)
+	}
+
+	/*t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
+	if err := WaitForTaskRunState(c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed"); err == nil {
+		taskrun, _ := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+		t.Fatalf("should have errored out: %#v", taskrun)
+	}
+
+	taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
+	}
+
+	expectedStepState := []v1beta1.StepState{{
+		ContainerState: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0,
+				Reason:   "Completed",
+			},
+		},
+		Name:          "unnamed-0",
+		ContainerName: "step-unnamed-0",
+	}}
+
+	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
+	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+		t.Fatalf("-got, +want: %v", d)
+	}
+	// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
+	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
+		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
+	}*/
+
 }

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
@@ -219,34 +219,8 @@ func TestTaskRunClusterTaskWithPermissions(t *testing.T) {
 	}
 	defer c.ClusterTaskClient.Delete(task.Name, &metav1.DeleteOptions{})
 
-	role := &rbacv1.Role{
-		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-to-clustertask", Namespace: namespace},
-		Rules: []rbacv1.PolicyRule{{
-			APIGroups: []string{"tekton.dev"},
-			Resources: []string{"clustertasks"},
-			Verbs:     []string{"get", "list", "watch"},
-		}},
-	}
-	if _, err := c.KubeClient.Kube.RbacV1().Roles(namespace).Create(role); err != nil {
-		t.Fatalf("error creating clustertask role %s", err)
-	}
-
-	roleBinding := &rbacv1.RoleBinding{
-		ObjectMeta: metav1.ObjectMeta{Name: "taskrun-to-cluster-task", Namespace: namespace},
-		RoleRef: rbacv1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
-			Kind:     "Role",
-			Name:     "taskrun-to-clustertask",
-		},
-		Subjects: []rbacv1.Subject{{
-			Kind:      "ServiceAccount",
-			Name:      "default",
-			Namespace: namespace,
-		}},
-	}
-	if _, err := c.KubeClient.Kube.RbacV1().RoleBindings(namespace).Create(roleBinding); err != nil {
-		t.Fatalf("error creating clustertask rolebinding %s", err)
-	}
+	// assuming the per namespace role binding to the aggregated view role performed in init_test.go
+	// is in play
 
 	taskRun := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{Name: taskRunName, Namespace: namespace},
@@ -320,6 +294,13 @@ func TestTaskRunClusterTaskWithoutPermissions(t *testing.T) {
 	}
 	defer c.ClusterTaskClient.Delete(task.Name, &metav1.DeleteOptions{})
 
+	// delete the view role binding created in init_test.go
+	viewRoleBindingName := fmt.Sprintf("view-%s-defaultSA", namespace)
+	err := c.KubeClient.Kube.RbacV1().RoleBindings(namespace).Delete(viewRoleBindingName, &metav1.DeleteOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		t.Fatalf("unexepcted error on view role binding delete: %s", err)
+	}
+
 	taskRun := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{Name: taskRunName, Namespace: namespace},
 		Spec: v1beta1.TaskRunSpec{
@@ -329,37 +310,5 @@ func TestTaskRunClusterTaskWithoutPermissions(t *testing.T) {
 	if _, err := c.TaskRunClient.Create(taskRun); err == nil {
 		t.Fatalf("Should have failed to create TaskRun: %s", err)
 	}
-
-	/*t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(c, taskRunName, TaskRunSucceed(taskRunName), "TaskRunSucceed"); err == nil {
-		taskrun, _ := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
-		t.Fatalf("should have errored out: %#v", taskrun)
-	}
-
-	taskrun, err := c.TaskRunClient.Get(taskRunName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Couldn't get expected TaskRun %s: %s", taskRunName, err)
-	}
-
-	expectedStepState := []v1beta1.StepState{{
-		ContainerState: corev1.ContainerState{
-			Terminated: &corev1.ContainerStateTerminated{
-				ExitCode: 0,
-				Reason:   "Completed",
-			},
-		},
-		Name:          "unnamed-0",
-		ContainerName: "step-unnamed-0",
-	}}
-
-	ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
-	ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID")
-	if d := cmp.Diff(taskrun.Status.Steps, expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
-		t.Fatalf("-got, +want: %v", d)
-	}
-	// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
-	if !strings.HasSuffix(taskrun.Status.Steps[0].ImageID, fqImageName) {
-		t.Fatalf("`ImageID: %s` does not end with `%s`", taskrun.Status.Steps[0].ImageID, fqImageName)
-	}*/
 
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/2917

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [/] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [/] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [/] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
If administrators want to enforce that the ServiceAccounts associated with any TaskRuns or PipelineRuns have `get` permissions to any ClusterTask referenced by the TaskRuns or PIpelineRuns, then can opt into the user of a validating admission webhook shipped with Tekton.

An environment variable named 'ENABLE_CLUSTER_TASK_ACCESS_VALIDATION' must be set to 'true' in the container of the webhook deployment in the tekton-pipelines namespace in order for the validating admission webhook to enforce those permissions.
```
