### PR TITLE
Add support for repeated PVC-claim but using subPath in AA-validation

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -760,14 +760,17 @@ func validateWorkspaceCompatibilityWithAffinityAssistant(tr *v1beta1.TaskRun) er
 		return nil
 	}
 
-	pvcWorkspaces := 0
+	workspaceVolumes := make(map[string]bool)
 	for _, w := range tr.Spec.Workspaces {
-		if w.PersistentVolumeClaim != nil || w.VolumeClaimTemplate != nil {
-			pvcWorkspaces++
+		if w.PersistentVolumeClaim != nil {
+			workspaceVolumes[w.PersistentVolumeClaim.ClaimName] = true
+		}
+		if w.VolumeClaimTemplate != nil {
+			workspaceVolumes[w.Name] = true
 		}
 	}
 
-	if pvcWorkspaces > 1 {
+	if len(workspaceVolumes) > 1 {
 		return fmt.Errorf("TaskRun mounts more than one PersistentVolumeClaim - that is forbidden when the Affinity Assistant is enabled")
 	}
 	return nil


### PR DESCRIPTION
 # Changes

The validation for compatibility with the Affinity Assistant does not
support the same PVC repeated, but using different subPaths.

This patch adds support for this case.

Closes https://github.com/tektoncd/pipeline/issues/3085
/kind bug

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fixes a bug with validation for the Affinity Assistant when the same PVC is used for
multiple workspaces but with different subPaths
```
