### PR TITLE
WIP: helper method to detect key collisions

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -108,7 +108,10 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 				}},
 			},
 		},
-		wantErr: apis.ErrMultipleOneOf("spec.workspaces.name"),
+		wantErr: &apis.FieldError{
+			Message: `item 1 value for field "Name" conflicts with value for item 0`,
+			Paths:   []string{"spec.workspaces.name"},
+		},
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {
@@ -197,7 +200,10 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			}},
 			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
 		},
-		wantErr: apis.ErrMultipleOneOf("spec.params.name"),
+		wantErr: &apis.FieldError{
+			Message: `item 1 value for field "Name" conflicts with value for item 0`,
+			Paths:   []string{"spec.params.name"},
+		},
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/apis/validate/key_conflict.go
+++ b/pkg/apis/validate/key_conflict.go
@@ -1,0 +1,65 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+
+	"knative.dev/pkg/apis"
+)
+
+// KeyConflict returns an error if any of the elements in things has the same
+// value for the field named fieldName.
+//
+// It also returns an error if things is not a slice, if any element in things
+// is not a struct, or if any field named fieldName in the struct is not a
+// string or is not defined. Things can be a slice of pointers to structs, and
+// fieldName can be a field of type *string.
+func KeyConflict(things interface{}, fieldName, fieldPath string) *apis.FieldError {
+	tsv := reflect.ValueOf(things)
+	if tsv.Kind() != reflect.Slice {
+		return &apis.FieldError{
+			Message: fmt.Sprintf("value is not a slice (%T)", things),
+			Paths:   []string{fieldPath},
+		}
+	}
+
+	seen := map[string]int{}
+	for i := 0; i < tsv.Len(); i++ {
+		tv := tsv.Index(i)
+		if tv.Kind() == reflect.Ptr {
+			tv = tv.Elem()
+		}
+		if tv.Kind() != reflect.Struct {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("item %d is not a struct", i),
+				Paths:   []string{fieldPath},
+			}
+		}
+		fv := tv.FieldByName(fieldName)
+		fvk := fv.Kind()
+		if fvk == reflect.Ptr {
+			fv = fv.Elem()
+			fvk = fv.Kind()
+		}
+		if fvk == reflect.Invalid {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("item %d value for field %q is not defined", i, fieldName),
+				Paths:   []string{fieldPath},
+			}
+		} else if fvk != reflect.String {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("item %d value for field %q is not a string (%s)", i, fieldName, fvk),
+				Paths:   []string{fieldPath},
+			}
+		}
+		sv := fv.String()
+		if idx, found := seen[sv]; found {
+			return &apis.FieldError{
+				Message: fmt.Sprintf("item %d value for field %q conflicts with value for item %d", i, fieldName, idx),
+				Paths:   []string{fieldPath},
+			}
+		}
+		seen[sv] = i
+	}
+	return nil
+}

--- a/pkg/apis/validate/key_conflict_test.go
+++ b/pkg/apis/validate/key_conflict_test.go
@@ -1,0 +1,71 @@
+package validate
+
+import "testing"
+
+func TestKeyConflict(t *testing.T) {
+	type kv struct{ Key, Value string }
+	fieldPath := ".field.path"
+	aString := "I'm just a string"
+
+	for _, test := range []struct {
+		name      string
+		things    interface{}
+		fieldName string
+		want      string
+	}{{
+		name:      "happy case; one item",
+		things:    []kv{{Key: "foo", Value: "bar"}},
+		fieldName: "Key",
+	}, {
+		name: "happy case; two unique items",
+		things: []kv{
+			{Key: "foo", Value: "bar"},
+			{Key: "bar", Value: "baz"},
+		},
+		fieldName: "Key",
+	}, {
+		name:      "happy case;  things[i] is a *struct",
+		things:    []*kv{{Key: "foo", Value: "bar"}},
+		fieldName: "Key",
+	}, {
+		name:      "things[i].key is a *string",
+		things:    []struct{ Key *string }{{Key: &aString}},
+		fieldName: "Key",
+	}, {
+		name: "key conflict",
+		things: []kv{
+			{Key: "foo", Value: "bar"},
+			{Key: "bar", Value: "bar"},
+			{Key: "bar", Value: "baz"},
+		},
+		fieldName: "Key",
+		want:      `item 2 value for field "Key" conflicts with value for item 1: .field.path`,
+	}, {
+		name:      "things is not a slice",
+		things:    12345,
+		fieldName: "DoesntMatter",
+		want:      "value is not a slice (int): .field.path",
+	}, {
+		name:      "things[i] is not a struct",
+		things:    []int{12345},
+		fieldName: "DoesntMatter",
+		want:      "item 0 is not a struct: .field.path",
+	}, {
+		name:      "things[i].key is not a string",
+		things:    []struct{ NonString int }{{NonString: 12345}},
+		fieldName: "NonString",
+		want:      `item 0 value for field "NonString" is not a string (int): .field.path`,
+	}, {
+		name:      "things[i].foo not defined",
+		things:    []kv{{Key: "foo", Value: "bar"}},
+		fieldName: "DoesntExist",
+		want:      `item 0 value for field "DoesntExist" is not defined: .field.path`,
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			got := KeyConflict(test.things, test.fieldName, fieldPath)
+			if got.Error() != test.want {
+				t.Errorf("\n got: %v\nwant: %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Today, we have a number of cases where repeated key/value pairs are used to simulate a map, in keeping with KRM style. We validate that key names (usually named `name:`) are unique. For example:

```
params:
- name: repo
  value: github.com/foo
- name: revision
  value: master
- name: repo
  value: github.com/bar
```

This is invalid because two items provide the value for the parameter named `foo`. Note that it would _still_ be invalid even if both params provided the same value.

In a lot of places in Tekton we _incorrectly_ return [`apis.ErrMultipleOneOf`](https://godoc.org/knative.dev/pkg/apis#ErrMultipleOneOf) in such cases -- this is incorrect because `MultipleOneOf` is intended to signify that only one of fields A or B should be set, but not both. For example, specifying `taskRef` and `taskSpec` is an `ErrMultipleOneOf`.

This PR adds a helper method that uses reflection to inspect a provided slice of structs, pull out the values of a field (e.g., `Name`), and make sure that slice doesn't specify two items with the same value for,  e.g., `name:`.

This PR includes unit tests for the new method, and converts an existing incorrect usage of `ErrMultipleOneOf` to demonstrate its usage.

/area testing
/kind cleanup
Spawned from https://github.com/knative/pkg/issues/1726

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Introducing a reflect-based helper method to validate key conflicts
```