### PR TITLE
Update releases tasks/pipeline to use workspaces

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -1,27 +1,26 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: publish-tekton-pipelines
 spec:
-  inputs:
-    resources:
-    - name: source
-      type: git
-      targetPath: go/src/github.com/tektoncd/pipeline
+  params:
+  - name: versionTag
+    description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
+  - name: imageRegistry
+    description: TODO(#569) This is a hack to make it easy for folks to switch the registry being used by the many many image outputs
+  - name: pathToProject
+    description: The path to the folder in the go/src dir that contains the project, which is used by `ko` to name the resulting images
+  - name: releaseAsLatest
+    description: Whether to tag and publish this release as Pipelines' latest
+    default: "true"
+  workspaces:
+  - name: source
+    mountPath: /workspace/go/src/github.com/tektoncd/pipeline
+  resources:
+    inputs:
     - name: bucket
       type: storage
-    params:
-    - name: versionTag
-      description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
-    - name: imageRegistry
-      description: TODO(#569) This is a hack to make it easy for folks to switch the registry being used by the many many image outputs
-    - name: pathToProject
-      description: The path to the folder in the go/src dir that contains the project, which is used by `ko` to name the resulting images
-    - name: releaseAsLatest
-      description: Whether to tag and publish this release as Pipelines' latest
-      default: "true"
-  outputs:
-    resources:
+    outputs:
     - name: bucket
       type: storage
     - name: builtBaseImage
@@ -49,14 +48,13 @@ spec:
     - name: notification
       type: cloudEvent
   steps:
-
   - name: build-push-base-images
     image: gcr.io/kaniko-project/executor:v0.17.1
     command:
     - /kaniko/executor
     args:
     - --dockerfile=/workspace/go/src/github.com/tektoncd/pipeline/images/Dockerfile
-    - --destination=$(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtBaseImage.url)
+    - --destination=$(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtBaseImage.url)
     - --context=/workspace/go/src/github.com/tektoncd/pipeline
 
     volumeMounts:
@@ -76,18 +74,18 @@ spec:
       # This matches the value configured in .ko.yaml
       defaultBaseImage: gcr.io/distroless/static:nonroot
       baseImageOverrides:
-        $(inputs.params.pathToProject)/$(outputs.resources.builtCredsInitImage.url): $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/build-base:latest
-        $(inputs.params.pathToProject)/$(outputs.resources.builtGitInitImage.url): $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/build-base:latest
+        $(inputs.params.pathToProject)/$(resources.outputs.builtCredsInitImage.url): $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/build-base:latest
+        $(inputs.params.pathToProject)/$(resources.outputs.builtGitInitImage.url): $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/build-base:latest
 
         # These match values configured in .ko.yaml
-        $(inputs.params.pathToProject)/$(outputs.resources.builtEntrypointImage.url): gcr.io/distroless/base:debug-nonroot
-        $(inputs.params.pathToProject)/$(outputs.resources.builtGcsFetcherImage.url): gcr.io/distroless/static:latest
-        $(inputs.params.pathToProject)/$(outputs.resources.builtPullRequestInitImage.url): gcr.io/distroless/static:latest
+        $(inputs.params.pathToProject)/$(resources.outputs.builtEntrypointImage.url): gcr.io/distroless/base:debug-nonroot
+        $(inputs.params.pathToProject)/$(resources.outputs.builtGcsFetcherImage.url): gcr.io/distroless/static:latest
+        $(inputs.params.pathToProject)/$(resources.outputs.builtPullRequestInitImage.url): gcr.io/distroless/static:latest
       baseBuildOverrides:
-        $(inputs.params.pathToProject)/$(outputs.resources.builtControllerImage.url):
+        $(params.pathToProject)/$(resources.outputs.builtControllerImage.url):
           flags:
             - name: ldflags
-              value: "-X $(inputs.params.pathToProject)/pkg/version.PipelineVersion=$(inputs.params.versionTag)"
+              value: "-X $(params.pathToProject)/pkg/version.PipelineVersion=$(params.versionTag)"
       EOF
 
       cat /workspace/go/src/github.com/tektoncd/pipeline/.ko.yaml
@@ -105,13 +103,13 @@ spec:
     command: ["mkdir"]
     args:
     - "-p"
-    - "/workspace/output/bucket/previous/$(inputs.params.versionTag)/"
+    - "/workspace/output/bucket/previous/$(params.versionTag)/"
 
   - name: run-ko
     image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
     env:
     - name: KO_DOCKER_REPO
-      value: $(inputs.params.imageRegistry)
+      value: $(params.imageRegistry)
     - name: GOPATH
       value: /workspace/go
     - name: GO111MODULE
@@ -150,12 +148,12 @@ spec:
       done
 
       # Rewrite "devel" to inputs.params.versionTag
-      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(inputs.params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(inputs.params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(inputs.params.versionTag)"/g' /workspace/go/src/github.com/tektoncd/pipeline/config/*.yaml
+      sed -i -e 's/\(pipeline.tekton.dev\/release\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(app.kubernetes.io\/version\): "devel"/\1: "$(params.versionTag)"/g' -e 's/\(version\): "devel"/\1: "$(params.versionTag)"/g' /workspace/go/src/github.com/tektoncd/pipeline/config/*.yaml
 
-      OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(inputs.params.versionTag)"
+      OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(params.versionTag)"
 
       # Publish images and create release.yaml
-      ko resolve --preserve-import-paths -t $(inputs.params.versionTag) -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
+      ko resolve --preserve-import-paths -t $(params.versionTag) -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
       # Publish images and create release.notags.yaml
       # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
       # This is currently the case for `cri-o` (and most likely others)
@@ -171,10 +169,10 @@ spec:
       #!/bin/sh
       set -ex
 
-      if [[ "$(inputs.params.releaseAsLatest)" == "true" ]]
+      if [[ "$(params.releaseAsLatest)" == "true" ]]
       then
         mkdir -p "/workspace/output/bucket/latest/"
-        OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(inputs.params.versionTag)"
+        OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(params.versionTag)"
         OUTPUT_BUCKET_LATEST_DIR="/workspace/output/bucket/latest"
         cp "$OUTPUT_BUCKET_RELEASE_DIR/release.yaml" "$OUTPUT_BUCKET_LATEST_DIR/release.yaml"
         cp "$OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml" "$OUTPUT_BUCKET_LATEST_DIR/release.notags.yaml"
@@ -188,19 +186,19 @@ spec:
 
       REGIONS=(us eu asia)
       IMAGES=(
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtEntrypointImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtNopImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtKubeconfigWriterImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtCredsInitImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtGitInitImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtControllerImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtWebhookImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtDigestExporterImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtPullRequestInitImage.url):$(inputs.params.versionTag)
-        $(inputs.params.imageRegistry)/$(inputs.params.pathToProject)/$(outputs.resources.builtGcsFetcherImage.url):$(inputs.params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtEntrypointImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtNopImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtKubeconfigWriterImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtCredsInitImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtGitInitImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtControllerImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtWebhookImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtDigestExporterImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtPullRequestInitImage.url):$(params.versionTag)
+        $(params.imageRegistry)/$(params.pathToProject)/$(outputs.resources.builtGcsFetcherImage.url):$(params.versionTag)
       )
       # Parse the built images from the release.yaml generated by ko
-      BUILT_IMAGES=( $(/workspace/go/src/github.com/tektoncd/pipeline/tekton/koparse/koparse.py --path /workspace/output/bucket/previous/$(inputs.params.versionTag)/release.yaml --base $(inputs.params.imageRegistry)/$(inputs.params.pathToProject) --images ${IMAGES[@]}) )
+      BUILT_IMAGES=( $(/workspace/go/src/github.com/tektoncd/pipeline/tekton/koparse/koparse.py --path /workspace/output/bucket/previous/$(params.versionTag)/release.yaml --base $(params.imageRegistry)/$(params.pathToProject) --images ${IMAGES[@]}) )
 
       # Auth with account credentials
       gcloud auth activate-service-account --key-file=/secret/release.json
@@ -212,21 +210,21 @@ spec:
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
 
-        if [[ "$(inputs.params.releaseAsLatest)" == "true" ]]
+        if [[ "$(params.releaseAsLatest)" == "true" ]]
         then
           gcloud -q container images add-tag ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
         fi
 
         for REGION in "${REGIONS[@]}"
         do
-          if [[ "$(inputs.params.releaseAsLatest)" == "true" ]]
+          if [[ "$(params.releaseAsLatest)" == "true" ]]
           then
-            for TAG in "latest" $(inputs.params.versionTag)
+            for TAG in "latest" $(params.versionTag)
             do
               gcloud -q container images add-tag ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
             done
           else
-            TAG="$(inputs.params.versionTag)"
+            TAG="$(params.versionTag)"
             gcloud -q container images add-tag ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
           fi
         done

--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: pipeline-release-nightly
@@ -9,11 +9,13 @@ spec:
     default: github.com/tektoncd/pipeline
   - name: imageRegistry
     default: gcr.io/tekton-nightly
+  - name: gitUrl
+    description: The git url to use to clone the source
+  - name: gitCommit
+    description: The git commit hash that will be tagged with the release
   - name: versionTag
     description: The X.Y.Z version that the artifacts should be tagged with
   resources:
-  - name: source-repo
-    type: git
   - name: bucket
     type: storage
   - name: builtBaseImage
@@ -40,27 +42,45 @@ spec:
     type: image
   - name: notification
     type: cloudEvent
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
   tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      params:
+      - name: url
+        value: $(params.gitUrl)
+      - name: revision
+        value: $(params.gitCommit)
+      - name: deleteExisting
+        value: "true"
+      workspaces:
+      - name: output
+        workspace: shared-data
     - name: unit-tests
       taskRef:
         name: golang-test
+      runAfter: [fetch-repo]
       params:
         - name: package
           value: $(params.package)
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
+      workspaces:
+      - name: source
+        workspace: shared-data
     - name: build
       taskRef:
         name: golang-build
+      runAfter: [fetch-repo]
       params:
         - name: package
           value: $(params.package)
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
+      workspaces:
+      - name: source
+        workspace: shared-data
     - name: publish-images
       runAfter: [build, unit-tests]
       taskRef:
@@ -72,10 +92,11 @@ spec:
           value: $(params.versionTag)
         - name: imageRegistry
           value: $(params.imageRegistry)
+      workspaces:
+      - name: source
+        workspace: shared-data
       resources:
         inputs:
-          - name: source
-            resource: source-repo
           - name: bucket
             resource: bucket
         outputs:

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: pipeline-release
@@ -12,12 +12,14 @@ spec:
     default: gcr.io/tekton-releases
   - name: versionTag
     description: The X.Y.Z version that the artifacts should be tagged with
+  - name: gitUrl
+    description: The git url to use to clone the source
+  - name: gitCommit
+    description: The git commit hash that will be tagged with the release
   - name: releaseAsLatest
     description: Whether to tag and publish this release as Pipelines' latest
     default: "true"
   resources:
-  - name: source-repo
-    type: git
   - name: bucket
     type: storage
   - name: builtBaseImage
@@ -44,10 +46,29 @@ spec:
     type: image
   - name: notification
     type: cloudEvent
+  workspaces:
+  - name: shared-data
+    description: |
+      This workspace will receive the cloned git repo and be passed
+      to the next Task for the commit to be checked.
   tasks:
+    - name: fetch-repo
+      taskRef:
+        name: git-clone
+      params:
+      - name: url
+        value: $(params.gitUrl)
+      - name: revision
+        value: $(params.gitCommit)
+      - name: deleteExisting
+        value: "true"
+      workspaces:
+      - name: output
+        workspace: shared-data
     - name: precheck
       taskRef:
         name: prerelease-checks
+      runAfter: [fetch-repo]
       params:
         - name: package
           value: $(params.package)
@@ -57,21 +78,22 @@ spec:
         inputs:
           - name: release-bucket
             resource: bucket
-          - name: source-to-release
-            resource: source-repo
+      workspaces:
+      - name: source
+        workspace: shared-data
     - name: unit-tests
       runAfter: [precheck]
       taskRef:
         name: golang-test
+      runAfter: [precheck]
       params:
         - name: package
           value: $(params.package)
         - name: flags
           value: -v -mod=vendor
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
+      workspaces:
+      - name: source
+        workspace: shared-data
     - name: build
       runAfter: [precheck]
       taskRef:
@@ -81,10 +103,9 @@ spec:
           value: $(params.package)
         - name: flags
           value: -mod=vendor -ldflags "-X github.com/tektoncd/pipeline/pkg/version.PipelineVersion=$(params.versionTag)"
-      resources:
-        inputs:
-          - name: source
-            resource: source-repo
+      workspaces:
+      - name: source
+        workspace: shared-data
     - name: publish-images
       runAfter: [build, unit-tests]
       taskRef:
@@ -98,10 +119,11 @@ spec:
           value: $(params.imageRegistry)
         - name: releaseAsLatest
           value: $(params.releaseAsLatest)
+      workspaces:
+      - name: source
+        workspace: shared-data
       resources:
         inputs:
-          - name: source
-            resource: source-repo
           - name: bucket
             resource: bucket
         outputs:

--- a/tekton/resources.yaml
+++ b/tekton/resources.yaml
@@ -20,6 +20,19 @@
 #   - name: targetURI
 #     value: http://post-release-trigger-sink  # This has to be changed to a valid URL
 # ---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pipeline-release-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: standard
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 5Gi
+---
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Let's try to use workspaces to do the release instead of relying on
PipelineResource and v1alpha1 golang catalog resources.

This updates the tasks and pipeline to use workspaces.
This also update a little bit the readme with `kubectl diff` commands
to show what will be applied before applying it.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Linked to https://github.com/tektoncd/plumbing/pull/456

/kind misc
/area release
/cc @afrittoli 
/hold

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Update the tasks and pipelines to use workspaces for the releases
```
