### PR TITLE
consuming task results in finally

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -788,6 +788,32 @@ spec:
           value: "someURL"
 ```
 
+#### Consuming `Task` execution results in `finally`
+
+Final tasks can be configured to consume `Results` of `PipelineTask` from the `tasks` section:
+
+```yaml
+spec:
+  tasks:
+    - name: clone-app-repo
+      taskRef:
+        name: git-clone
+  finally:
+    - name: discover-git-commit
+      params:
+        - name: commit
+          value: $(tasks.clone-app-repo.results.commit)
+```
+**Note:** The scheduling of such final task does not change, it will still be executed in parallel with other
+final tasks after all non-final tasks are done.
+
+The controller resolves task results before executing the finally task `discover-git-commit`. If the task
+`clone-app-repo` failed or skipped with [when expression](#guard-task-execution-using-whenexpressions) resulting in
+uninitialized task result `commit`, the finally Task `discover-git-commit` will be included in the list of
+`skippedTasks` and continues executing rest of the final tasks. The pipeline exits with `completion` instead of
+`success` if a finally task is added to the list of `skippedTasks`.
+
+
 ### `PipelineRun` Status with `finally`
 
 With `finally`, `PipelineRun` status is calculated based on `PipelineTasks` under `tasks` section and final tasks.
@@ -899,35 +925,6 @@ no `runAfter` can be specified in final tasks.
 `Tasks` in a `Pipeline` can be configured to run only if some conditions are satisfied using `conditions`. But the
 final tasks are guaranteed to be executed after all `PipelineTasks` therefore no `conditions` can be specified in
 final tasks.
-
-#### Cannot configure `Task` execution results with `finally`
-
-Final tasks can not be configured to consume `Results` of `PipelineTask` from `tasks` section i.e. the following
-example is not supported right now but we are working on adding support for the same (tracked in issue
-[#2557](https://github.com/tektoncd/pipeline/issues/2557)).
-
-```yaml
-spec:
-  tasks:
-    - name: count-comments-before
-      taskRef:
-        Name: count-comments
-    - name: add-comment
-      taskRef:
-        Name: add-comment
-    - name: count-comments-after
-      taskRef:
-        Name: count-comments
-  finally:
-    - name: check-count
-      taskRef:
-        Name: check-count
-      params:
-        - name: before-count
-          value: $(tasks.count-comments-before.results.count) #invalid
-        - name: after-count
-          value: $(tasks.count-comments-after.results.count) #invalid
-```
 
 #### Cannot configure `Pipeline` result with `finally`
 

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -164,6 +164,20 @@ spec:
       workspaces:
         - name: source
           workspace: git-source
+    - name: check-git-commit
+      params:
+        - name: commit
+          value: $(tasks.clone-app-repo.results.commit)
+      taskSpec:
+        params:
+          - name: commit
+        steps:
+          - name: check-commit-initialized
+            image: alpine
+            script: |
+              if [[ ! $(params.commit) ]]; then
+                exit 1
+              fi
 ---
 
 # PipelineRun to execute pipeline - clone-into-workspace-and-cleanup-workspace

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -581,7 +581,18 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 	if len(fnextRprts) != 0 {
 		// apply the runtime context just before creating taskRuns for final tasks in queue
 		resources.ApplyPipelineTaskContext(fnextRprts, pipelineRunFacts.GetPipelineTaskStatus(ctx))
-		nextRprts = append(nextRprts, fnextRprts...)
+
+		// Before creating TaskRun for scheduled final task, check if it's consuming a task result
+		// Resolve and apply task result wherever applicable, report warning in case resolution fails
+		for _, rprt := range fnextRprts {
+			resolvedResultRefs, err := resources.ResolveResultRef(pipelineRunFacts.State, rprt)
+			if err != nil {
+				logger.Infof("Final task %q is not executed as it could not resolve task params for %q: %v", rprt.PipelineTask.Name, pr.Name, err)
+				continue
+			}
+			resources.ApplyTaskResults(resources.PipelineRunState{rprt}, resolvedResultRefs)
+			nextRprts = append(nextRprts, rprt)
+		}
 	}
 
 	for _, rprt := range nextRprts {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -216,6 +216,19 @@ func (t *ResolvedPipelineRunTask) parentTasksSkip(facts *PipelineRunFacts) bool 
 	return false
 }
 
+// IsFinallySkipped returns true if a finally task is not executed and skipped due to task result validation failure
+func (t *ResolvedPipelineRunTask) IsFinallySkipped(facts *PipelineRunFacts) bool {
+	if t.IsStarted() {
+		return false
+	}
+	if facts.checkDAGTasksDone() && facts.isFinalTask(t.PipelineTask.Name) {
+		if _, err := ResolveResultRef(facts.State, t); err != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // GetRun is a function that will retrieve a Run by name.
 type GetRun func(name string) (*v1alpha1.Run, error)
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -376,6 +376,12 @@ func (facts *PipelineRunFacts) GetSkippedTasks() []v1beta1.SkippedTask {
 			}
 			skipped = append(skipped, skippedTask)
 		}
+		if rprt.IsFinallySkipped(facts) {
+			skippedTask := v1beta1.SkippedTask{
+				Name: rprt.PipelineTask.Name,
+			}
+			skipped = append(skipped, skippedTask)
+		}
 	}
 	return skipped
 }
@@ -464,6 +470,9 @@ func (facts *PipelineRunFacts) getPipelineTasksCount() pipelineRunStatusCount {
 			s.Failed++
 		// increment skip counter since the task is skipped
 		case t.Skip(facts):
+			s.Skipped++
+		// checking if any finally tasks were referring to invalid/missing task results
+		case t.IsFinallySkipped(facts):
 			s.Skipped++
 		// increment incomplete counter since the task is pending and not executed yet
 		default:

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -37,6 +37,15 @@ type ResolvedResultRef struct {
 	FromRun         string
 }
 
+// ResolveResultRef resolves any ResultReference that are found in the target ResolvedPipelineRunTask
+func ResolveResultRef(pipelineRunState PipelineRunState, target *ResolvedPipelineRunTask) (ResolvedResultRefs, error) {
+	resolvedResultRefs, err := convertToResultRefs(pipelineRunState, target)
+	if err != nil {
+		return nil, err
+	}
+	return resolvedResultRefs, nil
+}
+
 // ResolveResultRefs resolves any ResultReference that are found in the target ResolvedPipelineRunTask
 func ResolveResultRefs(pipelineRunState PipelineRunState, targets PipelineRunState) (ResolvedResultRefs, error) {
 	var allResolvedResultRefs ResolvedResultRefs

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -164,6 +164,18 @@ spec:
       workspaces:
         - name: source
           workspace: git-source
+    - name: display-git-commit
+      params:
+        - name: commit
+          value: $(tasks.clone-app-repo.results.commit)
+      taskSpec:
+        params:
+          - name: commit
+        steps:
+          - name: display-commit
+            image: alpine
+            script: |
+              echo $(params.commit)
 ---
 
 # PipelineRun to execute pipeline - clone-into-workspace-and-cleanup-workspace


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Final tasks can be configured to consume `results` of `PipelineTasks` from `tasks` section.

Based on the TEP, a final task failing to resolve task results is added to the list of `skippedTasks` and warning is recorded in controller logs.

```
unable to find result referenced by param "param1" in "final-task" ...
```

Implements TEP [#0004](https://github.com/tektoncd/community/blob/master/teps/0004-task-results-in-final-tasks.md)
Closes #2557 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Final tasks can be configured to consume `results` of `PipelineTasks` from `tasks` section. 
```