### PR TITLE
Add more details on using Results in WhenExpressions

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -45,22 +45,22 @@ spec:
           - name: source
             description: The workspace to check for the file
         results:
-          - name: status
+          - name: exists
             description: indicates whether the file exists or is missing
         steps:
           - name: check-file
             image: alpine
             script: |
               if test -f $(workspaces.source.path)/$(params.path); then
-                printf exists | tee /tekton/results/status
+                printf yes | tee /tekton/results/exists
               else
-                printf missing | tee /tekton/results/status
+                printf no | tee /tekton/results/exists
               fi
     - name: echo-file-exists
       when:
-        - input: "$(tasks.check-file.results.status)"
+        - input: "$(tasks.check-file.results.exists)"
           operator: in
-          values: ["exists"]
+          values: ["yes"]
       taskSpec:
         steps:
           - name: echo


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Add more information to the docs about using `Results` in `WhenExpressions`.

Specifically:
- add details and examples on how `Results` are used in `WhenExpressions` in addition to `Parameters`
- change the name of the result used in the `WhenExpressions` examples, from `status` to `exists` to clarify that it's not the task status

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
    NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
