### PR TITLE
Handle dag in pipelineresoultion

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -173,7 +173,16 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	// Validate the pipeline task graph
 	if err := validateGraph(ps.Tasks); err != nil {
-		return apis.ErrInvalidValue(err.Error(), "spec.tasks")
+		ferr := apis.ErrInvalidValue(err.Error(), "spec.tasks")
+		ferr.Details = "Invalid Graph"
+		return ferr
+	}
+
+	// Validate the pipeline finally graph
+	if err := validateGraph(ps.Finally); err != nil {
+		ferr := apis.ErrInvalidValue(err.Error(), "spec.finally")
+		ferr.Details = "Invalid Graph"
+		return ferr
 	}
 
 	if err := validateParamResults(ps.Tasks); err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In the pipelinerun controller, today we follow this logic:
- build the dag from the spec, using the dag module
- resolve the pipelinerun state using the spec and status, using the
  resources module
- get a list of candidate next tasks from the dag module, passing part
  of the state
- get a list of next tasks from the resources module, using the list
  of candidates and the pipeline run status

The separation of concerns between the dag, resources and reconciler
modules feels a bit mixed up.

This is just a PoC that resolves part of the issue, by moving the
invocation of the dag building as well as obtaining the list of
candidates to the dag module, and aggregating the dag to the pipeline
state struct.

I did not update tests yet, this is for discussion purposes.
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

/kind cleanup
