### PR TITLE
Remove default flag values for image names

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"log"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
@@ -34,25 +35,17 @@ const (
 )
 
 var (
-	entrypointImage = flag.String("entrypoint-image", "override-with-entrypoint:latest",
-		"The container image containing our entrypoint binary.")
-	nopImage = flag.String("nop-image", "override-with-nop:latest", "The container image used to stop sidecars")
-	gitImage = flag.String("git-image", "override-with-git:latest",
-		"The container image containing our Git binary.")
-	credsImage = flag.String("creds-image", "override-with-creds:latest",
-		"The container image for preparing our Build's credentials.")
-	kubeconfigWriterImage = flag.String("kubeconfig-writer-image", "override-with-kubeconfig-writer:latest",
-		"The container image containing our kubeconfig writer binary.")
-	shellImage  = flag.String("shell-image", "busybox", "The container image containing a shell")
-	gsutilImage = flag.String("gsutil-image", "google/cloud-sdk",
-		"The container image containing gsutil")
-	buildGCSFetcherImage = flag.String("build-gcs-fetcher-image", "gcr.io/cloud-builders/gcs-fetcher:latest",
-		"The container image containing our GCS fetcher binary.")
-	prImage = flag.String("pr-image", "override-with-pr:latest",
-		"The container image containing our PR binary.")
-	imageDigestExporterImage = flag.String("imagedigest-exporter-image", "override-with-imagedigest-exporter-image:latest",
-		"The container image containing our image digest exporter binary.")
-	namespace = flag.String("namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
+	entrypointImage          = flag.String("entrypoint-image", "", "The container image containing our entrypoint binary.")
+	nopImage                 = flag.String("nop-image", "", "The container image used to stop sidecars")
+	gitImage                 = flag.String("git-image", "", "The container image containing our Git binary.")
+	credsImage               = flag.String("creds-image", "", "The container image for preparing our Build's credentials.")
+	kubeconfigWriterImage    = flag.String("kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
+	shellImage               = flag.String("shell-image", "", "The container image containing a shell")
+	gsutilImage              = flag.String("gsutil-image", "", "The container image containing gsutil")
+	buildGCSFetcherImage     = flag.String("build-gcs-fetcher-image", "", "The container image containing our GCS fetcher binary.")
+	prImage                  = flag.String("pr-image", "", "The container image containing our PR binary.")
+	imageDigestExporterImage = flag.String("imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
+	namespace                = flag.String("namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
 )
 
 func main() {
@@ -68,6 +61,9 @@ func main() {
 		BuildGCSFetcherImage:     *buildGCSFetcherImage,
 		PRImage:                  *prImage,
 		ImageDigestExporterImage: *imageDigestExporterImage,
+	}
+	if err := images.Validate(); err != nil {
+		log.Fatal(err)
 	}
 	sharedmain.MainWithContext(injection.WithNamespaceScope(signals.NewContext(), *namespace), ControllerLogKey,
 		taskrun.NewController(*namespace, images),

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package pipeline
 
+import (
+	"fmt"
+	"sort"
+)
+
 // Images holds the images reference for a number of container images used
 // across tektoncd pipelines.
 type Images struct {
@@ -39,4 +44,34 @@ type Images struct {
 	PRImage string
 	// ImageDigestExporterImage is the container image containing our image digest exporter binary.
 	ImageDigestExporterImage string
+
+	// NOTE: Make sure to add any new images to Validate below!
+}
+
+// Validate returns an error if any image is not set.
+func (i Images) Validate() error {
+	var unset []string
+	for _, f := range []struct {
+		v, name string
+	}{
+		{i.EntrypointImage, "entrypoint"},
+		{i.NopImage, "nop"},
+		{i.GitImage, "git"},
+		{i.CredsImage, "creds"},
+		{i.KubeconfigWriterImage, "kubeconfig-writer"},
+		{i.ShellImage, "shell"},
+		{i.GsutilImage, "gsutil"},
+		{i.BuildGCSFetcherImage, "build-gcs-fetcher"},
+		{i.PRImage, "pr"},
+		{i.ImageDigestExporterImage, "imagedigest-exporter"},
+	} {
+		if f.v == "" {
+			unset = append(unset, f.name)
+		}
+	}
+	if len(unset) > 0 {
+		sort.Strings(unset)
+		return fmt.Errorf("found unset image flags: %s", unset)
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/images_test.go
+++ b/pkg/apis/pipeline/images_test.go
@@ -1,0 +1,44 @@
+package pipeline_test
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+)
+
+func TestValidate(t *testing.T) {
+	valid := pipeline.Images{
+		EntrypointImage:          "set",
+		NopImage:                 "set",
+		GitImage:                 "set",
+		CredsImage:               "set",
+		KubeconfigWriterImage:    "set",
+		ShellImage:               "set",
+		GsutilImage:              "set",
+		BuildGCSFetcherImage:     "set",
+		PRImage:                  "set",
+		ImageDigestExporterImage: "set",
+	}
+	if err := valid.Validate(); err != nil {
+		t.Errorf("valid Images returned error: %v", err)
+	}
+
+	invalid := pipeline.Images{
+		EntrypointImage:          "set",
+		NopImage:                 "set",
+		GitImage:                 "", // unset!
+		CredsImage:               "set",
+		KubeconfigWriterImage:    "set",
+		ShellImage:               "", // unset!
+		GsutilImage:              "set",
+		BuildGCSFetcherImage:     "", // unset!
+		PRImage:                  "", // unset!
+		ImageDigestExporterImage: "set",
+	}
+	wantErr := "found unset image flags: [build-gcs-fetcher git pr shell]"
+	if err := invalid.Validate(); err == nil {
+		t.Error("invalid Images expected error, got nil")
+	} else if err.Error() != wantErr {
+		t.Errorf("Unexpected error message: got %q, want %q", err.Error(), wantErr)
+	}
+}


### PR DESCRIPTION
These values were previously defined in two places (here in flag
defaults, and in config/controller.yaml), which could lead to confusing
mismatches (#3007)

/cc @dlorenc 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Image names passed as flags in config/controller.yaml are now required -- there are no longer default values defined,  and a missing flag value will result in a fatal error when starting the controller.
```