### PR TITLE
Support skipping single task only

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -82,6 +82,7 @@ spec:
           - input: "$(params.path)"
             operator: notin
             values: ["README.md"]
+        whenSkipped: RunBranch
         taskSpec:
           steps:
             - name: echo
@@ -99,6 +100,18 @@ spec:
             - name: echo
               image: ubuntu
               script: exit 1
+      - name: task-should-be-executed-after-skipped-parent-task # whenSkipped set to runBranch in parent task
+        runAfter:
+          - task-should-be-skipped-2
+        when:
+          - input: "$(params.path)"
+            operator: in
+            values: ["README.md"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: 'echo created README.md'
     finally:
       - name: finally-task-should-be-skipped-1 # when expression using execution status, evaluates to false
         when:

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -365,6 +365,15 @@ func PipelineTaskWhenExpression(input string, operator selection.Operator, value
 	}
 }
 
+// PipelineTaskWhenSkipped adds a WhenSkippedPolicy that describes should happen when a Task is skipped because its
+// WhenExpressions evaluated to false. WhenSkippedPolicy can be specified only in Tasks that are guarded with
+// WhenExpressions and do not have resource dependencies.
+func PipelineTaskWhenSkipped(whenSkippedPolicy v1beta1.WhenSkippedPolicy) PipelineTaskOp {
+	return func(pt *v1beta1.PipelineTask) {
+		pt.WhenSkipped = whenSkippedPolicy
+	}
+}
+
 // PipelineTaskWorkspaceBinding adds a workspace with the specified name, workspace and subpath on a PipelineTask.
 func PipelineTaskWorkspaceBinding(name, workspace, subPath string) PipelineTaskOp {
 	return func(pt *v1beta1.PipelineTask) {

--- a/internal/builder/v1beta1/pipeline_test.go
+++ b/internal/builder/v1beta1/pipeline_test.go
@@ -60,6 +60,16 @@ func TestPipeline(t *testing.T) {
 			tb.RunAfter("foo"),
 			tb.PipelineTaskTimeout(5*time.Second),
 		),
+		tb.PipelineTask("let-you-down", "let-you-down",
+			tb.PipelineTaskWhenExpression("foo", selection.In, []string{"bar"}),
+			tb.PipelineTaskWhenSkipped(v1beta1.RunBranch),
+			tb.RunAfter("foo"),
+			tb.PipelineTaskTimeout(5*time.Second),
+		),
+		tb.PipelineTask("make-you-cry", "make-you-cry",
+			tb.RunAfter("let-you-down"),
+			tb.PipelineTaskTimeout(5*time.Second),
+		),
 		tb.PipelineTask("foo", "", tb.PipelineTaskSpec(getTaskSpec())),
 		tb.PipelineTask("task-with-taskSpec", "",
 			tb.TaskSpecMetadata(v1beta1.PipelineTaskMetadata{
@@ -145,6 +155,18 @@ func TestPipeline(t *testing.T) {
 				WhenExpressions: []v1beta1.WhenExpression{{Input: "foo", Operator: selection.In, Values: []string{"foo", "bar"}}},
 				RunAfter:        []string{"foo"},
 				Timeout:         &metav1.Duration{Duration: 5 * time.Second},
+			}, {
+				Name:            "let-you-down",
+				TaskRef:         &v1beta1.TaskRef{Name: "let-you-down"},
+				WhenExpressions: []v1beta1.WhenExpression{{Input: "foo", Operator: selection.In, Values: []string{"bar"}}},
+				WhenSkipped:     v1beta1.RunBranch,
+				RunAfter:        []string{"foo"},
+				Timeout:         &metav1.Duration{Duration: 5 * time.Second},
+			}, {
+				Name:     "make-you-cry",
+				TaskRef:  &v1beta1.TaskRef{Name: "make-you-cry"},
+				RunAfter: []string{"let-you-down"},
+				Timeout:  &metav1.Duration{Duration: 5 * time.Second},
 			}, {
 				Name: "foo",
 				TaskSpec: &v1beta1.EmbeddedTask{

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2003,6 +2003,13 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 							},
 						},
 					},
+					"whenSkipped": {
+						SchemaProps: spec.SchemaProps{
+							Description: "WhenSkipped specifies what should happen when a Task is skipped because its WhenExpressions evaluated to false. WhenSkipped can be specified only in Tasks that are guarded with WhenExpressions and do not have resource dependencies. If WhenSkipped is not specified, the default policy is SkipBranch.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"retries": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False",

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -132,6 +132,12 @@ type PipelineTask struct {
 	// +optional
 	WhenExpressions WhenExpressions `json:"when,omitempty"`
 
+	// WhenSkipped specifies what should happen when a Task is skipped because its WhenExpressions evaluated to false.
+	// WhenSkipped can be specified only in Tasks that are guarded with WhenExpressions and do not have resource dependencies.
+	// If WhenSkipped is not specified, the default policy is SkipBranch.
+	// +optional
+	WhenSkipped WhenSkippedPolicy `json:"whenSkipped,omitempty"`
+
 	// Retries represents how many times this task should be retried in case of task failure: ConditionSucceeded set to False
 	// +optional
 	Retries int `json:"retries,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1270,6 +1270,10 @@
             "$ref": "#/definitions/v1beta1.WhenExpression"
           }
         },
+        "whenSkipped": {
+          "description": "WhenSkipped specifies what should happen when a Task is skipped because its WhenExpressions evaluated to false. WhenSkipped can be specified only in Tasks that are guarded with WhenExpressions and do not have resource dependencies. If WhenSkipped is not specified, the default policy is SkipBranch.",
+          "type": "string"
+        },
         "workspaces": {
           "description": "Workspaces maps workspaces from the pipeline spec to the workspaces declared in the Task.",
           "type": "array",

--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -159,3 +159,13 @@ func (wes WhenExpressions) ReplaceWhenExpressionsVariables(replacements map[stri
 	}
 	return replaced
 }
+
+// WhenSkippedPolicy describes what should happen when a Task is skipped because its WhenExpressions evaluated to false.
+// WhenSkippedPolicy can be specified only in Tasks that are guarded with WhenExpressions and do not have resource dependencies.
+// If none of the following policies is specified, the default one is SkipBranch.
+type WhenSkippedPolicy string
+
+const (
+	SkipBranch WhenSkippedPolicy = "SkipBranch"
+	RunBranch  WhenSkippedPolicy = "RunBranch"
+)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -212,7 +212,13 @@ func (t *ResolvedPipelineRunTask) parentTasksSkip(facts *PipelineRunFacts) bool 
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]
 	for _, p := range node.Prev {
-		if stateMap[p.Task.HashKey()].Skip(facts) {
+		parentTask := stateMap[p.Task.HashKey()]
+		if parentTask.Skip(facts) {
+			if parentTask.PipelineTask.WhenSkipped == v1beta1.RunBranch {
+				if parentTask.whenExpressionsSkip(facts) {
+					continue
+				}
+			}
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

When `WhenExpressions` evaluate to False, the guarded `Task` and
its branch (dependent `Tasks`) are skipped

A `Task` is dependent on and in the branch of another `Task` as specified
by ordering using `runAfter` or by resources using `Results`, `Workspaces`
 and `Resources`

In some use cases, when `WhenExpressions` evaluate to `False`,
users need to skip the guarded `Task` only and allow ordering-dependent
`Tasks` to execute

When  `WhenExpressions` evaluate to `False`, it is possible to allow for
execution of ordering-dependent `Tasks` as specified by `runAfter` using
the `whenSkipped` field by setting it to `runBranch`.

However, setting `whenSkipped` in `Tasks` without `WhenExpressions`
or `Tasks` with resource dependencies is invalid, and will cause
`Pipeline` validation errors. This ensures consistency in executing or
skipping subsequent tasks.

Further details in [TEP](https://github.com/tektoncd/community/blob/main/teps/0007-conditions-beta.md#skipping-1)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
When  `WhenExpressions` evaluate to `False`, it is possible to allow
execution of ordering-dependent `Tasks` as specified by `runAfter`
using the `whenSkipped` field by setting it to `runBranch`
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
