### PR TITLE
Clean up multiarch_utils.go

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -116,8 +116,6 @@ type waitFunc func(t *testing.T, c *clients, name string)
 
 func exampleTest(path string, waitValidateFunc waitFunc, kind string) func(t *testing.T) {
 	return func(t *testing.T) {
-		SkipIfExcluded(t)
-
 		t.Parallel()
 
 		// Setup unique namespaces for each test so they can run in complete

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -41,7 +41,7 @@ const (
 // TestGitPipelineRun is an integration test that will verify the source code is either fetched or pulled
 // successfully under different revision inputs (branch, commitid, tag, ref)
 func TestGitPipelineRun(t *testing.T) {
-	SkipIfExcluded(t)
+	skipIfExcluded(t)
 
 	t.Parallel()
 
@@ -84,7 +84,7 @@ func TestGitPipelineRun(t *testing.T) {
 
 // Test revision fetching with refspec specified
 func TestGitPipelineRunWithRefspec(t *testing.T) {
-	SkipIfExcluded(t)
+	skipIfExcluded(t)
 
 	t.Parallel()
 
@@ -307,7 +307,7 @@ func TestGitPipelineRunFail_HTTPS_PROXY(t *testing.T) {
 // successfully under different revision inputs (default branch, branch)
 // This test will run on spring-petclinic repository which does not contain a master branch as the default branch
 func TestGitPipelineRunWithNonMasterBranch(t *testing.T) {
-	SkipIfExcluded(t)
+	skipIfExcluded(t)
 
 	t.Parallel()
 

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -34,13 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	knativetest "knative.dev/pkg/test"
-	"knative.dev/pkg/test/logging"
-
-	// Mysteriously by k8s libs, or they fail to create `KubeClient`s from config. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	// Mysteriously by k8s libs, or they fail to create `KubeClient`s when using oidc authentication. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/345
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // Mysteriously by k8s libs, or they fail to create `KubeClient`s when using oidc authentication. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/345
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/logging" // Mysteriously by k8s libs, or they fail to create `KubeClient`s from config. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
 )
 
 var initMetrics sync.Once
@@ -51,7 +48,7 @@ func init() {
 }
 
 func setup(t *testing.T, fn ...func(*testing.T, *clients, string)) (*clients, string) {
-	SkipIfExcluded(t)
+	skipIfExcluded(t)
 
 	t.Helper()
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -174,7 +174,7 @@ func getTask(repo, namespace string) *v1beta1.Task {
 			}}},
 			Sidecars: []v1beta1.Sidecar{{Container: corev1.Container{
 				Name:  "registry",
-				Image: GetTestImage(Registry),
+				Image: getTestImage(registryImage),
 			}}},
 		},
 	}

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -209,8 +209,6 @@ func TestPipelineRun(t *testing.T) {
 		t.Run(td.name, func(t *testing.T) {
 			td := td
 
-			SkipIfExcluded(t)
-
 			t.Parallel()
 			c, namespace := setup(t)
 

--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -67,7 +67,7 @@ func getRegistryDeployment(namespace string) *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "registry",
-						Image: GetTestImage(Registry),
+						Image: getTestImage(registryImage),
 					}},
 				},
 			},

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -125,7 +125,7 @@ func TestTaskRunStatus(t *testing.T) {
 
 	taskRunName := "status-taskrun"
 
-	fqImageName := GetTestImage(BusyboxSha)
+	fqImageName := getTestImage(busyboxImage)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
 	task := &v1beta1.Task{


### PR DESCRIPTION
- unexport a bunch of stuff that doesn't need to be exported
- use sets.NewString instead of map[string]bool
- remove skipIfExcluded from things that already call setup()

/cc @barthy1 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```