### PR TITLE
Enhance v1beta1 validation code for task 🍸

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -33,88 +33,52 @@ import (
 var _ apis.Validatable = (*Task)(nil)
 
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
-	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
-		return err.ViaField("metadata")
-	}
-	return t.Spec.Validate(ctx)
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 
-func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
-
+func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if len(ts.Steps) == 0 {
-		return apis.ErrMissingField("steps")
+		errs = errs.Also(apis.ErrMissingField("steps"))
 	}
-	if err := ValidateVolumes(ts.Volumes).ViaField("volumes"); err != nil {
-		return err
-	}
-	if err := ValidateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate); err != nil {
-		return err
-	}
+	errs = errs.Also(ValidateVolumes(ts.Volumes).ViaField("volumes"))
+	errs = errs.Also(ValidateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
 	mergedSteps, err := MergeStepsWithStepTemplate(ts.StepTemplate, ts.Steps)
 	if err != nil {
-		return &apis.FieldError{
+		errs = errs.Also(&apis.FieldError{
 			Message: fmt.Sprintf("error merging step template and steps: %s", err),
 			Paths:   []string{"stepTemplate"},
-		}
+			Details: err.Error(),
+		})
 	}
 
-	if err := validateSteps(mergedSteps).ViaField("steps"); err != nil {
-		return err
-	}
-
-	// Validate Resources declaration
-	if err := ts.Resources.Validate(ctx); err != nil {
-		return err
-	}
-
-	// Validate that the parameters type are correct
-	if err := ValidateParameterTypes(ts.Params); err != nil {
-		return err
-	}
-
-	// Validate task step names
-	for _, step := range ts.Steps {
-		if errs := validation.IsDNS1123Label(step.Name); step.Name != "" && len(errs) > 0 {
-			return &apis.FieldError{
-				Message: fmt.Sprintf("invalid value %q", step.Name),
-				Paths:   []string{"taskspec.steps.name"},
-				Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
-			}
-		}
-	}
-
-	if err := ValidateParameterVariables(ts.Steps, ts.Params); err != nil {
-		return err
-	}
-
-	if err := ValidateResourcesVariables(ts.Steps, ts.Resources); err != nil {
-		return err
-	}
-
-	if err := ValidateResults(ts.Results); err != nil {
-		return err
-	}
-
-	if err := validateTaskContextVariables(ts.Steps); err != nil {
-		return err
-	}
-
-	return nil
+	errs = errs.Also(validateSteps(mergedSteps).ViaField("steps"))
+	errs = errs.Also(ts.Resources.Validate(ctx).ViaField("resources"))
+	errs = errs.Also(ValidateParameterTypes(ts.Params).ViaField("params"))
+	errs = errs.Also(ValidateParameterVariables(ts.Steps, ts.Params))
+	errs = errs.Also(ValidateResourcesVariables(ts.Steps, ts.Resources))
+	errs = errs.Also(validateTaskContextVariables(ts.Steps))
+	errs = errs.Also(validateResults(ctx, ts.Results).ViaField("results"))
+	return errs
 }
 
