### PR TITLE
Add context variables for PipelineRun & TaskRun UIDs and add validation for all context variables

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -16,6 +16,7 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
+| `context.pipelineRun.uid` | The uid of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipeline.name` | The name of this `Pipeline` . |
 
 
@@ -33,6 +34,7 @@ This page documents the variable substitions supported by `Tasks` and `Pipelines
 | `credentials.path` | The path to credentials injected from Secrets with matching annotations. |
 | `context.taskRun.name` | The name of the `TaskRun` that this `Task` is running in. |
 | `context.taskRun.namespace` | The namespace of the `TaskRun` that this `Task` is running in. |
+| `context.taskRun.uid` | The uid of the `TaskRun` that this `Task` is running in. |
 | `context.task.name` | The name of this `Task`. |
 
 ### `PipelineResource` variables available in a `Task`

--- a/examples/v1beta1/pipelineruns/using_context_variables.yaml
+++ b/examples/v1beta1/pipelineruns/using_context_variables.yaml
@@ -1,0 +1,34 @@
+kind: PipelineRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: test-pipelinerun-
+spec:
+  serviceAccountName: 'default'
+  pipelineSpec:
+    tasks:
+    - name: task1
+      params:
+      - name: pipeline-uid
+        value: "$(context.pipelineRun.uid)"
+      - name: pipeline-name
+        value: "$(context.pipeline.name)" 
+      - name: pipelineRun-name
+        value: "$(context.pipelineRun.name)"
+      taskSpec:
+        params:
+        - name: pipeline-uid
+        - name: pipeline-name
+        - name: pipelineRun-name
+        steps:
+        - image: ubuntu
+          name: print-uid
+          script: |
+            echo "TaskRun UID: $(context.taskRun.uid)"
+            echo "PipelineRun UID from params: $(params.pipeline-uid)"
+        - image: ubuntu
+          name: print-names
+          script: |
+            echo "Task name: $(context.task.name)"
+            echo "TaskRun name: $(context.taskRun.name)"
+            echo "Pipeline name from params: $(params.pipeline-name)"
+            echo "PipelineRun name from params: $(params.pipelineRun-name)"

--- a/examples/v1beta1/taskruns/using_context_variables.yaml
+++ b/examples/v1beta1/taskruns/using_context_variables.yaml
@@ -1,0 +1,16 @@
+kind: TaskRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: test-taskrun-
+spec:
+  taskSpec:
+    steps:
+    - image: ubuntu
+      name: print-uid
+      script: |
+        echo "TaskRunUID name: $(context.taskRun.uid)"
+    - image: ubuntu
+      name: print-names
+      script: |
+        echo "Task name: $(context.task.name)"
+        echo "TaskRun name: $(context.taskRun.name)"

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -94,6 +94,11 @@ func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 	if err := ValidateResults(ts.Results); err != nil {
 		return err
 	}
+
+	if err := validateTaskContextVariables(ts.Steps); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -246,6 +251,21 @@ func ValidateParameterVariables(steps []Step, params []ParamSpec) *apis.FieldErr
 		return err
 	}
 	return validateArrayUsage(steps, "params", arrayParameterNames)
+}
+
+func validateTaskContextVariables(steps []Step) *apis.FieldError {
+	taskRunContextNames := sets.NewString().Insert(
+		"name",
+		"namespace",
+		"uid",
+	)
+	taskContextNames := sets.NewString().Insert(
+		"name",
+	)
+	if err := validateVariables(steps, "context\\.taskRun", taskRunContextNames); err != nil {
+		return err
+	}
+	return validateVariables(steps, "context\\.task", taskContextNames)
 }
 
 func ValidateResourcesVariables(steps []Step, resources *TaskResources) *apis.FieldError {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -265,6 +265,58 @@ func TestTaskSpecValidate(t *testing.T) {
 				Description: "my great result",
 			}},
 		},
+	}, {
+		name: "valid task name context",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+					Args:  []string{"arg"},
+				},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(context.task.name)"`,
+			}},
+		},
+	}, {
+		name: "valid taskrun name context",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+					Args:  []string{"arg"},
+				},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(context.taskRun.name)"`,
+			}},
+		},
+	}, {
+		name: "valid taskrun uid context",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+					Args:  []string{"arg"},
+				},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(context.taskRun.uid)"`,
+			}},
+		},
+	}, {
+		name: "valid context",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+					Args:  []string{"arg"},
+				},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(context.taskRun.namespace)"`,
+			}},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -851,6 +903,23 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Message: `invalid key name "MY^RESULT"`,
 			Paths:   []string{"results[0].name"},
 			Details: "Name must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')",
