### PR TITLE
Makefile: fix the all target 🎪

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,11 @@ M = $(shell printf "\033[34;1m🐱\033[0m")
 
 export GO111MODULE=on
 
+COMMANDS=$(patsubst cmd/%,%,$(wildcard cmd/*))
+BINARIES=$(addprefix bin/,$(COMMANDS))
+
 .PHONY: all
-all: fmt lint | $(BIN) ; $(info $(M) building executable…) @ ## Build program binary
-	$Q $(GO) build \
-		-tags release \
-		-ldflags '-X $(MODULE)/cmd.Version=$(VERSION) -X $(MODULE)/cmd.BuildDate=$(DATE)' \
-		-o $(BIN)/$(basename $(MODULE)) main.go
+all: fmt $(BINARIES) | $(BIN) ; $(info $(M) building executable…) @ ## Build program binary
 
 $(BIN):
 	@mkdir -p $@
@@ -38,7 +37,7 @@ $(BIN)/%: | $(BIN) ; $(info $(M) building $(PACKAGE)…)
 FORCE:
 
 bin/%: cmd/% FORCE
-	$(GO) build -mod=vendor $(LDFLAGS) -v -o $@ ./$<
+	$Q $(GO) build -mod=vendor $(LDFLAGS) -v -o $@ ./$<
 
 .PHONY: cross
 cross: amd64 arm arm64 s390x ppc64le ## build cross platform binaries


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Running `make` should now succeed (and build all `cmd/*` 🙃)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @chmouel @sbwsg 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

/kind misc