### PR TITLE
Update e2e cancellation tests

### DIFF
--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -24,105 +24,66 @@ import (
 	"sync"
 	"testing"
 
-	jsonpatch "gomodules.xyz/jsonpatch/v2"
-
-	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	knativetest "knative.dev/pkg/test"
 )
 
-// TestTaskRunPipelineRunCancel is an integration test that will
-// verify that pipelinerun cancel lead to the the correct TaskRun statuses
-// and pod deletions.
+// TestTaskRunPipelineRunCancel cancels a PipelineRun and verifies TaskRun statuses and Pod deletions.
 func TestTaskRunPipelineRunCancel(t *testing.T) {
-	type tests struct {
-		name    string
-		retries bool
-	}
-
-	tds := []tests{
-		{
-			name:    "With retries",
-			retries: true,
-		}, {
-			name:    "No retries",
-			retries: false,
-		},
-	}
-
-	t.Parallel()
-
-	for _, tdd := range tds {
-		t.Run(tdd.name, func(t *testing.T) {
-			tdd := tdd
-			pipelineTask := v1beta1.PipelineTask{
-				Name:    "foo",
-				TaskRef: &v1beta1.TaskRef{Name: "banana"},
-			}
-			if tdd.retries {
-				pipelineTask.Retries = 1
-			}
-
+	// We run the test twice, once with a PipelineTask configured to retry
+	// on failure, to ensure that cancelling the PipelineRun doesn't cause
+	// the retrying TaskRun to retry.
+	for _, numRetries := range []int{0, 1} {
+		t.Run(fmt.Sprintf("retries=%d", numRetries), func(t *testing.T) {
 			c, namespace := setup(t)
 			t.Parallel()
 
 			knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 			defer tearDown(t, c, namespace)
 
-			t.Logf("Creating Task in namespace %s", namespace)
-			task := &v1beta1.Task{
-				ObjectMeta: metav1.ObjectMeta{Name: "banana", Namespace: namespace},
-				Spec: v1beta1.TaskSpec{
-					Steps: []v1beta1.Step{{Container: corev1.Container{
-						Image:   "ubuntu",
-						Command: []string{"/bin/bash"},
-						Args:    []string{"-c", "sleep 5000"},
-					}}},
-				},
-			}
-			if _, err := c.TaskClient.Create(task); err != nil {
-				t.Fatalf("Failed to create Task `banana`: %s", err)
-			}
-
-			t.Logf("Creating Pipeline in namespace %s", namespace)
-			pipeline := &v1beta1.Pipeline{
-				ObjectMeta: metav1.ObjectMeta{Name: "tomatoes", Namespace: namespace},
-				Spec: v1beta1.PipelineSpec{
-					Tasks: []v1beta1.PipelineTask{pipelineTask},
-				},
-			}
-			if _, err := c.PipelineClient.Create(pipeline); err != nil {
-				t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
-			}
-
+			pipelineRunName := "cancel-me"
 			pipelineRun := &v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{Name: "pear", Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName},
 				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{Name: pipeline.Name},
+					PipelineSpec: &v1beta1.PipelineSpec{
+						Tasks: []v1beta1.PipelineTask{{
+							Name:    "task",
+							Retries: numRetries,
+							TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: &v1beta1.TaskSpec{
+								Steps: []v1beta1.Step{{
+									Container: corev1.Container{
+										Image: "busybox",
+									},
+									Script: "sleep 5000",
+								}},
+							}},
+						}},
+					},
 				},
 			}
 
 			t.Logf("Creating PipelineRun in namespace %s", namespace)
 			if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
-				t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
+				t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRunName, err)
 			}
 
-			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", "pear", namespace)
-			if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, Running("pear"), "PipelineRunRunning"); err != nil {
-				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", "pear", err)
+			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRunName, namespace)
+			if err := WaitForPipelineRunState(c, pipelineRunName, pipelineRunTimeout, Running(pipelineRunName), "PipelineRunRunning"); err != nil {
+				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRunName, err)
 			}
 
-			taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=pear"})
+			taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
 			if err != nil {
-				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", "pear", err)
+				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
 			}
 
 			var wg sync.WaitGroup
 			var trName []string
