### PR TITLE
Add expansion of context.(pipeline|pipelinerun|task|taskRun).name and add tests

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -14,6 +14,9 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | -------- | ----------- |
 | `params.<param name>` | The value of the parameter at runtime. |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
+| `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
+| `context.pipeline.name` | The name of this `Pipeline` . |
+
 
 ## Variables available in a `Task`
 
@@ -27,6 +30,8 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | `workspaces.<workspaceName>.claim` | The name of the `PersistentVolumeClaim` specified as a volume source for the `Workspace`. Empty string for other volume types. |
 | `workspaces.<workspaceName>.volume` | The name of the volume populating the `Workspace`. |
 | `credentials.path` | The path to the credentials written by the `creds-init` init container. |
+| `context.taskRun.name` | The name of the `TaskRun` that this `Task` is running in. |
+| `context.task.name` | The name of this `Task`. |
 
 ### `PipelineResource` variables available in a `Task`
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -376,6 +376,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 
 	// Apply parameter substitution from the PipelineRun
 	pipelineSpec = resources.ApplyParameters(pipelineSpec, pr)
+	pipelineSpec = resources.ApplyContexts(pipelineSpec, pipelineMeta.Name, pr)
 
 	// pipelineState holds a list of pipeline tasks after resolving conditions and pipeline resources
 	// pipelineState also holds a taskRun for each pipeline task after the taskRun is created

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -53,6 +53,18 @@ func ApplyParameters(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.
 	return ApplyReplacements(p, stringReplacements, arrayReplacements)
 }
 
+// ApplyContexts applies the substitution from $(context.(pipelineRun|pipeline).*) with the specified values.
+// Currently supports only name substitution. Uses "" as a default if name is not specified.
+func ApplyContexts(spec *v1beta1.PipelineSpec, pipelineName string, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
+	stringReplacements := map[string]string{}
+	stringReplacements["context.pipelineRun.name"] = pr.Name
+	stringReplacements["context.pipeline.name"] = pipelineName
+
+	return ApplyReplacements(spec,
+		map[string]string{"context.pipelineRun.name": pr.Name, "context.pipeline.name": pipelineName},
+		map[string][]string{})
+}
+
 // ApplyTaskResults applies the ResolvedResultRef to each PipelineTask.Params in targets
 func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResultRefs) {
 	stringReplacements := map[string]string{}

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -96,6 +96,18 @@ func ApplyResources(spec *v1beta1.TaskSpec, resolvedResources map[string]v1beta1
 	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
+// ApplyContexts applies the substitution from $(context.(taskRun|task).*) with the specified values.
+// Currently supports only name substitution. Uses "" as a default if name is not specified.
+func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
+	stringReplacements := map[string]string{}
+	stringReplacements["context.taskRun.name"] = tr.Name
+	stringReplacements["context.task.name"] = rtr.TaskName
+
+	return ApplyReplacements(spec,
+		map[string]string{"context.taskRun.name": tr.Name, "context.task.name": rtr.TaskName},
+		map[string][]string{})
+}
+
 // ApplyWorkspaces applies the substitution from paths that the workspaces in w are mounted to, the
 // volumes that wb are realized with in the task spec ts and the PersistentVolumeClaim names for the
 // workspaces.

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -520,6 +520,9 @@ func (c *Reconciler) createPod(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	// Apply parameter substitution from the taskrun.
 	ts = resources.ApplyParameters(ts, tr, defaults...)
 
+	// Apply context substitution from the taskrun
+	ts = resources.ApplyContexts(ts, rtr, tr)
+
 	// Apply bound resource substitution from the taskrun.
 	ts = resources.ApplyResources(ts, inputResources, "inputs")
 	ts = resources.ApplyResources(ts, outputResources, "outputs")

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -140,6 +140,8 @@ var (
 			"--my-arg-with-default=$(inputs.params.myarghasdefault)",
 			"--my-arg-with-default2=$(inputs.params.myarghasdefault2)",
 			"--my-additional-arg=$(outputs.resources.myimage.url)",
+			"--my-taskname-arg=$(context.task.name)",
+			"--my-taskrun-arg=$(context.taskRun.name)",
 		)),
 		tb.Step("myotherimage", tb.StepName("myothercontainer"), tb.StepCommand("/mycmd"), tb.StepArgs(
 			"--my-other-arg=$(inputs.resources.workspace.url)",
@@ -955,7 +957,8 @@ func TestReconcile(t *testing.T) {
 					tb.Command(entrypointLocation),
 					tb.Args("-wait_file", "/tekton/tools/1", "-post_file", "/tekton/tools/2", "-termination_path",
 						"/tekton/termination", "-entrypoint", "/mycmd", "--", "--my-arg=foo", "--my-arg-with-default=bar",
-						"--my-arg-with-default2=thedefault", "--my-additional-arg=gcr.io/kristoff/sven"),
+						"--my-arg-with-default2=thedefault", "--my-additional-arg=gcr.io/kristoff/sven", "--my-taskname-arg=test-task-with-substitution",
+						"--my-taskrun-arg=test-taskrun-substitution"),
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


Add expansion of context.(pipeline|pipelinerun|task|taskRun).name and add tests and documentation. This addresses #1522

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```

$context.(task|taskRun|pipeline|pipelineRun).name can be used to reference the appropriate name when in pipelineRuns and taskRuns


```
