### PR TITLE
Step timeout

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -41,6 +41,7 @@ var (
 	terminationPath     = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
 	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
 	waitPollingInterval = time.Second
+	timeout             = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
 )
 
 func cp(src, dst string) error {
@@ -103,6 +104,7 @@ func main() {
 		Runner:          &realRunner{},
 		PostWriter:      &realPostWriter{},
 		Results:         strings.Split(*results, ","),
+		Timeout:         timeout,
 	}
 
 	// Copy any creds injected by the controller into the $HOME directory of the current

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"os"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // TestRealRunnerSignalForwarding will artificially put an interrupt signal (SIGINT) in the rr.signals chan.
@@ -14,9 +16,24 @@ func TestRealRunnerSignalForwarding(t *testing.T) {
 	rr := realRunner{}
 	rr.signals = make(chan os.Signal, 1)
 	rr.signals <- syscall.SIGINT
-	if err := rr.Run("sleep", "3600"); err.Error() == "signal: interrupt" {
+	if err := rr.Run(context.Background(), "sleep", "3600"); err.Error() == "signal: interrupt" {
 		t.Logf("SIGINT forwarded to Entrypoint")
 	} else {
 		t.Fatalf("Unexpected error received: %v", err)
+	}
+}
+
+// TestRealRunnerTimeout tests whether cmd is killed after a millisecond even though it's supposed to sleep for 10 milliseconds.
+func TestRealRunnerTimeout(t *testing.T) {
+	rr := realRunner{}
+	timeout := time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := rr.Run(ctx, "sleep", "0.01"); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error received: %v", err)
+		}
+	} else {
+		t.Fatalf("step didn't timeout")
 	}
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -12,6 +12,7 @@ weight: 1
   - [Defining `Steps`](#defining-steps)
     - [Reserved directories](#reserved-directories)
     - [Running scripts within `Steps`](#running-scripts-within-steps)
+    - [Specifying a timeout](#specifying-a-timeout)
   - [Specifying `Parameters`](#specifying-parameters)
   - [Specifying `Resources`](#specifying-resources)
   - [Specifying `Workspaces`](#specifying-workspaces)
@@ -241,7 +242,27 @@ steps:
     #!/usr/bin/env bash
     /bin/my-binary
 ```
+#### Specifying a timeout
 
+A `Step` can specify a `timeout` field.
+If the `Step` execution time exceeds the specified timeout, the `Step` kills
+its running process and any subsequent `Steps` in the `TaskRun` will not be
+executed. The `TaskRun` is placed into a `Failed` condition.  An accompanying log
+describing which `Step` timed out is written as the `Failed` condition's message.
+
+The timeout specification follows the duration format as specified in the [Go time package](https://golang.org/pkg/time/#ParseDuration) (e.g. 1s or 1ms).
+
+The example `Step` below is supposed to sleep for 60 seconds but will be canceled by the specified 5 second timeout.
+```yaml
+steps:
+  - name: sleep-then-timeout
+    image: ubuntu
+    script: | 
+      #!/usr/bin/env bash
+      echo "I am supposed to sleep for 60 seconds!"
+      sleep 60
+    timeout: 5s
+``` 
 ### Specifying `Parameters`
 
 You can specify parameters, such as compilation flags or artifact names, that you want to supply to the `Task` at execution time.

--- a/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
@@ -10,7 +10,7 @@ apiVersion: tekton.dev/v1beta1
 metadata:
   generateName: workspace-in-sidecar-
 spec:
-  timeout: 30s
+  timeout: 60s
   workspaces:
   - name: signals
     emptyDir: {}

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -125,10 +125,12 @@ type Step struct {
 	//
 	// If Script is not empty, the Step cannot have an Command or Args.
 	Script string `json:"script,omitempty"`
+	// Timeout is the time after which the step times out. Defaults to never.
+	// Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
-// Sidecar embeds the Container type, which allows it to include fields not
-// provided by Container.
+// Sidecar has nearly the same data structure as Step, consisting of a Container and an optional Script, but does not have the ability to timeout.
 type Sidecar struct {
 	corev1.Container `json:",inline"`
 

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/substitution"
@@ -157,6 +158,12 @@ func validateStep(s Step, names sets.String) (errs *apis.FieldError) {
 			})
 		}
 		names.Insert(s.Name)
+	}
+
+	if s.Timeout != nil {
+		if s.Timeout.Duration < time.Duration(0) {
+			return apis.ErrInvalidValue(s.Timeout.Duration, "negative timeout")
+		}
 	}
 
 	for j, vm := range s.VolumeMounts {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -19,12 +19,14 @@ package v1beta1_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -929,6 +931,17 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env  bash\n\t\t\t\thello \"$(context.task.missing)\""`,
 			Paths:   []string{"steps[0].script"},
+		},
+	}, {
+		name: "negative timeout string",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Timeout: &metav1.Duration{Duration: -10 * time.Second},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: "invalid value: -10s",
+			Paths:   []string{"steps[0].negative timeout"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1205,6 +1205,11 @@ func (in *SkippedTask) DeepCopy() *SkippedTask {
 func (in *Step) DeepCopyInto(out *Step) {
 	*out = *in
 	in.Container.DeepCopyInto(&out.Container)
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package entrypoint
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -63,6 +64,8 @@ type Entrypointer struct {
 
 	// Results is the set of files that might contain task results
 	Results []string
+	// Timeout is an optional user-specified duration within which the Step must complete
+	Timeout *time.Duration
 }
 
 // Waiter encapsulates waiting for files to exist.
@@ -73,7 +76,7 @@ type Waiter interface {
 
 // Runner encapsulates running commands.
 type Runner interface {
-	Run(args ...string) error
+	Run(ctx context.Context, args ...string) error
 }
 
 // PostWriter encapsulates writing a file when complete.
@@ -106,7 +109,6 @@ func (e Entrypointer) Go() error {
 				Value:      time.Now().Format(timeFormat),
 				ResultType: v1beta1.InternalTektonResultType,
 			})
-
 			return err
 		}
 	}
@@ -114,13 +116,34 @@ func (e Entrypointer) Go() error {
 	if e.Entrypoint != "" {
 		e.Args = append([]string{e.Entrypoint}, e.Args...)
 	}
+
 	output = append(output, v1beta1.PipelineResourceResult{
 		Key:        "StartedAt",
 		Value:      time.Now().Format(timeFormat),
 		ResultType: v1beta1.InternalTektonResultType,
 	})
 
-	err := e.Runner.Run(e.Args...)
+	var err error
+	if e.Timeout != nil && *e.Timeout < time.Duration(0) {
+		err = fmt.Errorf("negative timeout specified")
+	}
+
+	if err == nil {
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if e.Timeout != nil && *e.Timeout != time.Duration(0) {
+			ctx, cancel = context.WithTimeout(ctx, *e.Timeout)
+			defer cancel()
+		}
+		err = e.Runner.Run(ctx, e.Args...)
+		if err == context.DeadlineExceeded {
+			output = append(output, v1beta1.PipelineResourceResult{
+				Key:        "Reason",
+				Value:      "TimeoutExceeded",
+				ResultType: v1beta1.InternalTektonResultType,
+			})
+		}
+	}
 
 	// Write the post file *no matter what*
 	e.WritePostFile(e.PostFile, err)

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -108,13 +108,15 @@ func TestOrderContainers(t *testing.T) {
 }
 
 func TestEntryPointResults(t *testing.T) {
-	results := []v1beta1.TaskResult{{
-		Name:        "sum",
-		Description: "This is the sum result of the task",
-	}, {
-		Name:        "sub",
-		Description: "This is the sub result of the task",
-	}}
+	taskSpec := v1beta1.TaskSpec{
+		Results: []v1beta1.TaskResult{{
+			Name:        "sum",
+			Description: "This is the sum result of the task",
+		}, {
+			Name:        "sub",
+			Description: "This is the sub result of the task",
+		}},
+	}
 
 	steps := []corev1.Container{{
 		Image:   "step-1",
@@ -172,7 +174,7 @@ func TestEntryPointResults(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -182,13 +184,15 @@ func TestEntryPointResults(t *testing.T) {
 }
 
 func TestEntryPointResultsSingleStep(t *testing.T) {
-	results := []v1beta1.TaskResult{{
-		Name:        "sum",
-		Description: "This is the sum result of the task",
-	}, {
-		Name:        "sub",
-		Description: "This is the sub result of the task",
-	}}
+	taskSpec := v1beta1.TaskSpec{
+		Results: []v1beta1.TaskResult{{
+			Name:        "sum",
+			Description: "This is the sum result of the task",
+		}, {
+			Name:        "sub",
+			Description: "This is the sub result of the task",
+		}},
+	}
 
 	steps := []corev1.Container{{
 		Image:   "step-1",
@@ -210,7 +214,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -219,10 +223,12 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 	}
 }
 func TestEntryPointSingleResultsSingleStep(t *testing.T) {
-	results := []v1beta1.TaskResult{{
-		Name:        "sum",
-		Description: "This is the sum result of the task",
-	}}
+	taskSpec := v1beta1.TaskSpec{
+		Results: []v1beta1.TaskResult{{
+			Name:        "sum",
+			Description: "This is the sum result of the task",
+		}},
+	}
 
 	steps := []corev1.Container{{
 		Image:   "step-1",
@@ -244,7 +250,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -140,8 +140,9 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	}
 
 	// Rewrite steps with entrypoint binary. Append the entrypoint init
-	// container to place the entrypoint binary.
-	entrypointInit, stepContainers, err := orderContainers(b.Images.EntrypointImage, credEntrypointArgs, stepContainers, taskSpec.Results)
+	// container to place the entrypoint binary. Also add timeout flags
+	// to entrypoint binary.
+	entrypointInit, stepContainers, err := orderContainers(b.Images.EntrypointImage, credEntrypointArgs, stepContainers, &taskSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -61,13 +62,13 @@ func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.
 	}
 
 	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, &placeScripts, "script")
-	// convertListOfSteps operates on overlapping fields across Step and Sidecar, hence a conversion
-	// from Sidecar into Step
+
 	sideCarSteps := []v1beta1.Step{}
 	for _, step := range sidecars {
 		sidecarStep := v1beta1.Step{
-			step.Container,
-			step.Script,
+			Container: step.Container,
+			Script:    step.Script,
+			Timeout:   &metav1.Duration{},
 		}
 		sideCarSteps = append(sideCarSteps, sidecarStep)
 	}

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -168,6 +168,79 @@ func TestPipelineRunTimeout(t *testing.T) {
 	}
 }
 
+// TestStepTimeout is an integration test that will verify a Step can be timed out.
+func TestStepTimeout(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	c, namespace := setup(ctx, t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	t.Logf("Creating Task with Step step-no-timeout, Step step-timeout, and Step step-canceled in namespace %s", namespace)
+
+	taskrunName := "run-timeout"
+
+	t.Logf("Creating TaskRun %s in namespace %s", taskrunName, namespace)
+	taskRun := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: taskrunName, Namespace: namespace},
+		Spec: v1beta1.TaskRunSpec{
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1beta1.Step{{
+					Container: corev1.Container{
+						Name:  "no-timeout",
+						Image: "busybox",
+					},
+					Script:  "sleep 1",
+					Timeout: &metav1.Duration{Duration: 2 * time.Second},
+				}, {
+					Container: corev1.Container{
+						Name:  "timeout",
+						Image: "busybox",
+					},
+					Script:  "sleep 1",
+					Timeout: &metav1.Duration{Duration: time.Millisecond},
+				}, {
+					Container: corev1.Container{
+						Name:  "canceled",
+						Image: "busybox",
+					},
+					Script: "sleep 1",
+				},
+				},
+			},
+		},
+	}
+	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", taskrunName, err)
+	}
+
+	failMsg := "\"step-timeout\" exited because the step exceeded the specified timeout limit"
+	t.Logf("Waiting for %s in namespace %s to time out", "step-timeout", namespace)
+	if err := WaitForTaskRunState(ctx, c, taskrunName, FailedWithMessage(failMsg, "run-timeout"), "StepTimeout"); err != nil {
+		t.Logf("Error in taskRun %s status: %s\n", taskrunName, err)
+		t.Errorf("Expected: %s", failMsg)
+	}
+
+	tr, err := c.TaskRunClient.Get(ctx, taskrunName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Error getting Taskrun: %v", err)
+	}
+	if tr.Status.Steps[0].Terminated == nil {
+		if tr.Status.Steps[0].Terminated.Reason != "Completed" {
+			t.Errorf("step-no-timeout should not have been terminated")
+		}
+	}
+	if tr.Status.Steps[2].Terminated == nil {
+		t.Errorf("step-canceled should have been canceled after step-timeout timed out")
+	} else if exitcode := tr.Status.Steps[2].Terminated.ExitCode; exitcode != 1 {
+		t.Logf("step-canceled exited with exit code %d, expected exit code 1", exitcode)
+	}
+
+}
+
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This feature allows a Task author to specify a Step timeout in the TaskSpec.

An example use case is when a Task author would like to execute a Step for setting up an execution environment. One may expect this Step to execute within a few seconds. If the execution time takes longer than expected one may rather want to fail fast than wait for the TaskRun timeout to abort the TaskRun (example by @ImJasonH).

Closes #1690
Corresponding [TEP](https://github.com/tektoncd/community/blob/master/teps/0014-step-timeout.md)

Major thanks to @sbwsg for his guidance.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Task authors can now specify a timeout for a Step in the TaskSpec.
```

