### PR TITLE
Refactor cancellation test

### DIFF
--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -48,7 +48,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 
 			pipelineRunName := "cancel-me"
 			pipelineRun := &v1alpha1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName},
+				ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
 				Spec: v1alpha1.PipelineRunSpec{
 					PipelineSpec: &v1alpha1.PipelineSpec{
 						Tasks: []v1alpha1.PipelineTask{{
@@ -83,10 +83,8 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 
 			var wg sync.WaitGroup
-			var trName []string
 			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRunName, namespace)
 			for _, taskrunItem := range taskrunList.Items {
-				trName = append(trName, taskrunItem.Name)
 				wg.Add(1)
 				go func(name string) {
 					defer wg.Done()
@@ -134,6 +132,14 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 			wg.Wait()
 
+			var trName []string
+			taskrunList, err = c.TaskRunClient.List(metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+			if err != nil {
+				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+			}
+			for _, taskrunItem := range taskrunList.Items {
+				trName = append(trName, taskrunItem.Name)
+			}
 			matchKinds := map[string][]string{"PipelineRun": {pipelineRunName}, "TaskRun": trName}
 			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
 			expectedNumberOfEvents := 1 + len(trName)


### PR DESCRIPTION
This is a refactor in cancellation test, one things is to create
pipelinerun in the namespace created and second thing is to
count taskruns at the end, because new will get created after
retry

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
   NONE
```
