### PR TITLE
Add nop-image to release configs

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -24,6 +24,8 @@ spec:
     type: image
   - name: builtEntrypointImage
     type: image
+  - name: builtNopImage
+    type: image
   - name: builtKubeconfigWriterImage
     type: image
   - name: builtCredsInitImage
@@ -109,6 +111,8 @@ spec:
             resource: builtBaseImage
           - name: builtEntrypointImage
             resource: builtEntrypointImage
+          - name: builtNopImage
+            resource: builtNopImage
           - name: builtKubeconfigWriterImage
             resource: builtKubeconfigWriterImage
           - name: builtCredsInitImage

--- a/tekton/resources.yaml
+++ b/tekton/resources.yaml
@@ -71,6 +71,16 @@ spec:
 apiVersion: tekton.dev/v1alpha1
 kind: PipelineResource
 metadata:
+  name: nop-image
+spec:
+  type: image
+  params:
+  - name: url
+    value: cmd/nop  # Registry is provided via parameter, this is a hack see #569
+---
+apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+metadata:
   name: kubeconfigwriter-image
 spec:
   type: image


### PR DESCRIPTION
This should ensure that the nop-image is built and released alongside
other utility images.

Followup from #3014

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/assign @sbwsg 