### PR TITLE
Activate SA creds before running ko

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -111,13 +111,16 @@ spec:
       value: "off"
     - name: GOFLAGS
       value: "-mod=vendor"
-    - name: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
-      value: /secret/release.json
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: "/secret/release.json"
     script: |
       #!/usr/bin/env bash
       set -ex
 
-      # Auth with CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+      # Activate service account
+      gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+      # Setup docker-auth
       gcloud auth configure-docker
 
       # ko requires this variable to be set in order to set image creation timestamps correctly https://github.com/google/go-containerregistry/pull/146
@@ -134,7 +137,7 @@ spec:
       # include it. As of 9/20/2019, this amounts to about 11MB of additional
       # data in each image.
       TMPDIR=$(mktemp -d)
-      tar cvfz ${TMPDIR}/source.tar.gz vendor/
+      tar cfz ${TMPDIR}/source.tar.gz vendor/
       for d in cmd/*; do
         ln -s ${TMPDIR}/source.tar.gz ${d}/kodata/
       done


### PR DESCRIPTION
# Changes

Replaces `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` with an explicit call
to `gcloud auth activate-service-account`. `gcloud info
--run-diagnostics` pointed to this potentially being the issue causing
the nightly build failures.

In addition, I also removed the verbose option from the command that
tars up the vendor directory. This reduces the log by ~6000 lines!

Tested on the dogfooding cluster with a manual run:
`pipeline-release-nightly-dx7cq`

Fixes #2838

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

/kind bug