### PR TITLE
Fix small typo in install doc for default workspace config

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -279,7 +279,7 @@ data:
     nodeSelector:
       kops.k8s.io/instancegroup: build-instance-group
   default-managed-by-label-value: "my-tekton-installation"
-  default-task-run-workspace-binding: 
+  default-task-run-workspace-binding: |
     emptyDir: {}
 ```
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When defining a default taskrun workspace in the config-defaults YAML
file, the user should start their workspace configuration with the
`|` character, to indicate that it's a block string. This character
is currently missing from the example in the install doc.

This commit adds the trailing `|` character to the config-defaults
example in the install doc.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix the default-task-run-workspace-binding example in the install doc.
```