### PR TITLE
Use a hash of the workspace name in PVCs from template

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2339,7 +2339,7 @@ func TestReconcileWithVolumeClaimTemplateWorkspace(t *testing.T) {
 		t.Errorf("expected one PVC created. %d was created", len(pvcNames))
 	}
 
-	expectedPVCName := fmt.Sprintf("%s-%s-%s", claimName, workspaceName, pipelineRunName)
+	expectedPVCName := fmt.Sprintf("%s-%s", claimName, "cab465d09a")
 	if pvcNames[0] != expectedPVCName {
 		t.Errorf("expected the created PVC to be named %s. It was named %s", expectedPVCName, pvcNames[0])
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2870,7 +2870,7 @@ func TestReconcileWorkspaceWithVolumeClaimTemplate(t *testing.T) {
 		}
 	}
 
-	expectedPVCName := fmt.Sprintf("%s-%s-%s", claimName, workspaceName, taskRun.Name)
+	expectedPVCName := fmt.Sprintf("%s-%s", claimName, "a521418087")
 	_, err = clients.Kube.CoreV1().PersistentVolumeClaims(taskRun.Namespace).Get(expectedPVCName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("expected PVC %s to exist but instead got error when getting it: %v", expectedPVCName, err)

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -77,7 +77,7 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 		t.Fatalf("unexpexted error: %v", err)
 	}
 
-	expectedPVCName := fmt.Sprintf("%s-%s-%s", claimName1, ws1, ownerName)
+	expectedPVCName := claimName1 + "-ad02547921"
 	pvc, err := fakekubeclient.CoreV1().PersistentVolumeClaims(namespace).Get(expectedPVCName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -139,7 +139,7 @@ func TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata(t *testing.T) 
 		t.Fatalf("unexpexted error: %v", err)
 	}
 
-	expectedPVCName := fmt.Sprintf("%s-%s", workspaceName, ownerName)
+	expectedPVCName := fmt.Sprintf("%s-%s", "pvc", "3fc56c2bb2")
 	pvc, err := fakekubeclient.CoreV1().PersistentVolumeClaims(namespace).Get(expectedPVCName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
# Changes

Today, PVC name from volumeClaimTemplate is retrieved from
an optionally user submitted prefix in addition to the workspace name
and the owner name (PipelineRun name or TaskRun name).

The problem with this is that the workspace name need to follow the
naming requirements for Kubernetes resource names. It might also
be sensitive to very long names.

This commit only uses a fixed length hash of the workspace name
and the owner name (PipelineRun name or TaskRun name)

Closes #2941
/kind bug
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
PersistentVolumeClaims created from volumeClaimTemplate now ends with a hash instead of the workspace name and run name
```
