### PR TITLE
Add more details on bumping catalog deps

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -130,6 +130,13 @@ the pipelines repo, a terminal window and a text editor.
 14. Announce the release in Slack channels #general and #pipelines.
 
 15. Update [the catalog repo](https://github.com/tektoncd/catalog) test infrastructure
-to use the new release by updating the `RELEASE_YAML` link in [e2e-tests.sh](https://github.com/tektoncd/catalog/blob/v1beta1/test/e2e-tests.sh).
+to use the new release by updating:
+* The `RELEASE_YAML` link in [e2e-tests.sh](https://github.com/tektoncd/catalog/blob/master/test/e2e-tests.sh).
+* The images used in catalog Tasks that are built and published with Pipelines:
+  * [pull-request](https://github.com/tektoncd/catalog/blob/master/task/pull-request/0.1/pull-request.yaml)
+  * [git-batch-merge](https://github.com/tektoncd/catalog/blob/master/task/git-batch-merge/0.2/git-batch-merge.yaml)
+  * [git-clone](https://github.com/tektoncd/catalog/blob/master/task/git-clone/0.2/README.md)
+  * [kaniko](https://github.com/tektoncd/catalog/blob/master/task/kaniko/0.1/kaniko.yaml)
+  * [kubeconfig-creator](https://github.com/tektoncd/catalog/blob/master/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml)
 
 Congratulations, you're done!


### PR DESCRIPTION
# Changes

Looking at https://github.com/tektoncd/catalog/pull/508 I realized there
is more to update than just the e2e scripts.

I'm actually wondering if we want to bump all of these - I think if
we're doing to do that, we should bump the version of the Task as well
(doesn't seem like it makes sense to have different copies of the same
Task at the same version behave differently). So I'm wondering if we
want to be more selective about when we bump these?

Would like you hear your thoughts @vdemeester @vinamra28 

/hold

/kind documentation


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```