### PR TITLE
Add the nop image to the nightly pipeline release

### DIFF
--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -20,6 +20,8 @@ spec:
     type: image
   - name: builtEntrypointImage
     type: image
+  - name: builtNopImage
+    type: image
   - name: builtKubeconfigWriterImage
     type: image
   - name: builtCredsInitImage
@@ -83,6 +85,8 @@ spec:
             resource: builtBaseImage
           - name: builtEntrypointImage
             resource: builtEntrypointImage
+          - name: builtNopImage
+            resource: builtNopImage
           - name: builtKubeconfigWriterImage
             resource: builtKubeconfigWriterImage
           - name: builtCredsInitImage


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The nop image has been added to the full release task and pipeline, but it was still missing in the nightly
release pipeline, so adding it now.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
The `nop` image, used by the affinity assistant as well as to terminate sidecars, is now part of nightly builds.
```

/kind misc
/cc @ImJasonH 