### PR TITLE
Fix minor format issues

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -75,16 +75,16 @@ aggregates them into their respective files in `$HOME`.
 
 1. Then use that `ServiceAccount` in your `TaskRun` (in `run.yaml`):
 
-```yaml
-apiVersion: tekton.dev/v1beta1
-kind: TaskRun
-metadata:
-  name: build-push-task-run-2
-spec:
-  serviceAccountName: build-bot
-  taskRef:
-    name: build-push
-```
+   ```yaml
+   apiVersion: tekton.dev/v1beta1
+   kind: TaskRun
+   metadata:
+     name: build-push-task-run-2
+   spec:
+     serviceAccountName: build-bot
+     taskRef:
+       name: build-push
+   ```
 
 1. Or use that `ServiceAccount` in your `PipelineRun` (in `run.yaml`):
 
@@ -239,16 +239,16 @@ credentials are then used to authenticate when retrieving any
 
 1. Then use that `ServiceAccount` in your `TaskRun` (in `run.yaml`):
 
-```yaml
-apiVersion: tekton.dev/v1beta1
-kind: TaskRun
-metadata:
-  name: build-push-task-run-2
-spec:
-  serviceAccountName: build-bot
-  taskRef:
-    name: build-push
-```
+   ```yaml
+   apiVersion: tekton.dev/v1beta1
+   kind: TaskRun
+   metadata:
+     name: build-push-task-run-2
+   spec:
+     serviceAccountName: build-bot
+     taskRef:
+       name: build-push
+   ```
 
 1. Or use that `ServiceAccount` in your `PipelineRun` (in `run.yaml`):
 
@@ -408,7 +408,7 @@ For an example of using SSH credentials in a non-root `securityContext`, see the
 Given URLs, usernames, and passwords of the form: `https://url{n}.com`,
 `user{n}`, and `pass{n}`, generate the following for Docker:
 
-```json
+```
 === ~/.docker/config.json ===
 {
   "auths": {

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -63,6 +63,8 @@ A `Pipeline` definition supports the following fields:
   - [`results`](#configuring-execution-results-at-the-pipeline-level) - Specifies the location to which
     the `Pipeline` emits its execution results.
   - [`description`](#adding-a-description) - Holds an informative description of the `Pipeline` object.
+  - [`finally`](#adding-finally-to-the-pipeline) - Specifies one or more `Tasks`
+    to be executed in parallel after all other tasks have completed.
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -53,8 +53,8 @@ A `TaskRun` definition supports the following fields:
     object that provides custom credentials for executing the `TaskRun`.
   - [`params`](#specifying-parameters) - Specifies the desired execution parameters for the `Task`.
   - [`resources`](#specifying-resources) - Specifies the desired `PipelineResource` values.
-    -[`inputs`](#specifying-resources) - Specifies the input resources.
-    -[`outputs`](#specifying-resources) - Specifies the output resources.
+    - [`inputs`](#specifying-resources) - Specifies the input resources.
+    - [`outputs`](#specifying-resources) - Specifies the output resources.
   - [`timeout`](#configuring-the-failure-timeout) - Specifies the timeout before the `TaskRun` fails.
   - [`podTemplate`](#specifying-a-pod-template) - Specifies a [`Pod` template](podtemplates.md) to use as
     the starting point for configuring the `Pods` for the `Task`.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Some code blocks were not indented inside of ordered lists, resulting
in the lists' numbering being reset, so I indented them to match the
others in the list.

A 'json' code block was not fully valid json, so it was rendering with
a red `...` which was different than the rest of the page. The language
identifier was removed to match the other codeblocks in the doc.

The `finally` section was not referenced in the "definition" doc, so I
added it to make it more discoverable.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
NONE
```

/assign @sergetron
/kind documentation