### PR TITLE
Add nop-image to release instructions

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -38,8 +38,7 @@ To make a new release:
 
 To use [`tkn`](https://github.com/tektoncd/cli) to run the `publish-tekton-pipelines` `Task` and create a release:
 
-1. Pick the revision you want to release and update the
-   [`resources.yaml`](./resources.yaml) file to add a
+1. Pick the revision you want to release and add a
    `PipelineResoruce` for it, e.g.:
 
    ```yaml
@@ -113,6 +112,7 @@ To use [`tkn`](https://github.com/tektoncd/cli) to run the `publish-tekton-pipel
 		--resource=builtPullRequestInitImage=pull-request-init-image \
 		--resource=builtGcsFetcherImage=gcs-fetcher-image \
 		--resource=notification=post-release-trigger \
+		--resource=builtNopImage=nop-image \
 		pipeline-release
    ```
 


### PR DESCRIPTION
# Changes

In #3025 the nop-image was added to our release pipeline, this commit
updates our README to include an example that sets it.

Also removed the reference to resources.yaml from the instructions b/c
imo opening that file and modifying it is more confusing than helpful;
feels like it makes more sense to create a new PipelineResource instance
without bothering with that file.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```