### PR TITLE
Add credentials to pipelines' roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -43,6 +43,8 @@ Tekton:
 - [Adding support for other architectures](https://github.com/tektoncd/pipeline/issues/856)
 - [Rich type support for params](https://github.com/tektoncd/pipeline/issues/1393)
 - Looping syntax (in [Tasks](https://github.com/tektoncd/pipeline/issues/2112) and/or [Pipelines](https://github.com/tektoncd/pipeline/issues/2050))- either implement or decide it is outside of scope (i.e. better suited for a DSL)
+- [Supplying credentials for authenticated actions in Tasks](https://github.com/tetkoncd/pipeline/issues/2343) - documented guidelines
+  and implemented support for best practices when working with credentials.
 
 ## Beta for all components
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Getting credentials into Tasks is currently supported via multiple
mechanisms, each with its own set of tradeoffs and level of support
within Tekton Pipelines.

This PR adds credentials to our roadmap with intent to improve both upon
the implemented feature set and the documented guidance to credential handling
that Pipelines already offers.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)