-			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", "pear", namespace)
+			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRunName, namespace)
 			for _, taskrunItem := range taskrunList.Items {
 				trName = append(trName, taskrunItem.Name)
 				wg.Add(1)
@@ -136,9 +97,9 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 			wg.Wait()
 
-			pr, err := c.PipelineRunClient.Get("pear", metav1.GetOptions{})
+			pr, err := c.PipelineRunClient.Get(pipelineRunName, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Failed to get PipelineRun `%s`: %s", "pear", err)
+				t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRunName, err)
 			}
 
 			patches := []jsonpatch.JsonPatchOperation{{
@@ -151,36 +112,28 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				t.Fatalf("failed to marshal patch bytes in order to cancel")
 			}
 			if _, err := c.PipelineRunClient.Patch(pr.Name, types.JSONPatchType, patchBytes, ""); err != nil {
-				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", "pear", err)
+				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRunName, err)
 			}
 
-			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
-			if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", "pear"), "PipelineRunCancelled"); err != nil {
-				t.Errorf("Error waiting for PipelineRun `pear` to finished: %s", err)
+			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRunName, namespace)
+			if err := WaitForPipelineRunState(c, pipelineRunName, pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", pipelineRunName), "PipelineRunCancelled"); err != nil {
+				t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRunName, err)
 			}
 
-			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
+			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", pipelineRunName, namespace)
 			for _, taskrunItem := range taskrunList.Items {
 				wg.Add(1)
 				go func(name string) {
 					defer wg.Done()
-					err := WaitForTaskRunState(c, name, FailedWithReason(v1beta1.TaskRunReasonCancelled.String(), name), v1beta1.TaskRunReasonCancelled.String())
+					err := WaitForTaskRunState(c, name, FailedWithReason("TaskRunCancelled", name), "TaskRunCancelled")
 					if err != nil {
 						t.Errorf("Error waiting for TaskRun %s to be finished: %v", name, err)
-					}
-					for _, step := range taskrunItem.Status.Steps {
-						if step.Terminated == nil {
-							t.Errorf("TaskRun %s step %s does not have a terminated state but should", name, step.Name)
-						}
-						if d := cmp.Diff(step.Terminated.Reason, string(v1beta1.TaskRunReasonCancelled)); d != "" {
-							t.Fatalf("-got, +want: %v", d)
-						}
 					}
 				}(taskrunItem.Name)
 			}
 			wg.Wait()
 
-			matchKinds := map[string][]string{"PipelineRun": {"pear"}, "TaskRun": trName}
+			matchKinds := map[string][]string{"PipelineRun": {pipelineRunName}, "TaskRun": trName}
 			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
 			expectedNumberOfEvents := 1 + len(trName)
 			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)

--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -24,85 +24,67 @@ import (
 	"sync"
 	"testing"
 
-	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"gomodules.xyz/jsonpatch/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	knativetest "knative.dev/pkg/test"
 )
 
