### PR TITLE
Add docs, api, and reconciler support for Tekton bundles

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -82,6 +82,18 @@ spec:
 
 ```
 
+You may also use a `Tekton Bundle` to reference a pipeline defined remotely.
+
+ ```yaml
+ spec:
+   pipelineRef:
+     name: mypipeline
+     bundle: docker.com/myrepo/mycatalog:v1.0
+ ```
+
+The syntax and caveats are similar to using `Tekton Bundles` for  `Task` references
+in [Pipelines](pipelines.md#tekton-bundles) or [TaskRuns](taskruns.md#tekton-bundles).
+
 To embed a `Pipeline` definition in the `PipelineRun`, use the `pipelineSpec` field:
 
 ```yaml

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -12,6 +12,7 @@ weight: 3
   - [Specifying `Workspaces`](#specifying-workspaces)
   - [Specifying `Parameters`](#specifying-parameters)
   - [Adding `Tasks` to the `Pipeline`](#adding-tasks-to-the-pipeline)
+    - [Using Tekton Bundles](#tekton-bundles)
     - [Using the `from` parameter](#using-the-from-parameter)
     - [Using the `runAfter` parameter](#using-the-runafter-parameter)
     - [Using the `retries` parameter](#using-the-retries-parameter)
@@ -225,6 +226,58 @@ spec:
         - name: pathToContext
           value: /workspace/examples/microservices/leeroy-web
 ```
+
+### Tekton Bundles
+
+You may also specify your `Task`
+reference using a `Tekton Bundle`. A `Tekton Bundle` is an OCI artifact that
+contains Tekton resources like `Tasks` and `Pipelines` which can be referenced
+within a `taskRef`.
+
+ ```yaml
+ spec:
+   tasks:
+     - name: hello-world
+       taskRef:
+         name: echo-task
+         bundle: docker.com/myrepo/mycatalog
+ ```
+
+Here, the `bundle` field is the full reference url to the artifact. The name is the
+`metadata.name` field of the `Task`. 
+
+You may also specify a `tag` as you would with a Docker image which will give you a fixed,
+repeatable reference to a `Task`.
+
+ ```yaml
+ spec:
+   tasks:
+     - name: hello-world
+       taskRef:
+         name: echo-task
+         bundle: docker.com/myrepo/mycatalog:v1.0.1
+ ```
+
+You may also specify a fixed digest instead of a tag.
+
+ ```yaml
+ spec:
+   tasks:
+     - name: hello-world  
+       taskRef:
+         name: echo-task
+         bundle: docker.com/myrepo/mycatalog@sha256:abc123
+ ```
+
+Any of the above options will fetch the image using the `ImagePullSecrets` attached to the
+`ServiceAccount` specified in the `PipelineRun`. See the [Service Account](
+pipelineruns.md#service-accounts) section for details on how to configure a `ServiceAccount`
+on a `PipelineRun`. The `PipelineRun` will then run that `Task` without registering it in
+the cluster allowing multiple versions of the same named `Task` to be run at once.
+
+`Tekton Bundles` may be constructed with any toolsets that produce valid OCI image artifacts
+so long as the artifact adheres to the [contract](tekton-bundle-contract.md). Additionally,
+you may also use the `tkn` cli *(coming soon)*.
 
 ### Using the `from` parameter
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -10,6 +10,7 @@ weight: 2
 - [Overview](#taskruns)
 - [Configuring a `TaskRun`](#configuring-a-taskrun)
   - [Specifying the target `Task`](#specifying-the-target-task)
+  - [Tekton Bundles](#tekton-bundles)
   - [Specifying `Parameters`](#specifying-parameters)
   - [Specifying `Resources`](#specifying-resources)
   - [Specifying `ServiceAccount` credentials](#specifying-serviceaccount-credentials)
@@ -95,6 +96,53 @@ spec:
         args:
           - --destination=gcr.io/my-project/gohelloworld
 ```
+
+#### Tekton Bundles
+
+You may also reference `Tasks` that are defined outside of your cluster using `Tekton
+Bundles`. A `Tekton Bundle` is an OCI artifact that contains Tekton resources like `Tasks`
+which can be referenced within a `taskRef`.
+
+```yaml
+spec:
+taskRef:
+  name: echo-task
+  bundle: docker.com/myrepo/mycatalog
+```
+
+Here, the `bundle` field is the full reference url to the artifact. The name is the
+`metadata.name` field of the `Task`. 
+
+You may also specify a `tag` as you would with a Docker image which will give you a fixed,
+repeatable reference to a `Task`.
+
+```yaml
+spec:
+taskRef:
+  name: echo-task
+  bundle: docker.com/myrepo/mycatalog:v1.0.1
+```
+
+You may also specify a fixed digest instead of a tag.
+
+```yaml
+spec:
+taskRef:
+  name: echo-task
+  bundle: docker.com/myrepo/mycatalog@sha256:abc123
+```
+
+A working example can be found [here](../examples/v1beta1/taskruns/bundle.yaml).
+
+Any of the above options will fetch the image using the `ImagePullSecrets` attached to the
+`ServiceAccount` specified in the `TaskRun`. See the [Service Account](#service-account) 
+section for details on how to configure a `ServiceAccount` on a `TaskRun`. The `TaskRun`
+will then run that `Task` without registering it in the cluster allowing multiple versions
+of the same named `Task` to be run at once.
+
+`Tekton Bundles` may be constructed with any toolsets that produces valid OCI image artifacts so long as
+the artifact adheres to the [contract](tekton-bundle-contract.md). Additionally, you may also use the `tkn`
+cli *(coming soon)*.
 
 ### Specifying `Parameters`
 

--- a/docs/tekton-bundle-contracts.md
+++ b/docs/tekton-bundle-contracts.md
@@ -1,0 +1,38 @@
+<!--
+---
+linkTitle: "Tekton Bundle Contracts"
+weight: 8
+---
+-->
+# Tekton Bundle Contract
+
+When using a Tekton Bundle in a task or pipeline reference, the OCI artifact backing the
+bundle must adhere to the following contract.
+
+## Contract
+
+Only Tekton CRDs (eg, `Task` or `Pipeline`) may reside in a Tekton Bundle used as a Tekton
+bundle reference.
+
+Each layer of the image must map 1:1 with a single Tekton resource.
+
+Each layer must contain the following annotations:
+
+- `org.opencontainers.image.title` => `ObjectMeta.Name` of the resource
+- `cdf.tekton.image.kind` => `TypeMeta.Kind` of the resource, all lowercased (eg, `task`)
+- `cdf.tekton.image.apiVersion` => `TypeMeta.APIVersion` of the resource (eg 
+"tekton.dev/v1alpha1")  
+
+Each { `apiVersion`, `kind`, `title` } must be unique in the image. No resources of the
+same version and kind can be named the same.
+
+The contents of each layer must be the parsed YAML of the corresponding Tekton resource. If
+the resource is missing any identifying fields (missing an `apiVersion` for instance) than
+it will not be parseable.
+
+---
+
+Except as otherwise noted, the content of this page is licensed under the
+[Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),
+and code samples are licensed under the
+[Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/examples/v1beta1/taskruns/tekton-bundles.yaml
+++ b/examples/v1beta1/taskruns/tekton-bundles.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   taskRef:
     name: hello-world
-      bundle: registry.hub.docker.com/ptasci67/test-oci@sha256:c50242c60570219e7d527f854eaec2577ad865727d7b74f411f51c38b67a045c
+    bundle: registry.hub.docker.com/ptasci67/test-oci@sha256:c50242c60570219e7d527f854eaec2577ad865727d7b74f411f51c38b67a045c

--- a/examples/v1beta1/taskruns/tekton-bundles.yaml
+++ b/examples/v1beta1/taskruns/tekton-bundles.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   taskRef:
     name: hello-world
-    bundle: registry.hub.docker.com/ptasci67/test-oci@sha256:c50242c60570219e7d527f854eaec2577ad865727d7b74f411f51c38b67a045c
+    bundle: registry.hub.docker.com/ptasci67/test-oci@sha256:7a8e6b41d37e16c86dc38fbb395673fe496edb9ac759aee135df488b55b4c732

--- a/examples/v1beta1/taskruns/tekton-bundles.yaml
+++ b/examples/v1beta1/taskruns/tekton-bundles.yaml
@@ -1,0 +1,8 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: remote-task-reference-
+spec:
+  taskRef:
+    name: hello-world
+      bundle: registry.hub.docker.com/ptasci67/test-oci@sha256:c50242c60570219e7d527f854eaec2577ad865727d7b74f411f51c38b67a045c

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -70,6 +70,16 @@ func Pipeline(name string, ops ...PipelineOp) *v1beta1.Pipeline {
 	return p
 }
 
+// PipelineType will add a TypeMeta to the pipeline's definition.
+func PipelineType() PipelineOp {
+	return func(t *v1beta1.Pipeline) {
+		t.TypeMeta = metav1.TypeMeta{
+			Kind:       "Pipeline",
+			APIVersion: "tekton.dev/v1beta1",
+		}
+	}
+}
+
 // PipelineNamespace sets the namespace on the Pipeline
 func PipelineNamespace(namespace string) PipelineOp {
 	return func(t *v1beta1.Pipeline) {
@@ -192,6 +202,13 @@ func PipelineRunResult(name, value string) PipelineRunStatusOp {
 			Value: value,
 		}
 		s.PipelineResults = append(s.PipelineResults, *pResult)
+	}
+}
+
+// PipelineTaskRefBundle will add the specified URL as a bundle url on the task ref.
+func PipelineTaskRefBundle(url string) PipelineTaskOp {
+	return func(pt *v1beta1.PipelineTask) {
+		pt.TaskRef.Bundle = url
 	}
 }
 
@@ -537,6 +554,13 @@ func PipelineRunPipelineSpec(ops ...PipelineSpecOp) PipelineRunSpecOp {
 			op(ps)
 		}
 		prs.PipelineSpec = ps
+	}
+}
+
+// PipelineRunPipelineRefBundle will specify the given URL as the bundle url in the pipeline ref.
+func PipelineRunPipelineRefBundle(url string) PipelineRunSpecOp {
+	return func(prs *v1beta1.PipelineRunSpec) {
+		prs.PipelineRef.Bundle = url
 	}
 }
 

--- a/internal/builder/v1beta1/pipeline_test.go
+++ b/internal/builder/v1beta1/pipeline_test.go
@@ -34,7 +34,7 @@ import (
 func TestPipeline(t *testing.T) {
 	creationTime := time.Now()
 
-	pipeline := tb.Pipeline("tomatoes", tb.PipelineNamespace("foo"), tb.PipelineSpec(
+	pipeline := tb.Pipeline("tomatoes", tb.PipelineType(), tb.PipelineNamespace("foo"), tb.PipelineSpec(
 		tb.PipelineDeclaredResource("my-only-git-resource", "git"),
 		tb.PipelineDeclaredResource("my-only-image-resource", "image"),
 		tb.PipelineDescription("Test Pipeline"),
@@ -47,6 +47,7 @@ func TestPipeline(t *testing.T) {
 				tb.PipelineTaskConditionResource("some-resource", "my-only-git-resource", "bar", "never-gonna"),
 			),
 			tb.PipelineTaskWorkspaceBinding("task-workspace1", "workspace1", ""),
+			tb.PipelineTaskRefBundle("/some/registry"),
 		),
 		tb.PipelineTask("bar", "chocolate",
 			tb.PipelineTaskRefKind(v1beta1.ClusterTaskKind),
@@ -70,6 +71,10 @@ func TestPipeline(t *testing.T) {
 		tb.PipelineCreationTimestamp(creationTime),
 	)
 	expectedPipeline := &v1beta1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "Pipeline",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "tomatoes", Namespace: "foo",
 			CreationTimestamp: metav1.Time{Time: creationTime},
@@ -91,7 +96,7 @@ func TestPipeline(t *testing.T) {
 			}},
 			Tasks: []v1beta1.PipelineTask{{
 				Name:    "foo",
-				TaskRef: &v1beta1.TaskRef{Name: "banana"},
+				TaskRef: &v1beta1.TaskRef{Name: "banana", Bundle: "/some/registry"},
 				Params: []v1beta1.Param{{
 					Name:  "stringparam",
 					Value: *tb.ArrayOrString("value"),
@@ -173,6 +178,7 @@ func TestPipelineRun(t *testing.T) {
 		tb.PipelineRunTimeout(1*time.Hour),
 		tb.PipelineRunResourceBinding("some-resource", tb.PipelineResourceBindingRef("my-special-resource")),
 		tb.PipelineRunServiceAccountNameTask("foo", "sa-2"),
+		tb.PipelineRunPipelineRefBundle("/some/registry"),
 	), tb.PipelineRunStatus(tb.PipelineRunStatusCondition(
 		apis.Condition{Type: apis.ConditionSucceeded}),
 		tb.PipelineRunStartTime(startTime),
@@ -190,7 +196,7 @@ func TestPipelineRun(t *testing.T) {
 			},
 		},
 		Spec: v1beta1.PipelineRunSpec{
-			PipelineRef:         &v1beta1.PipelineRef{Name: "tomatoes"},
+			PipelineRef:         &v1beta1.PipelineRef{Name: "tomatoes", Bundle: "/some/registry"},
 			ServiceAccountName:  "sa",
 			ServiceAccountNames: []v1beta1.PipelineRunSpecServiceAccountName{{TaskName: "foo", ServiceAccountName: "sa-2"}},
 			Params: []v1beta1.Param{{

--- a/internal/builder/v1beta1/task.go
+++ b/internal/builder/v1beta1/task.go
@@ -659,6 +659,13 @@ func TaskRefAPIVersion(version string) TaskRefOp {
 	}
 }
 
+// TaskRefBundle sets the specified ref to the TaskRef's bundle.
+func TaskRefBundle(url string) TaskRefOp {
+	return func(ref *v1beta1.TaskRef) {
+		ref.Bundle = url
+	}
+}
+
 // TaskRunTaskSpec sets the specified TaskRunSpec reference to the TaskRunSpec.
 // Any number of TaskRunSpec modifier can be passed to transform it.
 func TaskRunTaskSpec(ops ...TaskSpecOp) TaskRunSpecOp {

--- a/internal/builder/v1beta1/task_test.go
+++ b/internal/builder/v1beta1/task_test.go
@@ -184,6 +184,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 			tb.TaskRunTaskRef("task-output",
 				tb.TaskRefKind(v1beta1.ClusterTaskKind),
 				tb.TaskRefAPIVersion("a1"),
+				tb.TaskRefBundle("some/bundle/url"),
 			),
 			tb.TaskRunParam("iparam", "ivalue"),
 			tb.TaskRunParam("arrayparam", "array", "values"),
@@ -277,6 +278,7 @@ func TestTaskRunWithTaskRef(t *testing.T) {
 				Name:       "task-output",
 				Kind:       v1beta1.ClusterTaskKind,
 				APIVersion: "a1",
+				Bundle:     "some/bundle/url",
 			},
 			Workspaces: []v1beta1.WorkspaceBinding{{
 				Name:     "bread",

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -203,6 +203,9 @@ type PipelineRef struct {
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
+	// Bundle url reference to a Tekton Bundle.
+	// +optional
+	Bundle string `json:"bundle,omitempty"`
 }
 
 // PipelineRunStatus defines the observed state of PipelineRun

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -94,6 +94,34 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 				},
 			},
 			want: apis.ErrInvalidValue("PipelineRunCancell should be PipelineRunCancelled", "spec.status"),
+		}, {
+			name: "bundle reference with no name",
+			pr: v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipelinelineName",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Bundle: "docker.com/myorg/myrepo",
+					},
+					PipelineSpec: &v1beta1.PipelineSpec{},
+				},
+			},
+			want: apis.ErrMissingField("spec.pipelineref.name"),
+		}, {
+			name: "invalid bundle reference",
+			pr: v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipelinelineName",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Name:   "my-pipeline",
+						Bundle: "not a valid reference",
+					},
+				},
+			},
+			want: apis.ErrInvalidValue("invalid bundle reference (could not parse reference: not a valid reference)", "spec.pipelineref.bundle"),
 		},
 	}
 

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -155,6 +155,9 @@ type TaskRef struct {
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
+	// Bundle url reference to a Tekton Bundle.
+	// +optional
+	Bundle string `json:"bundle,omitempty"`
 }
 
 // Check that Pipeline may be validated and defaulted.

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -200,6 +200,24 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("spec.params.name"),
+	}, {
+		name: "bundle reference with no name",
+		spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Bundle: "docker.com/myorg/myrepo",
+			},
+			TaskSpec: &v1beta1.TaskSpec{},
+		},
+		wantErr: apis.ErrMissingField("spec.taskref.name"),
+	}, {
+		name: "invalid bundle reference",
+		spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name:   "my-task",
+				Bundle: "invalid reference",
+			},
+		},
+		wantErr: apis.ErrInvalidValue("invalid bundle reference (could not parse reference: invalid reference)", "spec.taskref.bundle"),
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -17,12 +17,61 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/authn/k8schain"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/pipeline/pkg/remote/oci"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
+
+// GetPipelineFunc is a factory function that will use the given PipelineRef to return a valid GetPipeline function that
+// looks up the pipeline. It uses as context a k8s client, tekton client, namespace, and service account name to return
+// the pipeline. It knows whether it needs to look in the cluster or in a remote image to fetch the reference.
+func GetPipelineFunc(k8s kubernetes.Interface, tekton clientset.Interface, pr *v1beta1.PipelineRef, namespace, saName string) (GetPipeline, error) {
+	switch {
+	case pr != nil && pr.Bundle != "":
+		// If there is a bundle url at all, construct an OCI resolver to fetch the pipeline.
+		kc, err := k8schain.New(k8s, k8schain.Options{
+			Namespace:          namespace,
+			ServiceAccountName: saName,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get keychain: %w", err)
+		}
+		resolver := oci.NewResolver(pr.Bundle, kc)
+		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
+		// casting it to a TaskInterface.
+		return func(name string) (v1beta1.PipelineInterface, error) {
+			obj, err := resolver.Get("pipeline", name)
+			if err != nil {
+				return nil, err
+			}
+			if pipeline, ok := obj.(v1beta1.PipelineInterface); ok {
+				return pipeline, nil
+			}
+
+			if pipeline, ok := obj.(*v1alpha1.Pipeline); ok {
+				betaPipeline := &v1beta1.Pipeline{}
+				err := pipeline.ConvertTo(context.Background(), betaPipeline)
+				return betaPipeline, err
+			}
+
+			return nil, fmt.Errorf("failed to convert obj %s into Pipeline", obj.GetObjectKind().GroupVersionKind().String())
+		}, nil
+	default:
+		// Even if there is no task ref, we should try to return a local resolver.
+		local := &LocalPipelineRefResolver{
+			Namespace:    namespace,
+			Tektonclient: tekton,
+		}
+		return local.GetPipeline, nil
+	}
+}
 
 // LocalPipelineRefResolver uses the current cluster to resolve a pipeline reference.
 type LocalPipelineRefResolver struct {

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -17,18 +17,26 @@
 package resources_test
 
 import (
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/registry"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
 )
 
-func TestPipelineRef(t *testing.T) {
+func TestLocalPipelineRef(t *testing.T) {
 	testcases := []struct {
 		name      string
 		pipelines []runtime.Object
@@ -77,6 +85,86 @@ func TestPipelineRef(t *testing.T) {
 
 			if d := cmp.Diff(task, tc.expected); tc.expected != nil && d != "" {
 				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetPipelineFunc(t *testing.T) {
+	// Set up a fake registry to push an image to.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testcases := []struct {
+		name            string
+		localPipelines  []runtime.Object
+		remotePipelines []runtime.Object
+		ref             *v1beta1.PipelineRef
+		expected        runtime.Object
+	}{
+		{
+			name: "remote-pipeline",
+			localPipelines: []runtime.Object{
+				tb.Pipeline("simple", tb.PipelineType(), tb.PipelineNamespace("default"), tb.PipelineSpec(tb.PipelineTask("something", "something"))),
+				tb.Pipeline("dummy", tb.PipelineType(), tb.PipelineNamespace("default")),
+			},
+			remotePipelines: []runtime.Object{
+				tb.Pipeline("simple", tb.PipelineType(), tb.PipelineNamespace("default")),
+				tb.Pipeline("dummy", tb.PipelineType(), tb.PipelineNamespace("default")),
+			},
+			ref: &v1beta1.PipelineRef{
+				Name:   "simple",
+				Bundle: u.Host + "/remote-pipeline",
+			},
+			expected: tb.Pipeline("simple", tb.PipelineType(), tb.PipelineNamespace("default")),
+		}, {
+			name: "local-pipeline",
+			localPipelines: []runtime.Object{
+				tb.Pipeline("simple", tb.PipelineType(), tb.PipelineNamespace("default"), tb.PipelineSpec(tb.PipelineTask("something", "something"))),
+				tb.Pipeline("dummy", tb.PipelineType(), tb.PipelineNamespace("default")),
+			},
+			remotePipelines: []runtime.Object{
+				tb.Pipeline("simple", tb.PipelineType(), tb.PipelineNamespace("default")),
+				tb.Pipeline("dummy", tb.PipelineType(), tb.PipelineNamespace("default")),
+			},
+			ref: &v1beta1.PipelineRef{
+				Name: "simple",
+			},
+			expected: tb.Pipeline("simple", tb.PipelineType(), tb.PipelineNamespace("default"), tb.PipelineSpec(tb.PipelineTask("something", "something"))),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tektonclient := fake.NewSimpleClientset(tc.localPipelines...)
+			kubeclient := fakek8s.NewSimpleClientset(&v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "default",
+				},
+			})
+
+			_, err := test.CreateImage(u.Host+"/"+tc.name, tc.remotePipelines...)
+			if err != nil {
+				t.Fatalf("failed to upload test image: %s", err.Error())
+			}
+
+			fn, err := resources.GetPipelineFunc(kubeclient, tektonclient, tc.ref, "default", "default")
+			if err != nil {
+				t.Fatalf("failed to get pipeline fn: %s", err.Error())
+			}
+
+			pipeline, err := fn(tc.ref.Name)
+			if err != nil {
+				t.Fatalf("failed to call pipelinefn: %s", err.Error())
+			}
+
+			if diff := cmp.Diff(pipeline, tc.expected); tc.expected != nil && diff != "" {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -404,88 +404,75 @@ func ValidateServiceaccountMapping(p *v1beta1.PipelineSpec, pr *v1beta1.Pipeline
 	return nil
 }
 
-// ResolvePipelineRun retrieves all Tasks instances which are reference by tasks, getting
-// instances from getTask. If it is unable to retrieve an instance of a referenced Task, it
-// will return an error, otherwise it returns a list of all of the Tasks retrieved.
-// It will retrieve the Resources needed for the TaskRun using the mapping of providedResources.
-func ResolvePipelineRun(
+// ResolvePipelineRunTask retrieves a single Task's instance using the getTask to fetch
+// the spec. If it is unable to retrieve an instance of a referenced Task, it  will return
+// an error, otherwise it returns a list of all of the Tasks retrieved.  It will retrieve
+// the Resources needed for the TaskRun using the mapping of providedResources.
+func ResolvePipelineRunTask(
 	ctx context.Context,
 	pipelineRun v1beta1.PipelineRun,
 	getTask resources.GetTask,
 	getTaskRun resources.GetTaskRun,
-	getClusterTask resources.GetClusterTask,
 	getCondition GetCondition,
-	tasks []v1beta1.PipelineTask,
+	task v1beta1.PipelineTask,
 	providedResources map[string]*resourcev1alpha1.PipelineResource,
-) (PipelineRunState, error) {
+) (*ResolvedPipelineRunTask, error) {
 
-	state := []*ResolvedPipelineRunTask{}
-	for i := range tasks {
-		pt := tasks[i]
-
-		rprt := ResolvedPipelineRunTask{
-			PipelineTask: &pt,
-			TaskRunName:  GetTaskRunName(pipelineRun.Status.TaskRuns, pt.Name, pipelineRun.Name),
-		}
-
-		// Find the Task that this PipelineTask is using
-		var (
-			t        v1beta1.TaskInterface
-			err      error
-			spec     v1beta1.TaskSpec
-			taskName string
-			kind     v1beta1.TaskKind
-		)
-
-		if pt.TaskRef != nil {
-			if pt.TaskRef.Kind == v1beta1.ClusterTaskKind {
-				t, err = getClusterTask(pt.TaskRef.Name)
-			} else {
-				t, err = getTask(pt.TaskRef.Name)
-			}
-			if err != nil {
-				return nil, &TaskNotFoundError{
-					Name: pt.TaskRef.Name,
-					Msg:  err.Error(),
-				}
-			}
-			spec = t.TaskSpec()
-			taskName = t.TaskMetadata().Name
-			kind = pt.TaskRef.Kind
-		} else {
-			spec = *pt.TaskSpec.TaskSpec
-		}
-		spec.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
-		rtr, err := ResolvePipelineTaskResources(pt, &spec, taskName, kind, providedResources)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't match referenced resources with declared resources: %w", err)
-		}
-
-		rprt.ResolvedTaskResources = rtr
-
-		taskRun, err := getTaskRun(rprt.TaskRunName)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				return nil, fmt.Errorf("error retrieving TaskRun %s: %w", rprt.TaskRunName, err)
-			}
-		}
-		if taskRun != nil {
-			rprt.TaskRun = taskRun
-		}
-
-		// Get all conditions that this pipelineTask will be using, if any
-		if len(pt.Conditions) > 0 {
-			rcc, err := resolveConditionChecks(&pt, pipelineRun.Status.TaskRuns, rprt.TaskRunName, getTaskRun, getCondition, providedResources)
-			if err != nil {
-				return nil, err
-			}
-			rprt.ResolvedConditionChecks = rcc
-		}
-
-		// Add this task to the state of the PipelineRun
-		state = append(state, &rprt)
+	rprt := ResolvedPipelineRunTask{
+		PipelineTask: &task,
+		TaskRunName:  GetTaskRunName(pipelineRun.Status.TaskRuns, task.Name, pipelineRun.Name),
 	}
-	return state, nil
+
+	// Find the Task that this PipelineTask is using
+	var (
+		t        v1beta1.TaskInterface
+		err      error
+		spec     v1beta1.TaskSpec
+		taskName string
+		kind     v1beta1.TaskKind
+	)
+
+	if task.TaskRef != nil {
+		t, err = getTask(task.TaskRef.Name)
+		if err != nil {
+			return nil, &TaskNotFoundError{
+				Name: task.TaskRef.Name,
+				Msg:  err.Error(),
+			}
+		}
+		spec = t.TaskSpec()
+		taskName = t.TaskMetadata().Name
+		kind = task.TaskRef.Kind
+	} else {
+		spec = *task.TaskSpec.TaskSpec
+	}
+	spec.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
+	rtr, err := ResolvePipelineTaskResources(task, &spec, taskName, kind, providedResources)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't match referenced resources with declared resources: %w", err)
+	}
+
+	rprt.ResolvedTaskResources = rtr
+
+	taskRun, err := getTaskRun(rprt.TaskRunName)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("error retrieving TaskRun %s: %w", rprt.TaskRunName, err)
+		}
+	}
+	if taskRun != nil {
+		rprt.TaskRun = taskRun
+	}
+
+	// Get all conditions that this pipelineTask will be using, if any
+	if len(task.Conditions) > 0 {
+		rcc, err := resolveConditionChecks(&task, pipelineRun.Status.TaskRuns, rprt.TaskRunName, getTaskRun, getCondition, providedResources)
+		if err != nil {
+			return nil, err
+		}
+		rprt.ResolvedConditionChecks = rcc
+	}
+	return &rprt, nil
 }
 
 // getConditionCheckName should return a unique name for a `ConditionCheck` if one has not already been defined, and the existing one otherwise.

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -100,17 +100,6 @@ var task = &v1beta1.Task{
 	},
 }
 
-var clustertask = &v1beta1.ClusterTask{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "clustertask",
-	},
-	Spec: v1beta1.TaskSpec{
-		Steps: []v1beta1.Step{{Container: corev1.Container{
-			Name: "step1",
-		}}},
-	},
-}
-
 var trs = []v1beta1.TaskRun{{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: "namespace",

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -17,19 +17,26 @@
 package resources_test
 
 import (
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/runtime"
-
+	"github.com/google/go-containerregistry/pkg/registry"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakek8s "k8s.io/client-go/kubernetes/fake"
 )
 
-func TestTaskRef(t *testing.T) {
+func TestLocalTaskRef(t *testing.T) {
 	testcases := []struct {
 		name     string
 		tasks    []runtime.Object
@@ -92,6 +99,118 @@ func TestTaskRef(t *testing.T) {
 
 			if d := cmp.Diff(task, tc.expected); tc.expected != nil && d != "" {
 				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetTaskFunc(t *testing.T) {
+	// Set up a fake registry to push an image to.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testcases := []struct {
+		name        string
+		localTasks  []runtime.Object
+		remoteTasks []runtime.Object
+		ref         *v1beta1.TaskRef
+		expected    runtime.Object
+	}{
+		{
+			name: "remote-task",
+			localTasks: []runtime.Object{
+				tb.Task("simple", tb.TaskType(), tb.TaskNamespace("default"), tb.TaskSpec(tb.Step("something"))),
+			},
+			remoteTasks: []runtime.Object{
+				tb.Task("simple", tb.TaskType()),
+				tb.Task("dummy", tb.TaskType()),
+			},
+			ref: &v1alpha1.TaskRef{
+				Name:   "simple",
+				Bundle: u.Host + "/remote-task",
+			},
+			expected: tb.Task("simple", tb.TaskType()),
+		}, {
+			name: "local-task",
+			localTasks: []runtime.Object{
+				tb.Task("simple", tb.TaskType(), tb.TaskNamespace("default"), tb.TaskSpec(tb.Step("something"))),
+			},
+			remoteTasks: []runtime.Object{
+				tb.Task("simple", tb.TaskType()),
+				tb.Task("dummy", tb.TaskType()),
+			},
+			ref: &v1alpha1.TaskRef{
+				Name: "simple",
+			},
+			expected: tb.Task("simple", tb.TaskType(), tb.TaskNamespace("default"), tb.TaskSpec(tb.Step("something"))),
+		}, {
+			name: "remote-cluster-task",
+			localTasks: []runtime.Object{
+				tb.ClusterTask("simple", tb.ClusterTaskType(), tb.ClusterTaskSpec(tb.Step("something"))),
+			},
+			remoteTasks: []runtime.Object{
+				tb.ClusterTask("simple", tb.ClusterTaskType()),
+				tb.ClusterTask("dummy", tb.ClusterTaskType()),
+			},
+			ref: &v1alpha1.TaskRef{
+				Name:   "simple",
+				Kind:   v1alpha1.ClusterTaskKind,
+				Bundle: u.Host + "/remote-cluster-task",
+			},
+			expected: tb.ClusterTask("simple", tb.ClusterTaskType()),
+		}, {
+			name: "local-cluster-task",
+			localTasks: []runtime.Object{
+				tb.ClusterTask("simple", tb.ClusterTaskType(), tb.ClusterTaskSpec(tb.Step("something"))),
+			},
+			remoteTasks: []runtime.Object{
+				tb.ClusterTask("simple", tb.ClusterTaskType()),
+				tb.ClusterTask("dummy", tb.ClusterTaskType()),
+			},
+			ref: &v1alpha1.TaskRef{
+				Name: "simple",
+				Kind: v1alpha1.ClusterTaskKind,
+			},
+			expected: tb.ClusterTask("simple", tb.ClusterTaskType(), tb.ClusterTaskSpec(tb.Step("something"))),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tektonclient := fake.NewSimpleClientset(tc.localTasks...)
+			kubeclient := fakek8s.NewSimpleClientset(&v1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "default",
+				},
+			})
+
+			_, err := test.CreateImage(u.Host+"/"+tc.name, tc.remoteTasks...)
+			if err != nil {
+				t.Fatalf("failed to upload test image: %s", err.Error())
+			}
+
+			fn, kind, err := resources.GetTaskFunc(kubeclient, tektonclient, tc.ref, "default", "default")
+			if err != nil {
+				t.Fatalf("failed to get task fn: %s", err.Error())
+			}
+
+			expectedKind := tc.expected.GetObjectKind().GroupVersionKind().Kind
+			if expectedKind != string(kind) {
+				t.Errorf("expected kind %s did not match actual kind %s", expectedKind, kind)
+			}
+
+			task, err := fn(tc.ref.Name)
+			if err != nil {
+				t.Fatalf("failed to call taskfn: %s", err.Error())
+			}
+
+			if diff := cmp.Diff(task, tc.expected); tc.expected != nil && diff != "" {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -207,19 +207,6 @@ func (c *Reconciler) finishReconcileUpdateEmitEvents(ctx context.Context, tr *v1
 	return multierror.Append(previousError, err).ErrorOrNil()
 }
 
-func (c *Reconciler) getTaskResolver(tr *v1beta1.TaskRun) (*resources.LocalTaskRefResolver, v1beta1.TaskKind) {
-	resolver := &resources.LocalTaskRefResolver{
-		Namespace:    tr.Namespace,
-		Tektonclient: c.PipelineClientSet,
-	}
-	kind := v1beta1.NamespacedTaskKind
-	if tr.Spec.TaskRef != nil && tr.Spec.TaskRef.Kind == v1beta1.ClusterTaskKind {
-		kind = v1beta1.ClusterTaskKind
-	}
-	resolver.Kind = kind
-	return resolver, kind
-}
-
 // `prepare` fetches resources the taskrun depends on, runs validation and conversion
 // It may report errors back to Reconcile, it updates the taskrun status in case of
 // error but it does not sync updates back to etcd. It does not emit events.
@@ -236,8 +223,19 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	// and may not have had all of the assumed default specified.
 	tr.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
 
-	resolver, kind := c.getTaskResolver(tr)
-	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, resolver.GetTask)
+	getTaskfunc, kind, err := resources.GetTaskFunc(c.KubeClientSet, c.PipelineClientSet, tr.Spec.TaskRef, tr.Namespace, tr.Spec.ServiceAccountName)
+	if err != nil {
+		logger.Errorf("Failed to fetch task reference %s: %v", tr.Spec.TaskRef.Name)
+		tr.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  podconvert.ReasonFailedResolution,
+			Message: err.Error(),
+		})
+		return nil, nil, err
+	}
+
+	taskMeta, taskSpec, err := resources.GetTaskData(ctx, tr, getTaskfunc)
 	if err != nil {
 		logger.Errorf("Failed to determine Task spec to use for taskrun %s: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(podconvert.ReasonFailedResolution, err)

--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -29,12 +29,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var _ remote.Resolver = (*Resolver)(nil)
-
 // Resolver implements the Resolver interface using OCI images.
 type Resolver struct {
 	imageReference string
 	keychain       authn.Keychain
+}
+
+// NewResolver is a convenience function to return a new OCI resolver instance as a remote.Resolver.
+func NewResolver(ref string, keychain authn.Keychain) remote.Resolver {
+	return &Resolver{imageReference: ref, keychain: keychain}
 }
 
 func (o *Resolver) List() ([]remote.ResolvedObject, error) {

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package oci
+package oci_test
 
 import (
 	"fmt"
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/remote"
+	"github.com/tektoncd/pipeline/pkg/remote/oci"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -83,11 +84,7 @@ func TestOCIResolver(t *testing.T) {
 				t.Fatalf("could not push image: %#v", err)
 			}
 
-			resolver := Resolver{
-				imageReference: ref,
-				keychain:       authn.DefaultKeychain,
-			}
-
+			resolver := oci.NewResolver(ref, authn.DefaultKeychain)
 			listActual, err := resolver.List()
 			if err != nil {
 				t.Errorf("unexpected error listing contents of image: %#v", err)


### PR DESCRIPTION
# Changes

Introduces Tekton Bundles with docs, apis, examples, and updates to the reconcilers to allow Task and Pipeline references from Tekton Bundles

Summary of changes:
- adds docs for how to use Tekton Bundles as refs including a tekton bundle contract
- adds a field to task and pipeline refs to specify a tekton bundle url
- adds validation and tests to the api
- Wires up the OCI remote fetcher to the pipeline ref and task ref handlers
- adds tests into the pipelinerun and taskrun reconcilers to test for remote refs
- requires a change to the way we resolve tasks in the pipelinerun resource handler because we want to decide how to fetch each task ref on a case by case basis instead of using one uniform task fetcher

This is a large change but there are significant side-effects to any one part of this change and it felt half-hearted to only provide the API change to either tasksruns or pipelines and not both at the same time.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

    ```release-note
    Task and Pipeline refs now support remote references via Tekton Bundles
    ```