### PR TITLE
Add URL to the ResourcesResults returned by resources.

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -67,6 +67,14 @@ func main() {
 			},
 			ResourceName: resourceName,
 		},
+		{
+			Key:   "url",
+			Value: fetchSpec.URL,
+			ResourceRef: v1beta1.PipelineResourceRef{
+				Name: resourceName,
+			},
+			ResourceName: resourceName,
+		},
 	}
 
 	if err := termination.WriteMessage(terminationMessagePath, output); err != nil {

--- a/cmd/imagedigestexporter/main.go
+++ b/cmd/imagedigestexporter/main.go
@@ -71,6 +71,14 @@ func main() {
 				Name: imageResource.Name,
 			},
 		})
+		output = append(output, v1beta1.PipelineResourceResult{
+			Key:          "url",
+			Value:        imageResource.URL,
+			ResourceName: imageResource.Name,
+			ResourceRef: v1beta1.PipelineResourceRef{
+				Name: imageResource.Name,
+			},
+		})
 
 	}
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -656,7 +656,7 @@ If no value is specified for `targetPath`, it will default to
 _Please check the builder tool used on how to pass this path to create the
 output file._
 
-The `taskRun` will include the image digest in the `resourcesResult` field that
+The `taskRun` will include the image digest and URL in the `resourcesResult` field that
 is part of the `taskRun.Status`
 
 for example:

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -89,12 +89,15 @@ func TestKanikoTaskRun(t *testing.T) {
 	}
 	digest := ""
 	commit := ""
+	url := ""
 	for _, rr := range tr.Status.ResourcesResult {
 		switch rr.Key {
 		case "digest":
 			digest = rr.Value
 		case "commit":
 			commit = rr.Value
+		case "url":
+			url = rr.Value
 		}
 		// Every resource should have a ref with a name
 		if rr.ResourceRef.Name == "" {
@@ -106,6 +109,9 @@ func TestKanikoTaskRun(t *testing.T) {
 	}
 	if commit == "" {
 		t.Errorf("Commit not found in TaskRun.Status: %v", tr.Status)
+	}
+	if url == "" {
+		t.Errorf("Url not found in TaskRun.Status: %v", tr.Status)
 	}
 
 	if revision != commit {

--- a/test/v1alpha1/kaniko_task_test.go
+++ b/test/v1alpha1/kaniko_task_test.go
@@ -87,12 +87,15 @@ func TestKanikoTaskRun(t *testing.T) {
 	}
 	digest := ""
 	commit := ""
+	url := ""
 	for _, rr := range tr.Status.ResourcesResult {
 		switch rr.Key {
 		case "digest":
 			digest = rr.Value
 		case "commit":
 			commit = rr.Value
+		case "url":
+			url = rr.Value
 		}
 	}
 	if digest == "" {
@@ -100,6 +103,10 @@ func TestKanikoTaskRun(t *testing.T) {
 	}
 	if commit == "" {
 		t.Errorf("Commit not found in TaskRun.Status: %v", tr.Status)
+	}
+
+	if url == "" {
+		t.Errorf("URL not found in TaskRun.Status: %v", tr.Status)
 	}
 
 	if revision != commit {


### PR DESCRIPTION
# Changes

Today, this contains commits and digests (for Git and Image Resources). These are great,
but need the addition of a URL to really verify or fetch the content again. This could be
fetched off the Resource itself, but that would require resolving the Resource (since it could
be passed by reference and change after the fact).

We decided not to dereference Resources into the Status because they are still alpha. This
gives us the requried information, without coupling the beta API to an alpha field.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
The TaskRun.Status.ResourcesResult field now contains a URL for Git and Image PipelineResources, containing the URL of the resource data.
```
