### PR TITLE
fix TestTaskRunStatus e2e test to run on s390x

### DIFF
--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package test
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -126,13 +127,17 @@ func TestTaskRunStatus(t *testing.T) {
 	taskRunName := "status-taskrun"
 
 	fqImageName := "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
+	if runtime.GOARCH == "s390x" {
+		fqImageName = "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977"
+	}
+
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
 	task := &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: "status-task", Namespace: namespace},
 		Spec: v1beta1.TaskSpec{
 			// This was the digest of the latest tag as of 8/12/2019
 			Steps: []v1beta1.Step{{Container: corev1.Container{
-				Image:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
+				Image:   fqImageName,
 				Command: []string{"/bin/sh"},
 				Args:    []string{"-c", "echo hello"},
 			}}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
TestTaskRunStatus test fails for s390x architecture because busybox
image in the code is specified with concrete SHA. SHA is unique for
each image and as a result for s390x case the amd64 image with the SHA
is pulled. Test failed.

Adding s390x specific SHA to s390x build solves this problem.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
Update the TestTaskRunStatus e2e test to work on s390x architectures.
```
