### PR TITLE
Makefile: add a cross target 🌵

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,29 @@ FORCE:
 bin/%: cmd/% FORCE
 	$(GO) build -mod=vendor $(LDFLAGS) -v -o $@ ./$<
 
+.PHONY: cross
+cross: amd64 arm arm64 s390x ppc64le ## build cross platform binaries
+
+.PHONY: amd64
+amd64:
+	GOOS=linux GOARCH=amd64 go build -mod=vendor $(LDFLAGS) ./cmd/...
+
+.PHONY: arm
+arm:
+	GOOS=linux GOARCH=arm go build -mod=vendor $(LDFLAGS) ./cmd/...
+
+.PHONY: arm64
+arm64:
+	GOOS=linux GOARCH=arm64 go build -mod=vendor $(LDFLAGS) ./cmd/...
+
+.PHONY: s390x
+s390x:
+	GOOS=linux GOARCH=s390x go build -mod=vendor $(LDFLAGS) ./cmd/...
+
+.PHONY: ppc64le
+ppc64le:
+	GOOS=linux GOARCH=ppc64le go build -mod=vendor $(LDFLAGS) ./cmd/...
+
 KO = $(BIN)/ko
 $(BIN)/ko: PACKAGE=github.com/google/ko/cmd/ko
 
@@ -173,6 +196,7 @@ fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 .PHONY: clean
 clean: ; $(info $(M) cleaning…)	@ ## Cleanup everything
 	@rm -rf $(BIN)
+	@rm -rf bin
 	@rm -rf test/tests.* test/coverage.*
 
 .PHONY: help


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This will allow building for different target (x86_64, arm, arm64,
s390x and ppc64le).

This doesn't mean we support those architecture (especially as `ko`
doesn't really support multi-arch for now). But it is nice to be able
to see if our code compiles and can be package (manually,
*unofficially*, for those target). A check will be added in plumbing
so that we validate that, at least, a PR doesn't break those.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @snehlatamohite

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Add a Makefile target to compile the code on multiple GOOS/GOARCH (not officially supported "yet")
```