-func ValidateResults(results []TaskResult) *apis.FieldError {
+func validateResults(ctx context.Context, results []TaskResult) (errs *apis.FieldError) {
 	for index, result := range results {
-		if !resultNameFormatRegex.MatchString(result.Name) {
-			return apis.ErrInvalidKeyName(result.Name, fmt.Sprintf("results[%d].name", index), fmt.Sprintf("Name must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '%s')", ResultNameFormat))
-		}
+		errs = errs.Also(result.Validate(ctx).ViaIndex(index))
 	}
+	return errs
+}
 
+func (tr TaskResult) Validate(_ context.Context) *apis.FieldError {
+	if !resultNameFormatRegex.MatchString(tr.Name) {
+		return apis.ErrInvalidKeyName(tr.Name, "name", fmt.Sprintf("Name must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '%s')", ResultNameFormat))
+	}
 	return nil
 }
 
 // a mount path which conflicts with any other declared workspaces, with the explicitly
 // declared volume mounts, or with the stepTemplate. The names must also be unique.
-func ValidateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step, stepTemplate *corev1.Container) *apis.FieldError {
+func ValidateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step, stepTemplate *corev1.Container) (errs *apis.FieldError) {
 	mountPaths := sets.NewString()
 	for _, step := range steps {
 		for _, vm := range step.VolumeMounts {
@@ -128,109 +92,113 @@ func ValidateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 	}
 
 	wsNames := sets.NewString()
-	for _, w := range workspaces {
+	for idx, w := range workspaces {
 		// Workspace names must be unique
 		if wsNames.Has(w.Name) {
-			return &apis.FieldError{
-				Message: fmt.Sprintf("workspace name %q must be unique", w.Name),
-				Paths:   []string{"workspaces.name"},
-			}
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("workspace name %q must be unique", w.Name), "name").ViaIndex(idx))
+		} else {
+			wsNames.Insert(w.Name)
 		}
-		wsNames.Insert(w.Name)
 		// Workspaces must not try to use mount paths that are already used
 		mountPath := filepath.Clean(w.GetMountPath())
 		if _, ok := mountPaths[mountPath]; ok {
-			return &apis.FieldError{
-				Message: fmt.Sprintf("workspace mount path %q must be unique", mountPath),
-				Paths:   []string{"workspaces.mountpath"},
-			}
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("workspace mount path %q must be unique", mountPath), "mountpath").ViaIndex(idx))
 		}
 		mountPaths[mountPath] = struct{}{}
 	}
-	return nil
+	return errs
 }
 
-func ValidateVolumes(volumes []corev1.Volume) *apis.FieldError {
+func ValidateVolumes(volumes []corev1.Volume) (errs *apis.FieldError) {
 	// Task must not have duplicate volume names.
 	vols := sets.NewString()
-	for _, v := range volumes {
+	for idx, v := range volumes {
 		if vols.Has(v.Name) {
-			return &apis.FieldError{
-				Message: fmt.Sprintf("multiple volumes with same name %q", v.Name),
-				Paths:   []string{"name"},
-			}
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("multiple volumes with same name %q", v.Name), "name").ViaIndex(idx))
+		} else {
+			vols.Insert(v.Name)
 		}
-		vols.Insert(v.Name)
 	}
-	return nil
+	return errs
 }
 
