### PR TITLE
use status helper functions in pod status unit tests

### DIFF
--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -33,19 +33,6 @@ import (
 
 var ignoreVolatileTime = cmp.Comparer(func(_, _ apis.VolatileTime) bool { return true })
 
-var conditionRunning apis.Condition = apis.Condition{
-	Type:    apis.ConditionSucceeded,
-	Status:  corev1.ConditionUnknown,
-	Reason:  v1beta1.TaskRunReasonRunning.String(),
-	Message: "Not all Steps in the Task have finished executing",
-}
-var conditionSucceeded apis.Condition = apis.Condition{
-	Type:    apis.ConditionSucceeded,
-	Status:  corev1.ConditionTrue,
-	Reason:  v1beta1.TaskRunReasonSuccessful.String(),
-	Message: "All Steps have completed executing",
-}
-
 func TestMakeTaskRunStatus(t *testing.T) {
 	for _, c := range []struct {
 		desc      string
@@ -57,9 +44,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		podStatus: corev1.PodStatus{},
 
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -83,9 +68,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -119,9 +102,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -150,14 +131,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionTrue,
-					Reason:  v1beta1.TaskRunReasonSuccessful.String(),
-					Message: "All Steps have completed executing",
-				}},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -185,9 +159,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -218,14 +190,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
-					Reason:  v1beta1.TaskRunReasonFailed.String(),
-					Message: "\"step-failure\" exited with code 123 (image: \"image-id\"); for logs run: kubectl -n foo logs pod -c step-failure\n",
-				}},
-			},
+			Status: statusFailure("\"step-failure\" exited with code 123 (image: \"image-id\"); for logs run: kubectl -n foo logs pod -c step-failure\n"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -249,14 +214,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			Message: "boom",
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
-					Reason:  v1beta1.TaskRunReasonFailed.String(),
-					Message: "boom",
-				}},
-			},
+			Status: statusFailure("boom"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -280,14 +238,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
-					Reason:  v1beta1.TaskRunReasonFailed.String(),
-					Message: "OOMKilled",
-				}},
-			},
+			Status: statusFailure("OOMKilled"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -308,14 +259,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		desc:      "failure-unspecified",
 		podStatus: corev1.PodStatus{Phase: corev1.PodFailed},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
-					Reason:  v1beta1.TaskRunReasonFailed.String(),
-					Message: "build failed for unspecified reasons.",
-				}},
-			},
+			Status: statusFailure("build failed for unspecified reasons."),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -340,14 +284,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionUnknown,
-					Reason:  "Pending",
-					Message: `build step "step-status-name" is pending with reason "i'm pending"`,
-				}},
-			},
+			Status: statusPending("Pending", `build step "step-status-name" is pending with reason "i'm pending"`),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -372,14 +309,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionUnknown,
-					Reason:  "Pending",
-					Message: `pod status "the type":"Unknown"; message: "the message"`,
-				}},
-			},
+			Status: statusPending("Pending", `pod status "the type":"Unknown"; message: "the message"`),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -392,14 +322,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			Message: "pod status message",
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionUnknown,
-					Reason:  "Pending",
-					Message: "pod status message",
-				}},
-			},
+			Status: statusPending("Pending", "pod status message"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -409,14 +332,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 		desc:      "pending-no-message",
 		podStatus: corev1.PodStatus{Phase: corev1.PodPending},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionUnknown,
-					Reason:  "Pending",
-					Message: "Pending",
-				}},
-			},
+			Status: statusPending("Pending", "Pending"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -432,14 +348,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionUnknown,
-					Reason:  ReasonExceededNodeResources,
-					Message: "TaskRun Pod exceeded available resources",
-				}},
-			},
+			Status: statusPending(ReasonExceededNodeResources, "TaskRun Pod exceeded available resources"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -458,14 +367,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionUnknown,
-					Reason:  ReasonCreateContainerConfigError,
-					Message: "Pending",
-				}},
-			},
+			Status: statusPending(ReasonCreateContainerConfigError, "Pending"),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps:    []v1beta1.StepState{},
 				Sidecars: []v1beta1.SidecarState{},
@@ -490,9 +392,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -536,9 +436,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -586,9 +484,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionRunning},
-			},
+			Status: statusRunning(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -625,9 +521,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -661,9 +555,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -701,9 +593,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -748,9 +638,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -791,12 +679,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{Conditions: []apis.Condition{{
-				Reason:  "Failed",
-				Message: "build failed for unspecified reasons.",
-				Type:    apis.ConditionSucceeded,
-				Status:  corev1.ConditionFalse,
-			}}},
+			Status: statusFailure("build failed for unspecified reasons."),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -823,9 +706,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -852,9 +733,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			}},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -928,9 +807,7 @@ func TestMakeTaskRunStatus(t *testing.T) {
 			},
 		},
 		want: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{conditionSucceeded},
-			},
+			Status: statusSuccess(),
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 				Steps: []v1beta1.StepState{{
 					ContainerState: corev1.ContainerState{
@@ -1068,14 +945,7 @@ func TestMakeRunStatusJSONError(t *testing.T) {
 		},
 	}
 	wantTr := v1beta1.TaskRunStatus{
-		Status: duckv1beta1.Status{
-			Conditions: []apis.Condition{{
-				Type:    apis.ConditionSucceeded,
-				Status:  corev1.ConditionFalse,
-				Reason:  v1beta1.TaskRunReasonFailed.String(),
-				Message: "\"step-non-json\" exited with code 1 (image: \"image\"); for logs run: kubectl -n foo logs pod -c step-non-json\n",
-			}},
-		},
+		Status: statusFailure("\"step-non-json\" exited with code 1 (image: \"image\"); for logs run: kubectl -n foo logs pod -c step-non-json\n"),
 		TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 			PodName: "pod",
 			Steps: []v1beta1.StepState{{
@@ -1271,5 +1141,34 @@ func TestMarkStatusSuccess(t *testing.T) {
 
 	if d := cmp.Diff(expected, trs.GetCondition(apis.ConditionSucceeded), cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)); d != "" {
 		t.Errorf("Unexpected status: %s", diff.PrintWantGot(d))
+	}
+}
+
+func statusRunning() duckv1beta1.Status {
+	var trs v1beta1.TaskRunStatus
+	MarkStatusRunning(&trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
+	return trs.Status
+}
+
+func statusFailure(message string) duckv1beta1.Status {
+	var trs v1beta1.TaskRunStatus
+	MarkStatusFailure(&trs, message)
+	return trs.Status
+}
+
+func statusSuccess() duckv1beta1.Status {
+	var trs v1beta1.TaskRunStatus
+	MarkStatusSuccess(&trs)
+	return trs.Status
+}
+
+func statusPending(reason, message string) duckv1beta1.Status {
+	return duckv1beta1.Status{
+		Conditions: []apis.Condition{{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  reason,
+			Message: message,
+		}},
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

use status helper functions in pod status unit tests. Addresses https://github.com/tektoncd/pipeline/pull/2804#issuecomment-654527839

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

    ```release-note
    NONE
    ```
