### PR TITLE
Allow skipping some YAML tests

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -181,6 +181,18 @@ func getExamplePaths(t *testing.T, dir string) []string {
 			return filepath.SkipDir
 		}
 		if info.IsDir() == false && filepath.Ext(info.Name()) == ".yaml" {
+			// Ignore test matching the regexp in the TEST_EXAMPLES_IGNORES
+			// environement variable.
+			val, ok := os.LookupEnv("TEST_EXAMPLES_IGNORES")
+			if ok {
+				re := regexp.MustCompile(val)
+				submatch := re.FindSubmatch([]byte(path))
+				if submatch != nil {
+					t.Logf("Skipping test %s", path)
+					return nil
+				}
+			}
+			t.Logf("Adding test %s", path)
 			examplePaths = append(examplePaths, path)
 			return nil
 		}


### PR DESCRIPTION
Allow skipping some of the yaml tests if the environment variable
`TEST_EXAMPLES_IGNORES` is set and match the regexp :

For example :

`export TEST_EXAMPLES_IGNORES=".*clustertasks.*"`

will skip all the kankiko examples yamls.

We have a need for this because we want to run the go yaml examples testsuite
but need to skip some of those tests that are not compatible with openshift due
of some restrictions on that system.


/kind misc
/area testing

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Note

```release-note
NONE
```