-func validateSteps(steps []Step) *apis.FieldError {
+func validateSteps(steps []Step) (errs *apis.FieldError) {
 	// Task must not have duplicate step names.
 	names := sets.NewString()
 	for idx, s := range steps {
-		if s.Image == "" {
-			return apis.ErrMissingField("Image")
-		}
-
-		if s.Script != "" {
-			if len(s.Command) > 0 {
-				return &apis.FieldError{
-					Message: fmt.Sprintf("step %d script cannot be used with command", idx),
-					Paths:   []string{"script"},
-				}
-			}
-		}
-
-		if s.Name != "" {
-			if names.Has(s.Name) {
-				return apis.ErrInvalidValue(s.Name, "name")
-			}
-			names.Insert(s.Name)
-		}
-
-		for _, vm := range s.VolumeMounts {
-			if strings.HasPrefix(vm.MountPath, "/tekton/") &&
-				!strings.HasPrefix(vm.MountPath, "/tekton/home") {
-				return &apis.FieldError{
-					Message: fmt.Sprintf("step %d volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", idx, vm.Name, vm.MountPath),
-					Paths:   []string{"volumeMounts.mountPath"},
-				}
-			}
-			if strings.HasPrefix(vm.Name, "tekton-internal-") {
-				return &apis.FieldError{
-					Message: fmt.Sprintf(`step %d volumeMount name %q cannot start with "tekton-internal-"`, idx, vm.Name),
-					Paths:   []string{"volumeMounts.name"},
-				}
-			}
-		}
+		errs = errs.Also(validateStep(s, names).ViaIndex(idx))
 	}
-	return nil
+	return errs
 }
 
-func ValidateParameterTypes(params []ParamSpec) *apis.FieldError {
-	for _, p := range params {
-		// Ensure param has a valid type.
-		validType := false
-		for _, allowedType := range AllParamTypes {
-			if p.Type == allowedType {
-				validType = true
-			}
-		}
-		if !validType {
-			return apis.ErrInvalidValue(p.Type, fmt.Sprintf("taskspec.params.%s.type", p.Name))
-		}
+func validateStep(s Step, names sets.String) (errs *apis.FieldError) {
+	if s.Image == "" {
+		errs = errs.Also(apis.ErrMissingField("Image"))
+	}
 
-		// If a default value is provided, ensure its type matches param's declared type.
-		if (p.Default != nil) && (p.Default.Type != p.Type) {
-			return &apis.FieldError{
-				Message: fmt.Sprintf(
-					"\"%v\" type does not match default value's type: \"%v\"", p.Type, p.Default.Type),
-				Paths: []string{
-					fmt.Sprintf("taskspec.params.%s.type", p.Name),
-					fmt.Sprintf("taskspec.params.%s.default.type", p.Name),
-				},
-			}
+	if s.Script != "" {
+		if len(s.Command) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("script cannot be used with command"),
+				Paths:   []string{"script"},
+			})
+		}
+	}
+
+	if s.Name != "" {
+		if names.Has(s.Name) {
+			errs = errs.Also(apis.ErrInvalidValue(s.Name, "name"))
+		}
+		if e := validation.IsDNS1123Label(s.Name); len(e) > 0 {
+			errs = errs.Also(&apis.FieldError{
+				Message: fmt.Sprintf("invalid value %q", s.Name),
+				Paths:   []string{"name"},
+				Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+			})
+		}
+		names.Insert(s.Name)
+	}
+
+	for j, vm := range s.VolumeMounts {
+		if strings.HasPrefix(vm.MountPath, "/tekton/") &&
+			!strings.HasPrefix(vm.MountPath, "/tekton/home") {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("volumeMount cannot be mounted under /tekton/ (volumeMount %q mounted at %q)", vm.Name, vm.MountPath), "mountPath").ViaFieldIndex("volumeMounts", j))
+		}
+		if strings.HasPrefix(vm.Name, "tekton-internal-") {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf(`volumeMount name %q cannot start with "tekton-internal-"`, vm.Name), "name").ViaFieldIndex("volumeMounts", j))
+		}
+	}
+	return errs
+}
+
+func ValidateParameterTypes(params []ParamSpec) (errs *apis.FieldError) {
+	for _, p := range params {
+		errs = errs.Also(p.ValidateType())
+	}
+	return errs
+}
+
+func (p ParamSpec) ValidateType() *apis.FieldError {
+	// Ensure param has a valid type.
+	validType := false
+	for _, allowedType := range AllParamTypes {
+		if p.Type == allowedType {
+			validType = true
+		}
+	}
+	if !validType {
+		return apis.ErrInvalidValue(p.Type, fmt.Sprintf("%s.type", p.Name))
+	}
+
+	// If a default value is provided, ensure its type matches param's declared type.
+	if (p.Default != nil) && (p.Default.Type != p.Type) {
+		return &apis.FieldError{
+			Message: fmt.Sprintf(
+				"\"%v\" type does not match default value's type: \"%v\"", p.Type, p.Default.Type),
+			Paths: []string{
+				fmt.Sprintf("%s.type", p.Name),
+				fmt.Sprintf("%s.default.type", p.Name),
+			},
 		}
 	}
 	return nil
@@ -247,10 +215,8 @@ func ValidateParameterVariables(steps []Step, params []ParamSpec) *apis.FieldErr
 		}
 	}
 
