### PR TITLE
PodSecurityPolicy Config fixes to allow runnning in restricted envs.

### DIFF
--- a/config/101-podsecuritypolicy.yaml
+++ b/config/101-podsecuritypolicy.yaml
@@ -30,7 +30,7 @@ spec:
   hostIPC: false
   hostPID: false
   runAsUser:
-    rule: 'RunAsAny'
+    rule: 'MustRunAsNonRoot'
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -39,10 +39,6 @@ rules:
   - apiGroups: ["tekton.dev"]
     resources: ["tasks/status", "clustertasks/status", "taskruns/status", "pipelines/status", "pipelineruns/status", "pipelineresources/status"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["policy"]
-    resources: ["podsecuritypolicies"]
-    resourceNames: ["tekton-pipelines"]
-    verbs: ["use"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -30,6 +30,10 @@ rules:
     resources: ["configmaps"]
     verbs: ["get"]
     resourceNames: ["config-logging", "config-observability", "config-artifact-bucket", "config-artifact-pvc", "feature-flags", "config-leader-election"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -59,3 +63,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "update"]
     resourceNames: ["webhook-certs"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -105,6 +105,9 @@ spec:
           value: config-leader-election
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 1001
       volumes:
         - name: config-logging
           configMap:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -82,6 +82,7 @@ spec:
           value: tekton.dev/pipeline
         securityContext:
           allowPrivilegeEscalation: false
+          runAsUser: 1001
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
Fixes #2966

# Changes
1. Moves PSP rule from tekton-pipelines-controller-cluster-access ClusterRole to tekton-pipelines-controller Role. This reduces the scope of where the PSP can be used to prevent privilege escalation
2. Adds PSP rule to tekton-pipelines-webhook to allow the webhook to run when only restricted PSPs are available
3. Adds runAsNonRoot: false to the securityContext of both the controller and webhook deployments to help PSP choose a rule that will let the pods run-as-root

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ N/A] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ N/A ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
The tekton-pipelines-controller and tekton-pipelines-controller are now configured to run as a non-root user. To match these reduced requirements, the tekton-pipelines PodSecurityPolicy updates its runAsUser rule to use MustRunAsNonRoot and is further tightened-up to only allow "use" in the tekton-pipelines namespace.
```