### PR TITLE
default service account

### DIFF
--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -32,6 +32,7 @@ const (
 	NoTimeoutDuration              = 0 * time.Minute
 	defaultTimeoutMinutesKey       = "default-timeout-minutes"
 	defaultServiceAccountKey       = "default-service-account"
+	DefaultServiceAccountValue     = "default"
 	defaultManagedByLabelValueKey  = "default-managed-by-label-value"
 	DefaultManagedByLabelValue     = "tekton-pipelines"
 	defaultPodTemplateKey          = "default-pod-template"
@@ -82,6 +83,7 @@ func (cfg *Defaults) Equals(other *Defaults) bool {
 func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 	tc := Defaults{
 		DefaultTimeoutMinutes:      DefaultTimeoutMinutes,
+		DefaultServiceAccount:      DefaultServiceAccountValue,
 		DefaultManagedByLabelValue: DefaultManagedByLabelValue,
 		DefaultCloudEventsSink:     DefaultCloudEventSinkValue,
 	}

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -81,6 +81,7 @@ func TestNewDefaultsFromEmptyConfigMap(t *testing.T) {
 	expectedConfig := &config.Defaults{
 		DefaultTimeoutMinutes:      60,
 		DefaultManagedByLabelValue: "tekton-pipelines",
+		DefaultServiceAccount:      "default",
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigEmptyName, expectedConfig)
 }
@@ -205,6 +206,7 @@ func TestEquals(t *testing.T) {
 }
 
 func verifyConfigFileWithExpectedConfig(t *testing.T, fileName string, expectedConfig *config.Defaults) {
+	t.Helper()
 	cm := test.ConfigMapFromTestFile(t, fileName)
 	if Defaults, err := config.NewDefaultsFromConfigMap(cm); err == nil {
 		if d := cmp.Diff(Defaults, expectedConfig); d != "" {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults_test.go
@@ -46,7 +46,8 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			desc: "timeout is nil",
 			prs:  &v1alpha1.PipelineRunSpec{},
 			want: &v1alpha1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		{
@@ -55,14 +56,16 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
 			},
 			want: &v1alpha1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 			},
 		},
 		{
 			desc: "pod template is nil",
 			prs:  &v1alpha1.PipelineRunSpec{},
 			want: &v1alpha1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		{
@@ -75,7 +78,8 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 				},
 			},
 			want: &v1alpha1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 				PodTemplate: &v1alpha1.PodTemplate{
 					NodeSelector: map[string]string{
 						"label": "value",
@@ -108,7 +112,8 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		in:   &v1alpha1.PipelineRun{},
 		want: &v1alpha1.PipelineRun{
 			Spec: v1alpha1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 	}, {
@@ -120,8 +125,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		},
 		want: &v1alpha1.PipelineRun{
 			Spec: v1alpha1.PipelineRunSpec{
-				PipelineRef: &v1alpha1.PipelineRef{Name: "foo"},
-				Timeout:     &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				PipelineRef:        &v1alpha1.PipelineRef{Name: "foo"},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		wc: contexts.WithUpgradeViaDefaulting,
@@ -134,8 +140,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		},
 		want: &v1alpha1.PipelineRun{
 			Spec: v1alpha1.PipelineRunSpec{
-				PipelineRef: &v1alpha1.PipelineRef{Name: "foo"},
-				Timeout:     &metav1.Duration{Duration: 5 * time.Minute},
+				PipelineRef:        &v1alpha1.PipelineRef{Name: "foo"},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults_test.go
@@ -43,8 +43,9 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 		want: &v1alpha1.TaskRunSpec{
-			TaskRef: nil,
-			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+			TaskRef:            nil,
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 	}, {
 		desc: "taskref kind is empty",
@@ -53,8 +54,9 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 		want: &v1alpha1.TaskRunSpec{
-			TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.NamespacedTaskKind},
-			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+			TaskRef:            &v1alpha1.TaskRef{Kind: v1alpha1.NamespacedTaskKind},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 	}, {
 		desc: "timeout is nil",
@@ -62,14 +64,16 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
 		},
 		want: &v1alpha1.TaskRunSpec{
-			TaskRef: &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			TaskRef:            &v1alpha1.TaskRef{Kind: v1alpha1.ClusterTaskKind},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}, {
 		desc: "pod template is nil",
 		trs:  &v1alpha1.TaskRunSpec{},
 		want: &v1alpha1.TaskRunSpec{
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}, {
 		desc: "pod template is not nil",
@@ -81,7 +85,8 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			},
 		},
 		want: &v1alpha1.TaskRunSpec{
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			PodTemplate: &v1alpha1.PodTemplate{
 				NodeSelector: map[string]string{
 					"label": "value",
@@ -108,7 +113,8 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 					}},
 				},
 			},
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}}
 	for _, tc := range cases {
@@ -137,7 +143,8 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 	}, {
@@ -152,8 +159,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				TaskRef:            &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 	}, {
@@ -168,8 +176,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				TaskRef:            &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		wc: contexts.WithUpgradeViaDefaulting,
@@ -185,8 +194,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+				TaskRef:            &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {
@@ -243,8 +253,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "something-else"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+				TaskRef:            &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {
@@ -275,8 +286,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "user-specified"},
 			},
 			Spec: v1alpha1.TaskRunSpec{
-				TaskRef: &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+				TaskRef:            &v1alpha1.TaskRef{Name: "foo", Kind: v1alpha1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -41,7 +41,8 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			desc: "timeout is nil",
 			prs:  &v1beta1.PipelineRunSpec{},
 			want: &v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		{
@@ -50,14 +51,16 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
 			},
 			want: &v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 			},
 		},
 		{
 			desc: "pod template is nil",
 			prs:  &v1beta1.PipelineRunSpec{},
 			want: &v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		{
@@ -70,7 +73,8 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 				},
 			},
 			want: &v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 				PodTemplate: &v1beta1.PodTemplate{
 					NodeSelector: map[string]string{
 						"label": "value",
@@ -103,7 +107,8 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		in:   &v1beta1.PipelineRun{},
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 	}, {
@@ -115,8 +120,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		},
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
-				Timeout:     &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		wc: contexts.WithUpgradeViaDefaulting,
@@ -139,7 +145,8 @@ func TestPipelineRunDefaulting(t *testing.T) {
 						Type: "string",
 					}},
 				},
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		wc: contexts.WithUpgradeViaDefaulting,
@@ -152,8 +159,9 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		},
 		want: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
-				Timeout:     &metav1.Duration{Duration: 5 * time.Minute},
+				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -47,8 +47,9 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 		want: &v1beta1.TaskRunSpec{
-			TaskRef: nil,
-			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+			TaskRef:            nil,
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 	}, {
 		desc: "taskref kind is empty",
@@ -57,8 +58,9 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 		want: &v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Kind: v1beta1.NamespacedTaskKind},
-			Timeout: &metav1.Duration{Duration: 500 * time.Millisecond},
+			TaskRef:            &v1beta1.TaskRef{Kind: v1beta1.NamespacedTaskKind},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: 500 * time.Millisecond},
 		},
 	}, {
 		desc: "timeout is nil",
@@ -66,14 +68,16 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			TaskRef: &v1beta1.TaskRef{Kind: v1beta1.ClusterTaskKind},
 		},
 		want: &v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Kind: v1beta1.ClusterTaskKind},
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			TaskRef:            &v1beta1.TaskRef{Kind: v1beta1.ClusterTaskKind},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}, {
 		desc: "pod template is nil",
 		trs:  &v1beta1.TaskRunSpec{},
 		want: &v1beta1.TaskRunSpec{
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}, {
 		desc: "pod template is not nil",
@@ -85,7 +89,8 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			},
 		},
 		want: &v1beta1.TaskRunSpec{
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			PodTemplate: &v1beta1.PodTemplate{
 				NodeSelector: map[string]string{
 					"label": "value",
@@ -108,7 +113,8 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 					Type: v1beta1.ParamTypeString,
 				}},
 			},
