### PR TITLE
Pass port to ssh-keyscan when known_hosts not provided

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -45,6 +45,8 @@ aggregates them into their respective files in `$HOME`.
    data:
      ssh-privatekey: <base64 encoded>
      # This is non-standard, but its use is encouraged to make this more secure.
+     # If it is not provided then the git server's public key will be requested
+     # with `ssh-keyscan` during credential initialization.
      known_hosts: <base64 encoded>
    ```
 

--- a/pkg/credentials/gitcreds/ssh_test.go
+++ b/pkg/credentials/gitcreds/ssh_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitcreds
+
+import (
+	"testing"
+)
+
+func TestSSHKeyScanArgs(t *testing.T) {
+	for _, tc := range []struct {
+		url          string
+		expectedHost string
+		expectedPort string
+	}{{
+		url:          "github.com",
+		expectedHost: "github.com",
+	}, {
+		url:          "customdomain.com",
+		expectedHost: "customdomain.com",
+	}, {
+		url:          "customdomain.com:22",
+		expectedHost: "customdomain.com",
+		expectedPort: "22",
+	}, {
+		url:          "git.customdomain.com:7779",
+		expectedHost: "git.customdomain.com",
+		expectedPort: "7779",
+	}} {
+		host, port := sshKeyScanArgs(tc.url)
+		if host != tc.expectedHost {
+			t.Errorf("expected host %q received %q", tc.expectedHost, host)
+		}
+		if port != tc.expectedPort {
+			t.Errorf("expected port %q received %q", tc.expectedPort, port)
+		}
+	}
+}


### PR DESCRIPTION
# Changes

Fixes #2801

Creds-init performs an ssh-keyscan if no known_hosts file is
provided as part of a Secret. When the ssh server is using
a custom port ssh-keyscan expects the port to be provided
with the -p flag. Currently Tekton does not provide the flag
resulting in failure to generate known_hosts. The error for
this failure is also very opaque - manifesting as an "invalid
flag" message in the creds-init initContainer log and making
no mention of ssh-keyscan.

This commit:
- adds the -p flag to ssh-keyscan calls when a port is specified
in the given git URL.
- adds an additional note to auth.md mentioning ssh-keyscan
- wraps any error returned by ssh-keyscan to mention the utility,
hopefully aiding future debugging

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Specifying a git ssh server url with custom port previously failed during credentials initialization if a known_hosts field was not specified in the Secret. This has been fixed.
```
