### PR TITLE
Validate missing volume configs in Workspace Bindings

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -118,7 +118,7 @@ func validateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) *apis
 		}
 		seen.Insert(w.Name)
 
-		if err := w.Validate(ctx); err != nil {
+		if err := w.Validate(ctx).ViaField("workspace"); err != nil {
 			return err
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -74,6 +74,10 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) *apis.FieldError {
 	if ps.Workspaces != nil {
 		wsNames := make(map[string]int)
 		for idx, ws := range ps.Workspaces {
+			field := fmt.Sprintf("spec.workspaces[%d]", idx)
+			if err := ws.Validate(ctx).ViaField(field); err != nil {
+				return err
+			}
 			if prevIdx, alreadyExists := wsNames[ws.Name]; alreadyExists {
 				return &apis.FieldError{
 					Message: fmt.Sprintf("workspace %q provided by pipelinerun more than once, at index %d and %d", ws.Name, prevIdx, idx),

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -197,6 +197,26 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 			Message: `workspace "ws" provided by pipelinerun more than once, at index 0 and 1`,
 			Paths:   []string{"spec.workspaces"},
 		},
+	}, {
+		name: "workspaces must contain a valid volume config",
+		spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: "pipelinerefname",
+			},
+			Workspaces: []v1beta1.WorkspaceBinding{{
+				Name: "ws",
+			}},
+		},
+		wantErr: &apis.FieldError{
+			Message: "expected exactly one, got neither",
+			Paths: []string{
+				"spec.workspaces[0].configmap",
+				"spec.workspaces[0].emptydir",
+				"spec.workspaces[0].persistentvolumeclaim",
+				"spec.workspaces[0].secret",
+				"spec.workspaces[0].volumeclaimtemplate",
+			},
+		},
 	}}
 	for _, ps := range tests {
 		t.Run(ps.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -98,7 +98,7 @@ func validateWorkspaceBindings(ctx context.Context, wb []WorkspaceBinding) *apis
 		}
 		seen.Insert(w.Name)
 
-		if err := w.Validate(ctx); err != nil {
+		if err := w.Validate(ctx).ViaField("workspace"); err != nil {
 			return err
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation.go
@@ -26,11 +26,11 @@ import (
 // allVolumeSourceFields is a list of all the volume source field paths that a
 // WorkspaceBinding may include.
 var allVolumeSourceFields []string = []string{
-	"workspace.persistentvolumeclaim",
-	"workspace.volumeclaimtemplate",
-	"workspace.emptydir",
-	"workspace.configmap",
-	"workspace.secret",
+	"persistentvolumeclaim",
+	"volumeclaimtemplate",
+	"emptydir",
+	"configmap",
+	"secret",
 }
 
 // Validate looks at the Volume provided in wb and makes sure that it is valid.
@@ -53,17 +53,17 @@ func (b *WorkspaceBinding) Validate(ctx context.Context) *apis.FieldError {
 
 	// For a PersistentVolumeClaim to work, you must at least provide the name of the PVC to use.
 	if b.PersistentVolumeClaim != nil && b.PersistentVolumeClaim.ClaimName == "" {
-		return apis.ErrMissingField("workspace.persistentvolumeclaim.claimname")
+		return apis.ErrMissingField("persistentvolumeclaim.claimname")
 	}
 
 	// For a ConfigMap to work, you must provide the name of the ConfigMap to use.
 	if b.ConfigMap != nil && b.ConfigMap.LocalObjectReference.Name == "" {
-		return apis.ErrMissingField("workspace.configmap.name")
+		return apis.ErrMissingField("configmap.name")
 	}
 
 	// For a Secret to work, you must provide the name of the Secret to use.
 	if b.Secret != nil && b.Secret.SecretName == "" {
-		return apis.ErrMissingField("workspace.secret.secretName")
+		return apis.ErrMissingField("secret.secretName")
 	}
 
 	return nil


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Contributes to https://github.com/tektoncd/pipeline/issues/3089 but doesn't completely fix it. There's another bug hidden in there that a PipelineRun submitting a TaskRun with invalid workspace is not entering a failed state even though the TaskRun reconciler is loudly complaining about the workspace config.

When a PipelineRun specifies a Workspace Binding, it is required to
submit the volume configuration as part of that Binding. Currently
the volume details aren't validated and so a PipelineRun with a Workspace
Binding that only includes a "name" field will validate. The end
result is that the Workspace is passed to the TaskRun and fails
validation there instead.

This commit adds validation to PipelineRuns to ensure that any
Workspaces passed include some correct volume configuration data.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

```release-note
Fix an issue where PipelineRuns would pass validation even when a workspace binding was missing required volume info.
```