### PR TITLE
Define a helper method pkg/controller.FilterRunRef

### DIFF
--- a/pkg/controller/filter.go
+++ b/pkg/controller/filter.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package controller provides helper methods for external controllers for
+// Custom Task types.
+package controller
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+)
+
+// FilterRunRef returns a filter that can be passed to a Run Informer, which
+// filters out Runs for apiVersion and kinds that a controller doesn't care
+// about.
+//
+// For example, a controller impl that wants to be notified of updates to Runs
+// which reference a Task with apiVersion "example.dev/v0" and kind "Example":
+//
+//     runinformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//       FilterFunc: FilterRunRef("example.dev/v0", "Example"),
+//       Handler:    controller.HandleAll(impl.Enqueue),
+//     })
+func FilterRunRef(apiVersion, kind string) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		r, ok := obj.(*v1alpha1.Run)
+		if !ok {
+			// Somehow got informed of a non-Run object.
+			// Ignore.
+			return false
+		}
+		if r == nil || r.Spec.Ref == nil {
+			// These are invalid, but just in case they get
+			// created somehow, don't panic.
+			return false
+		}
+
+		return r.Spec.Ref.APIVersion == apiVersion && r.Spec.Ref.Kind == v1alpha1.TaskKind(kind)
+	}
+}

--- a/pkg/controller/filter_test.go
+++ b/pkg/controller/filter_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/controller"
+)
+
+const (
+	apiVersion = "example.dev/v0"
+	kind       = "Example"
+)
+
+func TestFilterRunRef(t *testing.T) {
+	for _, c := range []struct {
+		desc string
+		in   interface{}
+		want bool
+	}{{
+		desc: "not a Run",
+		in:   struct{}{},
+		want: false,
+	}, {
+		desc: "nil Run",
+		in:   (*v1alpha1.Run)(nil),
+		want: false,
+	}, {
+		desc: "nil ref",
+		in: &v1alpha1.Run{
+			Spec: v1alpha1.RunSpec{
+				Ref: nil,
+			},
+		},
+		want: false,
+	}, {
+		desc: "Run without matching apiVersion",
+		in: &v1alpha1.Run{
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: "not-matching",
+					Kind:       kind,
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Run without matching kind",
+		in: &v1alpha1.Run{
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       "not-matching",
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Run with matching apiVersion and kind",
+		in: &v1alpha1.Run{
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       kind,
+				},
+			},
+		},
+		want: true,
+	}, {
+		desc: "Run with matching apiVersion and kind and name",
+		in: &v1alpha1.Run{
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       kind,
+					Name:       "some-name",
+				},
+			},
+		},
+		want: true,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got := controller.FilterRunRef(apiVersion, kind)(c.in)
+			if got != c.want {
+				t.Fatalf("FilterRunRef(%q, %q) got %t, want %t", apiVersion, kind, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will be useful to external Custom Task controllers to filter out
update notifications for Runs of irrelevant types.

This is used in (and copied from!) my example CEL task, for instance: https://github.com/ImJasonH/cel-task/blob/6c75268b6b49859f3680ceab0cbbf938191a9606/main.go#L50


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
