### PR TITLE
Use sets.NewString from apimachinery

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
@@ -109,28 +110,28 @@ func ValidateResults(results []TaskResult) *apis.FieldError {
 // a mount path which conflicts with any other declared workspaces, with the explicitly
 // declared volume mounts, or with the stepTemplate. The names must also be unique.
 func ValidateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step, stepTemplate *corev1.Container) *apis.FieldError {
-	mountPaths := map[string]struct{}{}
+	mountPaths := sets.NewString()
 	for _, step := range steps {
 		for _, vm := range step.VolumeMounts {
-			mountPaths[filepath.Clean(vm.MountPath)] = struct{}{}
+			mountPaths.Insert(filepath.Clean(vm.MountPath))
 		}
 	}
 	if stepTemplate != nil {
 		for _, vm := range stepTemplate.VolumeMounts {
-			mountPaths[filepath.Clean(vm.MountPath)] = struct{}{}
+			mountPaths.Insert(filepath.Clean(vm.MountPath))
 		}
 	}
 
-	wsNames := map[string]struct{}{}
+	wsNames := sets.NewString()
 	for _, w := range workspaces {
 		// Workspace names must be unique
-		if _, ok := wsNames[w.Name]; ok {
+		if wsNames.Has(w.Name) {
 			return &apis.FieldError{
 				Message: fmt.Sprintf("workspace name %q must be unique", w.Name),
 				Paths:   []string{"workspaces.name"},
 			}
 		}
-		wsNames[w.Name] = struct{}{}
+		wsNames.Insert(w.Name)
 		// Workspaces must not try to use mount paths that are already used
 		mountPath := filepath.Clean(w.GetMountPath())
 		if _, ok := mountPaths[mountPath]; ok {
@@ -146,22 +147,22 @@ func ValidateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 
 func ValidateVolumes(volumes []corev1.Volume) *apis.FieldError {
 	// Task must not have duplicate volume names.
-	vols := map[string]struct{}{}
+	vols := sets.NewString()
 	for _, v := range volumes {
-		if _, ok := vols[v.Name]; ok {
+		if vols.Has(v.Name) {
 			return &apis.FieldError{
 				Message: fmt.Sprintf("multiple volumes with same name %q", v.Name),
 				Paths:   []string{"name"},
 			}
 		}
-		vols[v.Name] = struct{}{}
+		vols.Insert(v.Name)
 	}
 	return nil
 }
 
 func validateSteps(steps []Step) *apis.FieldError {
 	// Task must not have duplicate step names.
-	names := map[string]struct{}{}
+	names := sets.NewString()
 	for idx, s := range steps {
 		if s.Image == "" {
 			return apis.ErrMissingField("Image")
@@ -177,10 +178,10 @@ func validateSteps(steps []Step) *apis.FieldError {
 		}
 
 		if s.Name != "" {
-			if _, ok := names[s.Name]; ok {
+			if names.Has(s.Name) {
 				return apis.ErrInvalidValue(s.Name, "name")
 			}
-			names[s.Name] = struct{}{}
+			names.Insert(s.Name)
 		}
 
 		for _, vm := range s.VolumeMounts {
@@ -231,13 +232,13 @@ func ValidateParameterTypes(params []ParamSpec) *apis.FieldError {
 }
 
 func ValidateParameterVariables(steps []Step, params []ParamSpec) *apis.FieldError {
-	parameterNames := map[string]struct{}{}
-	arrayParameterNames := map[string]struct{}{}
+	parameterNames := sets.NewString()
+	arrayParameterNames := sets.NewString()
 
 	for _, p := range params {
-		parameterNames[p.Name] = struct{}{}
+		parameterNames.Insert(p.Name)
 		if p.Type == ParamTypeArray {
-			arrayParameterNames[p.Name] = struct{}{}
+			arrayParameterNames.Insert(p.Name)
 		}
 	}
 
@@ -251,21 +252,21 @@ func ValidateResourcesVariables(steps []Step, resources *TaskResources) *apis.Fi
 	if resources == nil {
 		return nil
 	}
-	resourceNames := map[string]struct{}{}
+	resourceNames := sets.NewString()
 	if resources.Inputs != nil {
 		for _, r := range resources.Inputs {
-			resourceNames[r.Name] = struct{}{}
+			resourceNames.Insert(r.Name)
 		}
 	}
 	if resources.Outputs != nil {
 		for _, r := range resources.Outputs {
-			resourceNames[r.Name] = struct{}{}
+			resourceNames.Insert(r.Name)
 		}
 	}
 	return validateVariables(steps, "resources.(?:inputs|outputs)", resourceNames)
 }
 
-func validateArrayUsage(steps []Step, prefix string, vars map[string]struct{}) *apis.FieldError {
+func validateArrayUsage(steps []Step, prefix string, vars sets.String) *apis.FieldError {
 	for _, step := range steps {
 		if err := validateTaskNoArrayReferenced("name", step.Name, prefix, vars); err != nil {
 			return err
@@ -309,7 +310,7 @@ func validateArrayUsage(steps []Step, prefix string, vars map[string]struct{}) *
 	return nil
 }
 
-func validateVariables(steps []Step, prefix string, vars map[string]struct{}) *apis.FieldError {
+func validateVariables(steps []Step, prefix string, vars sets.String) *apis.FieldError {
 	for _, step := range steps {
 		if err := validateTaskVariable("name", step.Name, prefix, vars); err != nil {
 			return err
@@ -353,14 +354,14 @@ func validateVariables(steps []Step, prefix string, vars map[string]struct{}) *a
 	return nil
 }
 
-func validateTaskVariable(name, value, prefix string, vars map[string]struct{}) *apis.FieldError {
+func validateTaskVariable(name, value, prefix string, vars sets.String) *apis.FieldError {
 	return substitution.ValidateVariable(name, value, prefix, "step", "taskspec.steps", vars)
 }
 
-func validateTaskNoArrayReferenced(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
+func validateTaskNoArrayReferenced(name, value, prefix string, arrayNames sets.String) *apis.FieldError {
 	return substitution.ValidateVariableProhibited(name, value, prefix, "step", "taskspec.steps", arrayNames)
 }
 
-func validateTaskArraysIsolated(name, value, prefix string, arrayNames map[string]struct{}) *apis.FieldError {
+func validateTaskArraysIsolated(name, value, prefix string, arrayNames sets.String) *apis.FieldError {
 	return substitution.ValidateVariableIsolated(name, value, prefix, "step", "taskspec.steps", arrayNames)
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
@@ -90,12 +91,12 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) *apis.FieldError {
 
 // validateWorkspaceBindings makes sure the volumes provided for the Task's declared workspaces make sense.
 func validateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) *apis.FieldError {
-	seen := map[string]struct{}{}
+	seen := sets.NewString()
 	for _, w := range wb {
-		if _, ok := seen[w.Name]; ok {
+		if seen.Has(w.Name) {
 			return apis.ErrMultipleOneOf("spec.workspaces.name")
 		}
-		seen[w.Name] = struct{}{}
+		seen.Insert(w.Name)
 
 		if err := w.Validate(ctx); err != nil {
 			return err
@@ -107,12 +108,12 @@ func validateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) *apis
 
 func validateParameters(params []Param) *apis.FieldError {
 	// Template must not duplicate parameter names.
-	seen := map[string]struct{}{}
+	seen := sets.NewString()
 	for _, p := range params {
-		if _, ok := seen[strings.ToLower(p.Name)]; ok {
+		if seen.Has(strings.ToLower(p.Name)) {
 			return apis.ErrMultipleOneOf("spec.params.name")
 		}
-		seen[p.Name] = struct{}{}
+		seen.Insert(p.Name)
 	}
 	return nil
 }

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -131,10 +132,10 @@ func InitializeArtifactStorage(images pipeline.Images, pr *v1beta1.PipelineRun, 
 
 	needStorage := false
 	// Build an index of resources used in the pipeline that are an AllowedOutputResource
-	possibleOutputs := map[string]struct{}{}
+	possibleOutputs := sets.NewString()
 	for _, r := range ps.Resources {
 		if _, ok := v1beta1.AllowedOutputResources[r.Type]; ok {
-			possibleOutputs[r.Name] = struct{}{}
+			possibleOutputs.Insert(r.Name)
 		}
 	}
 
@@ -142,7 +143,7 @@ func InitializeArtifactStorage(images pipeline.Images, pr *v1beta1.PipelineRun, 
 	for _, t := range ps.Tasks {
 		if t.Resources != nil {
 			for _, o := range t.Resources.Outputs {
-				if _, ok := possibleOutputs[o.Resource]; ok {
+				if possibleOutputs.Has(o.Resource) {
 					needStorage = true
 				}
 			}

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func testGraph(t *testing.T) *dag.Graph {
@@ -74,69 +75,43 @@ func TestGetSchedulable(t *testing.T) {
 	tcs := []struct {
 		name          string
 		finished      []string
-		expectedTasks map[string]struct{}
+		expectedTasks sets.String
 	}{{
-		name:     "nothing-done",
-		finished: []string{},
-		expectedTasks: map[string]struct{}{
-			"a": {},
-			"b": {},
-		},
+		name:          "nothing-done",
+		finished:      []string{},
+		expectedTasks: sets.NewString("a", "b"),
 	}, {
-		name:     "a-done",
-		finished: []string{"a"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"x": {},
-		},
+		name:          "a-done",
+		finished:      []string{"a"},
+		expectedTasks: sets.NewString("b", "x"),
 	}, {
-		name:     "b-done",
-		finished: []string{"b"},
-		expectedTasks: map[string]struct{}{
-			"a": {},
-		},
+		name:          "b-done",
+		finished:      []string{"b"},
+		expectedTasks: sets.NewString("a"),
 	}, {
-		name:     "a-and-b-done",
-		finished: []string{"a", "b"},
-		expectedTasks: map[string]struct{}{
-			"x": {},
-		},
+		name:          "a-and-b-done",
+		finished:      []string{"a", "b"},
+		expectedTasks: sets.NewString("x"),
 	}, {
-		name:     "a-x-done",
-		finished: []string{"a", "x"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"y": {},
-			"z": {},
-		},
+		name:          "a-x-done",
+		finished:      []string{"a", "x"},
+		expectedTasks: sets.NewString("b", "y", "z"),
 	}, {
-		name:     "a-x-b-done",
-		finished: []string{"a", "x", "b"},
-		expectedTasks: map[string]struct{}{
-			"y": {},
-			"z": {},
-		},
+		name:          "a-x-b-done",
+		finished:      []string{"a", "x", "b"},
+		expectedTasks: sets.NewString("y", "z"),
 	}, {
-		name:     "a-x-y-done",
-		finished: []string{"a", "x", "y"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"z": {},
-		},
+		name:          "a-x-y-done",
+		finished:      []string{"a", "x", "y"},
+		expectedTasks: sets.NewString("b", "z"),
 	}, {
-		name:     "a-x-y-done",
-		finished: []string{"a", "x", "y"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"z": {},
-		},
+		name:          "a-x-y-done",
+		finished:      []string{"a", "x", "y"},
+		expectedTasks: sets.NewString("b", "z"),
 	}, {
-		name:     "a-x-y-b-done",
-		finished: []string{"a", "x", "y", "b"},
-		expectedTasks: map[string]struct{}{
-			"w": {},
-			"z": {},
-		},
+		name:          "a-x-y-b-done",
+		finished:      []string{"a", "x", "y", "b"},
+		expectedTasks: sets.NewString("w", "z"),
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/reconciler/pipeline/dag/dagv1beta1_test.go
+++ b/pkg/reconciler/pipeline/dag/dagv1beta1_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func testGraphv1beta1(t *testing.T) *dag.Graph {
@@ -77,69 +78,43 @@ func TestGetSchedulable_v1beta1(t *testing.T) {
 	tcs := []struct {
 		name          string
 		finished      []string
-		expectedTasks map[string]struct{}
+		expectedTasks sets.String
 	}{{
-		name:     "nothing-done",
-		finished: []string{},
-		expectedTasks: map[string]struct{}{
-			"a": {},
-			"b": {},
-		},
+		name:          "nothing-done",
+		finished:      []string{},
+		expectedTasks: sets.NewString("a", "b"),
 	}, {
-		name:     "a-done",
-		finished: []string{"a"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"x": {},
-		},
+		name:          "a-done",
+		finished:      []string{"a"},
+		expectedTasks: sets.NewString("b", "x"),
 	}, {
-		name:     "b-done",
-		finished: []string{"b"},
-		expectedTasks: map[string]struct{}{
-			"a": {},
-		},
+		name:          "b-done",
+		finished:      []string{"b"},
+		expectedTasks: sets.NewString("a"),
 	}, {
-		name:     "a-and-b-done",
-		finished: []string{"a", "b"},
-		expectedTasks: map[string]struct{}{
-			"x": {},
-		},
+		name:          "a-and-b-done",
+		finished:      []string{"a", "b"},
+		expectedTasks: sets.NewString("x"),
 	}, {
-		name:     "a-x-done",
-		finished: []string{"a", "x"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"y": {},
-			"z": {},
-		},
+		name:          "a-x-done",
+		finished:      []string{"a", "x"},
+		expectedTasks: sets.NewString("b", "y", "z"),
 	}, {
-		name:     "a-x-b-done",
-		finished: []string{"a", "x", "b"},
-		expectedTasks: map[string]struct{}{
-			"y": {},
-			"z": {},
-		},
+		name:          "a-x-b-done",
+		finished:      []string{"a", "x", "b"},
+		expectedTasks: sets.NewString("y", "z"),
 	}, {
-		name:     "a-x-y-done",
-		finished: []string{"a", "x", "y"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"z": {},
-		},
+		name:          "a-x-y-done",
+		finished:      []string{"a", "x", "y"},
+		expectedTasks: sets.NewString("b", "z"),
 	}, {
-		name:     "a-x-y-done",
-		finished: []string{"a", "x", "y"},
-		expectedTasks: map[string]struct{}{
-			"b": {},
-			"z": {},
-		},
+		name:          "a-x-y-done",
+		finished:      []string{"a", "x", "y"},
+		expectedTasks: sets.NewString("b", "z"),
 	}, {
-		name:     "a-x-y-b-done",
-		finished: []string{"a", "x", "y", "b"},
-		expectedTasks: map[string]struct{}{
-			"w": {},
-			"z": {},
-		},
+		name:          "a-x-y-b-done",
+		finished:      []string{"a", "x", "y", "b"},
+		expectedTasks: sets.NewString("w", "z"),
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -38,6 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
@@ -527,149 +528,112 @@ func TestGetNextTasks(t *testing.T) {
 	tcs := []struct {
 		name         string
 		state        PipelineRunState
-		candidates   map[string]struct{}
+		candidates   sets.String
 		expectedNext []*ResolvedPipelineRunTask
 	}{{
 		name:         "no-tasks-started-no-candidates",
 		state:        noneStartedState,
-		candidates:   map[string]struct{}{},
+		candidates:   sets.NewString(),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "no-tasks-started-one-candidate",
-		state: noneStartedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-		},
+		name:         "no-tasks-started-one-candidate",
+		state:        noneStartedState,
+		candidates:   sets.NewString("mytask1"),
 		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0]},
 	}, {
-		name:  "no-tasks-started-other-candidate",
-		state: noneStartedState,
-		candidates: map[string]struct{}{
-			"mytask2": {},
-		},
+		name:         "no-tasks-started-other-candidate",
+		state:        noneStartedState,
+		candidates:   sets.NewString("mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[1]},
 	}, {
-		name:  "no-tasks-started-both-candidates",
-		state: noneStartedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-			"mytask2": {},
-		},
+		name:         "no-tasks-started-both-candidates",
+		state:        noneStartedState,
+		candidates:   sets.NewString("mytask1", "mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0], noneStartedState[1]},
 	}, {
 		name:         "one-task-started-no-candidates",
 		state:        oneStartedState,
-		candidates:   map[string]struct{}{},
+		candidates:   sets.NewString(),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-task-started-one-candidate",
-		state: oneStartedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-		},
+		name:         "one-task-started-one-candidate",
+		state:        oneStartedState,
+		candidates:   sets.NewString("mytask1"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-task-started-other-candidate",
-		state: oneStartedState,
-		candidates: map[string]struct{}{
-			"mytask2": {},
-		},
+		name:         "one-task-started-other-candidate",
+		state:        oneStartedState,
+		candidates:   sets.NewString("mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
 	}, {
-		name:  "one-task-started-both-candidates",
-		state: oneStartedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-			"mytask2": {},
-		},
+		name:         "one-task-started-both-candidates",
+		state:        oneStartedState,
+		candidates:   sets.NewString("mytask1", "mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
 	}, {
 		name:         "one-task-finished-no-candidates",
 		state:        oneFinishedState,
-		candidates:   map[string]struct{}{},
+		candidates:   sets.NewString(),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-task-finished-one-candidate",
-		state: oneFinishedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-		},
+		name:         "one-task-finished-one-candidate",
+		state:        oneFinishedState,
+		candidates:   sets.NewString("mytask1"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-task-finished-other-candidate",
-		state: oneFinishedState,
-		candidates: map[string]struct{}{
-			"mytask2": {},
-		},
+		name:         "one-task-finished-other-candidate",
+		state:        oneFinishedState,
+		candidates:   sets.NewString("mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
 	}, {
-		name:  "one-task-finished-both-candidate",
-		state: oneFinishedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-			"mytask2": {},
-		},
+		name:         "one-task-finished-both-candidate",
+		state:        oneFinishedState,
+		candidates:   sets.NewString("mytask1", "mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
 	}, {
 		name:         "one-task-failed-no-candidates",
 		state:        oneFailedState,
-		candidates:   map[string]struct{}{},
+		candidates:   sets.NewString(),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-task-failed-one-candidate",
-		state: oneFailedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-		},
+		name:         "one-task-failed-one-candidate",
+		state:        oneFailedState,
+		candidates:   sets.NewString("mytask1"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-task-failed-other-candidate",
-		state: oneFailedState,
-		candidates: map[string]struct{}{
-			"mytask2": {},
-		},
+		name:         "one-task-failed-other-candidate",
+		state:        oneFailedState,
+		candidates:   sets.NewString("mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
 	}, {
-		name:  "one-task-failed-both-candidates",
-		state: oneFailedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-			"mytask2": {},
-		},
+		name:         "one-task-failed-both-candidates",
+		state:        oneFailedState,
+		candidates:   sets.NewString("mytask1", "mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
 	}, {
 		name:         "all-finished-no-candidates",
 		state:        allFinishedState,
-		candidates:   map[string]struct{}{},
+		candidates:   sets.NewString(),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "all-finished-one-candidate",
-		state: allFinishedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-		},
+		name:         "all-finished-one-candidate",
+		state:        allFinishedState,
+		candidates:   sets.NewString("mytask1"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "all-finished-other-candidate",
-		state: allFinishedState,
-		candidates: map[string]struct{}{
-			"mytask2": {},
-		},
+		name:         "all-finished-other-candidate",
+		state:        allFinishedState,
+		candidates:   sets.NewString("mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "all-finished-both-candidates",
-		state: allFinishedState,
-		candidates: map[string]struct{}{
-			"mytask1": {},
-			"mytask2": {},
-		},
+		name:         "all-finished-both-candidates",
+		state:        allFinishedState,
+		candidates:   sets.NewString("mytask1", "mytask2"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "one-cancelled-one-candidate",
-		state: taskCancelled,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "one-cancelled-one-candidate",
+		state:        taskCancelled,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}}
 	for _, tc := range tcs {
@@ -741,49 +705,37 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 	tcs := []struct {
 		name         string
 		state        PipelineRunState
-		candidates   map[string]struct{}
+		candidates   sets.String
 		expectedNext []*ResolvedPipelineRunTask
 	}{{
-		name:  "tasks-cancelled-no-candidates",
-		state: taskCancelledByStatusState,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "tasks-cancelled-no-candidates",
+		state:        taskCancelledByStatusState,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "tasks-cancelled-bySpec-no-candidates",
-		state: taskCancelledBySpecState,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "tasks-cancelled-bySpec-no-candidates",
+		state:        taskCancelledBySpecState,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "tasks-running-no-candidates",
-		state: taskRunningState,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "tasks-running-no-candidates",
+		state:        taskRunningState,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "tasks-succeeded-bySpec-no-candidates",
-		state: taskSucceededState,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "tasks-succeeded-bySpec-no-candidates",
+		state:        taskSucceededState,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "tasks-retried-no-candidates",
-		state: taskRetriedState,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "tasks-retried-no-candidates",
+		state:        taskRetriedState,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{},
 	}, {
-		name:  "tasks-retried-one-candidates",
-		state: taskExpectedState,
-		candidates: map[string]struct{}{
-			"mytask5": {},
-		},
+		name:         "tasks-retried-one-candidates",
+		state:        taskExpectedState,
+		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineRunTask{taskExpectedState[0]},
 	}}
 

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	"github.com/tektoncd/pipeline/test/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
 )
 
@@ -32,7 +33,7 @@ func TestValidateVariables(t *testing.T) {
 		prefix       string
 		locationName string
 		path         string
-		vars         map[string]struct{}
+		vars         sets.String
 	}
 	for _, tc := range []struct {
 		name          string
@@ -45,9 +46,7 @@ func TestValidateVariables(t *testing.T) {
 			prefix:       "inputs.params",
 			locationName: "step",
 			path:         "taskspec.steps",
-			vars: map[string]struct{}{
-				"baz": {},
-			},
+			vars:         sets.NewString("baz"),
 		},
 		expectedError: nil,
 	}, {
@@ -57,10 +56,7 @@ func TestValidateVariables(t *testing.T) {
 			prefix:       "inputs.params",
 			locationName: "step",
 			path:         "taskspec.steps",
-			vars: map[string]struct{}{
-				"baz": {},
-				"foo": {},
-			},
+			vars:         sets.NewString("baz", "foo"),
 		},
 		expectedError: nil,
 	}, {
@@ -70,9 +66,7 @@ func TestValidateVariables(t *testing.T) {
 			prefix:       "something",
 			locationName: "step",
 			path:         "taskspec.steps",
-			vars: map[string]struct{}{
-				"baz": {},
-			},
+			vars:         sets.NewString("baz"),
 		},
 		expectedError: nil,
 	}, {
@@ -82,9 +76,7 @@ func TestValidateVariables(t *testing.T) {
 			prefix:       "inputs.params",
 			locationName: "step",
 			path:         "taskspec.steps",
-			vars: map[string]struct{}{
-				"foo": {},
-			},
+			vars:         sets.NewString("foo"),
 		},
 		expectedError: &apis.FieldError{
 			Message: `non-existent variable in "--flag=$(inputs.params.baz)" for step somefield`,
@@ -97,9 +89,7 @@ func TestValidateVariables(t *testing.T) {
 			prefix:       "inputs.params",
 			locationName: "step",
 			path:         "taskspec.steps",
-			vars: map[string]struct{}{
-				"foo": {},
-			},
+			vars:         sets.NewString("foo"),
 		},
 		expectedError: &apis.FieldError{
 			Message: `non-existent variable in "--flag=$(inputs.params.baz) $(input.params.foo)" for step somefield`,

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -75,7 +76,7 @@ func Apply(ts v1beta1.TaskSpec, wb []v1beta1.WorkspaceBinding) (*v1beta1.TaskSpe
 	}
 
 	v := GetVolumes(wb)
-	addedVolumes := map[string]struct{}{}
+	addedVolumes := sets.NewString()
 
 	// Initialize StepTemplate if it hasn't been already
 	if ts.StepTemplate == nil {
@@ -98,9 +99,9 @@ func Apply(ts v1beta1.TaskSpec, wb []v1beta1.WorkspaceBinding) (*v1beta1.TaskSpe
 		})
 
 		// Only add this volume if it hasn't already been added
-		if _, ok := addedVolumes[vv.Name]; !ok {
+		if !addedVolumes.Has(vv.Name) {
 			ts.Volumes = append(ts.Volumes, vv)
-			addedVolumes[vv.Name] = struct{}{}
+			addedVolumes.Insert(vv.Name)
 		}
 	}
 	return &ts, nil


### PR DESCRIPTION
# Changes

This replaces the use of `map[string]struct{}` with `sets.String` from K8s apimachinery.

This is a nice higher-level API to replace the Go idiom, which (while clever) isn't terribly approachable to folks unfamiliar with Go.

```release-notes
N/A internal cleanup
```

/kind cleanup
/assign @vdemeester @afrittoli @ImJasonH 