### PR TITLE
README: fix typo with doc text

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ a cluster with **Kubernetes version 1.16 or later***.
 | Version | Docs | Examples |
 | ------- | ---- | -------- |
 | [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
-| [v0.14.2](https://github.com/tektoncd/pipeline/releases/tag/v0.14.2) | [Docs @ v0.14.1](https://github.com/tektoncd/pipeline/tree/v0.14.2/docs#tekton-pipelines) | [Examples @ v0.14.2](https://github.com/tektoncd/pipeline/tree/v0.14.2/examples#examples) |
+| [v0.14.2](https://github.com/tektoncd/pipeline/releases/tag/v0.14.2) | [Docs @ v0.14.2](https://github.com/tektoncd/pipeline/tree/v0.14.2/docs#tekton-pipelines) | [Examples @ v0.14.2](https://github.com/tektoncd/pipeline/tree/v0.14.2/examples#examples) |
 | [v0.14.1](https://github.com/tektoncd/pipeline/releases/tag/v0.14.1) | [Docs @ v0.14.1](https://github.com/tektoncd/pipeline/tree/v0.14.1/docs#tekton-pipelines) | [Examples @ v0.14.1](https://github.com/tektoncd/pipeline/tree/v0.14.1/examples#examples) |
 | [v0.14.0](https://github.com/tektoncd/pipeline/releases/tag/v0.14.0) | [Docs @ v0.14.0](https://github.com/tektoncd/pipeline/tree/v0.14.0/docs#tekton-pipelines) | [Examples @ v0.14.0](https://github.com/tektoncd/pipeline/tree/v0.14.0/examples#examples) |
 | [v0.13.2](https://github.com/tektoncd/pipeline/releases/tag/v0.13.2) | [Docs @ v0.13.2](https://github.com/tektoncd/pipeline/tree/v0.13.2/docs#tekton-pipelines) | [Examples @ v0.13.2](https://github.com/tektoncd/pipeline/tree/v0.13.2/examples#examples) |


### PR DESCRIPTION
# Changes

README doc was pointing to 0.14.2 documentation but link text had 0.14.1 as its description

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).