### PR TITLE
Fix some assignment to nil map issues

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -887,6 +887,8 @@ func updatePipelineRunStatusFromTaskRuns(logger *zap.SugaredLogger, prName strin
 		for taskRunName, pipelineRunTaskRunStatus := range prStatus.TaskRuns {
 			taskRunByPipelineTask[pipelineRunTaskRunStatus.PipelineTaskName] = taskRunName
 		}
+	} else {
+		prStatus.TaskRuns = make(map[string]*v1beta1.PipelineRunTaskRunStatus)
 	}
 	// Loop over all the TaskRuns associated to Tasks
 	for _, taskrun := range trs {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -3158,6 +3158,13 @@ func TestUpdatePipelineRunStatusFromTaskRuns(t *testing.T) {
 		},
 	}
 
+	prStatusWithEmptyTaskRuns := v1beta1.PipelineRunStatus{
+		Status: prRunningStatus,
+		PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+			TaskRuns: nil,
+		},
+	}
+
 	prStatusWithOrphans := v1beta1.PipelineRunStatus{
 		Status: duckv1beta1.Status{
 			Conditions: []apis.Condition{
@@ -3196,6 +3203,18 @@ func TestUpdatePipelineRunStatusFromTaskRuns(t *testing.T) {
 					PipelineTaskName: "task-4",
 					Status:           nil,
 					ConditionChecks:  prccs4Recovered,
+				},
+			},
+		},
+	}
+
+	prStatusRecoveredSimple := v1beta1.PipelineRunStatus{
+		Status: prRunningStatus,
+		PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+			TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+				"pr-task-1-xxyyy": {
+					PipelineTaskName: "task-1",
+					Status:           &v1beta1.TaskRunStatus{},
 				},
 			},
 		},
@@ -3266,6 +3285,20 @@ func TestUpdatePipelineRunStatusFromTaskRuns(t *testing.T) {
 			prStatus:         prStatusWithCondition,
 			trs:              nil,
 			expectedPrStatus: prStatusWithCondition,
+		}, {
+			prName:   "status-nil-taskruns",
+			prStatus: prStatusWithEmptyTaskRuns,
+			trs: []*v1beta1.TaskRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pr-task-1-xxyyy",
+						Labels: map[string]string{
+							pipeline.GroupName + pipeline.PipelineTaskLabelKey: "task-1",
+						},
+					},
+				},
+			},
+			expectedPrStatus: prStatusRecoveredSimple,
 		}, {
 			prName:   "status-missing-taskruns",
 			prStatus: prStatusWithCondition,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
updatePipelineRunStatusFromTaskRuns causes panic if the taskruns
map in the pipeline run status is nil.
Add a unit test that reproduces the issue and fix it.

Fixes: #3000
(cherry picked from commit 7aef61d2cc58c09718ac1ca843f0e1506f56eb05)
Cherry picks #3001

/kind bug
/cc @sbwsg @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fix a panic in the pipeline controller that may happen when a pipeline hangs in starting state, because of a malformed condition name.
```