### PR TITLE
Remove the "baseBuildOverrides" flag from .ko.yaml

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -9,8 +9,3 @@ baseImageOverrides:
 
   # Our entrypoint image does not need root, it simply needs to be able to 'cp' the binary into a shared location.
   github.com/tektoncd/pipeline/cmd/entrypoint: gcr.io/distroless/base:debug-nonroot
-baseBuildOverrides:
-  github.com/tektoncd/pipeline/cmd/controller:
-    flags:
-    - name: ldflags
-      value: "-X github.com/tektoncd/pipeline/pkg/version.PipelineVersion=devel"


### PR DESCRIPTION
# Changes

This section never actually worked in ko. See https://github.com/google/ko/issues/167

It doesn't appear that we're setting the ldflags anywhere else, so maybe we don't need them?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
