### PR TITLE
Document all locations that variable substitution is available

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -113,3 +113,40 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `name` | The name of the resource. |
 | `type` | Type value of `"cloudEvent"`. |
 | `target-uri` | The URI to hit with cloud event payloads. |
+
+## Fields that accept variable substitutions
+
+| CRD | Field |
+| --- | ----- |
+| `Task` | `spec.steps[].name` |
+| `Task` | `spec.steps[].image` |
+| `Task` | `spec.steps[].env.value` |
+| `Task` | `spec.steps[].env.valuefrom.secretkeyref.name` |
+| `Task` | `spec.steps[].env.valuefrom.secretkeyref.key` |
+| `Task` | `spec.steps[].env.valuefrom.configmapkeyref.name` |
+| `Task` | `spec.steps[].env.valuefrom.configmapkeyref.key` |
+| `Task` | `spec.steps[].volumemounts.name` |
+| `Task` | `spec.steps[].volumemounts.mountpath` |
+| `Task` | `spec.steps[].volumemounts.subpath` |
+| `Task` | `spec.volumes[].name` |
+| `Task` | `spec.volumes[].configmap.name` |
+| `Task` | `spec.volumes[].secret.secretname` |
+| `Task` | `spec.volumes[].persistentvolumeclaim.claimname` |
+| `Task` | `spec.volumes[].projected.sources.configmap.name` |
+| `Task` | `spec.volumes[].projected.sources.secret.name` |
+| `Task` | `spec.volumes[].projected.sources.serviceaccounttoken.audience` |
+| `Task` | `spec.volumes[].csi.nodepublishsecretref.name` |
+| `Task` | `spec.volumes[].csi.volumeattributes.* `|
+| `Task` | `spec.sidecars[].name` |
+| `Task` | `spec.sidecars[].image` |
+| `Task` | `spec.sidecars[].env.value` |
+| `Task` | `spec.sidecars[].env.valuefrom.secretkeyref.name` |
+| `Task` | `spec.sidecars[].env.valuefrom.secretkeyref.key` |
+| `Task` | `spec.sidecars[].env.valuefrom.configmapkeyref.name` |
+| `Task` | `spec.sidecars[].env.valuefrom.configmapkeyref.key` |
+| `Task` | `spec.sidecars[].volumemounts.name` |
+| `Task` | `spec.sidecars[].volumemounts.mountpath` |
+| `Task` | `spec.sidecars[].volumemounts.subpath` |
+| `Pipeline` | `spec.tasks[].params[].value` |
+| `Pipeline` | `spec.tasks[].conditions[].params[].value` |
+| `Pipeline` | `spec.results[].value` |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #2605 , adding a table to [docs/variables.md](docs/variables.md) with locations in our CRDs where variables will be successfully interpolated into.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).


