### PR TITLE
Fix(git): add warning of the mismatch of git cred and url

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package git
+
+import "testing"
+
+func TestValidateGitSSHURLFormat(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{
+			url:  "git@github.com:user/project.git",
+			want: true,
+		},
+		{
+			url:  "git@127.0.0.1:user/project.git",
+			want: true,
+		},
+		{
+			url:  "http://github.com/user/project.git",
+			want: false,
+		},
+		{
+			url:  "https://github.com/user/project.git",
+			want: false,
+		},
+		{
+			url:  "http://127.0.0.1/user/project.git",
+			want: false,
+		},
+		{
+			url:  "https://127.0.0.1/user/project.git",
+			want: false,
+		},
+		{
+			url:  "http://host.xz/path/to/repo.git/",
+			want: false,
+		},
+		{
+			url:  "https://host.xz/path/to/repo.git/",
+			want: false,
+		},
+		{
+			url:  "ssh://user@host.xz:port/path/to/repo.git/",
+			want: true,
+		},
+		{
+			url:  "ssh://user@host.xz/path/to/repo.git/",
+			want: true,
+		},
+		{
+			url:  "ssh://host.xz:port/path/to/repo.git/",
+			want: true,
+		},
+		{
+			url:  "ssh://host.xz/path/to/repo.git/",
+			want: true,
+		},
+		{
+			url:  "git://host.xz/path/to/repo.git/",
+			want: false,
+		},
+		{
+			url:  "/path/to/repo.git/",
+			want: false,
+		},
+		{
+			url:  "file://~/path/to/repo.git/",
+			want: false,
+		},
+		{
+			url:  "user@host.xz:/path/to/repo.git/",
+			want: true,
+		},
+		{
+			url:  "host.xz:/path/to/repo.git/",
+			want: true,
+		},
+		{
+			url:  "user@host.xz:path/to/repo.git",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		got := ValidateGitSSHURLFormat(tt.url)
+		if got != tt.want {
+			t.Errorf("Validate URL(%v)'s SSH format got %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix(git): add warning of the mismatch of git cred and url
Fix #3094 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

    Fix(git): add warning of the mismatch of git cred and url
   

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
