### PR TITLE
Conditions Beta: Skipping

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -380,6 +380,33 @@ tasks:
       name: echo-hello
 ```
 
+When a `Condition` evaluates to `False`, to skip the guarded `Task` only and allow dependent `Tasks` to execute, use the 
+`continueAfterSkip` field and set it to `true` or `yes`. The `continueAfterSkip` field defaults to `false`, but to explicitly
+not execute dependent `Tasks`, set it to `false` or `no`. 
+
+In this example, `Task` `create-file` is executed, `Condition` `echo-when-file-missing` evaluates to `false` so `Task`
+`echo-when-file-missing` is skipped, but because `continueAfterSkip` is set to `true`, `Task` `echo-hello` is executed. 
+ 
+```yaml
+tasks: 
+  - name: create-file # executed
+    taskRef: create-readme-file 
+  - name: echo-when-file-missing  # skipped
+    when:
+      - name: file-missing
+        taskRef: 
+          name: file-missing
+    continueAfterSkip: `true`
+    taskRef:
+      name: echo-missing
+    runAfter:
+      - create-file
+  - name: echo-hello        # executed
+    taskRef: echo-hello
+    runAfter:
+    - echo-when-file-missing 
+```
+
 ### Configuring the failure timeout
 
 You can use the `Timeout` field in the `Task` spec within the `Pipeline` to set the timeout

--- a/examples/v1alpha1/pipelineruns/conditional-pipelinerun-continue-after-skip-ordering.yaml
+++ b/examples/v1alpha1/pipelineruns/conditional-pipelinerun-continue-after-skip-ordering.yaml
@@ -1,0 +1,56 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: always-false
+spec:
+  check:
+    image: alpine
+    script: |
+      exit 1 
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: echo-expected
+spec:
+  steps:
+    - name: echo-expected
+      image: ubuntu
+      script: 'echo expected'
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: echo-unexpected
+spec:
+  steps:
+    - name: echo-file-exists
+      image: ubuntu
+      script: 'echo UNEXPECTED!'
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: conditional-pipeline
+spec:
+  tasks:
+    - name: task-should-be-skipped # failed
+      conditions:
+        - conditionRef: always-false
+      continueAfterSkip: 'true' # allows executing dependent tasks
+      taskRef:
+        name: echo-unexpected
+    - name: task-should-execute # succeeded
+      taskRef:
+        name: echo-expected
+      runAfter: 
+        - task-should-be-skipped
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: conditional-pr-continue-after-skip-ordering
+spec:
+  pipelineRef:
+    name: conditional-pipeline
+  serviceAccountName: 'default'

--- a/examples/v1alpha1/pipelineruns/conditional-pipelinerun-continue-after-skip-resource.yaml
+++ b/examples/v1alpha1/pipelineruns/conditional-pipelinerun-continue-after-skip-resource.yaml
@@ -1,0 +1,134 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Condition
+metadata:
+  name: is-equal
+spec:
+  params:
+  - name: left
+    type: string
+  - name: right
+    type: string
+  check:
+    image: alpine
+    script: |
+      #!/bin/sh
+      if [ $(params.left) = $(params.right) ]; then
+        echo "$(params.left) == $(params.right)"
+        exit 0
+      else
+        echo "$(params.left) != $(params.right)"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: sum
+  annotations:
+    description: |
+      A simple task that sums the two provided integers
+spec:
+  inputs:
+    params:
+      - name: a
+        type: string
+        default: "1"
+        description: The first integer
+      - name: b
+        type: string
+        default: "1"
+        description: The second integer
+  results:
+    - name: sum
+      description: The sum of the two provided integers
+  steps:
+    - name: sum
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n $(( "$(inputs.params.a)" + "$(inputs.params.b)" )) | tee $(results.sum.path)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: multiply
+  annotations:
+    description: |
+      A simple task that multiplies the two provided integers
+spec:
+  inputs:
+    params:
+      - name: a
+        type: string
+        default: "1"
+        description: The first integer
+      - name: b
+        type: string
+        default: "1"
+        description: The second integer
+  results:
+    - name: product
+      description: The product of the two provided integers
+  steps:
+    - name: product
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n $(( "$(inputs.params.a)" * "$(inputs.params.b)" )) | tee $(results.product.path)
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: condition-pipeline
+spec:
+  params:
+  - name: a
+    type: string
+  - name: b
+    type: string
+  tasks:
+  - name: sum-inputs # condition evaluates to false, should be skipped (failed)
+    conditions:
+    - conditionRef: is-equal
+      params:
+        - name: left
+          value: "1"
+        - name: right
+          value: $(params.b)
+    continueAfterSkip: 'true'
+    taskRef:
+      name: sum
+    params:
+      - name: a
+        value: "$(params.a)"
+      - name: b
+        value: "$(params.b)"
+  - name: multiply-inputs # should execute (succeeded)
+    taskRef:
+      name: multiply
+    params:
+      - name: a
+        value: "$(params.a)"
+      - name: b
+        value: "$(params.b)"
+  - name: sum-and-multiply # should execute, resolution error (failed)
+    taskRef:
+      name: sum
+    params:
+      - name: a
+        value: "$(tasks.multiply-inputs.results.product)$(tasks.sum-inputs.results.sum)"
+      - name: b
+        value: "$(tasks.multiply-inputs.results.product)$(tasks.sum-inputs.results.sum)"
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineRun
+metadata:
+  name: condition-pipelinerun-resources
+spec:
+  params:
+  - name: a
+    value: "1"
+  - name: b
+    value: "2"
+  pipelineRef:
+    name: condition-pipeline

--- a/internal/builder/v1alpha1/pipeline.go
+++ b/internal/builder/v1alpha1/pipeline.go
@@ -306,6 +306,13 @@ func PipelineTaskConditionResource(name, resource string, from ...string) Pipeli
 	}
 }
 
+// ContinueAfterSkip sets the boolean to determine whether dependent tasks will execute upon Condition failure
+func ContinueAfterSkip(continueAfterSkip string) PipelineTaskOp {
+	return func(pt *v1alpha1.PipelineTask) {
+		pt.ContinueAfterSkip = continueAfterSkip
+	}
+}
+
 // PipelineTaskWorkspaceBinding adds a workspace with the specified name, workspace and subpath on a PipelineTask.
 func PipelineTaskWorkspaceBinding(name, workspace, subPath string) PipelineTaskOp {
 	return func(pt *v1alpha1.PipelineTask) {

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -67,6 +67,7 @@ func (source *PipelineTask) ConvertTo(ctx context.Context, sink *v1beta1.Pipelin
 		}
 	}
 	sink.Conditions = source.Conditions
+	sink.ContinueAfterSkip = source.ContinueAfterSkip
 	sink.Retries = source.Retries
 	sink.RunAfter = source.RunAfter
 	sink.Resources = source.Resources
@@ -117,6 +118,7 @@ func (sink *PipelineTask) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 		}
 	}
 	sink.Conditions = source.Conditions
+	sink.ContinueAfterSkip = source.ContinueAfterSkip
 	sink.Retries = source.Retries
 	sink.RunAfter = source.RunAfter
 	sink.Resources = source.Resources

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
@@ -81,6 +81,7 @@ func TestPipelineConversion_Success(t *testing.T) {
 					Conditions: []PipelineTaskCondition{{
 						ConditionRef: "condition1",
 					}},
+					ContinueAfterSkip: "false",
 					Retries:  10,
 					RunAfter: []string{"task1"},
 					Resources: &PipelineTaskResources{

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -121,6 +121,11 @@ type PipelineTask struct {
 	// +optional
 	Conditions []PipelineTaskCondition `json:"conditions,omitempty"`
 
+	// ContinueAfterSkip is a string that needs to be true for the dependent Tasks of a Task guarded by Conditions 
+	// to execute even when the Conditions evaluate to False and the Task is skipped
+	// +optional
+	ContinueAfterSkip string `json:"continueAfterSkip,omitempty"`
+
 	// Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False
 	// +optional
 	Retries int `json:"retries,omitempty"`
@@ -134,6 +139,7 @@ type PipelineTask struct {
 	// outputs.
 	// +optional
 	Resources *PipelineTaskResources `json:"resources,omitempty"`
+
 	// Parameters declares parameters passed to this task.
 	// +optional
 	Params []Param `json:"params,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -110,6 +110,11 @@ type PipelineTask struct {
 	// +optional
 	Conditions []PipelineTaskCondition `json:"conditions,omitempty"`
 
