### PR TITLE
Remove test builders from v1alpha1/pipeline_validation_test.go

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	v1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestPipeline_Validate(t *testing.T) {
-	tests := []struct {
+	for _, tt := range []struct {
 		name            string
 		p               *v1alpha1.Pipeline
 		failureExpected bool
@@ -214,244 +213,616 @@ func TestPipeline_Validate(t *testing.T) {
 	}, {
 		// Adding this case because `task.Resources` is a pointer, explicitly making sure this is handled
 		name: "task without resources",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
-			tb.PipelineTask("bar", "bar-task"),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("wow-image", "wonderful-resource")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "wonderful-resource",
+					Type: v1alpha1.PipelineResourceTypeImage,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "wow-image", Resource: "wonderful-resource",
+						}},
+					},
+				}, {
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "valid resource declarations and usage",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskInputResource("some-workspace", "great-resource"),
-				tb.PipelineTaskOutputResource("some-image", "wonderful-resource"),
-				tb.PipelineTaskCondition("some-condition",
-					tb.PipelineTaskConditionResource("some-workspace", "great-resource"))),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("wow-image", "wonderful-resource", tb.From("bar")),
-				tb.PipelineTaskCondition("some-condition-2",
-					tb.PipelineTaskConditionResource("wow-image", "wonderful-resource", "bar"))),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}, {
+					Name: "wonderful-resource",
+					Type: v1alpha1.PipelineResourceTypeImage,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "wow-image", Resource: "wonderful-resource", From: []string{"bar"},
+						}},
+					},
+					Conditions: []v1alpha1.PipelineTaskCondition{{
+						ConditionRef: "some-condition-2",
+						Resources: []v1alpha1.PipelineTaskInputResource{{
+							Name: "wow-image", Resource: "wonderful-resource", From: []string{"bar"},
+						}},
+					}},
+				}, {
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+						Outputs: []v1alpha1.PipelineTaskOutputResource{{
+							Name: "some-image", Resource: "wonderful-resource",
+						}},
+					},
+					Conditions: []v1alpha1.PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+						Resources: []v1alpha1.PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+					}},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "valid condition only resource",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskCondition("some-condition",
-					tb.PipelineTaskConditionResource("some-workspace", "great-resource"))),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Conditions: []v1alpha1.PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+						Resources: []v1alpha1.PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+					}},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "valid parameter variables",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeString),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(baz) and $(foo-is-baz)")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name: "baz",
+					Type: v1alpha1.ParamTypeString,
+				}, {
+					Name: "foo-is-baz",
+					Type: v1alpha1.ParamTypeString,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(baz) and $(foo-is-baz)"),
+					}},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "valid array parameter variables",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(baz)", "and", "$(foo-is-baz)")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("some", "default"),
+				}, {
+					Name: "foo-is-baz",
+					Type: v1alpha1.ParamTypeArray,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(baz)", "and", "$(foo-is-baz)"),
+					}},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "valid star array parameter variables",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("some", "default")),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(baz[*])", "and", "$(foo-is-baz[*])")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("some", "default"),
+				}, {
+					Name: "foo-is-baz",
+					Type: v1alpha1.ParamTypeArray,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(baz[*])", "and", "$(foo-is-baz[*])"),
+					}},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "pipeline parameter nested in task parameter",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(input.workspace.$(baz))")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name: "baz",
+					Type: v1alpha1.ParamTypeString,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(input.workspace.$(baz))"),
+					}},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
-		name: "from is on first task",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("the-resource", "great-resource", tb.From("bar"))),
-		)),
+		name: "from is on only task",
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "the-resource", Resource: "great-resource", From: []string{"bar"},
+						}},
+					},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "from task doesnt exist",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineTask("baz", "baz-task"),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("the-resource", "great-resource", tb.From("bar"))),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "the-resource", Resource: "great-resource", From: []string{"bazzz"},
+						}},
+					},
+				}, {
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "duplicate resource declaration",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("duplicate-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineDeclaredResource("duplicate-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("the-resource", "duplicate-resource")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}, {
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "the-resource", Resource: "great-resource",
+						}},
+					},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "output resources missing from declaration",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("the-resource", "great-resource"),
-				tb.PipelineTaskOutputResource("the-magic-resource", "missing-resource")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "the-resource", Resource: "great-resource",
+						}},
+						Outputs: []v1alpha1.PipelineTaskOutputResource{{
+							Name: "the-magic-resource", Resource: "missing-resource",
+						}},
+					},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "input resources missing from declaration",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("the-resource", "missing-resource"),
-				tb.PipelineTaskOutputResource("the-magic-resource", "great-resource")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "the-resource", Resource: "missing-resource",
+						}},
+						Outputs: []v1alpha1.PipelineTaskOutputResource{{
+							Name: "the-magic-resource", Resource: "great-resource",
+						}},
+					},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "invalid condition only resource",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskCondition("some-condition",
-					tb.PipelineTaskConditionResource("some-workspace", "missing-resource"))),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Conditions: []v1alpha1.PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+						Resources: []v1alpha1.PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "missing-resource",
+						}},
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "invalid from in condition",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineTask("foo", "foo-task"),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskCondition("some-condition",
-					tb.PipelineTaskConditionResource("some-workspace", "missing-resource", "foo"))),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+				}, {
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Conditions: []v1alpha1.PipelineTaskCondition{{
+						ConditionRef: "some-condition",
+						Resources: []v1alpha1.PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "missing-resource", From: []string{"foo"},
+						}},
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "from resource isn't output by task",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineDeclaredResource("great-resource", v1alpha1.PipelineResourceTypeGit),
-			tb.PipelineDeclaredResource("wonderful-resource", v1alpha1.PipelineResourceTypeImage),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskInputResource("some-workspace", "great-resource")),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskInputResource("wow-image", "wonderful-resource", tb.From("bar"))),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Resources: []v1alpha1.PipelineDeclaredResource{{
+					Name: "great-resource",
+					Type: v1alpha1.PipelineResourceTypeGit,
+				}, {
+					Name: "wonderful-resource",
+					Type: v1alpha1.PipelineResourceTypeImage,
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "some-workspace", Resource: "great-resource",
+						}},
+					},
+				}, {
+					Name:    "bar",
+					TaskRef: &v1alpha1.TaskRef{Name: "bar-task"},
+					Resources: &v1alpha1.PipelineTaskResources{
+						Inputs: []v1alpha1.PipelineTaskInputResource{{
+							Name: "wow-image", Resource: "wonderful-resource", From: []string{"bar"},
+						}},
+					},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "not defined parameter variable",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskParam("a-param", "$(params.does-not-exist)")))),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(params.does-not-exist)"),
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "not defined parameter variable with defined",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("foo", v1alpha1.ParamTypeString, tb.ParamSpecDefault("something")),
-			tb.PipelineTask("foo", "foo-task",
-				tb.PipelineTaskParam("a-param", "$(params.foo) and $(params.does-not-exist)")))),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "foo",
+					Type:    v1alpha1.ParamTypeString,
+					Default: v1beta1.NewArrayOrString("something"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(params.foo) and $(params.does-not-exist)"),
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "invalid parameter type",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", "invalidtype", tb.ParamSpecDefault("some", "default")),
-			tb.PipelineParamSpec("foo-is-baz", v1alpha1.ParamTypeArray),
-			tb.PipelineTask("bar", "bar-task"),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamType("invalidtype"),
+					Default: v1beta1.NewArrayOrString("some", "default"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "array parameter mismatching default type",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("astring")),
-			tb.PipelineTask("bar", "bar-task"),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("astring"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "string parameter mismatching default type",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeString, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task"),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamTypeString,
+					Default: v1beta1.NewArrayOrString("an", "array"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "array parameter used as string",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(params.baz)")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("an", "array"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(params.baz)"),
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "star array parameter used as string",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "$(params.baz[*])")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "baz",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("an", "array"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("$(params.baz[*])"),
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "array parameter string template not isolated",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz)", "last")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "a-param",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("an", "array"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("first", "value: $(params.baz)", "last"),
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "star array parameter string template not isolated",
-		p: tb.Pipeline("pipeline", tb.PipelineSpec(
-			tb.PipelineParamSpec("baz", v1alpha1.ParamTypeArray, tb.ParamSpecDefault("anarray", "elements")),
-			tb.PipelineTask("bar", "bar-task",
-				tb.PipelineTaskParam("a-param", "first", "value: $(params.baz[*])", "last")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Params: []v1alpha1.ParamSpec{{
+					Name:    "a-param",
+					Type:    v1alpha1.ParamTypeArray,
+					Default: v1beta1.NewArrayOrString("an", "array"),
+				}},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Params: []v1alpha1.Param{{
+						Name:  "a-param",
+						Value: *v1beta1.NewArrayOrString("first", "value: $(params.baz[*])", "last"),
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
-		name: "invalid dependency graph between the tasks",
-		p: tb.Pipeline("foo", tb.PipelineSpec(
-			tb.PipelineTask("foo", "foo", tb.RunAfter("bar")),
-			tb.PipelineTask("bar", "bar", tb.RunAfter("foo")),
-		)),
+		name: "circular dependency graph between the tasks",
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:     "foo",
+					TaskRef:  &v1alpha1.TaskRef{Name: "foo-task"},
+					RunAfter: []string{"bar"},
+				}, {
+					Name:     "bar",
+					TaskRef:  &v1alpha1.TaskRef{Name: "bar-task"},
+					RunAfter: []string{"foo"},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "unused pipeline spec workspaces do not cause an error",
-		p: tb.Pipeline("name", tb.PipelineSpec(
-			tb.PipelineWorkspaceDeclaration("foo"),
-			tb.PipelineWorkspaceDeclaration("bar"),
-			tb.PipelineTask("foo", "foo"),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Workspaces: []v1alpha1.PipelineWorkspaceDeclaration{
+					{Name: "foo"},
+					{Name: "bar"},
+				},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+				}},
+			},
+		},
 		failureExpected: false,
 	}, {
 		name: "workspace bindings relying on a non-existent pipeline workspace cause an error",
-		p: tb.Pipeline("name", tb.PipelineSpec(
-			tb.PipelineWorkspaceDeclaration("foo"),
-			tb.PipelineTask("taskname", "taskref",
-				tb.PipelineTaskWorkspaceBinding("taskWorkspaceName", "pipelineWorkspaceName", "")),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Workspaces: []v1alpha1.PipelineWorkspaceDeclaration{
+					{Name: "foo"},
+				},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+					Workspaces: []v1alpha1.WorkspacePipelineTaskBinding{{
+						Name: "taskWorkspaceName", Workspace: "pipelineWorkspaceName",
+					}},
+				}},
+			},
+		},
 		failureExpected: true,
 	}, {
 		name: "multiple workspaces sharing the same name are not allowed",
-		p: tb.Pipeline("name", tb.PipelineSpec(
-			tb.PipelineWorkspaceDeclaration("foo"),
-			tb.PipelineWorkspaceDeclaration("foo"),
-		)),
+		p: &v1alpha1.Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+			Spec: v1alpha1.PipelineSpec{
+				Workspaces: []v1alpha1.PipelineWorkspaceDeclaration{
+					{Name: "foo"},
+					{Name: "foo"},
+				},
+				Tasks: []v1alpha1.PipelineTask{{
+					Name:    "foo",
+					TaskRef: &v1alpha1.TaskRef{Name: "foo-task"},
+				}},
+			},
+		},
 		failureExpected: true,
-	}}
-	for _, tt := range tests {
+	}} {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.p.Validate(context.Background())
 			if (!tt.failureExpected) && (err != nil) {


### PR DESCRIPTION
/area testing
/kind cleanup
/assign @pritidesai 

#3178 
Followup from #3124


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```