### PR TITLE
Fix pipelinerun_taskrun_duration_seconds metric

### DIFF
--- a/pkg/reconciler/taskrun/metrics.go
+++ b/pkg/reconciler/taskrun/metrics.go
@@ -204,7 +204,7 @@ func (r *Recorder) DurationAndCount(tr *v1beta1.TaskRun) error {
 			return err
 		}
 
-		stats.Record(ctx, prTRDuration.M(float64(duration/time.Second)))
+		metrics.Record(ctx, prTRDuration.M(float64(duration/time.Second)))
 		metrics.Record(ctx, trCount.M(1))
 		return nil
 	}


### PR DESCRIPTION
# Changes

This CL changes reporting taskrun duration as
part of pipelinerun metric to use knative
metrics Record API to match with the rest of the
existing metrics.

We have been using opensensus stats Record API for
reporting pipelinerun_taskrun_duration_seconds metric
as oppose to other metrics that we used knative metrics
API to report them. At this point only the metrics
that are reported with knative metrics are being
correctly plumbed to metrics backend. So as a result
pipelinerun_taskrun_duration_seconds was missing on
the metrics backend.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
