### PR TITLE
Omit cleaning up the Affinity Assistant if disabled

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -84,7 +84,13 @@ func getClaimName(w v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReferen
 	return ""
 }
 
-func (c *Reconciler) cleanupAffinityAssistants(pr *v1beta1.PipelineRun) error {
+func (c *Reconciler) cleanupAffinityAssistants(ctx context.Context, pr *v1beta1.PipelineRun) error {
+
+	// omit cleanup if the feature is disabled
+	if c.isAffinityAssistantDisabled(ctx) {
+		return nil
+	}
+
 	var errs []error
 	for _, w := range pr.Spec.Workspaces {
 		if w.PersistentVolumeClaim != nil || w.VolumeClaimTemplate != nil {

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -67,7 +67,7 @@ func TestCreateAndDeleteOfAffinityAssistant(t *testing.T) {
 		t.Errorf("unexpected error when retrieving StatefulSet: %v", err)
 	}
 
-	err = c.cleanupAffinityAssistants(testPipelineRun)
+	err = c.cleanupAffinityAssistants(context.Background(), testPipelineRun)
 	if err != nil {
 		t.Errorf("unexpected error from cleanupAffinityAssistants: %v", err)
 	}
@@ -143,6 +143,50 @@ func TestThatAffinityAssistantNameIsNoLongerThan53(t *testing.T) {
 
 	if len(affinityAssistantName) > 53 {
 		t.Errorf("affinity assistant name can not be longer than 53 chars")
+	}
+}
+
+// TestThatCleanupIsAvoidedIfAssistantIsDisabled tests that
+// cleanup of Affinity Assistants is omitted when the
+// Affinity Assistant is disabled
+func TestThatCleanupIsAvoidedIfAssistantIsDisabled(t *testing.T) {
+	testPipelineRun := &v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pipelinerun",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			Workspaces: []v1beta1.WorkspaceBinding{{
+				Name: "test-workspace",
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: "myclaim",
+				},
+			}},
+		},
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.GetNamespace()},
+		Data: map[string]string{
+			featureFlagDisableAffinityAssistantKey: "true",
+		},
+	}
+
+	fakeClientSet := fakek8s.NewSimpleClientset(
+		configMap,
+	)
+
+	c := Reconciler{
+		KubeClientSet: fakeClientSet,
+		Images:        pipeline.Images{},
+	}
+	store := config.NewStore(logtesting.TestLogger(t))
+	store.OnConfigChanged(configMap)
+
+	_ = c.cleanupAffinityAssistants(store.ToContext(context.Background()), testPipelineRun)
+
+	if len(fakeClientSet.Actions()) != 0 {
+		t.Errorf("Expected 0 k8s client requests, did %d request", len(fakeClientSet.Actions()))
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -167,7 +167,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 			logger.Errorf("Failed to delete PVC for PipelineRun %s: %v", pr.Name, err)
 			return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 		}
-		if err := c.cleanupAffinityAssistants(pr); err != nil {
+		if err := c.cleanupAffinityAssistants(ctx, pr); err != nil {
 			logger.Errorf("Failed to delete StatefulSet for PipelineRun %s: %v", pr.Name, err)
 			return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 		}


### PR DESCRIPTION
# Changes

This commit introduces a check if the Assistant is
disabled, and only cleanup the Assistant if disabled

Related to #3212
/kind cleanup

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
```release-note
NONE
```