### PR TITLE
Clarify the API compatibility policy and improve the deprecations table.

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -55,7 +55,9 @@ and we are following [the Kubernetes deprecation policy](https://kubernetes.io/d
     introduced in a backwards compatible manner first, with a deprecation warning
     in the release notes and migration instructions.
   * You will be given at least 9 months to migrate before a backward incompatible
-    change is made.
+    change is made. This means an older beta API version will continue to be
+    supported in new releases for a period of at least 9 months from the time a
+    newer version is made available.
 
 ## Approving API changes
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -18,7 +18,7 @@ being deprecated.
 
 ## Deprecation Table
 
-| Feature Being Deprecated | Deprecation Announcement | [API Compatibility Policy](https://github.com/tektoncd/pipeline/tree/master/api_compatibility_policy.md) | Earliest Date of Removal |
+| Feature Being Deprecated | Deprecation Announcement | [API Compatibility Policy](https://github.com/tektoncd/pipeline/tree/master/api_compatibility_policy.md) | Earliest Date or Release of Removal |
 | ------------------------ | ------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------ |
 | [`tekton.dev/task` label on ClusterTasks](https://github.com/tektoncd/pipeline/issues/2533) | [v0.12.0](https://github.com/tektoncd/pipeline/releases/tag/v0.12.0) | Beta | January 30 2021 |
 | [Step `$HOME` env var defaults to `/tekton/home`](https://github.com/tektoncd/pipeline/issues/2013) | [v0.11.0-rc1](https://github.com/tektoncd/pipeline/releases/tag/v0.11.0-rc1) | Beta | December 4 2020 |


### PR DESCRIPTION
# Changes

In discussion around #2697, we realized the existing API compatiblity
policy is a little unclear, leading to confusion.
We discussed and clarified the intentions of this policy in #2790.
This change adds an example to the policy, and tweaks the deprecations
table to make a bit more sense.

Fixes https://github.com/tektoncd/pipeline/issues/2790

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
```
