### PR TITLE
Don't require pointer to binding

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,8 @@ run:
   issues-exit-code: 1
   build-tags:
   - e2e
+  skip-files:
+  - .*/zz_generated.deepcopy.go
   skip-dirs:
   - vendor
   - pkg/client

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -234,7 +234,7 @@ type GetTaskRun func(name string) (*v1beta1.TaskRun, error)
 func GetResourcesFromBindings(pr *v1beta1.PipelineRun, getResource resources.GetResource) (map[string]*resourcev1alpha1.PipelineResource, error) {
 	rs := map[string]*resourcev1alpha1.PipelineResource{}
 	for _, resource := range pr.Spec.Resources {
-		r, err := resources.GetResourceFromBinding(&resource, getResource)
+		r, err := resources.GetResourceFromBinding(resource, getResource)
 		if err != nil {
 			return rs, fmt.Errorf("error following resource reference for %s: %w", resource.Name, err)
 		}

--- a/pkg/reconciler/taskrun/resources/image_exporter.go
+++ b/pkg/reconciler/taskrun/resources/image_exporter.go
@@ -45,7 +45,7 @@ func AddOutputImageDigestExporter(
 				return fmt.Errorf("failed to get bound resource: %w while adding output image digest exporter", err)
 			}
 
-			resource, err := GetResourceFromBinding(&boundResource.PipelineResourceBinding, gr)
+			resource, err := GetResourceFromBinding(boundResource.PipelineResourceBinding, gr)
 			if err != nil {
 				return fmt.Errorf("failed to get output pipeline Resource for taskRun %q resource %v; error: %w while adding output image digest exporter", tr.Name, boundResource, err)
 			}

--- a/pkg/reconciler/taskrun/resources/taskresourceresolution.go
+++ b/pkg/reconciler/taskrun/resources/taskresourceresolution.go
@@ -55,7 +55,7 @@ func ResolveTaskResources(ts *v1beta1.TaskSpec, taskName string, kind v1beta1.Ta
 	}
 
 	for _, r := range inputs {
-		rr, err := GetResourceFromBinding(&r.PipelineResourceBinding, gr)
+		rr, err := GetResourceFromBinding(r.PipelineResourceBinding, gr)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't retrieve referenced input PipelineResource: %w", err)
 		}
@@ -64,7 +64,7 @@ func ResolveTaskResources(ts *v1beta1.TaskSpec, taskName string, kind v1beta1.Ta
 	}
 
 	for _, r := range outputs {
-		rr, err := GetResourceFromBinding(&r.PipelineResourceBinding, gr)
+		rr, err := GetResourceFromBinding(r.PipelineResourceBinding, gr)
 
 		if err != nil {
 			return nil, fmt.Errorf("couldn't retrieve referenced output PipelineResource: %w", err)
@@ -77,7 +77,7 @@ func ResolveTaskResources(ts *v1beta1.TaskSpec, taskName string, kind v1beta1.Ta
 
 // GetResourceFromBinding will return an instance of a PipelineResource to use for r, either by getting it with getter or by
 // instantiating it from the embedded spec.
-func GetResourceFromBinding(r *v1beta1.PipelineResourceBinding, getter GetResource) (*resourcev1alpha1.PipelineResource, error) {
+func GetResourceFromBinding(r v1beta1.PipelineResourceBinding, getter GetResource) (*resourcev1alpha1.PipelineResource, error) {
 	if (r.ResourceRef != nil && r.ResourceRef.Name != "") && r.ResourceSpec != nil {
 		return nil, errors.New("Both ResourseRef and ResourceSpec are defined. Expected only one")
 	}

--- a/pkg/reconciler/taskrun/resources/taskresourceresolution_test.go
+++ b/pkg/reconciler/taskrun/resources/taskresourceresolution_test.go
@@ -273,7 +273,7 @@ func TestGetResourceFromBinding_Ref(t *testing.T) {
 			Name: "git-repo",
 		},
 	}
-	binding := &v1beta1.PipelineResourceBinding{
+	binding := v1beta1.PipelineResourceBinding{
 		ResourceRef: &v1beta1.PipelineResourceRef{
 			Name: "foo-resource",
 		},
@@ -292,7 +292,7 @@ func TestGetResourceFromBinding_Ref(t *testing.T) {
 }
 
 func TestGetResourceFromBinding_Spec(t *testing.T) {
-	binding := &v1beta1.PipelineResourceBinding{
+	binding := v1beta1.PipelineResourceBinding{
 		ResourceSpec: &resourcev1alpha1.PipelineResourceSpec{
 			Type: resourcev1alpha1.PipelineResourceTypeGit,
 			Params: []resourcev1alpha1.ResourceParam{{
@@ -318,7 +318,7 @@ func TestGetResourceFromBinding_Spec(t *testing.T) {
 }
 
 func TestGetResourceFromBinding_NoNameOrSpec(t *testing.T) {
-	binding := &v1beta1.PipelineResourceBinding{}
+	binding := v1beta1.PipelineResourceBinding{}
 	gr := func(n string) (*resourcev1alpha1.PipelineResource, error) {
 		return nil, nil
 	}
@@ -330,7 +330,7 @@ func TestGetResourceFromBinding_NoNameOrSpec(t *testing.T) {
 }
 
 func TestGetResourceFromBinding_NameAndSpec(t *testing.T) {
-	binding := &v1beta1.PipelineResourceBinding{
+	binding := v1beta1.PipelineResourceBinding{
 		ResourceSpec: &resourcev1alpha1.PipelineResourceSpec{
 			Type: resourcev1alpha1.PipelineResourceTypeGit,
 			Params: []resourcev1alpha1.ResourceParam{{
@@ -353,7 +353,7 @@ func TestGetResourceFromBinding_NameAndSpec(t *testing.T) {
 }
 
 func TestGetResourceFromBinding_ErrorGettingResource(t *testing.T) {
-	binding := &v1beta1.PipelineResourceBinding{
+	binding := v1beta1.PipelineResourceBinding{
 		ResourceRef: &v1beta1.PipelineResourceRef{
 			Name: "foo-resource",
 		},


### PR DESCRIPTION
# Changes

Seems like bumping the golangci version
(https://github.com/tektoncd/plumbing/pull/430) revealed some new
linting issues.

Pointers to items being ranged over are reused, so if this pointer is
stored anywhere and used later, it can lead to bugs.

I didn't see any reason why this needed to be a pointer so passing
around the value instead.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
