### PR TITLE
Add multiarch specific fixes to the pipeline tests

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -116,6 +116,8 @@ type waitFunc func(t *testing.T, c *clients, name string)
 
 func exampleTest(path string, waitValidateFunc waitFunc, kind string) func(t *testing.T) {
 	return func(t *testing.T) {
+		SkipIfExcluded(t)
+
 		t.Parallel()
 
 		// Setup unique namespaces for each test so they can run in complete

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -41,6 +41,8 @@ const (
 // TestGitPipelineRun is an integration test that will verify the source code is either fetched or pulled
 // successfully under different revision inputs (branch, commitid, tag, ref)
 func TestGitPipelineRun(t *testing.T) {
+	SkipIfExcluded(t)
+
 	t.Parallel()
 
 	revisions := []string{"master", "c15aced0e5aaee6456fbe6f7a7e95e0b5b3b2b2f", "release-0.1", "v0.1.0", "refs/pull/347/head"}
@@ -82,6 +84,8 @@ func TestGitPipelineRun(t *testing.T) {
 
 // Test revision fetching with refspec specified
 func TestGitPipelineRunWithRefspec(t *testing.T) {
+	SkipIfExcluded(t)
+
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -303,6 +307,8 @@ func TestGitPipelineRunFail_HTTPS_PROXY(t *testing.T) {
 // successfully under different revision inputs (default branch, branch)
 // This test will run on spring-petclinic repository which does not contain a master branch as the default branch
 func TestGitPipelineRunWithNonMasterBranch(t *testing.T) {
+	SkipIfExcluded(t)
+
 	t.Parallel()
 
 	revisions := []string{"", "main"}

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -51,6 +51,8 @@ func init() {
 }
 
 func setup(t *testing.T, fn ...func(*testing.T, *clients, string)) (*clients, string) {
+	SkipIfExcluded(t)
+
 	t.Helper()
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
 

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -168,7 +168,7 @@ func getTask(repo, namespace string) *v1beta1.Task {
 			}}},
 			Sidecars: []v1beta1.Sidecar{{Container: corev1.Container{
 				Name:  "registry",
-				Image: "registry",
+				Image: GetTestImage(Registry),
 			}}},
 		},
 	}

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"runtime"
+	"testing"
+)
+
+var (
+	imageNames    = initImageNames()
+	excludedTests = initExcludedTests()
+)
+
+const (
+	// Busybox image with specific sha
+	BusyboxSha = iota
+	// Registry image
+	Registry
+)
+
+func initImageNames() map[int]string {
+	mapping := make(map[int]string)
+
+	switch arch := runtime.GOARCH; arch {
+	case "s390x":
+		mapping[BusyboxSha] = "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977"
+		mapping[Registry] = "ibmcom/registry:2.6.2.5"
+
+	default:
+		mapping[BusyboxSha] = "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
+		mapping[Registry] = "registry"
+	}
+	return mapping
+}
+
+func initExcludedTests() map[string]bool {
+	mapping := make(map[string]bool)
+	tests := []string{}
+	switch arch := runtime.GOARCH; arch {
+	case "s390x":
+		//examples
+		tests = []string{
+			"TestExamples/v1alpha1/taskruns/dind-sidecar",
+			"TestExamples/v1beta1/taskruns/dind-sidecar",
+			"TestExamples/v1alpha1/taskruns/build-gcs-targz",
+			"TestExamples/v1beta1/taskruns/build-gcs-targz",
+			"TestExamples/v1alpha1/taskruns/build-push-kaniko",
+			"TestExamples/v1alpha1/taskruns/pull-private-image",
+			"TestExamples/v1beta1/taskruns/pull-private-image",
+			"TestExamples/v1alpha1/pipelineruns/pipelinerun",
+			"TestExamples/v1beta1/pipelineruns/pipelinerun",
+			"TestExamples/v1beta1/taskruns/build-gcs-zip",
+			"TestExamples/v1alpha1/taskruns/build-gcs-zip",
+			"TestExamples/v1alpha1/taskruns/git-volume",
+			"TestExamples/v1beta1/taskruns/git-volume",
+			"TestExamples/v1beta1/taskruns/docker-creds",
+			"TestExamples/v1alpha1/taskruns/docker-creds",
+			"TestExamples/v1beta1/taskruns/steps-run-in-order",
+			"TestExamples/v1alpha1/taskruns/steps-run-in-order",
+			"TestExamples/v1beta1/taskruns/step-by-digest",
+			"TestExamples/v1alpha1/taskruns/step-by-digest",
+			"TestExamples/v1alpha1/taskruns/gcs-resource",
+			"TestExamples/v1beta1/taskruns/gcs-resource",
+			"TestExamples/v1beta1/taskruns/authenticating-git-commands",
+			"TestExamples/v1beta1/pipelineruns/pipelinerun-with-final-tasks",
+			"TestExamples/v1beta1/taskruns/pullrequest_input_copystep_output",
+			"TestExamples/v1alpha1/taskruns/pullrequest_input_copystep_output",
+			"TestExamples/v1beta1/taskruns/pullrequest",
+			"TestExamples/v1alpha1/taskruns/pullrequest",
+			"TestExamples/v1beta1/taskruns/step-script",
+			"TestExamples/v1alpha1/taskruns/step-script",
+			"TestExamples/v1beta1/pipelineruns/conditional-pipelinerun",
+			"TestExamples/v1alpha1/pipelineruns/pipelinerun-with-resourcespec",
+			"TestExamples/v1beta1/pipelineruns/pipelinerun-with-resourcespec",
+			"TestExamples/v1beta1/taskruns/git-ssh-creds-without-known_hosts",
+			"TestExamples/v1alpha1/taskruns/optional-resources",
+			"TestExamples/v1beta1/taskruns/optional-resources",
+			"TestExamples/v1beta1/taskruns/task-output-image",
+			//e2e
+			"TestEntrypointRunningStepsInOrder",
+			"TestWorkingDirIgnoredNonSlashWorkspace",
+			"TestTaskRun_EmbeddedResource",
+			"TestTaskRunPipelineRunCancel",
+			"TestEntrypointRunningStepsInOrder",
+			"TestGitPipelineRun",
+			"TestGitPipelineRunFail",
+			"TestGitPipelineRunWithRefspec",
+			"TestGitPipelineRun_Disable_SSLVerify",
+			"TestGitPipelineRunWithNonMasterBranch",
+			"TestHelmDeployPipelineRun",
+			"TestKanikoTaskRun",
+			"TestPipelineRun",
+			"TestSidecarTaskSupport",
+			"TestWorstkingDirCreated",
+			"TestWorkingDirIgnoredNonSlashWorkspace",
+			"TestWorkingDirCreated",
+			"TestPipelineRun/service_account_propagation_and_pipeline_param",
+			"TestPipelineRun/pipelinerun_succeeds_with_LimitRange_minimum_in_namespace",
+		}
+	default:
+		// do nothing
+	}
+
+	for _, test := range tests {
+		mapping[test] = true
+	}
+
+	return mapping
+}
+
+// get test image based on unique id
+func GetTestImage(image int) string {
+	return imageNames[image]
+}
+
+// check if test name is in the excluded list and skip it
+func SkipIfExcluded(t *testing.T) {
+	if excludedTests[t.Name()] {
+		t.Skipf("skip for %s architecture", runtime.GOARCH)
+	}
+}

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -208,6 +208,9 @@ func TestPipelineRun(t *testing.T) {
 	for i, td := range tds {
 		t.Run(td.name, func(t *testing.T) {
 			td := td
+
+			SkipIfExcluded(t)
+
 			t.Parallel()
 			c, namespace := setup(t)
 

--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -67,7 +67,7 @@ func getRegistryDeployment(namespace string) *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "registry",
-						Image: "registry",
+						Image: GetTestImage(Registry),
 					}},
 				},
 			},

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package test
 
 import (
-	"runtime"
 	"strings"
 	"testing"
 
@@ -126,10 +125,7 @@ func TestTaskRunStatus(t *testing.T) {
 
 	taskRunName := "status-taskrun"
 
-	fqImageName := "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649"
-	if runtime.GOARCH == "s390x" {
-		fqImageName = "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977"
-	}
+	fqImageName := GetTestImage(BusyboxSha)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
 	task := &v1beta1.Task{


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Code to run the tests has many amd64 specific images.
Tests fail on non amd64 architecture because of that.
This code provides one place to keep multiarch
specific updates, separated for each architecture.

Multiarch utils do following:
- replace image names to arch specific ones where it is applicable
- skip the tests, which fail for non amd64 arch now, based on test name
 and architecture
- skipping will be applied for e2e and examples tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

# Release Notes

```release-note
Add multiarch specific fixes to the tests
 ```
