### PR TITLE
restricting tekton.dev labels in metadata

### DIFF
--- a/pkg/apis/validate/metadata.go
+++ b/pkg/apis/validate/metadata.go
@@ -19,6 +19,8 @@ package validate
 import (
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
@@ -39,6 +41,16 @@ func ObjectMetadata(meta metav1.Object) *apis.FieldError {
 		return &apis.FieldError{
 			Message: "Invalid resource name: length must be no more than 63 characters",
 			Paths:   []string{"name"},
+		}
+	}
+
+	// metadata must not contain any label with tekton.dev/*
+	for k := range meta.GetLabels() {
+		if strings.HasPrefix(k, pipeline.GroupName) {
+			return &apis.FieldError{
+				Message: "Invalid label key: can not change tekton resource name",
+				Paths:   []string{"labels"},
+			}
 		}
 	}
 	return nil

--- a/pkg/apis/validate/metadata_test.go
+++ b/pkg/apis/validate/metadata_test.go
@@ -20,15 +20,19 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestMetadataInvalidLongName(t *testing.T) {
+func TestMetadata_Failure(t *testing.T) {
 
 	invalidMetas := []*metav1.ObjectMeta{
 		{Name: strings.Repeat("s", validate.MaxLength+1)},
 		{Name: "bad.name"},
+		{Labels: map[string]string{pipeline.GroupName: "mytekton"}},
+		{Labels: map[string]string{pipeline.GroupName + pipeline.TaskLabelKey: "mytask"}},
 	}
 	for _, invalidMeta := range invalidMetas {
 		if err := validate.ObjectMetadata(invalidMeta); err == nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tekton resources are automatically assigned certain labels including the ones with [tekton.dev](https://github.com/tektoncd/pipeline/blob/master/docs/labels.md#automatically-added-labels). The labels are created and propagated from one resource to another using this group name. We should restrict possibility of overwriting those labels otherwise it could result in conflicting resources.

Result of the discussion in PR [2826](https://github.com/tektoncd/pipeline/pull/2826#discussion_r448683708)

On hold until we confirm this is something we want to restrict 🤔  

This will break folks using these labels in metadata, see an [example](https://github.com/tektoncd/catalog/tree/master/github#usage) in catalog.

/cc @vdemeester 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Restricting user defined tekton.dev/ labels.

```