-	if err := validateVariables(steps, "params", parameterNames); err != nil {
-		return err
-	}
-	return validateArrayUsage(steps, "params", arrayParameterNames)
+	errs := validateVariables(steps, "params", parameterNames)
+	return errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
 }
 
 func validateTaskContextVariables(steps []Step) *apis.FieldError {
@@ -262,10 +228,8 @@ func validateTaskContextVariables(steps []Step) *apis.FieldError {
 	taskContextNames := sets.NewString().Insert(
 		"name",
 	)
-	if err := validateVariables(steps, "context\\.taskRun", taskRunContextNames); err != nil {
-		return err
-	}
-	return validateVariables(steps, "context\\.task", taskContextNames)
+	errs := validateVariables(steps, "context\\.taskRun", taskRunContextNames)
+	return errs.Also(validateVariables(steps, "context\\.task", taskContextNames))
 }
 
 func ValidateResourcesVariables(steps []Step, resources *TaskResources) *apis.FieldError {
@@ -286,102 +250,73 @@ func ValidateResourcesVariables(steps []Step, resources *TaskResources) *apis.Fi
 	return validateVariables(steps, "resources.(?:inputs|outputs)", resourceNames)
 }
 
-func validateArrayUsage(steps []Step, prefix string, vars sets.String) *apis.FieldError {
-	for _, step := range steps {
-		if err := validateTaskNoArrayReferenced("name", step.Name, prefix, vars); err != nil {
-			return err
-		}
-		if err := validateTaskNoArrayReferenced("image", step.Image, prefix, vars); err != nil {
-			return err
-		}
-		if err := validateTaskNoArrayReferenced("workingDir", step.WorkingDir, prefix, vars); err != nil {
-			return err
-		}
-		if err := validateTaskNoArrayReferenced("script", step.Script, prefix, vars); err != nil {
-			return err
-		}
-		for i, cmd := range step.Command {
-			if err := validateTaskArraysIsolated(fmt.Sprintf("command[%d]", i), cmd, prefix, vars); err != nil {
-				return err
-			}
-		}
-		for i, arg := range step.Args {
-			if err := validateTaskArraysIsolated(fmt.Sprintf("arg[%d]", i), arg, prefix, vars); err != nil {
-				return err
-			}
-		}
-		for _, env := range step.Env {
-			if err := validateTaskNoArrayReferenced(fmt.Sprintf("env[%s]", env.Name), env.Value, prefix, vars); err != nil {
-				return err
-			}
-		}
-		for i, v := range step.VolumeMounts {
-			if err := validateTaskNoArrayReferenced(fmt.Sprintf("volumeMount[%d].Name", i), v.Name, prefix, vars); err != nil {
-				return err
-			}
-			if err := validateTaskNoArrayReferenced(fmt.Sprintf("volumeMount[%d].MountPath", i), v.MountPath, prefix, vars); err != nil {
-				return err
-			}
-			if err := validateTaskNoArrayReferenced(fmt.Sprintf("volumeMount[%d].SubPath", i), v.SubPath, prefix, vars); err != nil {
-				return err
-			}
-		}
+func validateArrayUsage(steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
+	for idx, step := range steps {
+		errs = errs.Also(validateStepArrayUsage(step, prefix, vars)).ViaFieldIndex("steps", idx)
 	}
-	return nil
+	return errs
 }
 
-func validateVariables(steps []Step, prefix string, vars sets.String) *apis.FieldError {
-	for _, step := range steps {
-		if err := validateTaskVariable("name", step.Name, prefix, vars); err != nil {
-			return err
-		}
-		if err := validateTaskVariable("image", step.Image, prefix, vars); err != nil {
-			return err
-		}
-		if err := validateTaskVariable("workingDir", step.WorkingDir, prefix, vars); err != nil {
-			return err
-		}
-		if err := validateTaskVariable("script", step.Script, prefix, vars); err != nil {
-			return err
-		}
-		for i, cmd := range step.Command {
-			if err := validateTaskVariable(fmt.Sprintf("command[%d]", i), cmd, prefix, vars); err != nil {
-				return err
-			}
-		}
-		for i, arg := range step.Args {
-			if err := validateTaskVariable(fmt.Sprintf("arg[%d]", i), arg, prefix, vars); err != nil {
-				return err
-			}
-		}
-		for _, env := range step.Env {
-			if err := validateTaskVariable(fmt.Sprintf("env[%s]", env.Name), env.Value, prefix, vars); err != nil {
-				return err
-			}
-		}
-		for i, v := range step.VolumeMounts {
-			if err := validateTaskVariable(fmt.Sprintf("volumeMount[%d].Name", i), v.Name, prefix, vars); err != nil {
-				return err
-			}
-			if err := validateTaskVariable(fmt.Sprintf("volumeMount[%d].MountPath", i), v.MountPath, prefix, vars); err != nil {
-				return err
-			}
-			if err := validateTaskVariable(fmt.Sprintf("volumeMount[%d].SubPath", i), v.SubPath, prefix, vars); err != nil {
-				return err
-			}
-		}
+func validateStepArrayUsage(step Step, prefix string, vars sets.String) *apis.FieldError {
+	errs := validateTaskNoArrayReferenced(step.Name, prefix, vars).ViaField("name")
+	errs = errs.Also(validateTaskNoArrayReferenced(step.Image, prefix, vars).ViaField("image"))
+	errs = errs.Also(validateTaskNoArrayReferenced(step.WorkingDir, prefix, vars).ViaField("workingDir"))
+	errs = errs.Also(validateTaskNoArrayReferenced(step.Script, prefix, vars).ViaField("script"))
+	for i, cmd := range step.Command {
+		errs = errs.Also(validateTaskArraysIsolated(cmd, prefix, vars).ViaFieldIndex("command", i))
 	}
-	return nil
+	for i, arg := range step.Args {
+		errs = errs.Also(validateTaskArraysIsolated(arg, prefix, vars).ViaFieldIndex("args", i))
+
+	}
+	for _, env := range step.Env {
+		errs = errs.Also(validateTaskNoArrayReferenced(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range step.VolumeMounts {
+		errs = errs.Also(validateTaskNoArrayReferenced(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(validateTaskNoArrayReferenced(v.MountPath, prefix, vars).ViaField("mountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(validateTaskNoArrayReferenced(v.SubPath, prefix, vars).ViaField("subPath").ViaFieldIndex("volumeMount", i))
+	}
+	return errs
 }
 
-func validateTaskVariable(name, value, prefix string, vars sets.String) *apis.FieldError {
-	return substitution.ValidateVariable(name, value, prefix, "step", "taskspec.steps", vars)
+func validateVariables(steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
+	for idx, step := range steps {
+		errs = errs.Also(validateStepVariables(step, prefix, vars).ViaFieldIndex("steps", idx))
+	}
+	return errs
 }
 
-func validateTaskNoArrayReferenced(name, value, prefix string, arrayNames sets.String) *apis.FieldError {
-	return substitution.ValidateVariableProhibited(name, value, prefix, "step", "taskspec.steps", arrayNames)
+func validateStepVariables(step Step, prefix string, vars sets.String) *apis.FieldError {
+	errs := validateTaskVariable(step.Name, prefix, vars).ViaField("name")
+	errs = errs.Also(validateTaskVariable(step.Image, prefix, vars).ViaField("image"))
+	errs = errs.Also(validateTaskVariable(step.WorkingDir, prefix, vars).ViaField("workingDir"))
+	errs = errs.Also(validateTaskVariable(step.Script, prefix, vars).ViaField("script"))
+	for i, cmd := range step.Command {
+		errs = errs.Also(validateTaskVariable(cmd, prefix, vars).ViaFieldIndex("command", i))
+	}
+	for i, arg := range step.Args {
+		errs = errs.Also(validateTaskVariable(arg, prefix, vars).ViaFieldIndex("args", i))
+	}
+	for _, env := range step.Env {
+		errs = errs.Also(validateTaskVariable(env.Value, prefix, vars).ViaFieldKey("env", env.Name))
+	}
+	for i, v := range step.VolumeMounts {
+		errs = errs.Also(validateTaskVariable(v.Name, prefix, vars).ViaField("name").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(validateTaskVariable(v.MountPath, prefix, vars).ViaField("MountPath").ViaFieldIndex("volumeMount", i))
+		errs = errs.Also(validateTaskVariable(v.SubPath, prefix, vars).ViaField("SubPath").ViaFieldIndex("volumeMount", i))
+	}
+	return errs
 }
 
-func validateTaskArraysIsolated(name, value, prefix string, arrayNames sets.String) *apis.FieldError {
-	return substitution.ValidateVariableIsolated(name, value, prefix, "step", "taskspec.steps", arrayNames)
+func validateTaskVariable(value, prefix string, vars sets.String) *apis.FieldError {
+	return substitution.ValidateVariableP(value, prefix, vars)
+}
+
+func validateTaskNoArrayReferenced(value, prefix string, arrayNames sets.String) *apis.FieldError {
+	return substitution.ValidateVariableProhibitedP(value, prefix, arrayNames)
+}
+
+func validateTaskArraysIsolated(value, prefix string, arrayNames sets.String) *apis.FieldError {
+	return substitution.ValidateVariableIsolatedP(value, prefix, arrayNames)
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -30,14 +30,14 @@ import (
 
 var validResource = v1beta1.TaskResource{
 	ResourceDeclaration: v1beta1.ResourceDeclaration{
-		Name: "source",
+		Name: "validsource",
 		Type: "git",
 	},
 }
 
 var invalidResource = v1beta1.TaskResource{
 	ResourceDeclaration: v1beta1.ResourceDeclaration{
-		Name: "source",
+		Name: "invalidsource",
 		Type: "what",
 	},
 }
@@ -380,7 +380,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value: what`,
-			Paths:   []string{"taskspec.resources.inputs.source.type"},
+			Paths:   []string{"resources.inputs[0].invalidsource.type"},
 		},
 	}, {
 		name: "one invalid input resource",
@@ -392,7 +392,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value: what`,
-			Paths:   []string{"taskspec.resources.inputs.source.type"},
+			Paths:   []string{"resources.inputs[1].invalidsource.type"},
 		},
 	}, {
 		name: "duplicated inputs resources",
@@ -405,7 +405,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `expected exactly one, got both`,
-			Paths:   []string{"taskspec.resources.inputs.name"},
+			Paths:   []string{"resources.inputs.name"},
 		},
 	}, {
 		name: "invalid output resource",
@@ -417,7 +417,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value: what`,
-			Paths:   []string{"taskspec.resources.outputs.source.type"},
+			Paths:   []string{"resources.outputs[0].invalidsource.type"},
 		},
 	}, {
 		name: "one invalid output resource",
@@ -429,7 +429,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value: what`,
-			Paths:   []string{"taskspec.resources.outputs.source.type"},
+			Paths:   []string{"resources.outputs[1].invalidsource.type"},
 		},
 	}, {
 		name: "duplicated outputs resources",
@@ -442,7 +442,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `expected exactly one, got both`,
-			Paths:   []string{"taskspec.resources.outputs.name"},
+			Paths:   []string{"resources.outputs.name"},
 		},
 	}, {
 		name: "invalid param type",
@@ -462,7 +462,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value: invalidtype`,
-			Paths:   []string{"taskspec.params.param-with-invalid-type.type"},
+			Paths:   []string{"params.param-with-invalid-type.type"},
 		},
 	}, {
 		name: "param mismatching default/type 1",
@@ -477,7 +477,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `"array" type does not match default value's type: "string"`,
-			Paths:   []string{"taskspec.params.task.type", "taskspec.params.task.default.type"},
+			Paths:   []string{"params.task.type", "params.task.default.type"},
 		},
 	}, {
 		name: "param mismatching default/type 2",
@@ -492,7 +492,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `"string" type does not match default value's type: "array"`,
-			Paths:   []string{"taskspec.params.task.type", "taskspec.params.task.default.type"},
+			Paths:   []string{"params.task.type", "params.task.default.type"},
 		},
 	}, {
 		name: "invalid step",
@@ -516,7 +516,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `invalid value "replaceImage"`,
-			Paths:   []string{"taskspec.steps.name"},
+			Paths:   []string{"steps[0].name"},
 			Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
 		},
 	}, {
@@ -529,8 +529,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `non-existent variable in "--flag=$(params.inexistent)" for step arg[0]`,
-			Paths:   []string{"taskspec.steps.arg[0]"},
+			Message: `non-existent variable in "--flag=$(params.inexistent)"`,
+			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
 		name: "array used in unaccepted field",
@@ -551,8 +551,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.baz)" for step image`,
-			Paths:   []string{"taskspec.steps.image"},
+			Message: `variable type invalid in "$(params.baz)"`,
+			Paths:   []string{"steps[0].image"},
 		},
 	}, {
 		name: "array star used in unaccepted field",
@@ -573,8 +573,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.baz[*])" for step image`,
-			Paths:   []string{"taskspec.steps.image"},
+			Message: `variable type invalid in "$(params.baz[*])"`,
+			Paths:   []string{"steps[0].image"},
 		},
 	}, {
 		name: "array star used illegaly in script field",
@@ -597,8 +597,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 				}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable type invalid in "$(params.baz[*])" for step script`,
-			Paths:   []string{"taskspec.steps.script"},
+			Message: `variable type invalid in "$(params.baz[*])"`,
+			Paths:   []string{"steps[0].script"},
 		},
 	}, {
 		name: "array not properly isolated",
@@ -619,8 +619,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable is not properly isolated in "not isolated: $(params.baz)" for step arg[0]`,
-			Paths:   []string{"taskspec.steps.arg[0]"},
+			Message: `variable is not properly isolated in "not isolated: $(params.baz)"`,
+			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
 		name: "array star not properly isolated",
@@ -641,8 +641,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable is not properly isolated in "not isolated: $(params.baz[*])" for step arg[0]`,
-			Paths:   []string{"taskspec.steps.arg[0]"},
+			Message: `variable is not properly isolated in "not isolated: $(params.baz[*])"`,
+			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
 		name: "inferred array not properly isolated",
@@ -663,8 +663,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable is not properly isolated in "not isolated: $(params.baz)" for step arg[0]`,
-			Paths:   []string{"taskspec.steps.arg[0]"},
+			Message: `variable is not properly isolated in "not isolated: $(params.baz)"`,
+			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
 		name: "inferred array star not properly isolated",
@@ -685,8 +685,30 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `variable is not properly isolated in "not isolated: $(params.baz[*])" for step arg[0]`,
-			Paths:   []string{"taskspec.steps.arg[0]"},
+			Message: `variable is not properly isolated in "not isolated: $(params.baz[*])"`,
+			Paths:   []string{"steps[0].args[0]"},
+		},
+	}, {
+		name: "Inexistent param variable in volumeMount with existing",
+		fields: fields{
+			Params: []v1beta1.ParamSpec{
+				{
+					Name:        "foo",
+					Description: "param",
+					Default:     v1beta1.NewArrayOrString("default"),
+				},
+			},
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Name:  "mystep",
+				Image: "myimage",
+				VolumeMounts: []corev1.VolumeMount{{
+					Name: "$(params.inexistent)-foo",
+				}},
+			}}},
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "$(params.inexistent)-foo"`,
+			Paths:   []string{"steps[0].volumeMount[0].name"},
 		},
 	}, {
 		name: "Inexistent param variable with existing",
@@ -703,8 +725,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `non-existent variable in "$(params.foo) && $(params.inexistent)" for step arg[0]`,
-			Paths:   []string{"taskspec.steps.arg[0]"},
+			Message: `non-existent variable in "$(params.foo) && $(params.inexistent)"`,
+			Paths:   []string{"steps[0].args[0]"},
 		},
 	}, {
 		name: "Multiple volumes with same name",
@@ -718,7 +740,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: `multiple volumes with same name "workspace"`,
-			Paths:   []string{"volumes.name"},
+			Paths:   []string{"volumes[1].name"},
 		},
 	}, {
 		name: "step with script and command",
@@ -732,8 +754,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}},
 		},
 		expectedError: apis.FieldError{
-			Message: "step 0 script cannot be used with command",
-			Paths:   []string{"steps.script"},
+			Message: "script cannot be used with command",
+			Paths:   []string{"steps[0].script"},
 		},
 	}, {
 		name: "step volume mounts under /tekton/",
@@ -747,8 +769,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `step 0 volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/foo")`,
-			Paths:   []string{"steps.volumeMounts.mountPath"},
+			Message: `volumeMount cannot be mounted under /tekton/ (volumeMount "foo" mounted at "/tekton/foo")`,
+			Paths:   []string{"steps[0].volumeMounts[0].mountPath"},
 		},
 	}, {
 		name: "step volume mount name starts with tekton-internal-",
@@ -762,22 +784,24 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}}},
 		},
 		expectedError: apis.FieldError{
-			Message: `step 0 volumeMount name "tekton-internal-foo" cannot start with "tekton-internal-"`,
-			Paths:   []string{"steps.volumeMounts.name"},
+			Message: `volumeMount name "tekton-internal-foo" cannot start with "tekton-internal-"`,
+			Paths:   []string{"steps[0].volumeMounts[0].name"},
 		},
 	}, {
 		name: "declared workspaces names are not unique",
 		fields: fields{
 			Steps: validSteps,
 			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name: "same-workspace",
+				Name:      "same-workspace",
+				MountPath: "/foo",
 			}, {
-				Name: "same-workspace",
+				Name:      "same-workspace",
+				MountPath: "/bar",
 			}},
 		},
 		expectedError: apis.FieldError{
 			Message: "workspace name \"same-workspace\" must be unique",
-			Paths:   []string{"workspaces.name"},
+			Paths:   []string{"workspaces[1].name"},
 		},
 	}, {
 		name: "declared workspaces clash with each other",
@@ -793,7 +817,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: "workspace mount path \"/foo\" must be unique",
-			Paths:   []string{"workspaces.mountpath"},
+			Paths:   []string{"workspaces[1].mountpath"},
 		},
 	}, {
 		name: "workspace mount path already in volumeMounts",
@@ -815,7 +839,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: "workspace mount path \"/foo\" must be unique",
-			Paths:   []string{"workspaces.mountpath"},
+			Paths:   []string{"workspaces[0].mountpath"},
 		},
 	}, {
 		name: "workspace default mount path already in volumeMounts",
@@ -836,7 +860,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: "workspace mount path \"/workspace/some-workspace\" must be unique",
-			Paths:   []string{"workspaces.mountpath"},
+			Paths:   []string{"workspaces[0].mountpath"},
 		},
 	}, {
 		name: "workspace mount path already in stepTemplate",
@@ -855,7 +879,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: "workspace mount path \"/foo\" must be unique",
-			Paths:   []string{"workspaces.mountpath"},
+			Paths:   []string{"workspaces[0].mountpath"},
 		},
 	}, {
 		name: "workspace default mount path already in stepTemplate",
@@ -873,7 +897,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 		},
 		expectedError: apis.FieldError{
 			Message: "workspace mount path \"/workspace/some-workspace\" must be unique",
-			Paths:   []string{"workspaces.mountpath"},
+			Paths:   []string{"workspaces[0].mountpath"},
 		},
 	}, {
 		name: "result name not validate",
@@ -890,7 +914,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Details: "Name must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')",
 		},
 	}, {
-		name: "context  not validate",
+		name: "context not validate",
 		fields: fields{
 			Steps: []v1beta1.Step{{
 				Container: corev1.Container{
@@ -903,8 +927,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}},
 		},
 		expectedError: apis.FieldError{
-			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env  bash\n\t\t\t\thello \"$(context.task.missing)\"" for step script`,
-			Paths:   []string{"taskspec.steps.script"},
+			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env  bash\n\t\t\t\thello \"$(context.task.missing)\""`,
+			Paths:   []string{"steps[0].script"},
 		},
 	}}
 	for _, tt := range tests {
@@ -924,7 +948,8 @@ func TestTaskSpecValidateError(t *testing.T) {
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}
-			if d := cmp.Diff(tt.expectedError, *err, cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+			t.Logf("the error(s): %v (%v)", *err, err.Error())
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -55,7 +55,7 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	// Validate TaskSpec if it's present
 	if ts.TaskSpec != nil {
-		if err := ts.TaskSpec.Validate(ctx); err != nil {
+		if err := ts.TaskSpec.Validate(ctx).ViaField("taskspec"); err != nil {
 			return err
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -182,7 +182,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		},
 		wantErr: &apis.FieldError{
 			Message: `invalid value "invalid-name-with-$weird-char/%"`,
-			Paths:   []string{"taskspec.steps.name"},
+			Paths:   []string{"taskspec.steps[0].name"},
 			Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
 		},
 	}, {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Opening this to gather some feedback.

This make a better use of knative.dev/pkg apis errors package in order
to make the code simpler, *and* the report better.

- This allows reporting multiple validation error at once — so, one
  failure message (webhook error) would be more useful to the user.
- This enhance the report as it displays more information, like
  `resources.inputs[0].invalidsource.type` instead of
  `resources.inputs.source.type` (the index appear, it's easier for the
  user to know where the error is).
- This reduce `if err != nil` path, simplifying the code.

/hold

- This needs more work (at least on this package)
- <del>Tests that depends on some of this may fail, I need to fix it</del>
- It's gonna be really useful on function like [`validateVariables`](https://github.com/tektoncd/pipeline/blob/master/pkg/apis/pipeline/v1beta1/task_validation.go#L333) — it's now used there :wink: 
- This PR would only do the `Task` part (without moving too much code away), follow-up includes
  - applying this to the rest of the `v1beta1` package
  - extract some code into more files (those are big files, lot's of stuff could be extracted) and more functions
  - make a pass on what is exported, and why

/cc @afrittoli @bobcatfish @sbwsg @nikhil-thomas 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


 ```release-note
 Task validation now reports all the error at once, and is a bit more detailed.
 ```