### PR TITLE
Document using custom SSH port for git repos

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -110,6 +110,27 @@ When the `Run` executes, before steps execute, a `~/.ssh/config` will be
 generated containing the key configured in the `Secret`. This key is then used
 to authenticate when retrieving any `PipelineResources`.
 
+### Using a custom port for SSH authentication
+
+In order to interact with your git server over a custom SSH port you must
+specify the port as part of the Secret. Here's an example:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-key-custom-port
+  annotations:
+    tekton.dev/git-0: example.com:2222
+type: kubernetes.io/ssh-auth
+data:
+  ssh-privatekey: <base64 encoded>
+  known_hosts: <base64 encoded>
+```
+
+Any PipelineResource referencing a repo at `example.com` will now connect
+to it over port 2222.
+
 ### Using SSH authentication in your own `git` `Tasks`
 
 The SSH credentials described above can be used when invoking `git` commands


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/2949

Tekton supports fetching repos from git over custom SSH ports
but we don't have the steps documented anywhere.

This PR adds a couple lines to our auth.md which describes
how to connect to git over a custom SSH port.

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Documented accessing git repos over a custom SSH port.
```

/kind documentation