### PR TITLE
cloudevent: make sure we enter the channel before…

### DIFF
--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -137,7 +137,9 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 		return err
 	}
 
+	wasIn := make(chan error)
 	go func() {
+		wasIn <- nil
 		if result := ceClient.Send(cloudevents.ContextWithRetriesExponentialBackoff(ctx, 10*time.Millisecond, 10), *event); !cloudevents.IsACK(result) {
 			logger.Warnf("Failed to send cloudevent: %s", result.Error())
 			recorder := controller.GetEventRecorder(ctx)
@@ -148,5 +150,5 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 		}
 	}()
 
-	return nil
+	return <-wasIn
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

… returning. This effectively wait for the goroutine to be schedule
before getting out of `SendCloudEventWithRetries`. That way we are
sure the "sending cloud event" goroutine is scheduled. This doesn't
wait for `ceClient.Send` to execute, just making sure we got in the
goroutine.

This should fix flaky tests observed during release pipeline runs.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @sbwsg @dibyom 
/area testing
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

