### PR TITLE
Added flags to control if a step should be skipped.

### DIFF
--- a/cmd/entrypoint/README.md
+++ b/cmd/entrypoint/README.md
@@ -9,7 +9,7 @@ The following flags are available :
 - `-entrypoint`: "original" command to be executed (as
   entrypoint). This will be executed as a sub-process on `entrypoint`
 - `-post_file`: file path to write once the sub-process has
-  finished. If the sub-process failed, it will write to
+  finished. If the sub-process fails, it will write to
   `{{post_file}}.err` instead of `{{post_file}}`.
 - `-wait_file`: file path to watch before starting the sub-process. It
   watches for `{{wait_file}}` and `{{wait_file}}.err` presence and
@@ -19,11 +19,18 @@ The following flags are available :
 - `-wait_file_content`: excepts the `wait_file` to add actual
   content. It will continue watching for `wait_file` until it has
   content.
+- `-run_always`: If specified, do not skip the execution if
+  `{{wait_file}}.err` is present. The default values can be set by the
+  `TEKTON_RUN_ALWAYS` environment variable.
+- `-discard_error`: If specified, write to `{{post_file}}` instead of
+  `{{post_file}}.err` if `{{wait_file}}.err` is present or the
+  sub-process fails. The default value can be set by the
+  `TEKTON_DISCARD_ERROR` environment variable.
 
 The following example of usage for `entrypoint`, wait's for
 `/tekton/downward/ready` file to exists and have some content before
 executing `/ko-app/bash -- -args mkdir -p /workspace/git-resource`,
