### PR TITLE
Allow to specify target cluster architecture for tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -156,6 +156,10 @@ go test -v -count=1 -tags=e2e -timeout=20m ./test
 go test -v -count=1 -tags=e2e -timeout=20m ./test --kubeconfig ~/special/kubeconfig --cluster myspecialcluster
 ```
 
+If tests are applied to the cluster with hardware architecture different to the base one
+(for instance `go test` starts on amd64 architecture and `--kubeconfig` points to s390x Kubernetes cluster),
+use `TEST_RUNTIME_ARCH` environment variable to specify the target hardware architecture(amd64, s390x, ppc64le, arm, arm64, etc)
+
 You can also use
 [all of flags defined in `knative/pkg/test`](https://github.com/knative/pkg/tree/master/test#flags).
 

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"os"
 	"runtime"
 	"testing"
 )
@@ -33,10 +34,20 @@ const (
 	Registry
 )
 
+// return architecture of the cluster where test suites will be executed.
+// default value is similar to build architecture, TEST_RUNTIME_ARCH is used when test target cluster has another architecture
+func getTestArch() string {
+	val, ok := os.LookupEnv("TEST_RUNTIME_ARCH")
+	if ok {
+		return val
+	}
+	return runtime.GOARCH
+}
+
 func initImageNames() map[int]string {
 	mapping := make(map[int]string)
 
-	switch arch := runtime.GOARCH; arch {
+	switch getTestArch() {
 	case "s390x":
 		mapping[BusyboxSha] = "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977"
 		mapping[Registry] = "ibmcom/registry:2.6.2.5"
@@ -51,7 +62,7 @@ func initImageNames() map[int]string {
 func initExcludedTests() map[string]bool {
 	mapping := make(map[string]bool)
 	tests := []string{}
-	switch arch := runtime.GOARCH; arch {
+	switch getTestArch() {
 	case "s390x":
 		//examples
 		tests = []string{
@@ -131,6 +142,6 @@ func GetTestImage(image int) string {
 // check if test name is in the excluded list and skip it
 func SkipIfExcluded(t *testing.T) {
 	if excludedTests[t.Name()] {
-		t.Skipf("skip for %s architecture", runtime.GOARCH)
+		t.Skipf("skip for %s architecture", getTestArch())
 	}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
When e2e or examples tests are started, hardware architectutere of the host
is always used. However test cases can be exectuted on cluster with another architecture,
using `--kubeconfig` parameter.
`TEST_RUNTIME_ARCH` allows to specify target cluster architecture to be able to use
correct restrictions and modifications, specific to concrete arch.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
Add TEST_RUNTIME_ARCH environment variable to specify target architecture of the tests
```
