### PR TITLE
Add concurrency limit to roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -21,7 +21,7 @@ is a constant balancing act, and we want to be careful and deliberate with what 
 include.
 
 Features we don't have or aren't yet 100% satisfied with for "feature complete"
-Tekton:
+Tekton (also discoverable via [the area/roadmap label](https://github.com/tektoncd/pipeline/labels/area%2Froadmap)):
 
 - [Failure strategies](https://github.com/tektoncd/pipeline/issues/1684)
 - [Conditional execution](https://github.com/tektoncd/pipeline/blob/master/docs/conditions.md)
@@ -43,8 +43,9 @@ Tekton:
 - [Adding support for other architectures](https://github.com/tektoncd/pipeline/issues/856)
 - [Rich type support for params](https://github.com/tektoncd/pipeline/issues/1393)
 - Looping syntax (in [Tasks](https://github.com/tektoncd/pipeline/issues/2112) and/or [Pipelines](https://github.com/tektoncd/pipeline/issues/2050))- either implement or decide it is outside of scope (i.e. better suited for a DSL)
-- [Supplying credentials for authenticated actions in Tasks](https://github.com/tetkoncd/pipeline/issues/2343) - documented guidelines
+- [Supplying credentials for authenticated actions in Tasks](https://github.com/tektoncd/pipeline/issues/2343) - documented guidelines
   and implemented support for best practices when working with credentials.
+- [Provide a pipeline concurrency limit](https://github.com/tektoncd/pipeline/issues/1305)
 
 ## Beta for all components
 


### PR DESCRIPTION
# Changes

Discussed with other pipelines owners today (@vdemeester, @sbwsg,
@dibyom @ImJasonH and we think it makes sense to include this in the
roadmap tho we'd want to flesh out the details and might not want it
exactly as described in the original issue.

Also added area/roadmap labels to the items listed here!

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```