+	// ContinueAfterSkip is a string that needs to be true for the dependent Tasks of a Task guarded by Conditions 
+	// to execute even when the Conditions evaluate to False and the Task is skipped
+	// +optional
+	ContinueAfterSkip string `json:"continueAfterSkip,omitempty"`
+
 	// Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False
 	// +optional
 	Retries int `json:"retries,omitempty"`


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

When a `Condition` fails, the guarded `Task` and its branch
(dependent `Tasks`) are skipped. A `Task` is dependent on and in the
branch of another `Task` as specified by ordering using `runAfter` or by
resources using `Results`, `Workspaces` and `Resources`.

In some use cases of `Conditions`, when a `Condition` evaluates to
`False`, users need to skip the guarded `Task` only and allow dependent
`Tasks` to execute. An example use case is when there’s a particular
`Task` that a `Pipeline` wants to execute when the git branch is
dev/staging/qa, but not when it’s the main/master/prod branch.
Another use case is when a user wants to send out a notification whether
or not a parent guarded `Task` was executed, as described in
[this issue](https://github.com/tektoncd/pipeline/issues/2937).

In this PR, we add a `continueAfterSkip` field to specify whether to
terminate the whole `Task` branch, or to skip the guarded `Task` only
and continue with the rest of the `Task` branch.

When a `Condition` evaluates to `False`, to skip the guarded `Task`
only and allow dependent `Tasks` to execute, users can pass in the
`continueAfterSkip` field and set it to `true` or `yes` (case insensitive).
The field defaults to `false` -- the rest of the `Task` branch is skipped
by default as it was previously.

When `continueAfterSkip` is set to `True`, subsequent `Tasks` based on
ordering dependencies should execute and the subsequent `Tasks` based
resource dependencies will have resource validation errors.

TEP: https://github.com/tektoncd/community/pull/159

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
- When a Condition evaluates to False, to skip the guarded Task only and allow dependent Tasks to execute, users can pass in the continueAfterSkip field and set it to true or yes (case insensitive).
- The field defaults to false -- the rest of the Task branch is skipped by default as it was previously.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