-and will write to `/tekton/tools/0` in case of succes, or
+and will write to `/tekton/tools/0` in case of success, or
 `/tekton/tools/0.err` in case of failure.
 
 ```shell

--- a/cmd/entrypoint/README.md
+++ b/cmd/entrypoint/README.md
@@ -22,10 +22,10 @@ The following flags are available :
 - `-run_always`: If specified, do not skip the execution if
   `{{wait_file}}.err` is present. The default values can be set by the
   `TEKTON_RUN_ALWAYS` environment variable.
-- `-discard_error`: If specified, write to `{{post_file}}` instead of
+- `-ignore_error`: If specified, write to `{{post_file}}` instead of
   `{{post_file}}.err` if `{{wait_file}}.err` is present or the
   sub-process fails. The default value can be set by the
-  `TEKTON_DISCARD_ERROR` environment variable.
+  `TEKTON_IGNORE_ERROR` environment variable.
 
 The following example of usage for `entrypoint`, wait's for
 `/tekton/downward/ready` file to exists and have some content before

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -41,7 +41,7 @@ var (
 	terminationPath     = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
 	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
 	runAlways           = flag.Bool("run_always", boolFromEnv("TEKTON_RUN_ALWAYS"), "If specified, do not skip if a previous step fails")
-	discardError        = flag.Bool("discard_error", boolFromEnv("TEKTON_DISCARD_ERROR"), "If specified, do not post error file if a previous or current step fails")
+	ignoreError         = flag.Bool("ignore_error", boolFromEnv("TEKTON_IGNORE_ERROR"), "If specified, do not post error file if a previous or current step fails")
 	waitPollingInterval = time.Second
 )
 
@@ -74,7 +74,7 @@ func main() {
 		},
 		Runner: &realRunner{},
 		PostWriter: &realPostWriter{
-			discardError: *discardError,
+			ignoreError: *ignoreError,
 		},
 		Results: strings.Split(*results, ","),
 	}

--- a/cmd/entrypoint/post_writer.go
+++ b/cmd/entrypoint/post_writer.go
@@ -8,13 +8,15 @@ import (
 )
 
 // realPostWriter actually writes files.
-type realPostWriter struct{}
+type realPostWriter struct {
+	discardError bool
+}
 
 var _ entrypoint.PostWriter = (*realPostWriter)(nil)
 
-func (*realPostWriter) Write(file string) {
-	if file == "" {
-		return
+func (rpw *realPostWriter) Write(file string, err error) {
+	if err != nil && !rpw.discardError {
+		file += ".err"
 	}
 	if _, err := os.Create(file); err != nil {
 		log.Fatalf("Creating %q: %v", file, err)

--- a/cmd/entrypoint/post_writer.go
+++ b/cmd/entrypoint/post_writer.go
@@ -9,13 +9,13 @@ import (
 
 // realPostWriter actually writes files.
 type realPostWriter struct {
-	discardError bool
+	ignoreError bool
 }
 
 var _ entrypoint.PostWriter = (*realPostWriter)(nil)
 
 func (rpw *realPostWriter) Write(file string, err error) {
-	if err != nil && !rpw.discardError {
+	if err != nil && !rpw.ignoreError {
 		file += ".err"
 	}
 	if _, err := os.Create(file); err != nil {

--- a/cmd/entrypoint/post_writer_test.go
+++ b/cmd/entrypoint/post_writer_test.go
@@ -32,7 +32,7 @@ func TestRealPostWriterWrite(t *testing.T) {
 		expectedFile: postfile + ".err",
 	}, {
 		desc:         "discard error",
-		rpw:          realPostWriter{discardError: true},
+		rpw:          realPostWriter{ignoreError: true},
 		err:          errors.New("test error"),
 		expectedFile: postfile,
 	}} {

--- a/cmd/entrypoint/post_writer_test.go
+++ b/cmd/entrypoint/post_writer_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRealPostWriterWrite(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	//defer os.RemoveAll(tmp)
+	postfile := filepath.Join(tmp, "file")
+	for _, c := range []struct {
+		desc         string
+		rpw          realPostWriter
+		err          error
+		expectedFile string
+	}{{
+		desc:         "post regular file",
+		rpw:          realPostWriter{},
+		err:          nil,
+		expectedFile: postfile,
+	}, {
+		desc:         "post error file",
+		rpw:          realPostWriter{},
+		err:          errors.New("test error"),
+		expectedFile: postfile + ".err",
+	}, {
+		desc:         "discard error",
+		rpw:          realPostWriter{discardError: true},
+		err:          errors.New("test error"),
+		expectedFile: postfile,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			rpw := c.rpw
+			rpw.Write(postfile, c.err)
+			if _, err := os.Stat(c.expectedFile); os.IsNotExist(err) {
+				t.Errorf("file %q not found", c.expectedFile)
+			} else if err != nil {
+				t.Fatalf("error stating %q: %v", postfile, err)
+			}
+		})
+	}
+}

--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -9,7 +9,9 @@ import (
 )
 
 // realWaiter actually waits for files, by polling.
-type realWaiter struct{}
+type realWaiter struct {
+	runAlways bool
+}
 
 var _ entrypoint.Waiter = (*realWaiter)(nil)
 
@@ -22,7 +24,7 @@ var _ entrypoint.Waiter = (*realWaiter)(nil)
 //
 // If a file of the same name with a ".err" extension exists then this Wait
 // will end with a skipError.
-func (*realWaiter) Wait(file string, expectContent bool) error {
+func (rw *realWaiter) Wait(file string, expectContent bool) error {
 	if file == "" {
 		return nil
 	}
@@ -35,6 +37,9 @@ func (*realWaiter) Wait(file string, expectContent bool) error {
 			return fmt.Errorf("waiting for %q: %w", file, err)
 		}
 		if _, err := os.Stat(file + ".err"); err == nil {
+			if rw.runAlways {
+				return nil
+			}
 			return skipError("error file present, bail and skip the step")
 		}
 	}

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -17,7 +17,6 @@ limitations under the License.
 package entrypoint
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -79,7 +78,7 @@ type Runner interface {
 // PostWriter encapsulates writing a file when complete.
 type PostWriter interface {
 	// Write writes to the path when complete.
-	Write(file string)
+	Write(file string, err error)
 }
 
 // Go optionally waits for a file, runs the command, and writes a
@@ -164,10 +163,7 @@ func (e Entrypointer) readResultsFromDisk() error {
 
 // WritePostFile write the postfile
 func (e Entrypointer) WritePostFile(postFile string, err error) {
-	if err != nil && postFile != "" {
-		postFile = fmt.Sprintf("%s.err", postFile)
-	}
 	if postFile != "" {
-		e.PostWriter.Write(postFile)
+		e.PostWriter.Write(postFile, err)
 	}
 }

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -221,7 +221,12 @@ func (f *fakeRunner) Run(args ...string) error {
 
 type fakePostWriter struct{ wrote *string }
 
-func (f *fakePostWriter) Write(file string) { f.wrote = &file }
+func (f *fakePostWriter) Write(file string, err error) {
+	if err != nil {
+		file += ".err"
+	}
+	f.wrote = &file
+}
 
 type fakeErrorWaiter struct{ waited *string }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The following flags and corresponding environment variables are added to the entrypoint binary to control if a step should be skipped:

* If `-run_always` is given (default to the `TEKTON_RUN_ALWAYS` environment variable), the step will run regardless of any error from a previous step.

* If `-ignore_error` is given (default to the `TEKTON_IGNORE_ERROR` environment variable), the step will generate a regular post file instead of an error file.

`TEKTON_RUN_ALWAYS` provides the ability to create a "finally" step (a "clean-up" step to run regardless of any failure). `TEKTON_IGNORE_ERROR` provides the ability to create a "recovery" step (a step to repair a previous failure), although it doesn't change the exit status of the step.

These two flags provide slightly overlapping functionalities: one can create a "finally" step by either setting `TEKTON_RUN_ALWAYS` in that step, or by setting `TEKTON_IGNORE_ERROR` in its previous step. However, the latter is especially useful to allow steps injected by output resources to run, e.g., for GCS storage resources to upload artifacts regardless of any failure from a "regular" step. 

Partially addressed #1559 and #2448 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

* **EXPERIMENTAL**: Users can set the `TEKTON_RUN_ALWAYS` environment variable to true in a step to run the step regardless of any error from a previous step.
* **EXPERIMENTAL**: Users can set the `TEKTON_IGNORE_ERROR` environment variable to true in a step to run subsequent steps regardless of any error from a previous or current step.