### PR TITLE
Add Default TaskRun Workspace Bindings to config-default

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -62,3 +62,9 @@ data:
     # TaskRun specific sink, so the default is the only option available.
     # If no sink is specified, no CloudEvent is generated
     # default-cloud-events-sink:
+      
+    # default-task-run-workspace-binding contains the default workspace
+    # configuration provided for any Workspaces that a Task declares
+    # but that a TaskRun does not explicitly provide.
+    # default-task-run-workspace-binding: |
+    #   emptyDir: {}

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -84,6 +84,8 @@ spec:
         # If you are changing these names, you will also need to update
         # the controller's Role in 200-role.yaml to include the new
         # values in the "configmaps" "get" rule.
+        - name: CONFIG_DEFAULTS_NAME
+          value: config-defaults
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME

--- a/docs/install.md
+++ b/docs/install.md
@@ -265,6 +265,7 @@ The example below customizes the following:
 - the default `app.kubernetes.io/managed-by` label is applied to all Pods created to execute `TaskRuns`.
 - the default Pod template to include a node selector to select the node where the Pod will be scheduled by default.
   For more information, see [`PodTemplate` in `TaskRuns`](./taskruns.md#specifying-a-pod-template) or [`PodTemplate` in `PipelineRuns`](./pipelineruns.md#specifying-a-pod-template).
+- the default `Workspace` configuration can be set for any `Workspaces` that a Task declares but that a TaskRun does not explicitly provide
 
 ```yaml
 apiVersion: v1
@@ -278,6 +279,8 @@ data:
     nodeSelector:
       kops.k8s.io/instancegroup: build-instance-group
   default-managed-by-label-value: "my-tekton-installation"
+  default-task-run-workspace-binding: 
+    emptyDir: {}
 ```
 
 **Note:** The `_example` key in the provided [config-defaults.yaml](./../config/config-defaults.yaml)

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -98,6 +98,8 @@ Note the following:
   start with the name of a directory. For example, a `mountPath` of `"/foobar"` is  absolute and exposes
   the `Workspace` at `/foobar` inside the `Task's` `Steps`, but a `mountPath` of `"foobar"` is relative and
   exposes the `Workspace` at `/workspace/foobar`.
+- A default `Workspace` configuration can be set for any `Workspaces` that a Task declares but that a TaskRun 
+  does not explicitly provide. It can be set in the `config-defaults` ConfigMap in `default-task-run-workspace-binding`.
     
 Below is an example `Task` definition that includes a `Workspace` called `messages` to which the `Task` writes a message:
 

--- a/examples/v1beta1/taskruns/no-ci/default-workspaces.yaml
+++ b/examples/v1beta1/taskruns/no-ci/default-workspaces.yaml
@@ -1,0 +1,45 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test-task
+spec:
+  workspaces:
+  - name: source
+  steps:
+  - name: write-file
+    image: ubuntu
+    script: |
+      echo "Hello, world!" > /workspace/source/hello.txt || exit 0
+  - name: read-file
+    image: ubuntu
+    script: |
+      grep "Hello, world" /workspace/source/hello.txt
+---
+# Uses default workspace specified in config-defaults
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-taskrun
+spec:
+  taskRef:
+    name: test-task
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-configmap
+data:
+  hello.txt: "Hello, world!"
+---
+# Uses provided workspace (not default)
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: test-taskrun-configmap
+spec:
+  workspaces:
+  - name: source
+    configMap:
+      name: my-configmap
+  taskRef:
+    name: test-task

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -28,29 +28,31 @@ import (
 )
 
 const (
-	DefaultTimeoutMinutes         = 60
-	NoTimeoutDuration             = 0 * time.Minute
-	defaultTimeoutMinutesKey      = "default-timeout-minutes"
-	defaultServiceAccountKey      = "default-service-account"
-	defaultManagedByLabelValueKey = "default-managed-by-label-value"
-	DefaultManagedByLabelValue    = "tekton-pipelines"
-	defaultPodTemplateKey         = "default-pod-template"
-	defaultCloudEventsSinkKey     = "default-cloud-events-sink"
-	DefaultCloudEventSinkValue    = ""
+	DefaultTimeoutMinutes          = 60
+	NoTimeoutDuration              = 0 * time.Minute
+	defaultTimeoutMinutesKey       = "default-timeout-minutes"
+	defaultServiceAccountKey       = "default-service-account"
+	defaultManagedByLabelValueKey  = "default-managed-by-label-value"
+	DefaultManagedByLabelValue     = "tekton-pipelines"
+	defaultPodTemplateKey          = "default-pod-template"
+	defaultCloudEventsSinkKey      = "default-cloud-events-sink"
+	DefaultCloudEventSinkValue     = ""
+	defaultTaskRunWorkspaceBinding = "default-task-run-workspace-binding"
 )
 
 // Defaults holds the default configurations
 // +k8s:deepcopy-gen=true
 type Defaults struct {
-	DefaultTimeoutMinutes      int
-	DefaultServiceAccount      string
-	DefaultManagedByLabelValue string
-	DefaultPodTemplate         *pod.Template
-	DefaultCloudEventsSink     string
+	DefaultTimeoutMinutes          int
+	DefaultServiceAccount          string
+	DefaultManagedByLabelValue     string
+	DefaultPodTemplate             *pod.Template
+	DefaultCloudEventsSink         string
+	DefaultTaskRunWorkspaceBinding string
 }
 
-// GetBucketConfigName returns the name of the configmap containing all
-// customizations for the storage bucket.
+// GetDefaultsConfigName returns the name of the configmap containing all
+// defined defaults.
 func GetDefaultsConfigName() string {
 	if e := os.Getenv("CONFIG_DEFAULTS_NAME"); e != "" {
 		return e
@@ -72,7 +74,8 @@ func (cfg *Defaults) Equals(other *Defaults) bool {
 		other.DefaultServiceAccount == cfg.DefaultServiceAccount &&
 		other.DefaultManagedByLabelValue == cfg.DefaultManagedByLabelValue &&
 		other.DefaultPodTemplate.Equals(cfg.DefaultPodTemplate) &&
-		other.DefaultCloudEventsSink == cfg.DefaultCloudEventsSink
+		other.DefaultCloudEventsSink == cfg.DefaultCloudEventsSink &&
+		other.DefaultTaskRunWorkspaceBinding == cfg.DefaultTaskRunWorkspaceBinding
 }
 
 // NewDefaultsFromMap returns a Config given a map corresponding to a ConfigMap
@@ -111,6 +114,9 @@ func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 		tc.DefaultCloudEventsSink = defaultCloudEventsSink
 	}
 
+	if bindingYAML, ok := cfgMap[defaultTaskRunWorkspaceBinding]; ok {
+		tc.DefaultTaskRunWorkspaceBinding = bindingYAML
+	}
 	return &tc, nil
 }
 

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -172,6 +172,26 @@ func TestEquals(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "different default workspace",
+			left: &config.Defaults{
+				DefaultTaskRunWorkspaceBinding: "emptyDir: {}",
+			},
+			right: &config.Defaults{
+				DefaultTaskRunWorkspaceBinding: "source",
+			},
+			expected: false,
+		},
+		{
+			name: "same default workspace",
+			left: &config.Defaults{
+				DefaultTaskRunWorkspaceBinding: "emptyDir: {}",
+			},
+			right: &config.Defaults{
+				DefaultTaskRunWorkspaceBinding: "emptyDir: {}",
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -24,7 +24,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/hashicorp/go-multierror"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource"
@@ -288,6 +290,12 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
+	if err := c.updateTaskRunWithDefaultWorkspaces(ctx, tr, taskSpec); err != nil {
+		logger.Errorf("Failed to update taskrun %s with default workspace: %v", tr.Name, err)
+		tr.Status.MarkResourceFailed(podconvert.ReasonFailedResolution, err)
+		return nil, nil, controller.NewPermanentError(err)
+	}
+
 	if err := workspace.ValidateBindings(taskSpec.Workspaces, tr.Spec.Workspaces); err != nil {
 		logger.Errorf("TaskRun %q workspaces are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
@@ -396,6 +404,39 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun,
 	}
 
 	logger.Infof("Successfully reconciled taskrun %s/%s with status: %#v", tr.Name, tr.Namespace, tr.Status.GetCondition(apis.ConditionSucceeded))
+	return nil
+}
+
+func (c *Reconciler) updateTaskRunWithDefaultWorkspaces(ctx context.Context, tr *v1beta1.TaskRun, taskSpec *v1beta1.TaskSpec) error {
+	configMap := config.FromContextOrDefaults(ctx)
+	defaults := configMap.Defaults
+	if defaults.DefaultTaskRunWorkspaceBinding != "" {
+		var defaultWS v1beta1.WorkspaceBinding
+		if err := yaml.Unmarshal([]byte(defaults.DefaultTaskRunWorkspaceBinding), &defaultWS); err != nil {
+			return fmt.Errorf("failed to unmarshal %v", defaults.DefaultTaskRunWorkspaceBinding)
+		}
+		workspaceBindings := map[string]v1beta1.WorkspaceBinding{}
+		for _, tsWorkspace := range taskSpec.Workspaces {
+			workspaceBindings[tsWorkspace.Name] = v1beta1.WorkspaceBinding{
+				Name:                  tsWorkspace.Name,
+				SubPath:               defaultWS.SubPath,
+				VolumeClaimTemplate:   defaultWS.VolumeClaimTemplate,
+				PersistentVolumeClaim: defaultWS.PersistentVolumeClaim,
+				EmptyDir:              defaultWS.EmptyDir,
+				ConfigMap:             defaultWS.ConfigMap,
+				Secret:                defaultWS.Secret,
+			}
+		}
+
+		for _, trWorkspace := range tr.Spec.Workspaces {
+			workspaceBindings[trWorkspace.Name] = trWorkspace
+		}
+
+		tr.Spec.Workspaces = []v1beta1.WorkspaceBinding{}
+		for _, wsBinding := range workspaceBindings {
+			tr.Spec.Workspaces = append(tr.Spec.Workspaces, wsBinding)
+		}
+	}
 	return nil
 }
 

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package workspace
 
 import (


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Currently, users have to completely specify `Workspaces` they don't care 
about or whose configuration should be entirely in the hands of admins.

This PR enables users to specify default `Workspaces` for `TaskRuns`, 
for example they can use `emptyDir` by default.

The `WorkspaceBinding` can be set in the `config-defaults` ConfigMap 
in `default-task-run-workspace-binding`.

Fixes #2398 and partially fixes #2595.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
Users can now set a default `Workspace` configuration for any `Workspaces` that a Task declares but that a TaskRun does not explicitly provide. It can be set in the `config-defaults` ConfigMap in `default-task-run-workspace-binding`.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
/cc sbwsg