### PR TITLE
pkg/{termination,pod,reconciler}: use v1beta1 struct 🍶

### DIFF
--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,7 +107,7 @@ func TestOrderContainers(t *testing.T) {
 }
 
 func TestEntryPointResults(t *testing.T) {
-	results := []v1alpha1.TaskResult{{
+	results := []v1beta1.TaskResult{{
 		Name:        "sum",
 		Description: "This is the sum result of the task",
 	}, {
@@ -181,7 +181,7 @@ func TestEntryPointResults(t *testing.T) {
 }
 
 func TestEntryPointResultsSingleStep(t *testing.T) {
-	results := []v1alpha1.TaskResult{{
+	results := []v1beta1.TaskResult{{
 		Name:        "sum",
 		Description: "This is the sum result of the task",
 	}, {
@@ -218,7 +218,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 	}
 }
 func TestEntryPointSingleResultsSingleStep(t *testing.T) {
-	results := []v1alpha1.TaskResult{{
+	results := []v1beta1.TaskResult{{
 		Name:        "sum",
 		Description: "This is the sum result of the task",
 	}}

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/system"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -129,7 +128,7 @@ func TestPodBuild(t *testing.T) {
 	}, {
 		desc: "simple with running-in-environment-with-injected-sidecar set to false",
 		ts: v1beta1.TaskSpec{
-			Steps: []v1alpha1.Step{{Container: corev1.Container{
+			Steps: []v1beta1.Step{{Container: corev1.Container{
 				Name:    "name",
 				Image:   "image",
 				Command: []string{"cmd"}, // avoid entrypoint lookup.
@@ -570,12 +569,12 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 	}, {
 		desc: "sidecar container with enable-ready-annotation-on-pod-create",
 		ts: v1beta1.TaskSpec{
-			Steps: []v1alpha1.Step{{Container: corev1.Container{
+			Steps: []v1beta1.Step{{Container: corev1.Container{
 				Name:    "primary-name",
 				Image:   "primary-image",
 				Command: []string{"cmd"}, // avoid entrypoint lookup.
 			}}},
-			Sidecars: []v1alpha1.Sidecar{{
+			Sidecars: []v1beta1.Sidecar{{
 				Container: corev1.Container{
 					Name:  "sc-name",
 					Image: "sidecar-image",
@@ -920,7 +919,7 @@ script-heredoc-randomly-generated-78c5n
 	}, {
 		desc: "setting image pull secret",
 		ts: v1beta1.TaskSpec{
-			Steps: []v1alpha1.Step{
+			Steps: []v1beta1.Step{
 				{
 					Container: corev1.Container{
 						Name:    "image-pull",
@@ -931,7 +930,7 @@ script-heredoc-randomly-generated-78c5n
 			},
 		},
 		trs: v1beta1.TaskRunSpec{
-			PodTemplate: &v1alpha1.PodTemplate{
+			PodTemplate: &v1beta1.PodTemplate{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "imageSecret"}},
 			},
 		},

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 )
 
 func TestConvertScripts_NothingToConvert_EmptySidecars(t *testing.T) {
-	gotInit, gotScripts, gotSidecars := convertScripts(images.ShellImage, []v1alpha1.Step{{
+	gotInit, gotScripts, gotSidecars := convertScripts(images.ShellImage, []v1beta1.Step{{
 		Container: corev1.Container{
 			Image: "step-1",
 		},
@@ -35,7 +35,7 @@ func TestConvertScripts_NothingToConvert_EmptySidecars(t *testing.T) {
 		Container: corev1.Container{
 			Image: "step-2",
 		},
-	}}, []v1alpha1.Sidecar{})
+	}}, []v1beta1.Sidecar{})
 	want := []corev1.Container{{
 		Image: "step-1",
 	}, {
@@ -54,7 +54,7 @@ func TestConvertScripts_NothingToConvert_EmptySidecars(t *testing.T) {
 }
 
 func TestConvertScripts_NothingToConvert_NilSidecars(t *testing.T) {
-	gotInit, gotScripts, gotSidecars := convertScripts(images.ShellImage, []v1alpha1.Step{{
+	gotInit, gotScripts, gotSidecars := convertScripts(images.ShellImage, []v1beta1.Step{{
 		Container: corev1.Container{
 			Image: "step-1",
 		},
@@ -81,7 +81,7 @@ func TestConvertScripts_NothingToConvert_NilSidecars(t *testing.T) {
 }
 
 func TestConvertScripts_NothingToConvert_WithSidecar(t *testing.T) {
-	gotInit, gotScripts, gotSidecars := convertScripts(images.ShellImage, []v1alpha1.Step{{
+	gotInit, gotScripts, gotSidecars := convertScripts(images.ShellImage, []v1beta1.Step{{
 		Container: corev1.Container{
 			Image: "step-1",
 		},
@@ -89,7 +89,7 @@ func TestConvertScripts_NothingToConvert_WithSidecar(t *testing.T) {
 		Container: corev1.Container{
 			Image: "step-2",
 		},
-	}}, []v1alpha1.Sidecar{{
+	}}, []v1beta1.Sidecar{{
 		Container: corev1.Container{
 			Image: "sidecar-1",
 		},
@@ -130,7 +130,7 @@ func TestConvertScripts(t *testing.T) {
 		MountPath: "/another/one",
 	}}
 
-	gotInit, gotSteps, gotSidecars := convertScripts(images.ShellImage, []v1alpha1.Step{{
+	gotInit, gotSteps, gotSidecars := convertScripts(images.ShellImage, []v1beta1.Step{{
 		Script: `#!/bin/sh
 script-1`,
 		Container: corev1.Container{Image: "step-1"},
@@ -153,7 +153,7 @@ script-3`,
 			VolumeMounts: preExistingVolumeMounts,
 			Args:         []string{"my", "args"},
 		},
-	}}, []v1alpha1.Sidecar{})
+	}}, []v1beta1.Sidecar{})
 	wantInit := &corev1.Container{
 		Name:    "place-scripts",
 		Image:   images.ShellImage,
@@ -225,7 +225,7 @@ func TestConvertScripts_WithSidecar(t *testing.T) {
 		MountPath: "/another/one",
 	}}
 
-	gotInit, gotSteps, gotSidecars := convertScripts(images.ShellImage, []v1alpha1.Step{{
+	gotInit, gotSteps, gotSidecars := convertScripts(images.ShellImage, []v1beta1.Step{{
 		Script: `#!/bin/sh
 script-1`,
 		Container: corev1.Container{Image: "step-1"},
@@ -240,7 +240,7 @@ script-3`,
 			VolumeMounts: preExistingVolumeMounts,
 			Args:         []string{"my", "args"},
 		},
-	}}, []v1alpha1.Sidecar{{
+	}}, []v1beta1.Sidecar{{
 		Script: `#!/bin/sh
 sidecar-1`,
 		Container: corev1.Container{Image: "sidecar-1"},

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	"github.com/tektoncd/pipeline/pkg/workspace"
@@ -47,7 +46,7 @@ const (
 // createAffinityAssistants creates an Affinity Assistant StatefulSet for every workspace in the PipelineRun that
 // use a PersistentVolumeClaim volume. This is done to achieve Node Affinity for all TaskRuns that
 // share the workspace volume and make it possible for the tasks to execute parallel while sharing volume.
-func (c *Reconciler) createAffinityAssistants(ctx context.Context, wb []v1alpha1.WorkspaceBinding, pr *v1beta1.PipelineRun, namespace string) error {
+func (c *Reconciler) createAffinityAssistants(ctx context.Context, wb []v1beta1.WorkspaceBinding, pr *v1beta1.PipelineRun, namespace string) error {
 	logger := logging.FromContext(ctx)
 
 	var errs []error

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1221,9 +1221,9 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 				Reason:  v1beta1.PipelineRunReasonRunning.String(),
 				Message: "running...",
 			}),
-			tb.PipelineRunTaskRunsStatus(prName+ptName, &v1alpha1.PipelineRunTaskRunStatus{
+			tb.PipelineRunTaskRunsStatus(prName+ptName, &v1beta1.PipelineRunTaskRunStatus{
 				PipelineTaskName: ptName,
-				Status:           &v1alpha1.TaskRunStatus{},
+				Status:           &v1beta1.TaskRunStatus{},
 			}),
 			tb.PipelineRunStartTime(time.Now()),
 		),

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -32,7 +32,7 @@ func TestPipelineRef(t *testing.T) {
 	testcases := []struct {
 		name      string
 		pipelines []runtime.Object
-		ref       *v1alpha1.PipelineRef
+		ref       *v1beta1.PipelineRef
 		expected  runtime.Object
 		wantErr   bool
 	}{
@@ -42,7 +42,7 @@ func TestPipelineRef(t *testing.T) {
 				tb.Pipeline("simple", tb.PipelineNamespace("default")),
 				tb.Pipeline("dummy", tb.PipelineNamespace("default")),
 			},
-			ref: &v1alpha1.PipelineRef{
+			ref: &v1beta1.PipelineRef{
 				Name: "simple",
 			},
 			expected: tb.Pipeline("simple", tb.PipelineNamespace("default")),
@@ -51,7 +51,7 @@ func TestPipelineRef(t *testing.T) {
 		{
 			name:      "pipeline-not-found",
 			pipelines: []runtime.Object{},
-			ref: &v1alpha1.PipelineRef{
+			ref: &v1beta1.PipelineRef{
 				Name: "simple",
 			},
 			expected: nil,

--- a/pkg/reconciler/taskrun/validate_resources.go
+++ b/pkg/reconciler/taskrun/validate_resources.go
@@ -19,13 +19,13 @@ package taskrun
 import (
 	"fmt"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 )
 
-func validateResources(requiredResources []v1beta1.TaskResource, providedResources map[string]*v1alpha1.PipelineResource) error {
+func validateResources(requiredResources []v1beta1.TaskResource, providedResources map[string]*resourcev1alpha1.PipelineResource) error {
 	required := make([]string, 0, len(requiredResources))
 	optional := make([]string, 0, len(requiredResources))
 	for _, resource := range requiredResources {
@@ -64,9 +64,9 @@ func validateResources(requiredResources []v1beta1.TaskResource, providedResourc
 	return nil
 }
 
-func validateParams(paramSpecs []v1beta1.ParamSpec, params []v1alpha1.Param) error {
+func validateParams(paramSpecs []v1beta1.ParamSpec, params []v1beta1.Param) error {
 	var neededParams []string
-	paramTypes := make(map[string]v1alpha1.ParamType)
+	paramTypes := make(map[string]v1beta1.ParamType)
 	neededParams = make([]string, 0, len(paramSpecs))
 	for _, inputResourceParam := range paramSpecs {
 		neededParams = append(neededParams, inputResourceParam.Name)
@@ -109,7 +109,7 @@ func validateParams(paramSpecs []v1beta1.ParamSpec, params []v1alpha1.Param) err
 }
 
 // ValidateResolvedTaskResources validates task inputs, params and output matches taskrun
-func ValidateResolvedTaskResources(params []v1alpha1.Param, rtr *resources.ResolvedTaskResources) error {
+func ValidateResolvedTaskResources(params []v1beta1.Param, rtr *resources.ResolvedTaskResources) error {
 	if err := validateParams(rtr.TaskSpec.Params, params); err != nil {
 		return fmt.Errorf("invalid input params for task %s: %w", rtr.TaskName, err)
 	}

--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -20,7 +20,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +36,7 @@ const (
 )
 
 type PvcHandler interface {
-	CreatePersistentVolumeClaimsForWorkspaces(wb []v1alpha1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error
+	CreatePersistentVolumeClaimsForWorkspaces(wb []v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error
 }
 
 type defaultPVCHandler struct {
@@ -52,7 +52,7 @@ func NewPVCHandler(clientset clientset.Interface, logger *zap.SugaredLogger) Pvc
 // where claim-name is provided by the user in the volumeClaimTemplate, and owner-name is the name of the
 // resource with the volumeClaimTemplate declared, a PipelineRun or TaskRun. If the PVC did not exist, a new PVC
 // with that name is created with the provided OwnerReference.
-func (c *defaultPVCHandler) CreatePersistentVolumeClaimsForWorkspaces(wb []v1alpha1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error {
+func (c *defaultPVCHandler) CreatePersistentVolumeClaimsForWorkspaces(wb []v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error {
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(wb, ownerReference, namespace) {
 		_, err := c.clientset.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
@@ -72,7 +72,7 @@ func (c *defaultPVCHandler) CreatePersistentVolumeClaimsForWorkspaces(wb []v1alp
 	return errorutils.NewAggregate(errs)
 }
 
-func getPersistentVolumeClaims(workspaceBindings []v1alpha1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) map[string]*corev1.PersistentVolumeClaim {
+func getPersistentVolumeClaims(workspaceBindings []v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) map[string]*corev1.PersistentVolumeClaim {
 	claims := make(map[string]*corev1.PersistentVolumeClaim)
 	for _, workspaceBinding := range workspaceBindings {
 		if workspaceBinding.VolumeClaimTemplate == nil {
@@ -92,7 +92,7 @@ func getPersistentVolumeClaims(workspaceBindings []v1alpha1.WorkspaceBinding, ow
 // must be a PersistentVolumeClaim from a volumeClaimTemplate. The returned name must be consistent given the same
 // workspaceBinding name and ownerReference name - because it is first used for creating a PVC and later,
 // possibly several TaskRuns to lookup the PVC to mount.
-func GetPersistentVolumeClaimName(claim *corev1.PersistentVolumeClaim, wb v1alpha1.WorkspaceBinding, owner metav1.OwnerReference) string {
+func GetPersistentVolumeClaimName(claim *corev1.PersistentVolumeClaim, wb v1beta1.WorkspaceBinding, owner metav1.OwnerReference) string {
 	if claim.Name == "" {
 		return fmt.Sprintf("%s-%s", "pvc", getPersistentVolumeClaimIdentity(wb.Name, owner.Name))
 	}

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +42,7 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 	claimName1 := "pvc1"
 	ws1 := "myws1"
 	ownerName := "taskrun1"
-	workspaces := []v1alpha1.WorkspaceBinding{{
+	workspaces := []v1beta1.WorkspaceBinding{{
 		Name: ws1,
 		VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -120,7 +120,7 @@ func TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata(t *testing.T) 
 	// workspace with volumeClaimTemplate without metadata
 	workspaceName := "ws-with-volume-claim-template-without-metadata"
 	ownerName := "taskrun1"
-	workspaces := []v1alpha1.WorkspaceBinding{{
+	workspaces := []v1beta1.WorkspaceBinding{{
 		Name: workspaceName,
 		VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
 			Spec: corev1.PersistentVolumeClaimSpec{},

--- a/pkg/termination/parse.go
+++ b/pkg/termination/parse.go
@@ -20,28 +20,28 @@ import (
 	"fmt"
 	"sort"
 
-	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 // ParseMessage parses a termination message as results.
 //
 // If more than one item has the same key, only the latest is returned. Items
 // are sorted by their key.
-func ParseMessage(msg string) ([]v1alpha1.PipelineResourceResult, error) {
+func ParseMessage(msg string) ([]v1beta1.PipelineResourceResult, error) {
 	if msg == "" {
 		return nil, nil
 	}
-	var r []v1alpha1.PipelineResourceResult
+	var r []v1beta1.PipelineResourceResult
 	if err := json.Unmarshal([]byte(msg), &r); err != nil {
 		return nil, fmt.Errorf("parsing message json: %v", err)
 	}
 
 	// Remove duplicates (last one wins) and sort by key.
-	m := map[string]v1alpha1.PipelineResourceResult{}
+	m := map[string]v1beta1.PipelineResourceResult{}
 	for _, rr := range r {
 		m[rr.Key] = rr
 	}
-	var r2 []v1alpha1.PipelineResourceResult
+	var r2 []v1beta1.PipelineResourceResult
 	for _, v := range m {
 		r2 = append(r2, v)
 	}

--- a/pkg/termination/parse_test.go
+++ b/pkg/termination/parse_test.go
@@ -19,18 +19,18 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 )
 
 func TestParseMessage(t *testing.T) {
 	for _, c := range []struct {
 		desc, msg string
-		want      []v1alpha1.PipelineResourceResult
+		want      []v1beta1.PipelineResourceResult
 	}{{
 		desc: "valid message",
 		msg:  `[{"key": "digest","value":"hereisthedigest"},{"key":"foo","value":"bar"}]`,
-		want: []v1alpha1.PipelineResourceResult{{
+		want: []v1beta1.PipelineResourceResult{{
 			Key:   "digest",
 			Value: "hereisthedigest",
 		}, {
@@ -47,7 +47,7 @@ func TestParseMessage(t *testing.T) {
 		{"key":"foo","value":"first"},
 		{"key":"foo","value":"middle"},
 		{"key":"foo","value":"last"}]`,
-		want: []v1alpha1.PipelineResourceResult{{
+		want: []v1beta1.PipelineResourceResult{{
 			Key:   "foo",
 			Value: "last",
 		}},
@@ -57,7 +57,7 @@ func TestParseMessage(t *testing.T) {
 		{"key":"zzz","value":"last"},
 		{"key":"ddd","value":"middle"},
 		{"key":"aaa","value":"first"}]`,
-		want: []v1alpha1.PipelineResourceResult{{
+		want: []v1beta1.PipelineResourceResult{{
 			Key:   "aaa",
 			Value: "first",
 		}, {

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	v1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
 const (
@@ -30,12 +30,12 @@ const (
 )
 
 // WriteMessage writes the results to the termination message path.
-func WriteMessage(path string, pro []v1alpha1.PipelineResourceResult) error {
+func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
 	// if the file at path exists, concatenate the new values otherwise create it
 	// file at path already exists
 	fileContents, err := ioutil.ReadFile(path)
 	if err == nil {
-		var existingEntries []v1alpha1.PipelineResourceResult
+		var existingEntries []v1beta1.PipelineResourceResult
 		if err := json.Unmarshal([]byte(fileContents), &existingEntries); err == nil {
 			// append new entries to existing entries
 			pro = append(existingEntries, pro...)

--- a/pkg/termination/write_test.go
+++ b/pkg/termination/write_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"knative.dev/pkg/logging"
 )
@@ -41,7 +41,7 @@ func TestExistingFile(t *testing.T) {
 	defer func() {
 		_ = logger.Sync()
 	}()
-	output := []v1alpha1.PipelineResourceResult{{
+	output := []v1beta1.PipelineResourceResult{{
 		Key:   "key1",
 		Value: "hello",
 	}}
@@ -50,7 +50,7 @@ func TestExistingFile(t *testing.T) {
 		logger.Fatalf("Errot while writing message: %s", err)
 	}
 
-	output = []v1alpha1.PipelineResourceResult{{
+	output = []v1beta1.PipelineResourceResult{{
 		Key:   "key2",
 		Value: "world",
 	}}
@@ -78,7 +78,7 @@ func TestMaxSizeFile(t *testing.T) {
 	// Remember to clean up the file afterwards
 	defer os.Remove(tmpFile.Name())
 
-	output := []v1alpha1.PipelineResourceResult{{
+	output := []v1beta1.PipelineResourceResult{{
 		Key:   "key1",
 		Value: value,
 	}}


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

v1alpha1.PipelineResourceResult is an alias to
v1beta1.PipelineResourceResult already so it can be used in-place.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/kind cleanup