### PR TITLE
Add results path variable to results docs

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -403,6 +403,8 @@ a `results` field but it's the responsibility of the `Task` to generate its cont
 It's important to note that Tekton does not perform any processing on the contents of results; they are emitted
 verbatim from your Task including any leading or trailing whitespace characters. Make sure to write only the
 precise string you want returned from your `Task` into the `/tekton/results/` files that your `Task` creates.
+You can use [`$(results.name.path)`](https://github.com/tektoncd/pipeline/blob/master/docs/variables.md#variables-available-in-a-task)
+to avoid having to hardcode this path.
 
 In the example below, the `Task` specifies two files in the `results` field:
 `current-date-unix-timestamp` and `current-date-human-readable`.
@@ -426,12 +428,12 @@ spec:
       image: bash:latest
       script: |
         #!/usr/bin/env bash
-        date +%s | tee /tekton/results/current-date-unix-timestamp
+        date +%s | tee $(results.current-date-unix-timestamp.path)
     - name: print-date-human-readable
       image: bash:latest
       script: |
         #!/usr/bin/env bash
-        date | tee /tekton/results/current-date-human-readable
+        date | tee $(results.current-date-human-readable.path)
 ```
 
 The stored results can be used [at the `Task` level](./pipelines.md#configuring-execution-results-at-the-task-level)


### PR DESCRIPTION
# Changes

I didn't realize this variable existed until @chhsia0 used it in
https://github.com/tektoncd/community/pull/182
All this time ive been hardcoding this path XD hoping to help some other
folks realize this is possible as well.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```