### PR TITLE
Enhance v1beta1 validation code for clustertask 🍸

### DIFF
--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -26,8 +26,6 @@ import (
 var _ apis.Validatable = (*ClusterTask)(nil)
 
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
-	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
-		return err.ViaField("metadata")
-	}
-	return t.Spec.Validate(ctx)
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This make a better use of knative.dev/pkg apis errors package in order
to make the code simpler, *and* the report better.

- This allows reporting multiple validation error at once — so, one
  failure message (webhook error) would be more useful to the user.
- This reduce `if err != nil` path, simplifying the code.

This commit tackles `ClusterTask` 🙃

Follows-up #3185

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @pritidesai @bobcatfish @ImJasonH @savitaashture 

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
ClusterTask validation now reports all the error at once, and is a bit more detailed.
```