### PR TITLE
Add support for repeated PVC-claim but using subPath in AA-validation

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -302,10 +302,12 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
-	if err := validateWorkspaceCompatibilityWithAffinityAssistant(tr); err != nil {
-		logger.Errorf("TaskRun %q workspaces are invalid: %v", tr.Name, err)
-		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
-		return nil, nil, controller.NewPermanentError(err)
+	if _, usesAssistant := tr.Annotations[workspace.AnnotationAffinityAssistantName]; usesAssistant {
+		if err := workspace.ValidateOnlyOnePVCIsUsed(tr.Spec.Workspaces); err != nil {
+			logger.Errorf("TaskRun %q workspaces incompatible with Affinity Assistant: %v", tr.Name, err)
+			tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
+			return nil, nil, controller.NewPermanentError(err)
+		}
 	}
 
 	// Initialize the cloud events if at least a CloudEventResource is defined
@@ -746,29 +748,6 @@ func storeTaskSpec(ctx context.Context, tr *v1beta1.TaskRun, ts *v1beta1.TaskSpe
 	// Only store the TaskSpec once, if it has never been set before.
 	if tr.Status.TaskSpec == nil {
 		tr.Status.TaskSpec = ts
-	}
-	return nil
-}
-
-// validateWorkspaceCompatibilityWithAffinityAssistant validates the TaskRun's compatibility
-// with the Affinity Assistant - if associated with an Affinity Assistant.
-// No more than one PVC-backed workspace can be used for a TaskRun that is associated with an
-// Affinity Assistant.
-func validateWorkspaceCompatibilityWithAffinityAssistant(tr *v1beta1.TaskRun) error {
-	_, isAssociatedWithAnAffinityAssistant := tr.Annotations[workspace.AnnotationAffinityAssistantName]
-	if !isAssociatedWithAnAffinityAssistant {
-		return nil
-	}
-
-	pvcWorkspaces := 0
-	for _, w := range tr.Spec.Workspaces {
-		if w.PersistentVolumeClaim != nil || w.VolumeClaimTemplate != nil {
-			pvcWorkspaces++
-		}
-	}
-
-	if pvcWorkspaces > 1 {
-		return fmt.Errorf("TaskRun mounts more than one PersistentVolumeClaim - that is forbidden when the Affinity Assistant is enabled")
 	}
 	return nil
 }

--- a/pkg/workspace/validate.go
+++ b/pkg/workspace/validate.go
@@ -48,3 +48,25 @@ func ValidateBindings(w []v1beta1.WorkspaceDeclaration, wb []v1beta1.WorkspaceBi
 	}
 	return nil
 }
+
+// ValidateOnlyOnePVCIsUsed checks that a list of WorkspaceBinding uses only one
+// persistent volume claim.
+//
+// This is only useful to validate that WorkspaceBindings in TaskRuns are compatible
+// with affinity rules enforced by the AffinityAssistant.
+func ValidateOnlyOnePVCIsUsed(wb []v1beta1.WorkspaceBinding) error {
+	workspaceVolumes := make(map[string]bool)
+	for _, w := range wb {
+		if w.PersistentVolumeClaim != nil {
+			workspaceVolumes[w.PersistentVolumeClaim.ClaimName] = true
+		}
+		if w.VolumeClaimTemplate != nil {
+			workspaceVolumes[w.Name] = true
+		}
+	}
+
+	if len(workspaceVolumes) > 1 {
+		return fmt.Errorf("more than one PersistentVolumeClaim is bound")
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Picks up from #3091 and adds some tests for the validation. Original commit message:

The validation for compatibility with the Affinity Assistant does not
support the same PVC repeated, but using different subPaths.

This patch adds support for this case and tests for the validation.

Co-authored-by: Scott <sbws@google.com>

Closes #3085

Closes #3091 

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixes a bug with validation for the Affinity Assistant when the same PVC is used for multiple workspaces but with different subPaths
```