### PR TITLE
Feat: Add pause condition in pipeline run

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -20,6 +20,7 @@ weight: 4
   - [Configuring a failure timeout](#configuring-a-failure-timeout)
 - [Monitoring execution status](#monitoring-execution-status)
 - [Cancelling a `PipelineRun`](#cancelling-a-pipelinerun)
+- [Pausing a `PipelineRun`](#pausing-a-pipelinerun)
 - [Events](events.md#pipelineruns)
 
 
@@ -491,6 +492,23 @@ metadata:
 spec:
   # […]
   status: "PipelineRunCancelled"
+```
+
+## Pausing a `PipelineRun`
+
+To pause a `PipelineRun` that's currently executing, update its definition to mark it paused.
+Note: `Pause` will only be valid in `runAfter` pipelines. When you do so, after the completion of the current pipeline, the next pipeline that runs after the previous one will be paused. For example:
+
+. For example:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "PipelineRunPaused"
 ```
 
 ---

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -106,9 +106,14 @@ func PipelineDescription(desc string) PipelineSpecOp {
 	}
 }
 
-// PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
+// PipelineRunCancelled sets the status to cancel to the PielineRunSpec.
 func PipelineRunCancelled(spec *v1beta1.PipelineRunSpec) {
 	spec.Status = v1beta1.PipelineRunSpecStatusCancelled
+}
+
+// PipelineRunPaused sets the status to pause to the PipelineRunSpec.
+func PipelineRunPaused(spec *v1beta1.PipelineRunSpec){
+	spec.Status = v1beta1.PipelineRunSpecStatusPaused
 }
 
 // PipelineDeclaredResource adds a resource declaration to the Pipeline Spec,

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -98,6 +98,11 @@ func (pr *PipelineRun) IsCancelled() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusCancelled
 }
 
+// IsPaused returns true if the PipelineRun's spec status is set to Paused state
+func (pr *PipelineRun) IsPaused() bool {
+	return pr.Spec.Status == PipelineRunSpecStatusPaused
+}
+
 // GetNamespacedName returns a k8s namespaced name that identifies this PipelineRun
 func (pr *PipelineRun) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}
@@ -192,6 +197,8 @@ const (
 	// PipelineRunSpecStatusCancelled indicates that the user wants to cancel the task,
 	// if not already cancelled or terminated
 	PipelineRunSpecStatusCancelled = "PipelineRunCancelled"
+
+	PipelineRunSpecStatusPaused = "PipelineRunPaused"
 )
 
 // PipelineRef can be used to refer to a specific instance of a Pipeline.
@@ -230,6 +237,8 @@ const (
 	// This reason may be found with a corev1.ConditionFalse status, if the cancellation was processed successfully
 	// This reason may be found with a corev1.ConditionUnknown status, if the cancellation is being processed or failed
 	PipelineRunReasonCancelled PipelineRunReason = "Cancelled"
+	// PipelineRunReasonPaused is the reason set when the PipelineRun paused by the user
+	PipelineRunReasonPaused PipelineRunReason = "PipelineRunPaused"
 	// PipelineRunReasonTimedOut is the reason set when the PipelineRun has timed out
 	PipelineRunReasonTimedOut PipelineRunReason = "PipelineRunTimeout"
 	// PipelineRunReasonStopping indicates that no new Tasks will be scheduled by the controller, and the

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -66,8 +66,8 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	if ps.Status != "" {
-		if ps.Status != PipelineRunSpecStatusCancelled {
-			return apis.ErrInvalidValue(fmt.Sprintf("%s should be %s", ps.Status, PipelineRunSpecStatusCancelled), "spec.status")
+		if ps.Status != PipelineRunSpecStatusCancelled && ps.Status != PipelineRunSpecStatusPaused {
+			return apis.ErrInvalidValue(fmt.Sprintf("%s should be %s or %s", ps.Status, PipelineRunSpecStatusCancelled, PipelineRunSpecStatusPaused), "spec.status")
 		}
 	}
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1106,6 +1106,52 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 	}
 }
 
+func TestReconcileOnPausedPipelineRun(t *testing.T) {
+	// TestReconcileOnPausedPipelineRun runs "Reconcile" on a PipelineRun that has been paused.
+	// It verifies that reconcile is successful, the pipeline status updated and events generated.
+	prs := []*v1beta1.PipelineRun{tb.PipelineRun("test-pipeline-run-paused",
+		tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa"),
+			tb.PipelineRunPaused,
+		),
+		tb.PipelineRunStatus(tb.PipelineRunStartTime(time.Now())),
+	)}
+	ps := []*v1beta1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
+		tb.PipelineTask("hello-world", "hello-world"),
+	))}
+	ts := []*v1beta1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
+	trs := []*v1beta1.TaskRun{
+		tb.TaskRun("test-pipeline-run-paused-hello-world",
+			tb.TaskRunNamespace("foo"),
+			tb.TaskRunOwnerReference("kind", "name"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-paused"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("hello-world"),
+				tb.TaskRunServiceAccountName("test-sa"),
+			),
+		),
+	}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+	}
+	prt := NewPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	wantEvents := []string{
+		"Normal PipelineRunPaused PipelineRun \"test-pipeline-run-paused\" was paused",
+	}
+	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-paused", wantEvents, false)
+
+	condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+	if !condition.IsUnknown() || condition.Reason != ReasonPaused {
+		t.Errorf("Expected PipelineRun condition to indicate the pause failed but reason was %s", condition.Reason)
+	}
+}
+
 func TestReconcileWithTimeout(t *testing.T) {
 	// TestReconcileWithTimeout runs "Reconcile" on a PipelineRun that has timed out.
 	// It verifies that reconcile is successful, the pipeline status updated and events generated.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Feat: Add pause condition in pipeline run.

The pause condition will be valid in runAfter pipelines.
When users change the pipeline run's status to paused, after the
completion of the current pipeline, the next pipeline that runs after
the previous one will be paused.

The way we handle `pause` is similar to the way we handle `cancel`.

Reference #2217

/cc @withlin 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
    
      Feat: Add pause condition in pipeline run.

      The pause condition will be valid in runAfter pipelines.
      When users change the pipeline run's status to paused, after the
      completion of the current pipeline, the next pipeline that runs after
      the previous one will be paused.

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

    ```release-note
    Your release note here
    ```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

    ```release-note
    action required: your release note here
    ```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

    ```release-note
    NONE
    ```
-->
