### PR TITLE
Fix: host.docker.internal instead of host.docker.local

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -48,7 +48,7 @@ Apply your `Task` YAML file as follows:
 kubectl apply -f <name-of-task-file.yaml>
 ```
 
-To see details about your created `Task`, use the following command:  
+To see details about your created `Task`, use the following command:
 ```bash
 tkn task describe echo-hello-world
 ```
@@ -564,8 +564,7 @@ Complete these prerequisites to run this tutorial locally:
 - Install the [required tools](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements).
 - Install [Docker for Desktop](https://www.docker.com/products/docker-desktop) and configure it to use six CPUs,
   10 GB of RAM and 2GB of swap space.
-- Set `host.docker.local:5000` as an insecure registry with Docker for
-  Desktop. See the [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/).
+- Set `host.docker.internal:5000` as an insecure registry with Docker for Desktop. See the [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/).
   for details.
 - Pass `--insecure` as an argument to your Kaniko tasks so that you can push to an insecure registry.
 - Run a local (insecure) Docker registry as follows:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tutorial.md says to use "host.docker.local" instead of "host.docker.internal" #2970

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

## Release Notes
```release-note
NONE
```

/kind documentation