### PR TITLE
Consolidating local setup instructions into single document

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,35 +98,11 @@ The recommended configuration is:
 
 ### To setup a cluster using MiniKube:
 
-- Follow instructions for your platform to [Install Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a session as follows:
-
-```bash
-minikube start eval $(minikube docker-env)
-```
+- Follow the instructions for [running locally with Minikube](docs/developers/local-setup.md#using-minikube)
 
 ### To setup a cluster with Docker Desktop:
 
-Docker Desktop versions come integrated with an edge version of Kubernetes that has been proven to work for both developing and running Pipelines.  To find out what Kubernetes a specific version of Docker Desktop includes, please refer to the release notes for your platform here: https://docs.docker.com/.
-
-To enable the Kubernetes that comes with Docker Desktop:
-
-1.  From the Docker Desktop dropdown menu, open the `preferences...` interface.
-
-1. Under the `Resources` tab ensure that in the `ADVANCED` menuitem you have at allocated at least 4 CPUs, 8.0 GiB Memory, and 1.0 GiB Swap.
-
-1.  Under the `Kubernetes` tab, check the   `Enable Kubernetes` box.
-
-    * *Note: the Kubernetes version Docker Desktop will use is displayed at the top of the window.*
-
-1.  Click the `Apply and Restart` button to save the preferences.
-
-1.  Switch the proper `kubectl` config context:
-
-    ```bash
-    kubectl config get-contexts # You should see docker-for-desktop in the previous command output
-    kubectl config use-context docker-for-desktop
-    ```
-    * *Note: Docker Desktop menu provides a `Kubernetes` menuitem that allows you to select between contexts which is equivalent to the `kubectl` command.*
+- Follow the instructions for [running locally with Docker Desktop](docs/developers/local-setup.md#using-docker-desktop)
 
 ### To setup a cluster with GKE:
 

--- a/docs/developers/local-setup.md
+++ b/docs/developers/local-setup.md
@@ -1,0 +1,74 @@
+# Local Setup
+
+This section provides guidelines for running Tekton on your local workstation via the following methods:
+
+- [Docker for Desktop](#using-docker-desktop)
+- [Minikube](#using-minikube)
+
+## Using Docker Desktop
+
+### Prerequisites
+
+Complete these prerequisites to run Tekton locally using Docker Desktop:
+
+- Install the [required tools](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements).
+- Install [Docker Desktop](https://www.docker.com/products/docker-desktop) 
+- Configure Docker Desktop ([Mac](https://docs.docker.com/docker-for-mac/#resources), [Windows](https://docs.docker.com/docker-for-windows/#resources))to use six CPUs, 10 GB of RAM and 2GB of swap space.
+- Set `host.docker.internal:5000` as an insecure registry with Docker for Desktop. See the [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/).
+  for details.
+- Pass `--insecure` as an argument to your Kaniko tasks so that you can push to an insecure registry.
+- Run a local (insecure) Docker registry as follows:
+
+  `docker run -d -p 5000:5000 --name registry-srv -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2`
+
+- (Optional) Install a Docker registry viewer to verify the images have been pushed:
+
+`docker run -it -p 8080:8080 --name registry-web --link registry-srv -e REGISTRY_URL=http://registry-srv:5000/v2 -e REGISTRY_NAME=localhost:5000 hyper/docker-registry-web`
+
+- Verify that you can push to `host.docker.internal:5000/myregistry/<image_name>`.
+
+### Reconfigure `image` resources
+
+You must reconfigure any `image` resource definitions in your `PipelineResources` as follows:
+
+- Set the URL to `host.docker.internal:5000/myregistry/<image_name>`
+- Set the `KO_DOCKER_REPO` variable to `localhost:5000/myregistry` before using `ko`
+- Set your applications (such as deployment definitions) to push to
+  `localhost:5000/myregistry/<image name>`.
+
+### Reconfigure logging
+
+- You can keep your logs in memory only without sending them to a logging service
+  such as [Stackdriver](https://cloud.google.com/logging/).
+- You can deploy Elasticsearch, Beats, or Kibana locally to view logs. You can find an
+  example configuration at <https://github.com/mgreau/tekton-pipelines-elastic-tutorials>.
+- To learn more about obtaining logs, see [Logs](logs.md).
+
+## Using Minikube
+
+### Prerequisites
+
+Complete these prerequisites to run Tekton locally using Minikube:
+
+- Install the [required tools](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements).
+- Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a session as follows:
+```bash
+minikube start --memory 6144 --cpus 2
+```
+- Point your shell to minikube's docker-daemon by running `eval $(minikube -p minikube docker-env)`
+- Set up a [registry on minikube](https://github.com/kubernetes/minikube/tree/master/deploy/addons/registry-aliases) by running `minikube addons enable registry` and `minikube addons enable registry-aliases`
+
+### Reconfigure `image` resources
+
+The `registry-aliases` addon will create several aliases for the minikube registry. You'll need to reconfigure your `image` resource definitions to use one of these aliases in your `PipelineResources` (for this tutorial, we use `example.com`; for a full list of aliases, you can run `minikube ssh -- cat /etc/hosts`. You can also configure your own alias by editing minikube's `/etc/hosts` file and the `coredns` configmap in the `kube-system` namespace).
+
+- Set the URL to `example.com/<image_name>`
+- When using `ko`, be sure to [use the `-L` flag](https://github.com/google/ko/blob/master/README.md#with-minikube) (i.e. `ko apply -L -f config/`)
+- Set your applications (such as deployment definitions) to push to
+  `example.com/<image name>`.
+
+If you wish to use a different image URL, you can add the appropriate line to minikube's `/etc/hosts`.
+
+### Reconfigure logging
+
+See the information in the "Docker for Desktop" section

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -555,74 +555,7 @@ You can also see the statuses of the individual `TaskRuns`.
 
 ## Running this tutorial locally
 
-This section provides guidelines for completing this tutorial on your local workstation on:
-
-- [Docker for Desktop](#prerequisites-docker-for-desktop)
-- [Minikube](#prerequisites-minikube)
-
-### Prerequisites: Docker for Desktop
-
-Complete these prerequisites to run this tutorial locally using Docker for Desktop:
-
-- Install the [required tools](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements).
-- Install [Docker for Desktop](https://www.docker.com/products/docker-desktop) and configure it to use six CPUs,
-  10 GB of RAM and 2GB of swap space.
-- Set `host.docker.internal:5000` as an insecure registry with Docker for Desktop. See the [Docker insecure registry documentation](https://docs.docker.com/registry/insecure/).
-  for details.
-- Pass `--insecure` as an argument to your Kaniko tasks so that you can push to an insecure registry.
-- Run a local (insecure) Docker registry as follows:
-
-  `docker run -d -p 5000:5000 --name registry-srv -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2`
-
-- (Optional) Install a Docker registry viewer to verify the images have been pushed:
-
-`docker run -it -p 8080:8080 --name registry-web --link registry-srv -e REGISTRY_URL=http://registry-srv:5000/v2 -e REGISTRY_NAME=localhost:5000 hyper/docker-registry-web`
-
-- Verify that you can push to `host.docker.internal:5000/myregistry/<image_name>`.
-
-### Reconfigure `image` resources
-
-You must reconfigure any `image` resource definitions in your `PipelineResources` as follows:
-
-- Set the URL to `host.docker.internal:5000/myregistry/<image_name>`
-- Set the `KO_DOCKER_REPO` variable to `localhost:5000/myregistry` before using `ko`
-- Set your applications (such as deployment definitions) to push to
-  `localhost:5000/myregistry/<image name>`.
-
-### Reconfigure logging
-
-- You can keep your logs in memory only without sending them to a logging service
-  such as [Stackdriver](https://cloud.google.com/logging/).
-- You can deploy Elasticsearch, Beats, or Kibana locally to view logs. You can find an
-  example configuration at <https://github.com/mgreau/tekton-pipelines-elastic-tutorials>.
-- To learn more about obtaining logs, see [Logs](logs.md).
-
-### Prerequisites: Minikube
-
-Complete these prerequisites to run this tutorial locally using Minikube:
-
-- Install the [required tools](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md#requirements).
-- Install [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a session as follows:
-```bash
-minikube start --memory 6144 --cpus 2
-```
-- Point your shell to minikube's docker-daemon by running `eval $(minikube -p minikube docker-env)`
-- Set up a [registry on minikube](https://github.com/kubernetes/minikube/tree/master/deploy/addons/registry-aliases) by running `minikube addons enable registry` and `minikube addons enable registry-aliases`
-
-### Reconfigure `image` resources
-
-The `registry-aliases` addon will create several aliases for the minikube registry. You'll need to reconfigure your `image` resource definitions to use one of these aliases in your `PipelineResources` (for this tutorial, we use `example.com`; for a full list of aliases, you can run `minikube ssh -- cat /etc/hosts`. You can also configure your own alias by editing minikube's `/etc/hosts` file and the `coredns` configmap in the `kube-system` namespace).
-
-- Set the URL to `example.com/<image_name>`
-- When using `ko`, be sure to [use the `-L` flag](https://github.com/google/ko/blob/master/README.md#with-minikube) (i.e. `ko apply -L -f config/`)
-- Set your applications (such as deployment definitions) to push to
-  `example.com/<image name>`.
-
-If you wish to use a different image URL, you can add the appropriate line to minikube's `/etc/hosts`.
-
-### Reconfigure logging
-
-See the information in the "Docker for Desktop" section
+To run this tutorial on your local workstation, see the docs for [setting up your local environment](developers/local-setup.md).
 
 ## Further reading
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR consolidates the instructions for setting up Tekton on a local environment (i.e. Minikube or Docker Desktop) into a single document. Previously, there were conflicting version in `DEVELOPMENT.md` and `docs/tutorial.md`; those documents now contain links to the new file. 

(continues from #3010 )

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
