### PR TITLE
Remove vendor-specific cluster setup instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,13 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 
 ## Before you begin
 
+1. You must have a Kubernetes cluster running version 1.16 or later.
+
+   If you don't already have a cluster, you can create one for testing with `kind`.
+   [Install `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and create a cluster by running [`kind create cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). This
+   will create a cluster running locally, with RBAC enabled and your user granted
+   the `cluster-admin` role.
+
 1. Choose the version of Tekton Pipelines you want to install. You have the following options:
 
    * **[Official](https://github.com/tektoncd/pipeline/releases)** - install this unless you have
@@ -21,21 +28,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
    * **[`HEAD`]** - this is the bleeding edge. It contains unreleased code that may result
      in unpredictable behavior. To get started, see the [development guide](https://github.com/tektoncd/pipeline/blob/master/DEVELOPMENT.md) instead of this page.
 
-2. If you don't have an existing Kubernetes cluster, set one up, version 1.16 or later:
-
-   ```bash
-   #Example command for creating a cluster on GKE
-   gcloud container clusters create $CLUSTER_NAME \
-     --zone=$CLUSTER_ZONE --cluster-version=latest
-   ```
-
-3. Grant `cluster-admin` permissions to the current user:
-
-   ```bash
-   kubectl create clusterrolebinding cluster-admin-binding \
-   --clusterrole=cluster-admin \
-   --user=$(gcloud config get-value core/account)
-   ```
+1. Grant `cluster-admin` permissions to the current user.
 
    See [Role-based access control](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control)
    for more information.


### PR DESCRIPTION
Instead, assume a cluster already exists, or briefly document using
`kind` to set up a local cluster for testing.

Rationale for this change (first in a series) is outlined in this doc (shared with tekton-dev@): https://docs.google.com/document/d/1sMt06g40Jt0Pr5g0Rgfe02az1A9FAFme8mf962UuSEQ/edit

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/assign @sergetron 