### PR TITLE
fix(substition): fix configmap and secret volume param substition

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -134,7 +134,11 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `Task` | `spec.steps[].volumemounts.subpath` |
 | `Task` | `spec.volumes[].name` |
 | `Task` | `spec.volumes[].configmap.name` |
+| `Task` | `spec.volumes[].configmap.items[].key` |
+| `Task` | `spec.volumes[].configmap.items[].path` |
 | `Task` | `spec.volumes[].secret.secretname` |
+| `Task` | `spec.volumes[].secret.items[].key` |
+| `Task` | `spec.volumes[].secret.items[].path` |
 | `Task` | `spec.volumes[].persistentvolumeclaim.claimname` |
 | `Task` | `spec.volumes[].projected.sources.configmap.name` |
 | `Task` | `spec.volumes[].projected.sources.secret.name` |

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -171,9 +171,17 @@ func ApplyReplacements(spec *v1beta1.TaskSpec, stringReplacements map[string]str
 		spec.Volumes[i].Name = substitution.ApplyReplacements(v.Name, stringReplacements)
 		if v.VolumeSource.ConfigMap != nil {
 			spec.Volumes[i].ConfigMap.Name = substitution.ApplyReplacements(v.ConfigMap.Name, stringReplacements)
+			for index, item := range v.ConfigMap.Items {
+				spec.Volumes[i].ConfigMap.Items[index].Key = substitution.ApplyReplacements(item.Key, stringReplacements)
+				spec.Volumes[i].ConfigMap.Items[index].Path = substitution.ApplyReplacements(item.Path, stringReplacements)
+			}
 		}
 		if v.VolumeSource.Secret != nil {
 			spec.Volumes[i].Secret.SecretName = substitution.ApplyReplacements(v.Secret.SecretName, stringReplacements)
+			for index, item := range v.Secret.Items {
+				spec.Volumes[i].Secret.Items[index].Key = substitution.ApplyReplacements(item.Key, stringReplacements)
+				spec.Volumes[i].Secret.Items[index].Path = substitution.ApplyReplacements(item.Path, stringReplacements)
+			}
 		}
 		if v.PersistentVolumeClaim != nil {
 			spec.Volumes[i].PersistentVolumeClaim.ClaimName = substitution.ApplyReplacements(v.PersistentVolumeClaim.ClaimName, stringReplacements)

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -143,6 +143,10 @@ var (
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: "$(inputs.params.FOO)",
 					},
+					Items: []corev1.KeyToPath{{
+						Key:  "$(inputs.params.FOO)",
+						Path: "$(inputs.params.FOO)",
+					}},
 				},
 			},
 		}, {
@@ -150,6 +154,10 @@ var (
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: "$(inputs.params.FOO)",
+					Items: []corev1.KeyToPath{{
+						Key:  "$(inputs.params.FOO)",
+						Path: "$(inputs.params.FOO)",
+					}},
 				},
 			},
 		}, {
@@ -546,7 +554,11 @@ func TestApplyParameters(t *testing.T) {
 
 		spec.Volumes[0].Name = "world"
 		spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name = "world"
+		spec.Volumes[0].VolumeSource.ConfigMap.Items[0].Key = "world"
+		spec.Volumes[0].VolumeSource.ConfigMap.Items[0].Path = "world"
 		spec.Volumes[1].VolumeSource.Secret.SecretName = "world"
+		spec.Volumes[1].VolumeSource.Secret.Items[0].Key = "world"
+		spec.Volumes[1].VolumeSource.Secret.Items[0].Path = "world"
 		spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "world"
 		spec.Volumes[3].VolumeSource.Projected.Sources[0].ConfigMap.Name = "world"
 		spec.Volumes[3].VolumeSource.Projected.Sources[0].Secret.Name = "world"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

fix(substition): fix configmap and secret volume param substition

Fix #3070 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
     fix(substition): fix configmap and secret volume param substition
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
     fix(substition): fix configmap and secret volume param substition
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
