### PR TITLE
Remove mention of ssh-keygen from auth doc

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -494,9 +494,10 @@ Host url2.com
 ...
 ```
 
-Note: Because `known_hosts` is a non-standard extension of
-`kubernetes.io/ssh-auth`, when it is not present this will be generated through
-`ssh-keygen url{n}.com` instead.
+Note: When `known_hosts` is not provided, Tekton will configure SSH to
+accept _any_ public key that is returned on its first request to the server.
+This is implemented by setting git's `core.sshCommand` to
+`ssh -o StrictHostKeyChecking=accept-new`.
 
 ### Least privilege
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The auth docs mention that tekton generates a known_hosts file using
ssh-keygen but this isn't quite right - we used to fetch the key
using ssh-keyscan but now accept it by updating git's core.sshCommand.

This PR updates the auth doc to describe the implementation we use to
populate known_hosts when its missing.

# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix how we describe the way Tekton populates known_hosts files when they're missing from Secrets.
```