### PR TITLE
Implement basic no-op reconciler for all Runs

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
+	"github.com/tektoncd/pipeline/pkg/reconciler/run"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun"
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/injection"
@@ -74,5 +75,6 @@ func main() {
 	sharedmain.MainWithContext(injection.WithNamespaceScope(signals.NewContext(), *namespace), ControllerLogKey,
 		taskrun.NewController(*namespace, images),
 		pipelinerun.NewController(*namespace, images),
+		run.NewController,
 	)
 }

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -31,13 +31,13 @@ rules:
     # Controller needs cluster access to all of the CRDs that it is responsible for
     # managing.
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
+    resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions", "runs"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["taskruns/finalizers", "pipelineruns/finalizers"]
+    resources: ["taskruns/finalizers", "pipelineruns/finalizers", "runs/finalizers"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["tekton.dev"]
-    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status"]
+    resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status", "runs/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tektoncd/pipeline
 go 1.13
 
 require (
+	cloud.google.com/go/storage v1.6.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.1 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
 	github.com/aws/aws-sdk-go v1.30.16 // indirect
@@ -25,6 +26,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gomodules.xyz/jsonpatch/v2 v2.1.0
+	google.golang.org/api v0.20.0
 	google.golang.org/protobuf v1.22.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	k8s.io/api v0.17.6

--- a/pkg/reconciler/run/controller.go
+++ b/pkg/reconciler/run/controller.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package run
+
+import (
+	"context"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	runinformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/run"
+	runreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1alpha1/run"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/tracker"
+)
+
+// NewController instantiates a new controller.Impl from knative.dev/pkg/controller
+func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	logger := logging.FromContext(ctx)
+	pipelineclientset := pipelineclient.Get(ctx)
+	runInformer := runinformer.Get(ctx)
+
+	c := &Reconciler{
+		pipelineClientSet: pipelineclientset,
+	}
+	impl := runreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
+		configStore := config.NewStore(logger.Named("config-store"))
+		configStore.WatchConfigs(cmw)
+
+		return controller.Options{
+			AgentName:   pipeline.RunControllerName,
+			ConfigStore: configStore,
+		}
+	})
+
+	logger.Info("Setting up event handlers")
+	runInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    impl.Enqueue,
+		UpdateFunc: controller.PassNew(impl.Enqueue),
+	})
+	c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
+
+	return impl
+}

--- a/pkg/reconciler/run/run.go
+++ b/pkg/reconciler/run/run.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package run
+
+import (
+	"context"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	runreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1alpha1/run"
+	corev1 "k8s.io/api/core/v1"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/tracker"
+)
+
+const (
+	// runAgentName defines logging agent name for Run Controller
+	runAgentName = "run-controller"
+)
+
+// Reconciler implements controller.Reconciler for Run resources.
+type Reconciler struct {
+	pipelineClientSet clientset.Interface
+	tracker           tracker.Interface
+}
+
+// Check that our Reconciler implements runreconciler.Interface
+var _ runreconciler.Interface = (*Reconciler)(nil)
+
+// Reconcile compares the actual state with the desired, and attempts to
+// converge the two. It then updates the Status block of the Run resource with
+// the current status of the resource.
+func (c *Reconciler) ReconcileKind(ctx context.Context, r *v1alpha1.Run) pkgreconciler.Event {
+	// TODO(jasonhall): Implement default reconciliation:
+	// - initial update timeout
+	// - cancellation handling (open question)
+	// - timeout handling (open question)
+
+	return pkgreconciler.NewEvent(corev1.EventTypeNormal, "RunReconciled", "Run reconciled: \"%s/%s\"", r.Namespace, r.Name)
+}


### PR DESCRIPTION
This wires up a reconciler in the core controller binary that is
notified of changes to and creations of all Run objects of any type. It
currently does nothing in response to these events, but in the future
this will be used to enforce initial update timeouts, and possibly more
default behavior in the future.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```