-// TestTaskRunPipelineRunCancel is an integration test that will
-// verify that pipelinerun cancel lead to the the correct TaskRun statuses
-// and pod deletions.
+// TestTaskRunPipelineRunCancel cancels a PipelineRun and verifies TaskRun statuses and Pod deletions.
 func TestTaskRunPipelineRunCancel(t *testing.T) {
-	type tests struct {
-		name    string
-		retries bool
-	}
-
-	tds := []tests{
-		{
-			name:    "With retries",
-			retries: true,
-		}, {
-			name:    "No retries",
-			retries: false,
-		},
-	}
-
-	t.Parallel()
-
-	for _, tdd := range tds {
-		t.Run(tdd.name, func(t *testing.T) {
-			tdd := tdd
-			var pipelineTask = tb.PipelineTask("foo", "banana")
-			if tdd.retries {
-				pipelineTask = tb.PipelineTask("foo", "banana", tb.Retries(1))
-			}
-
+	// We run the test twice, once with a PipelineTask configured to retry
+	// on failure, to ensure that cancelling the PipelineRun doesn't cause
+	// the retrying TaskRun to retry.
+	for _, numRetries := range []int{0, 1} {
+		t.Run(fmt.Sprintf("retries=%d", numRetries), func(t *testing.T) {
 			c, namespace := setup(t)
 			t.Parallel()
 
 			knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
 			defer tearDown(t, c, namespace)
 
-			t.Logf("Creating Task in namespace %s", namespace)
-			task := tb.Task("banana", tb.TaskSpec(
-				tb.Step("ubuntu", tb.StepCommand("/bin/bash"), tb.StepArgs("-c", "sleep 5000")),
-			))
-			if _, err := c.TaskClient.Create(task); err != nil {
-				t.Fatalf("Failed to create Task `banana`: %s", err)
+			pipelineRunName := "cancel-me"
+			pipelineRun := &v1alpha1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName},
+				Spec: v1alpha1.PipelineRunSpec{
+					PipelineSpec: &v1alpha1.PipelineSpec{
+						Tasks: []v1alpha1.PipelineTask{{
+							Name:    "task",
+							Retries: numRetries,
+							TaskSpec: &v1alpha1.TaskSpec{TaskSpec: v1beta1.TaskSpec{
+								Steps: []v1beta1.Step{{
+									Container: corev1.Container{
+										Image: "busybox",
+									},
+									Script: "sleep 5000",
+								}},
+							}},
+						}},
+					},
+				},
 			}
-
-			t.Logf("Creating Pipeline in namespace %s", namespace)
-			pipeline := tb.Pipeline("tomatoes",
-				tb.PipelineSpec(pipelineTask),
-			)
-			if _, err := c.PipelineClient.Create(pipeline); err != nil {
-				t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
-			}
-
-			pipelineRun := tb.PipelineRun("pear", tb.PipelineRunSpec(pipeline.Name))
 
 			t.Logf("Creating PipelineRun in namespace %s", namespace)
 			if _, err := c.PipelineRunClient.Create(pipelineRun); err != nil {
-				t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
+				t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRunName, err)
 			}
 
-			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", "pear", namespace)
-			if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, Running("pear"), "PipelineRunRunning"); err != nil {
-				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", "pear", err)
+			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRunName, namespace)
+			if err := WaitForPipelineRunState(c, pipelineRunName, pipelineRunTimeout, Running(pipelineRunName), "PipelineRunRunning"); err != nil {
+				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRunName, err)
 			}
 
-			taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=pear"})
+			taskrunList, err := c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
 			if err != nil {
-				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", "pear", err)
+				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
 			}
 
 			var wg sync.WaitGroup
 			var trName []string
-			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", "pear", namespace)
+			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRunName, namespace)
 			for _, taskrunItem := range taskrunList.Items {
 				trName = append(trName, taskrunItem.Name)
 				wg.Add(1)
@@ -116,9 +98,9 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 			wg.Wait()
 
-			pr, err := c.PipelineRunClient.Get("pear", metav1.GetOptions{})
+			pr, err := c.PipelineRunClient.Get(pipelineRunName, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Failed to get PipelineRun `%s`: %s", "pear", err)
+				t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRunName, err)
 			}
 
 			patches := []jsonpatch.JsonPatchOperation{{
@@ -131,15 +113,15 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				t.Fatalf("failed to marshal patch bytes in order to cancel")
 			}
 			if _, err := c.PipelineRunClient.Patch(pr.Name, types.JSONPatchType, patchBytes, ""); err != nil {
-				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", "pear", err)
+				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRunName, err)
 			}
 
-			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
-			if err := WaitForPipelineRunState(c, "pear", pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", "pear"), "PipelineRunCancelled"); err != nil {
-				t.Errorf("Error waiting for PipelineRun `pear` to finished: %s", err)
+			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRunName, namespace)
+			if err := WaitForPipelineRunState(c, pipelineRunName, pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", pipelineRunName), "PipelineRunCancelled"); err != nil {
+				t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRunName, err)
 			}
 
-			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", "pear", namespace)
+			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", pipelineRunName, namespace)
 			for _, taskrunItem := range taskrunList.Items {
 				wg.Add(1)
 				go func(name string) {
@@ -152,7 +134,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 			wg.Wait()
 
-			matchKinds := map[string][]string{"PipelineRun": {"pear"}, "TaskRun": trName}
+			matchKinds := map[string][]string{"PipelineRun": {pipelineRunName}, "TaskRun": trName}
 			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
 			expectedNumberOfEvents := 1 + len(trName)
 			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)


### PR DESCRIPTION
- don't use test builders
- create PipelineRuns directly, with specs inline
- copy v1alpha1 version of test to v1beta1

#3178 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```