### PR TITLE
Dont write creds-init files if none of that type are mounted

### DIFF
--- a/examples/v1beta1/taskruns/creds-init-only-mounts-provided-credentials.yaml
+++ b/examples/v1beta1/taskruns/creds-init-only-mounts-provided-credentials.yaml
@@ -1,0 +1,46 @@
+# This example mounts a fake git ssh credential into a Task
+# and confirms that only the expected credential appears
+# on the Task container's disk.
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/ssh-auth
+metadata:
+  name: phony-ssh-key
+  annotations:
+    tekton.dev/git-0: localhost
+data:
+  ssh-privatekey: SGVsbG8sIHdvcmxkCg== # "Hello, world!"
+  known_hosts: SGVsbG8sIHdvcmxkCg== # "Hello, world!"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: phony-ssh-key-service-account
+secrets:
+- name: phony-ssh-key
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: creds-init-only-mounts-provided-credentials-
+spec:
+  serviceAccountName: phony-ssh-key-service-account
+  taskSpec:
+    steps:
+    - name: check-credentials
+      image: alpine
+      script: |
+        #!/usr/bin/env ash
+        set -xe
+
+        # We expect the ssh credential to show up because it's
+        # declared on the service account above.
+        test -f $HOME/.ssh/id_phony-ssh-key
+
+        # We don't expect any docker credentials to appear in the container.
+        test ! -d $HOME/.docker
+
+        # We don't expect any git basic auth credentials or related
+        # configuration to appear in the container.
+        test ! -f $HOME/.git-credentials
+        test ! -f $HOME/.gitconfig

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tektoncd/pipeline
 go 1.13
 
 require (
+	cloud.google.com/go/storage v1.8.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.1 // indirect
 	github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher v0.0.0-20191203181535-308b93ad1f39
 	github.com/cloudevents/sdk-go/v2 v2.1.0
@@ -24,6 +25,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/text v0.3.3 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0
+	google.golang.org/api v0.25.0
 	gopkg.in/yaml.v2 v2.3.0 // indirect
 	k8s.io/api v0.17.6
 	k8s.io/apimachinery v0.17.6

--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -149,13 +149,13 @@ func (*basicDockerBuilder) MatchingAnnotations(secret *corev1.Secret) []string {
 	return flags
 }
 
+// Write builds a .docker/config.json file from a combination
+// of kubernetes docker registry secrets and tekton docker
+// secret entries and writes it to the given directory. If
+// no entries exist then nothing will be written to disk.
 func (*basicDockerBuilder) Write(directory string) error {
 	dockerDir := filepath.Join(directory, ".docker")
 	basicDocker := filepath.Join(dockerDir, "config.json")
-	if err := os.MkdirAll(dockerDir, os.ModePerm); err != nil {
-		return err
-	}
-
 	cf := configFile{Auth: config.Entries}
 	auth := map[string]entry{}
 	if dockerCfg != "" {
@@ -179,6 +179,13 @@ func (*basicDockerBuilder) Write(directory string) error {
 	for k, v := range config.Entries {
 		auth[k] = v
 	}
+	if len(auth) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(dockerDir, os.ModePerm); err != nil {
+		return err
+	}
+
 	cf.Auth = auth
 	content, err := json.Marshal(cf)
 	if err != nil {

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -279,3 +279,28 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Errorf("got: %v, wanted: %v", string(b), expected)
 	}
 }
+
+// TestNoAuthProvided confirms that providing zero secrets results in no docker
+// credential file being written to disk.
+func TestNoAuthProvided(t *testing.T) {
+	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	fooDir := credentials.VolumeName("foo")
+	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
+		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	AddFlags(fs)
+	err := fs.Parse([]string{})
+	if err != nil {
+		t.Fatalf("flag.CommandLine.Parse() = %v", err)
+	}
+	os.Setenv("HOME", credentials.VolumePath)
+	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
+		t.Fatalf("Write() = %v", err)
+	}
+	_, err = ioutil.ReadFile(filepath.Join(credentials.VolumePath, ".docker", "config.json"))
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("expected does not exist error but received: %v", err)
+	}
+}

--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -70,7 +70,13 @@ func (dc *basicGitConfig) Set(value string) error {
 	return nil
 }
 
+// Write builds a .gitconfig file from dc.entries and writes it to disk
+// in the directory provided. If dc.entries is empty then nothing is
+// written.
 func (dc *basicGitConfig) Write(directory string) error {
+	if len(dc.entries) == 0 {
+		return nil
+	}
 	gitConfigPath := filepath.Join(directory, ".gitconfig")
 	gitConfigs := []string{
 		"[credential]\n	helper = store\n",

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -73,7 +73,12 @@ func (dc *sshGitConfig) Set(value string) error {
 	return nil
 }
 
+// Write puts dc's ssh entries into files in a .ssh directory, under
+// the given directory. If dc has no entries then nothing is written.
 func (dc *sshGitConfig) Write(directory string) error {
+	if len(dc.entries) == 0 {
+		return nil
+	}
 	sshDir := filepath.Join(directory, ".ssh")
 	if err := os.MkdirAll(sshDir, os.ModePerm); err != nil {
 		return err


### PR DESCRIPTION
# Changes

This commit fixes the immediate bug described in https://github.com/tektoncd/pipeline/issues/2791, but does not implement the feature request. I'll leave that for a follow-up.

Currently our creds-init code builds files on disk even when a credential
of a given type doesn't exist. For example, a .ssh/known_hosts file
is written even if there are no git ssh keys mounted in the step container.
It will be an empty file. The same is true for .docker/config.json and
.gitconfig.

This commit changes our creds init code to only write files for credentials
that have actually been mounted from correctly annotated secrets.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```