### PR TITLE
Fail step execution if the postFile already exists

### DIFF
--- a/cmd/entrypoint/post_writer.go
+++ b/cmd/entrypoint/post_writer.go
@@ -20,3 +20,8 @@ func (*realPostWriter) Write(file string) {
 		log.Fatalf("Creating %q: %v", file, err)
 	}
 }
+
+func (*realPostWriter) Exists(file string) bool {
+	_, err := os.Stat(file)
+	return !os.IsNotExist(err)
+}


### PR DESCRIPTION
This might indicate that the step was re-executed for some reason, which
indicates an internal error in step execution (#2813). Rather than risk
re-running a step in this case, we should fail loudly.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```
Steps will fail if for some reason their postFile already exists before step is run; this might indicate some internal error where steps are re-run.
```
