### PR TITLE
Make string variable interpolation deterministic, and single-pass.

### DIFF
--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -118,10 +118,14 @@ func matchGroups(matches []string, pattern *regexp.Regexp) map[string]string {
 }
 
 func ApplyReplacements(in string, replacements map[string]string) string {
+	replacementsList := []string{}
 	for k, v := range replacements {
-		in = strings.Replace(in, fmt.Sprintf("$(%s)", k), v, -1)
+		replacementsList = append(replacementsList, fmt.Sprintf("$(%s)", k), v)
 	}
-	return in
+	// strings.Replacer does all replacements in one pass, preventing multiple replacements
+	// See #2093 for an explanation on why we need to do this.
+	replacer := strings.NewReplacer(replacementsList...)
+	return replacer.Replace(in)
 }
 
 // Take an input string, and output an array of strings related to possible arrayReplacements. If there aren't any

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -167,6 +167,24 @@ func TestApplyReplacements(t *testing.T) {
 	}
 }
 
+func TestNestedReplacements(t *testing.T) {
+	replacements := map[string]string{
+		// Foo should turn into barbar, which could then expand into bazbaz depending on how this is expanded
+		"foo": "$(bar)$(bar)",
+		"bar": "baz",
+	}
+	input := "$(foo) is cool"
+	expected := "$(bar)$(bar) is cool"
+
+	// Run this test a lot of times to ensure the behavior is deterministic
+	for i := 0; i <= 1000; i++ {
+		got := substitution.ApplyReplacements(input, replacements)
+		if d := cmp.Diff(expected, got); d != "" {
+			t.Errorf("ApplyReplacements() output did not match expected value %s", diff.PrintWantGot(d))
+		}
+	}
+}
+
 func TestApplyArrayReplacements(t *testing.T) {
 	type args struct {
 		input              string


### PR DESCRIPTION
# Changes

Make string variable interpolation deterministic, and single-pass.

Right now we replace string variables one at a time, in an order governed by
iteration through a map[string]string. This has two implications:
- We may expand variables twice. If one variable expands to another variable, that one may be expanded. And so on.
- Whether or not this secondary expansion occurs (and even how it occurs!) can vary from run to run.

This commit changes to replace everything at once, using the strings.Replacer package.
It also adds a test to ensure replacements are stable and non-recursive.

See https://github.com/tektoncd/pipeline/issues/2093

Note, we could go the other way this PR and instead embrace nested expansions. This one is simply my preference based on some reasons outlined in the issue.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
The variable interpolation algorithm has been changed. Nested expansion is no longer supported.
If you use replacements ( $(...) syntax) in your TaskRuns or PipelineRuns that resolve to secondary replacements, these will no longer work.

The algorithm is now deterministic and will result in the same expansion every run.
```
