### PR TITLE
Remove an unused line of code from oci/resolver.go

### DIFF
--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -108,8 +108,6 @@ func readLayer(layer v1.Layer) (runtime.Object, error) {
 		return nil, fmt.Errorf("Could not read contents of image layer: %w", err)
 	}
 
-	runtime.NewScheme()
-
 	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode(contents, nil, nil)
 	return obj, err
 }


### PR DESCRIPTION
# Changes

This function was called, but the result is ignored. It doesn't appear
to have any side-effects, and all tests pass without it.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```
NONE
```
