### PR TITLE
Cleanup some code in artifact storage.

### DIFF
--- a/pkg/apis/resource/v1alpha1/storage/artifact_pvc.go
+++ b/pkg/apis/resource/v1alpha1/storage/artifact_pvc.go
@@ -19,6 +19,7 @@ package storage
 import (
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
@@ -39,7 +40,7 @@ type ArtifactPVC struct {
 
 // GetType returns the type of the artifact storage.
 func (p *ArtifactPVC) GetType() string {
-	return ArtifactStoragePVCType
+	return pipeline.ArtifactStoragePVCType
 }
 
 // StorageBasePath returns the path to be used to store artifacts in a pipelinerun temporary storage.

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -178,6 +178,12 @@ func createPVC(ctx context.Context, pr *v1beta1.PipelineRun, c kubernetes.Interf
 			if err != nil {
 				return nil, err
 			}
+
+			// The storage class name on pod spec has three states. Tekton doesn't support the empty-string case.
+			// - nil if we don't care
+			// - "" if we explicitly want to have no class names
+			// - "$name" if we want a specific name
+			// https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
 			var pvcStorageClassName *string
 			if pvcConfig.StorageClassName == "" {
 				pvcStorageClassName = nil


### PR DESCRIPTION
# Changes

- We had some constants in two locations - this removes/dedupes these.
- We were doing some unusual string pointer manipulation- this cleans it up
a bit and adds some comments explaining why.
- Minor cleanups around set manipulation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
