### PR TITLE
fixes 2978, missing command in monitoring steps

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -331,8 +331,12 @@ When a `TaskRun` changes status, [events](events.md#taskruns) are triggered acco
 ### Monitoring `Steps`
 
 If multiple `Steps` are defined in the `Task` invoked by the `TaskRun`, you can monitor their execution
-status in the `steps.results` field using the following command, where `<name>` is the name of the target
+status in the `status.steps` field using the following command, where `<name>` is the name of the target
 `TaskRun`:
+
+```bash
+kubectl get taskrun <name> -o yaml
+```
 
 The exact Task Spec used to instantiate the TaskRun is also included in the Status for full auditability.
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This fixes #2978 , adding the missing command to the docs.

Should this be backported to 0.14.1 and 0.14.2 ?

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

/kind documentation
/release-note-none