### PR TITLE
Change podconvert.MakePod func into a configuration struct with methods

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -75,9 +75,18 @@ var (
 	}}
 )
 
-// MakePod converts TaskRun and TaskSpec objects to a Pod which implements the taskrun specified
-// by the supplied CRD.
-func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskRun, taskSpec v1beta1.TaskSpec, kubeclient kubernetes.Interface, entrypointCache EntrypointCache, overrideHomeEnv bool) (*corev1.Pod, error) {
+// Builder exposes options to configure Pod construction from TaskSpecs/Runs.
+type Builder struct {
+	Images          pipeline.Images
+	KubeClient      kubernetes.Interface
+	EntrypointCache EntrypointCache
+	OverrideHomeEnv bool
+}
+
+// Build creates a Pod using the configuration options set on b and the TaskRun
+// and TaskSpec provided in its arguments. An error is returned if there are
+// any problems during the conversion.
+func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec v1beta1.TaskSpec) (*corev1.Pod, error) {
 	var initContainers []corev1.Container
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -87,7 +96,7 @@ func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskR
 	volumes = append(volumes, implicitVolumes...)
 	volumeMounts = append(volumeMounts, implicitVolumeMounts...)
 
-	if overrideHomeEnv {
+	if b.OverrideHomeEnv {
 		implicitEnvVars = append(implicitEnvVars, corev1.EnvVar{
 			Name:  "HOME",
 			Value: homeDir,
@@ -97,7 +106,7 @@ func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskR
 	// Create Volumes and VolumeMounts for any credentials found in annotated
 	// Secrets, along with any arguments needed by Step entrypoints to process
 	// those secrets.
-	credEntrypointArgs, credVolumes, credVolumeMounts, err := credsInit(taskRun.Spec.ServiceAccountName, taskRun.Namespace, kubeclient)
+	credEntrypointArgs, credVolumes, credVolumeMounts, err := credsInit(taskRun.Spec.ServiceAccountName, taskRun.Namespace, b.KubeClient)
 	if err != nil {
 		return nil, err
 	}
@@ -113,33 +122,33 @@ func MakePod(ctx context.Context, images pipeline.Images, taskRun *v1beta1.TaskR
 
 	// Convert any steps with Script to command+args.
 	// If any are found, append an init container to initialize scripts.
-	scriptsInit, stepContainers, sidecarContainers := convertScripts(images.ShellImage, steps, taskSpec.Sidecars)
+	scriptsInit, stepContainers, sidecarContainers := convertScripts(b.Images.ShellImage, steps, taskSpec.Sidecars)
 	if scriptsInit != nil {
 		initContainers = append(initContainers, *scriptsInit)
 		volumes = append(volumes, scriptsVolume)
 	}
 
 	// Initialize any workingDirs under /workspace.
-	if workingDirInit := workingDirInit(images.ShellImage, stepContainers); workingDirInit != nil {
+	if workingDirInit := workingDirInit(b.Images.ShellImage, stepContainers); workingDirInit != nil {
 		initContainers = append(initContainers, *workingDirInit)
 	}
 
 	// Resolve entrypoint for any steps that don't specify command.
-	stepContainers, err = resolveEntrypoints(entrypointCache, taskRun.Namespace, taskRun.Spec.ServiceAccountName, stepContainers)
+	stepContainers, err = resolveEntrypoints(b.EntrypointCache, taskRun.Namespace, taskRun.Spec.ServiceAccountName, stepContainers)
 	if err != nil {
 		return nil, err
 	}
 
 	// Rewrite steps with entrypoint binary. Append the entrypoint init
 	// container to place the entrypoint binary.
-	entrypointInit, stepContainers, err := orderContainers(images.EntrypointImage, credEntrypointArgs, stepContainers, taskSpec.Results)
+	entrypointInit, stepContainers, err := orderContainers(b.Images.EntrypointImage, credEntrypointArgs, stepContainers, taskSpec.Results)
 	if err != nil {
 		return nil, err
 	}
 	initContainers = append(initContainers, entrypointInit)
 	volumes = append(volumes, toolsVolume, downwardVolume)
 
-	limitRangeMin, err := getLimitRangeMinimum(taskRun.Namespace, kubeclient)
+	limitRangeMin, err := getLimitRangeMinimum(taskRun.Namespace, b.KubeClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -55,7 +55,7 @@ var (
 	featureFlagSetReadyAnnotationOnPodCreate = "enable-ready-annotation-on-pod-create"
 )
 
-func TestMakePod(t *testing.T) {
+func TestPodBuild(t *testing.T) {
 	implicitEnvVars := []corev1.EnvVar{{
 		Name:  "HOME",
 		Value: homeDir,
@@ -1142,9 +1142,15 @@ script-heredoc-randomly-generated-78c5n
 			// No entrypoints should be looked up.
 			entrypointCache := fakeCache{}
 
-			got, err := MakePod(store.ToContext(context.Background()), images, tr, c.ts, kubeclient, entrypointCache, true)
+			builder := Builder{
+				Images:          images,
+				KubeClient:      kubeclient,
+				EntrypointCache: entrypointCache,
+				OverrideHomeEnv: true,
+			}
+			got, err := builder.Build(store.ToContext(context.Background()), tr, c.ts)
 			if err != nil {
-				t.Fatalf("MakePod: %v", err)
+				t.Fatalf("builder.Build: %v", err)
 			}
 
 			if !strings.HasPrefix(got.Name, "taskrun-name-pod-") {

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -538,7 +538,13 @@ func (c *Reconciler) createPod(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	// Apply creds-init path substitutions.
 	ts = resources.ApplyCredentialsPath(ts, pipeline.CredsDir)
 
-	pod, err := podconvert.MakePod(ctx, c.Images, tr, *ts, c.KubeClientSet, c.entrypointCache, shouldOverrideHomeEnv)
+	podbuilder := podconvert.Builder{
+		Images:          c.Images,
+		KubeClient:      c.KubeClientSet,
+		EntrypointCache: c.entrypointCache,
+		OverrideHomeEnv: shouldOverrideHomeEnv,
+	}
+	pod, err := podbuilder.Build(ctx, tr, *ts)
 	if err != nil {
 		return nil, fmt.Errorf("translating TaskSpec to Pod: %w", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1760,7 +1760,13 @@ func makePod(taskRun *v1beta1.TaskRun, task *v1beta1.Task) (*corev1.Pod, error) 
 		return nil, err
 	}
 
-	return podconvert.MakePod(context.Background(), images, taskRun, task.Spec, kubeclient, entrypointCache, true)
+	builder := podconvert.Builder{
+		Images:          images,
+		KubeClient:      kubeclient,
+		EntrypointCache: entrypointCache,
+		OverrideHomeEnv: true,
+	}
+	return builder.Build(context.Background(), taskRun, task.Spec)
 }
 
 func TestReconcilePodUpdateStatus(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

While working on a feature to optionally disable Tekton's built-in credentials
initialization process, it became apparent that the podconvert.MakePod func
would need an extra boolean argument in its signature. The signature is already
quite long which makes reading it difficult.

This commit separates the signature into configuration options and the task
spec / run arguments. In a follow-up commit I plan to add the boolean flag described
above as another configuration option in the PodBuilder struct.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
