### PR TITLE
Cherry-pick "Ensure pullrequest-init is based on a root image"

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -6,6 +6,9 @@ baseImageOverrides:
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   # GCS fetcher needs root due to workspace permissions
   github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher: gcr.io/distroless/static:latest
+  # PullRequest resource needs root because in output mode it needs to access pr.json
+  # which might have been copied or written with any level of permissions.
+  github.com/tektoncd/pipeline/cmd/pullrequest-init: gcr.io/distroless/static:latest
 
   # Our entrypoint image does not need root, it simply needs to be able to 'cp' the binary into a shared location.
   github.com/tektoncd/pipeline/cmd/entrypoint: gcr.io/distroless/base:debug-nonroot

--- a/examples/v1beta1/taskruns/pullrequest_input_copystep_output.yaml
+++ b/examples/v1beta1/taskruns/pullrequest_input_copystep_output.yaml
@@ -1,0 +1,47 @@
+# This examples taskrun exercises the behaviour of the pullrequest
+# resource when the output pullrequest resource matches exactly the
+# input pullrequest resource.
+#
+# A step is used to copy the input resource's data directly to the
+# output resource's workspace directory. The output resource should
+# then read the copied data and skip sending any changes to GitHub.
+#
+# Importantly the output pullrequest should _not_ fail to read the
+# data from its workspace directory, regardless of which user the
+# copy step ran as and the ownership permissions attached to the
+# pr.json file.
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: pr-test-copy-prjson-from-input-to-output
+spec:
+  taskSpec:
+    resources:
+      inputs:
+        - name: pr
+          type: pullRequest
+      outputs:
+        - name: pr
+          type: pullRequest
+    steps:
+    - name: copy-pr-to-output
+      image: busybox
+      script: |
+        #!/bin/sh
+        mkdir -p $(outputs.resources.pr.path)
+        cp -r $(inputs.resources.pr.path)/* $(outputs.resources.pr.path)/
+  resources:
+    inputs:
+    - name: pr
+      resourceSpec:
+        type: pullRequest
+        params:
+        - name: url
+          value: https://github.com/tektoncd/pipeline/pull/100
+    outputs:
+    - name: pr
+      resourceSpec:
+        type: pullRequest
+        params:
+        - name: url
+          value: https://github.com/tektoncd/pipeline/pull/100

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -81,7 +81,8 @@ spec:
 
         # These match values configured in .ko.yaml
         $(inputs.params.pathToProject)/$(outputs.resources.builtEntrypointImage.url): gcr.io/distroless/base:debug-nonroot
-        $(inputs.params.pathToPrjoect)/$(outputs.resources.builtGcsFetcherImage.url): gcr.io/distroless/static:latest
+        $(inputs.params.pathToProject)/$(outputs.resources.builtGcsFetcherImage.url): gcr.io/distroless/static:latest
+        $(inputs.params.pathToProject)/$(outputs.resources.builtPullRequestInitImage.url): gcr.io/distroless/static:latest
       baseBuildOverrides:
         $(inputs.params.pathToProject)/$(outputs.resources.builtControllerImage.url):
           flags:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a cherry-pick of https://github.com/tektoncd/pipeline/pull/3055
and is only here to have integration run against it.

The PullRequest Resource, when used as an output, is able to
read in a pr.json to determine if there have been any changes
that require syncing to github. pr.json may have been written
by any prior Step with any ownership settings. If pr.json
was written with root permissions then the PullRequest Resource
needs to be have permissions to read that file.

The PullRequest Resource image has been based on a nonroot
image in our `.ko.yaml` since 0.13 of Tekton Pipelines ([`.ko.yaml` was
updated here](https://github.com/tektoncd/pipeline/pull/2606)).

However, the published images did not match the configuration in the
`.ko.yaml` until 0.15.0 ([our `tekton/publish.yaml` was brought into line
with `.ko.yaml` here](https://github.com/tektoncd/pipeline/pull/3018)).

Given that copying or writing pr.json in a Step can result in the file
being owned by root using a nonroot image is not a suitable choice
of base image - the output PullRequest attempts to open pr.json and
hits a permissions error.

This commit updates the PullRequest image to be based on
distroless static instead of nonroot and adds an example yaml
file that should exercise the behaviour of copying the file from
an input to output pullrequest resource.

```release-note
NONE
```
