### PR TITLE
Add docs for v0.16.x 📝

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ a cluster with **Kubernetes version 1.16 or later***.
 | Version | Docs | Examples |
 | ------- | ---- | -------- |
 | [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
+| [v0.16.2](https://github.com/tektoncd/pipeline/releases/tag/v0.16.2) | [Docs @ v0.16.2](https://github.com/tektoncd/pipeline/tree/v0.16.2/docs#tekton-pipelines) | [Examples @ v0.16.2](https://github.com/tektoncd/pipeline/tree/v0.16.2/examples#examples) |
+| [v0.16.1](https://github.com/tektoncd/pipeline/releases/tag/v0.16.1) | [Docs @ v0.16.1](https://github.com/tektoncd/pipeline/tree/v0.16.1/docs#tekton-pipelines) | [Examples @ v0.16.1](https://github.com/tektoncd/pipeline/tree/v0.16.1/examples#examples) |
+| [v0.16.0](https://github.com/tektoncd/pipeline/releases/tag/v0.16.0) | [Docs @ v0.16.0](https://github.com/tektoncd/pipeline/tree/v0.16.0/docs#tekton-pipelines) | [Examples @ v0.16.0](https://github.com/tektoncd/pipeline/tree/v0.16.0/examples#examples) |
 | [v0.15.2](https://github.com/tektoncd/pipeline/releases/tag/v0.15.2) | [Docs @ v0.15.2](https://github.com/tektoncd/pipeline/tree/v0.15.2/docs#tekton-pipelines) | [Examples @ v0.15.2](https://github.com/tektoncd/pipeline/tree/v0.15.2/examples#examples) |
 | [v0.15.1](https://github.com/tektoncd/pipeline/releases/tag/v0.15.1) | [Docs @ v0.15.1](https://github.com/tektoncd/pipeline/tree/v0.15.1/docs#tekton-pipelines) | [Examples @ v0.15.1](https://github.com/tektoncd/pipeline/tree/v0.15.1/examples#examples) |
 | [v0.15.0](https://github.com/tektoncd/pipeline/releases/tag/v0.15.0) | [Docs @ v0.15.0](https://github.com/tektoncd/pipeline/tree/v0.15.0/docs#tekton-pipelines) | [Examples @ v0.15.0](https://github.com/tektoncd/pipeline/tree/v0.15.0/examples#examples) |


### PR DESCRIPTION
# Changes

Adding docs for the recent 0.16.0 release, the 0.16.1 release I'm
currently working on and the release we'll make next week for 0.16.2

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/kind documentation

Waiting for 0.16.1 and 0.16.2:

/hold