### PR TITLE
Add omitempty for SchedulerName, ImagePullSecrets, HostNetwork

### DIFF
--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -92,14 +92,15 @@ type Template struct {
 	PriorityClassName *string `json:"priorityClassName,omitempty" protobuf:"bytes,7,opt,name=priorityClassName"`
 	// SchedulerName specifies the scheduler to be used to dispatch the Pod
 	// +optional
-	SchedulerName string `json:"schedulerName"`
+	SchedulerName string `json:"schedulerName,omitempty"`
 
 	// ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
-	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets"`
+	// +optional
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// HostNetwork specifies whether the pod may use the node network namespace
 	// +optional
-	HostNetwork bool `json:"hostNetwork"`
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 func (tpl *Template) Equals(other *Template) bool {


### PR DESCRIPTION
# Changes 

This pull request adds `omitempty` for the following pod template fields:
* SchedulerName
* ImagePullSecrets
* HostNetwork

As documented in #17, `SchedulerName` and `HostNetwork` are designated as optional fields and as such should be omitted if not declared. Why ImagePullSecrets is not considered optional seems interesting to me, and perhaps should be discussed a bit further before being introduced. But overall, it might have been overlooked when introducing #2547.

Please let me know if there should be further discussions with regard to this being a breaking change.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Omit SchedulerName, HostNetwork, and ImagePullSecrets if not declared for PodTemplate
```