-			Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			ServiceAccountName: config.DefaultServiceAccountValue,
+			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
 	}}
 	for _, tc := range cases {
@@ -137,7 +143,8 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1beta1.TaskRunSpec{
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 	}, {
@@ -152,8 +159,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 	}, {
@@ -168,8 +176,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			},
 		},
 		wc: contexts.WithUpgradeViaDefaulting,
@@ -185,8 +194,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "tekton-pipelines"},
 			},
 			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {
@@ -243,8 +253,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "something-else"},
 			},
 			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {
@@ -275,8 +286,9 @@ func TestTaskRunDefaulting(t *testing.T) {
 				Labels: map[string]string{"app.kubernetes.io/managed-by": "user-specified"},
 			},
 			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
-				Timeout: &metav1.Duration{Duration: 5 * time.Minute},
+				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
 		wc: func(ctx context.Context) context.Context {

--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/credentials"
 	"github.com/tektoncd/pipeline/pkg/credentials/dockercreds"
@@ -43,8 +44,10 @@ const credsInitHomeMountPrefix = "tekton-creds-init-home"
 // caller. If no matching annotated secrets are found, nil lists with a
 // nil error are returned.
 func credsInit(serviceAccountName, namespace string, kubeclient kubernetes.Interface) ([]string, []corev1.Volume, []corev1.VolumeMount, error) {
+	// service account if not specified in pipeline/task spec, read it from the ConfigMap
+	// and defaults to `default` if its missing from the ConfigMap as well
 	if serviceAccountName == "" {
-		serviceAccountName = "default"
+		serviceAccountName = config.DefaultServiceAccountValue
 	}
 
 	sa, err := kubeclient.CoreV1().ServiceAccounts(namespace).Get(serviceAccountName, metav1.GetOptions{})

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -461,7 +461,8 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-success"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "unit-test-task-spec"),
-		tb.TaskRunSpec(tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep")))),
+		tb.TaskRunSpec(tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep"))),
+			tb.TaskRunServiceAccountName(config.DefaultServiceAccountValue)),
 	)
 
 	// ignore IgnoreUnexported ignore both after and before steps fields
@@ -3764,5 +3765,7 @@ func getTaskRunWithTaskSpec(tr, pr, p, t string, labels, annotations map[string]
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, t),
 		tb.TaskRunLabels(labels),
 		tb.TaskRunAnnotations(annotations),
-		tb.TaskRunSpec(tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep")))))
+		tb.TaskRunSpec(tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep"))),
+			tb.TaskRunServiceAccountName(config.DefaultServiceAccountValue),
+		))
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -569,6 +569,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-home-env",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-9l9zj",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -613,6 +614,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-working-dir",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-9l9zj",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -937,6 +939,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-9l9zj",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -1032,6 +1035,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-substitution",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(
 					workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 						Name:         "tekton-creds-init-home-78c5n",
@@ -1165,6 +1169,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-taskspec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-mz4c7",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -1238,6 +1243,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-cluster-task",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-9l9zj",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -1284,6 +1290,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-resource-spec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-mz4c7",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -1357,6 +1364,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-pod",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-9l9zj",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
@@ -1402,6 +1410,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-credentials-variable",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-9l9zj",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`Pipelinerun` can specify service account name in the specification. If its not specified, controller reads `default-service-account` from `config-defaults` ConfigMap. And if `config-defaults` is also missing `default-service-account`, service account is set to `default`. Before this PR, this `default` value was set in [creds-init.go](https://github.com/tektoncd/pipeline/blob/master/pkg/pod/creds_init.go#L47) just before creating the Pod. So the pod is created with `default` service account but pipelinerun/taskrun spec is not made aware of this change. Instead of delaying this decision/set until a pod is created, this PR is setting the service account as part of pipelinerun/taskrun spec. This brings consistency from the controller perspective while choosing the default service account when not explicitly specified in ConfigMap. 

To summarize, controller reads service account from `config-defaults` ConfigMap and sets it in the pipelinerun/taskrun spec if spec is missing service account. And now (with this PR) if service account is also missing from `config-defaults`, controller sets the service account to `default` in the spec.  

This was discovered while working on issue #2815 and PR #3160. 

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Service account when missing from pipelinerun/taskrun spec and ConfigMap, controller sets it to default in the spec.
```