### PR TITLE
Enable the "misspell" linter, and fix some misspellings.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
   - gosec
   - gocritic
   - golint
+  - misspell
 output:
   uniq-by-line: false
 issues:

--- a/pkg/apis/pipeline/v1alpha1/resource_paths.go
+++ b/pkg/apis/pipeline/v1alpha1/resource_paths.go
@@ -24,7 +24,7 @@ func InputResourcePath(r ResourceDeclaration) string {
 	return path("/workspace", r)
 }
 
-// OutputResourcePath returns the path to the output resouce in a Pod
+// OutputResourcePath returns the path to the output resource in a Pod
 func OutputResourcePath(r ResourceDeclaration) string {
 	return path("/workspace/output", r)
 }

--- a/pkg/apis/pipeline/v1beta1/resource_paths.go
+++ b/pkg/apis/pipeline/v1beta1/resource_paths.go
@@ -24,7 +24,7 @@ func InputResourcePath(r ResourceDeclaration) string {
 	return path("/workspace", r)
 }
 
-// OutputResourcePath returns the path to the output resouce in a Pod
+// OutputResourcePath returns the path to the output resource in a Pod
 func OutputResourcePath(r ResourceDeclaration) string {
 	return path("/workspace/output", r)
 }

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
@@ -295,6 +295,6 @@ func TestResolvedConditionCheck_ToTaskResourceBindings(t *testing.T) {
 	}}
 
 	if d := cmp.Diff(expected, rcc.ToTaskResourceBindings()); d != "" {
-		t.Errorf("Did not get expected task resouce binding from condition %s", diff.PrintWantGot(d))
+		t.Errorf("Did not get expected task resource binding from condition %s", diff.PrintWantGot(d))
 	}
 }


### PR DESCRIPTION
# Changes

This is way fewer than I expected to see!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```