### PR TITLE
Add namespace variable interpolation for pipelinerun namespace and

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -15,6 +15,7 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | `params.<param name>` | The value of the parameter at runtime. |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
+| `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipeline.name` | The name of this `Pipeline` . |
 
 
@@ -31,6 +32,7 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | `workspaces.<workspaceName>.volume` | The name of the volume populating the `Workspace`. |
 | `credentials.path` | The path to credentials injected from Secrets with matching annotations. |
 | `context.taskRun.name` | The name of the `TaskRun` that this `Task` is running in. |
+| `context.taskRun.namespace` | The namespace of the `TaskRun` that this `Task` is running in. |
 | `context.task.name` | The name of this `Task`. |
 
 ### `PipelineResource` variables available in a `Task`

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -56,12 +56,10 @@ func ApplyParameters(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.
 // ApplyContexts applies the substitution from $(context.(pipelineRun|pipeline).*) with the specified values.
 // Currently supports only name substitution. Uses "" as a default if name is not specified.
 func ApplyContexts(spec *v1beta1.PipelineSpec, pipelineName string, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
-	stringReplacements := map[string]string{}
-	stringReplacements["context.pipelineRun.name"] = pr.Name
-	stringReplacements["context.pipeline.name"] = pipelineName
-
 	return ApplyReplacements(spec,
-		map[string]string{"context.pipelineRun.name": pr.Name, "context.pipeline.name": pipelineName},
+		map[string]string{"context.pipelineRun.name": pr.Name,
+			"context.pipeline.name":         pipelineName,
+			"context.pipelineRun.namespace": pr.Namespace},
 		map[string][]string{})
 }
 

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -452,12 +452,38 @@ func TestContext(t *testing.T) {
 					tb.PipelineTaskParam("first-task-first-param", "pipelineRunName-1"),
 				))),
 	}, {
+		description: "context pipelineRunNameNamespace replacement with defined pipelineRunNamepsace in spec",
+		pr:          tb.PipelineRun("pipelineRunName", tb.PipelineRunNamespace("prns")),
+		original: tb.Pipeline("test-pipeline",
+			tb.PipelineSpec(
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "$(context.pipelineRun.namespace)-1"),
+				))),
+		expected: tb.Pipeline("test-pipeline",
+			tb.PipelineSpec(
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "prns-1"),
+				))),
+	}, {
 		description: "context pipelineRunName replacement with no defined pipeline in spec",
 		pr:          &v1beta1.PipelineRun{},
 		original: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(
 				tb.PipelineTask("first-task-1", "first-task",
 					tb.PipelineTaskParam("first-task-first-param", "$(context.pipelineRun.name)-1"),
+				))),
+		expected: tb.Pipeline("test-pipeline",
+			tb.PipelineSpec(
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "-1"),
+				))),
+	}, {
+		description: "context pipelineRunNamespace replacement with no defined pipelineRunNamespace in spec",
+		pr:          tb.PipelineRun("pipelineRunName"),
+		original: tb.Pipeline("test-pipeline",
+			tb.PipelineSpec(
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "$(context.pipelineRun.namespace)-1"),
 				))),
 		expected: tb.Pipeline("test-pipeline",
 			tb.PipelineSpec(

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -99,12 +99,8 @@ func ApplyResources(spec *v1beta1.TaskSpec, resolvedResources map[string]v1beta1
 // ApplyContexts applies the substitution from $(context.(taskRun|task).*) with the specified values.
 // Currently supports only name substitution. Uses "" as a default if name is not specified.
 func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
-	stringReplacements := map[string]string{}
-	stringReplacements["context.taskRun.name"] = tr.Name
-	stringReplacements["context.task.name"] = rtr.TaskName
-
 	return ApplyReplacements(spec,
-		map[string]string{"context.taskRun.name": tr.Name, "context.task.name": rtr.TaskName},
+		map[string]string{"context.taskRun.name": tr.Name, "context.task.name": rtr.TaskName, "context.taskRun.namespace": tr.Namespace},
 		map[string][]string{})
 }
 

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -839,7 +839,7 @@ func TestContext(t *testing.T) {
 			}},
 		},
 	}, {
-		description: "context taskRunName replacement with no defined taskRun in spec container",
+		description: "context taskRunName replacement with no defined taskRun name in spec container",
 		rtr: resources.ResolvedTaskResources{
 			TaskName: "Task1",
 		},
@@ -857,6 +857,55 @@ func TestContext(t *testing.T) {
 				Container: corev1.Container{
 					Name:  "ImageName",
 					Image: "-1",
+				},
+			}},
+		},
+	}, {
+		description: "context taskRun namespace replacement with no defined namepsace in spec container",
+		rtr: resources.ResolvedTaskResources{
+			TaskName: "Task1",
+		},
+		tr: v1beta1.TaskRun{},
+		spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:  "ImageName",
+					Image: "$(context.taskRun.namespace)-1",
+				},
+			}},
+		},
+		want: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:  "ImageName",
+					Image: "-1",
+				},
+			}},
+		},
+	}, {
+		description: "context taskRun namespace replacement with defined namepsace in spec container",
+		rtr: resources.ResolvedTaskResources{
+			TaskName: "Task1",
+		},
+		tr: v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "taskrunName",
+				Namespace: "trNamespace",
+			},
+		},
+		spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:  "ImageName",
+					Image: "$(context.taskRun.namespace)-1",
+				},
+			}},
+		},
+		want: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:  "ImageName",
+					Image: "trNamespace-1",
 				},
 			}},
 		},


### PR DESCRIPTION
taskrun namespace

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Add namespace variable interpolation for pipelinerun namespace and taskrun namespace this will be the final diff for #1522
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
     support context.taskRun.namepsace and context.pipelineRun.namespace variable interpolation.
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