+		},
+	}, {
+		name: "context  not validate",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+					Args:  []string{"arg"},
+				},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(context.task.missing)"`,
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env  bash\n\t\t\t\thello \"$(context.task.missing)\"" for step script`,
+			Paths:   []string{"taskspec.steps.script"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -56,11 +56,13 @@ func ApplyParameters(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.
 // ApplyContexts applies the substitution from $(context.(pipelineRun|pipeline).*) with the specified values.
 // Currently supports only name substitution. Uses "" as a default if name is not specified.
 func ApplyContexts(spec *v1beta1.PipelineSpec, pipelineName string, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
-	return ApplyReplacements(spec,
-		map[string]string{"context.pipelineRun.name": pr.Name,
-			"context.pipeline.name":         pipelineName,
-			"context.pipelineRun.namespace": pr.Namespace},
-		map[string][]string{})
+	replacements := map[string]string{
+		"context.pipelineRun.name":      pr.Name,
+		"context.pipeline.name":         pipelineName,
+		"context.pipelineRun.namespace": pr.Namespace,
+		"context.pipelineRun.uid":       string(pr.ObjectMeta.UID),
+	}
+	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
 // ApplyTaskResults applies the ResolvedResultRef to each PipelineTask.Params in targets

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -490,6 +490,23 @@ func TestContext(t *testing.T) {
 				tb.PipelineTask("first-task-1", "first-task",
 					tb.PipelineTaskParam("first-task-first-param", "-1"),
 				))),
+	}, {
+		description: "context pipeline name replacement with pipelinerun uid",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: "UID-1",
+			},
+		},
+		original: tb.Pipeline("test-pipeline",
+			tb.PipelineSpec(
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "$(context.pipelineRun.uid)"),
+				))),
+		expected: tb.Pipeline("test-pipeline",
+			tb.PipelineSpec(
+				tb.PipelineTask("first-task-1", "first-task",
+					tb.PipelineTaskParam("first-task-first-param", "UID-1"),
+				))),
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := ApplyContexts(&tc.original.Spec, tc.original.Name, tc.pr)

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -97,11 +97,15 @@ func ApplyResources(spec *v1beta1.TaskSpec, resolvedResources map[string]v1beta1
 }
 
 // ApplyContexts applies the substitution from $(context.(taskRun|task).*) with the specified values.
-// Currently supports only name substitution. Uses "" as a default if name is not specified.
+// Uses "" as a default if a value is not available.
 func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
-	return ApplyReplacements(spec,
-		map[string]string{"context.taskRun.name": tr.Name, "context.task.name": rtr.TaskName, "context.taskRun.namespace": tr.Namespace},
-		map[string][]string{})
+	replacements := map[string]string{
+		"context.taskRun.name":      tr.Name,
+		"context.task.name":         rtr.TaskName,
+		"context.taskRun.namespace": tr.Namespace,
+		"context.taskRun.uid":       string(tr.ObjectMeta.UID),
+	}
+	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
 // ApplyWorkspaces applies the substitution from paths that the workspaces in w are mounted to, the

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -928,6 +928,32 @@ func TestContext(t *testing.T) {
 				},
 			}},
 		},
+	}, {
+		description: "context UID replacement",
+		rtr: resources.ResolvedTaskResources{
+			TaskName: "Task1",
+		},
+		tr: v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: "UID-1",
+			},
+		},
+		spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:  "ImageName",
+					Image: "$(context.taskRun.uid)",
+				},
+			}},
+		},
+		want: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:  "ImageName",
+					Image: "UID-1",
+				},
+			}},
+		},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
 			got := resources.ApplyContexts(&tc.spec, &tc.rtr, &tc.tr)

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -27,7 +27,7 @@ import (
 
 const parameterSubstitution = `[_a-zA-Z][_a-zA-Z0-9.-]*(\[\*\])?`
 
-const braceMatchingRegex = "(\\$(\\(%s.(?P<var>%s)\\)))"
+const braceMatchingRegex = "(\\$(\\(%s\\.(?P<var>%s)\\)))"
 
 func ValidateVariable(name, value, prefix, locationName, path string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -50,6 +50,16 @@ func TestValidateVariables(t *testing.T) {
 		},
 		expectedError: nil,
 	}, {
+		name: "valid variable uid",
+		args: args{
+			input:        "--flag=$(context.taskRun.uid)",
+			prefix:       "context.taskRun",
+			locationName: "step",
+			path:         "taskspec.steps",
+			vars:         sets.NewString("uid"),
+		},
+		expectedError: nil,
+	}, {
 		name: "multiple variables",
 		args: args{
 			input:        "--flag=$(inputs.params.baz) $(input.params.foo)",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

A user may want to tag an oci image with the TaskRun or PipelineRun UIDs.
Currently, they can't do that because `metadata.uid` for TaskRuns and
PipelineRuns are not exposed.

In this PR, we add the UID context variable for TaskRuns and
PipelineRun. Users can now use `$(context.taskRun.uid)` and
`$(context.pipelineRun.uid)` to access and use UIDs.

In addition, we add validation for all context variables that are
supported so far -- `context.task.name`, `context.taskRun.name`,
`context.taskRun.namespace`, `context.taskRun.uid`,
`context.pipeline.name`, `context.pipelineRun.name`,
`context.pipelineRun.namespace`, `context.pipelineRun.uid`.

Partially fixes #2958

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
- User can access the uid of the `PipelineRun` that a `Pipeline` is running in using `context.pipelineRun.uid`.
- User can access the uid of the `TaskRun` that a `Task` is running in using `context.taskRun.uid`. 
- All context variables that are supported so far are now validated. 
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
