### PR TITLE
Remove legacy Cluster Resource behavior left in place for the 0.14.0 …

### DIFF
--- a/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
@@ -151,7 +151,6 @@ func TestNewClusterResource(t *testing.T) {
 				t.Errorf("Test: %q; TestNewClusterResource() error = %v", c.desc, err)
 			}
 			c.want.ShellImage = "override-with-shell-image:latest"
-			c.want.LegacyName = "test-resource"
 			if d := cmp.Diff(got, c.want); d != "" {
 				t.Errorf("Diff:\n%s", diff.PrintWantGot(d))
 			}
@@ -192,14 +191,6 @@ func TestClusterResource_GetInputTaskModifier(t *testing.T) {
 						},
 					},
 				}},
-			},
-		},
-		// We need to temporarily create another directory for the legacy name
-		// See #2694.
-		{
-			Container: corev1.Container{
-				Name:    "ln-dir-test-cluster-resource-mz4c7",
-				Command: []string{"ln", "-s", "/workspace/test-cluster-resource", "/workspace"},
 			},
 		},
 	}

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -852,13 +852,6 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 						},
 					},
 				},
-				{
-					Container: corev1.Container{
-						Name:    "ln-dir-cluster3-mz4c7",
-						Image:   "busybox",
-						Command: []string{"ln", "-s", "/workspace/cluster3", "/workspace/cluster3"},
-					},
-				},
 			},
 			Resources: &v1beta1.TaskResources{
 				Inputs: clusterInputs,
@@ -920,13 +913,6 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 							},
 							Name: "CADATA",
 						}},
-					},
-				},
-				{
-					Container: corev1.Container{
-						Name:    "ln-dir-cluster2-mz4c7",
-						Image:   "busybox",
-						Command: []string{"ln", "-s", "/workspace/cluster2", "/workspace/cluster2"},
 					},
 				},
 			},

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -142,16 +142,6 @@ func getClusterResourceTask(namespace, name, configName string) *v1beta1.Task {
 					Name:      "config-vol",
 					MountPath: "/config",
 				}},
-			}}, {Container: corev1.Container{
-				// See #2694
-				Name:    "check-legacy-contents",
-				Image:   "ubuntu",
-				Command: []string{"bash"},
-				Args:    []string{"-c", "cmp -b /workspace/helloworld-cluster/kubeconfig /config/test.data"},
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "config-vol",
-					MountPath: "/config",
-				}},
 			}},
 			},
 		},


### PR DESCRIPTION
…release.

# Changes

This is a cleanup commit that should go in after 0.14.0 is cut. It was introduced
in #2697, to fix #2694.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
The ClusterResource has been updated to write it's kubeconfig to the correct location on disk. Previously it was written to a location under /workspace/input/<resource ref name>, instead of the correct /workspace/input/<resource binding name>. If you hardcode resource paths in your tasks, you will need to update these. If you refer to paths by interpolation ( $(resources.inputs.<resource name>) ), you do not need to make any changes.

This changes was introduced in 0.13.0, but both paths were included. This removes the legacy path.
```
