### PR TITLE
Flesh out the docs on using results in Pipelines

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -17,8 +17,9 @@ weight: 3
     - [Using the `retries` parameter](#using-the-retries-parameter)
     - [Guard `Task` execution using `Conditions`](#guard-task-execution-using-conditions)
     - [Configuring the failure timeout](#configuring-the-failure-timeout)
-    - [Configuring execution results at the `Task` level](#configuring-execution-results-at-the-task-level)
-  - [Configuring execution results at the `Pipeline` level](#configuring-execution-results-at-the-pipeline-level)
+  - [Using `Results`](#using-results)
+    - [Passing one Task's `Results` into the `Parameters` of another](#passing-one-tasks-results-into-the-parameters-of-another)
+    - [Emitting `Results` from a `Pipeline`](#emitting-results-from-a-pipeline)
   - [Configuring the `Task` execution order](#configuring-the-task-execution-order)
   - [Adding a description](#adding-a-description)
   - [Adding `Finally` to the `Pipeline`](#adding-finally-to-the-pipeline)
@@ -397,37 +398,61 @@ spec:
       Timeout: "0h1m30s"
 ```
 
-### Configuring execution results at the `Task` level
+## Using `Results`
 
-Tasks can emit [`Results`](tasks.md#storing-execution-results) while they execute. You can
-use these `Results` values as parameter values in subsequent `Tasks` within your `Pipeline`
-through [variable substitution](variables.md#variables-available-in-a-pipeline). Tekton infers the
-`Task` order so that the `Task` emitting the referenced `Results` values executes before the
-`Task` that consumes them. 
+Tasks can emit [`Results`](tasks.md#emitting-results) when they execute. A Pipeline can use these
+`Results` for two different purposes:
 
-In the example below, the result of the `previous-task-name` `Task` is declared as `bar-result`:
+1. A Pipeline can pass the `Result` of a `Task` in to the `Parameters` of another.
+2. A Pipeline can itself emit `Results` and include data from the `Results` of its Tasks.
+
+### Passing one Task's `Results` into the `Parameters` of another
+
+Sharing `Results` between `Tasks` in a `Pipeline` happens via
+[variable substitution](variables.md#variables-available-in-a-pipeline) - one `Task` emits
+a `Result` and another receives it as a `Parameter` with a variable such as
+`$(tasks.<task-name>.results.<result-name>)`.
+
+When one `Task` receives the `Results` of another, there is a dependency created between those
+two `Tasks`. In order for the receiving `Task` to get data from another `Task's` `Result`,
+the `Task` producing the `Result` must run first. Tekton enforces this `Task` ordering
+by ensuring that the `Task` emitting the `Result` executes before any `Task` that uses it. 
+
+In the snippet below, a param is provided its value from the `commit` `Result` emitted by the
+`checkout-source` `Task`. Tekton will make sure that the `checkout-source` `Task` runs
+before this one.
 
 ```yaml
 params:
   - name: foo
-    value: "$(tasks.previous-task-name.results.bar-result)"
+    value: "$(tasks.checkout-source.results.commit)"
 ```
 
 For an end-to-end example, see [`Task` `Results` in a `PipelineRun`](../examples/v1beta1/pipelineruns/task_results_example.yaml).
 
-## Configuring execution results at the `Pipeline` level
+### Emitting `Results` from a `Pipeline`
 
-You can configure your `Pipeline` to emit `Results` during its execution as references to
-the `Results` emitted by each `Task` within it. 
+A `Pipeline` can emit `Results` of its own for a variety of reasons - an external
+system may need to read them when the `Pipeline` is complete, they might summarise
+the most important `Results` from the `Pipeline's` `Tasks`, or they might simply
+be used to expose non-critical messages generated during the execution of the `Pipeline`.
+
+A `Pipeline's` `Results` can be composed of one or many `Task` `Results` emitted during
+the course of the `Pipeline's` execution. A `Pipeline` `Result` can refer to its `Tasks'`
+`Results` using a variable of the form `$(tasks.<task-name>.results.<result-name>)`.
+
+After a `Pipeline` has executed the `PipelineRun` will be populated with the `Results`
+emitted by the `Pipeline`. These will be written to the `PipelineRun's`
+`status.pipelineResults` field.
 
 In the example below, the `Pipeline` specifies a `results` entry with the name `sum` that
-references the `Result` emitted by the `second-add` `Task`.
+references the `outputValue` `Result` emitted by the `calculate-sum` `Task`.
 
 ```yaml
   results:
     - name: sum
       description: the sum of all three operands
-      value: $(tasks.second-add.results.sum)
+      value: $(tasks.calculate-sum.results.outputValue)
 ```
 
 For an end-to-end example, see [`Results` in a `PipelineRun`](../examples/v1beta1/pipelineruns/pipelinerun-results.yaml).


### PR DESCRIPTION
# Changes

The existing documentation related to Results in Pipelines was
accurate but didn't go a long way to justify the feature's
existence. There was also a broken link to Task Results and
a slightly muddy description of how results affect Task ordering.

Here I've tried to clarify a little bit both the intended usage of
results in Pipelines and the technical details surrounding them.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```