### PR TITLE
Include More Details on Pod Deletion for Cancelled/Timed Out TaskRuns

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -254,18 +254,23 @@ For more information, see the [`LimitRange` code example](../examples/v1beta1/ta
 
 ## Configuring the failure timeout
 
-You can use the `timeout` field to set the `TaskRun's` desired timeout value in minutes.
-If you do not specify this value in the `TaskRun`, the global default timeout value applies.
-If you set the timeout to 0, the `TaskRun` fails immediately upon encountering an error.
+You can use the `timeout` field to set the `TaskRun's` desired timeout value. If you do not specify this 
+value for the `TaskRun`, the global default timeout value applies. If you set the timeout to 0, the `TaskRun` will 
+have no timeout and will run until it completes successfully or fails from an error.
 
 The global default timeout is set to 60 minutes when you first install Tekton. You can set
 a different global default timeout value using the `default-timeout-minutes` field in
-[`config/config-defaults.yaml`](./../config/config-defaults.yaml).
+[`config/config-defaults.yaml`](./../config/config-defaults.yaml). If you set the global timeout to 0, 
+all `TaskRuns` that do not have a timeout set will have no timeout and will run until it completes successfully 
+or fails from an error.
 
 The `timeout` value is a `duration` conforming to Go's
 [`ParseDuration`](https://golang.org/pkg/time/#ParseDuration) format. For example, valid
-values are `1h30m`, `1h`, `1m`, and `60s`. If you set the global timeout to 0, all `TaskRuns`
-that do not have an individual timeout set will fail immediately upon encountering an error.
+values are `1h30m`, `1h`, `1m`, `60s`, and `0`. 
+
+If a `TaskRun` runs longer than its timeout value, the pod associated with the `TaskRun` will be deleted. This 
+means that the logs of the `TaskRun` are not preserved. The deletion of the `TaskRun` pod is necessary in order to 
+stop `TaskRun` step containers from running. 
 
 ### Specifying `ServiceAccount' credentials
 
@@ -367,9 +372,13 @@ Status:
 
 ## Cancelling a `TaskRun`
 
-To cancel a `TaskRun` that's currently executing, update its definition
-to mark it as cancelled. When you do so, all running `Pods` associated with
-that `TaskRun` are deleted. For example:
+To cancel a `TaskRun` that's currently executing, update its status to mark it as cancelled. 
+
+When you cancel a TaskRun, the running pod associated with that `TaskRun` is deleted. This 
+means that the logs of the `TaskRun` are not preserved. The deletion of the `TaskRun` pod is necessary 
+in order to stop `TaskRun` step containers from running. 
+
+Example of cancelling a `TaskRun`:
 
 ```yaml
 apiVersion: tekton.dev/v1alpha1


### PR DESCRIPTION
Part of #3051 

This pull request updates documentation on pod deletion for both timed out/cancelled TaskRuns to mention that TaskRun pod deletion is part of the process. It also provides a brief amount of information on why this takes place. 

In addition to the updates above, there are some minor changes also made to reorganize the content. 

# Submitter Checklist

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
