### PR TITLE
Introduce Optional Workspaces

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -14,6 +14,7 @@ This page documents the variable substitutions supported by `Tasks` and `Pipelin
 | -------- | ----------- |
 | `params.<param name>` | The value of the parameter at runtime. |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
+| `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.uid` | The uid of the `PipelineRun` that this `Pipeline` is running in. |
@@ -28,7 +29,8 @@ This page documents the variable substitutions supported by `Tasks` and `Pipelin
 | `resources.inputs.<resourceName>.path` | The path to the input resource's directory. |
 | `resources.outputs.<resourceName>.path` | The path to the output resource's directory. |
 | `results.<resultName>.path` | The path to the file where the `Task` writes its results data. |
-| `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. |
+| `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. Empty string if an optional `Workspace` has not been provided by the TaskRun. |
+| `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if an optional`Workspace` has not been provided by the TaskRun. |
 | `workspaces.<workspaceName>.claim` | The name of the `PersistentVolumeClaim` specified as a volume source for the `Workspace`. Empty string for other volume types. |
 | `workspaces.<workspaceName>.volume` | The name of the volume populating the `Workspace`. |
 | `credentials.path` | The path to credentials injected from Secrets with matching annotations. |

--- a/examples/v1beta1/pipelineruns/optional-workspaces.yaml
+++ b/examples/v1beta1/pipelineruns/optional-workspaces.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-source-code-configmap
+data:
+  main.js: |
+    console.log("Hello, World!");
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-js
+spec:
+  workspaces:
+  - name: prelaunch
+    optional: true
+  - name: launch
+  steps:
+  - image: node:lts-alpine3.11
+    script: |
+      #!/usr/bin/env sh
+      if [ $(workspaces.prelaunch.bound) == "true" ] ; then
+        node "$(workspaces.prelaunch.path)/init.js"
+      else
+        echo "Skipping prelaunch."
+      fi
+      if [ -f "$(workspaces.launch.path)/main.js" ] ; then
+        node "$(workspaces.launch.path)/main.js"
+      else
+        echo "Error: missing main.js file in launch workspace!"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo
+spec:
+  params:
+  - name: values
+    type: array
+  steps:
+  - image: alpine
+    command: ["echo"]
+    args: ["$(params.values[*])"]
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: optional-workspaces-
+spec:
+  workspaces:
+  - name: launch
+    configMap:
+      name: example-source-code-configmap
+  pipelineSpec:
+    workspaces:
+    - name: launch
+      description: |
+        The program to run. Must provide a main.js at its root.
+    - name: prelaunch
+      optional: true
+      description: |
+        Prelaunch program to run before the launch program. Use this
+        to set up any environment-specific requirements. Must provide
+        an init.js file at its root.
+    tasks:
+    - name: print-bound-state
+      taskRef:
+        name: echo
+      params:
+      - name: values
+        value:
+        - "Was a prelaunch workspace provided? "
+        - $(workspaces.prelaunch.bound)
+        - "\n"
+        - "Was a launch workspace provided? "
+        - "$(workspaces.launch.bound)"
+        - "\n"
+    - name: run-js
+      runAfter: [print-bound-state]
+      workspaces:
+      - name: launch
+        workspace: launch
+      taskRef:
+        name: run-js

--- a/examples/v1beta1/taskruns/optional-workspaces.yaml
+++ b/examples/v1beta1/taskruns/optional-workspaces.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: optional-workspaces-
+spec:
+  workspaces:
+  - name: source-code
+    emptyDir: {}
+  taskSpec:
+    workspaces:
+    - name: source-code
+      optional: true
+    - name: extra-config
+      optional: true
+    steps:
+    - name: check-workspaces
+      image: alpine:3.12.0
+      script: |
+        if [ "$(workspaces.source-code.bound)" == "true" ]; then
+          printf "Source code workspace was provided at %s!\n" "$(workspaces.source-code.path)"
+        fi
+        if [ "$(workspaces.extra-config.bound)" == "true" ]; then
+          printf "Unexpected extra configuration mounted at %s\n" "$(workspaces.extra-config.path)"
+          exit 1
+        fi

--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -36,6 +36,9 @@ type WorkspaceDeclaration struct {
 	// ReadOnly dictates whether a mounted volume is writable. By default this
 	// field is false and so mounted volumes are writable.
 	ReadOnly bool `json:"readOnly,omitempty"`
+	// Optional marks a Workspace as not being required in TaskRuns. By default
+	// this field is false and so declared workspaces are required.
+	Optional bool `json:"optional,omitempty"`
 }
 
 // GetMountPath returns the mountPath for w which is the MountPath if provided or the
@@ -91,6 +94,9 @@ type PipelineWorkspaceDeclaration struct {
 	// tasks are intended to have access to the data on the workspace.
 	// +optional
 	Description string `json:"description,omitempty"`
+	// Optional marks a Workspace as not being required in PipelineRuns. By default
+	// this field is false and so declared workspaces are required.
+	Optional bool `json:"optional,omitempty"`
 }
 
 // WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -387,6 +387,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 	// Apply parameter substitution from the PipelineRun
 	pipelineSpec = resources.ApplyParameters(pipelineSpec, pr)
 	pipelineSpec = resources.ApplyContexts(pipelineSpec, pipelineMeta.Name, pr)
+	pipelineSpec = resources.ApplyWorkspaces(pipelineSpec, pr)
 
 	// pipelineRunState holds a list of pipeline tasks after resolving conditions and pipeline resources
 	// pipelineRunState also holds a taskRun for each pipeline task after the taskRun is created

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -84,6 +84,20 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 	}
 }
 
+func ApplyWorkspaces(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
+	p = p.DeepCopy()
+	replacements := map[string]string{}
+	for _, declaredWorkspace := range p.Workspaces {
+		key := fmt.Sprintf("workspaces.%s.bound", declaredWorkspace.Name)
+		replacements[key] = "false"
+	}
+	for _, boundWorkspace := range pr.Spec.Workspaces {
+		key := fmt.Sprintf("workspaces.%s.bound", boundWorkspace.Name)
+		replacements[key] = "true"
+	}
+	return ApplyReplacements(p, replacements, map[string][]string{})
+}
+
 // ApplyReplacements replaces placeholders for declared parameters with the specified replacements.
 func ApplyReplacements(p *v1beta1.PipelineSpec, replacements map[string]string, arrayReplacements map[string][]string) *v1beta1.PipelineSpec {
 	p = p.DeepCopy()

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -255,8 +255,11 @@ func ValidateWorkspaceBindings(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun)
 	}
 
 	for _, ws := range p.Workspaces {
+		if ws.Optional {
+			continue
+		}
 		if _, ok := pipelineRunWorkspaces[ws.Name]; !ok {
-			return fmt.Errorf("pipeline expects workspace with name %q be provided by pipelinerun", ws.Name)
+			return fmt.Errorf("pipeline requires workspace with name %q be provided by pipelinerun", ws.Name)
 		}
 	}
 	return nil

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/tektoncd/pipeline/pkg/workspace"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -108,24 +109,37 @@ func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1bet
 	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
-// ApplyWorkspaces applies the substitution from paths that the workspaces in w are mounted to, the
-// volumes that wb are realized with in the task spec ts and the PersistentVolumeClaim names for the
+// ApplyWorkspaces applies the substitution from paths that the workspaces in declarations mounted to, the
+// volumes that bindings are realized with in the task spec and the PersistentVolumeClaim names for the
 // workspaces.
-func ApplyWorkspaces(spec *v1beta1.TaskSpec, w []v1beta1.WorkspaceDeclaration, wb []v1beta1.WorkspaceBinding) *v1beta1.TaskSpec {
+func ApplyWorkspaces(spec *v1beta1.TaskSpec, declarations []v1beta1.WorkspaceDeclaration, bindings []v1beta1.WorkspaceBinding) *v1beta1.TaskSpec {
 	stringReplacements := map[string]string{}
 
-	for _, ww := range w {
-		stringReplacements[fmt.Sprintf("workspaces.%s.path", ww.Name)] = ww.GetMountPath()
+	bindNames := sets.NewString()
+	for _, binding := range bindings {
+		bindNames.Insert(binding.Name)
 	}
-	v := workspace.GetVolumes(wb)
-	for name, vv := range v {
-		stringReplacements[fmt.Sprintf("workspaces.%s.volume", name)] = vv.Name
-	}
-	for _, w := range wb {
-		if w.PersistentVolumeClaim != nil {
-			stringReplacements[fmt.Sprintf("workspaces.%s.claim", w.Name)] = w.PersistentVolumeClaim.ClaimName
+
+	for _, declaration := range declarations {
+		prefix := fmt.Sprintf("workspaces.%s.", declaration.Name)
+		if declaration.Optional && !bindNames.Has(declaration.Name) {
+			stringReplacements[prefix+"bound"] = "false"
+			stringReplacements[prefix+"path"] = ""
 		} else {
-			stringReplacements[fmt.Sprintf("workspaces.%s.claim", w.Name)] = ""
+			stringReplacements[prefix+"bound"] = "true"
+			stringReplacements[prefix+"path"] = declaration.GetMountPath()
+		}
+	}
+
+	vols := workspace.GetVolumes(bindings)
+	for name, vol := range vols {
+		stringReplacements[fmt.Sprintf("workspaces.%s.volume", name)] = vol.Name
+	}
+	for _, binding := range bindings {
+		if binding.PersistentVolumeClaim != nil {
+			stringReplacements[fmt.Sprintf("workspaces.%s.claim", binding.Name)] = binding.PersistentVolumeClaim.ClaimName
+		} else {
+			stringReplacements[fmt.Sprintf("workspaces.%s.claim", binding.Name)] = ""
 		}
 	}
 	return ApplyReplacements(spec, stringReplacements, map[string][]string{})

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -708,49 +708,91 @@ func TestApplyWorkspaces(t *testing.T) {
 			},
 		}},
 	}
-	want := applyMutation(ts, func(spec *v1beta1.TaskSpec) {
-		spec.StepTemplate.Env[0].Value = "ws-9l9zj"
-		spec.StepTemplate.Env[1].Value = "foo"
-		spec.StepTemplate.Env[2].Value = ""
+	for _, tc := range []struct {
+		name  string
+		spec  *v1beta1.TaskSpec
+		decls []v1beta1.WorkspaceDeclaration
+		binds []v1beta1.WorkspaceBinding
+		want  *v1beta1.TaskSpec
+	}{{
+		name: "workspace-variable-replacement",
+		spec: ts.DeepCopy(),
+		decls: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}, {
+			Name:      "otherws",
+			MountPath: "/foo",
+		}},
+		binds: []v1beta1.WorkspaceBinding{{
+			Name: "myws",
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "foo",
+			},
+		}, {
+			Name:     "otherws",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+		want: applyMutation(ts, func(spec *v1beta1.TaskSpec) {
+			spec.StepTemplate.Env[0].Value = "ws-9l9zj"
+			spec.StepTemplate.Env[1].Value = "foo"
+			spec.StepTemplate.Env[2].Value = ""
 
-		spec.Steps[0].Name = "ws-9l9zj"
-		spec.Steps[0].Image = "ws-mz4c7"
-		spec.Steps[0].WorkingDir = "ws-mz4c7"
-		spec.Steps[0].Args = []string{"/workspace/myws"}
+			spec.Steps[0].Name = "ws-9l9zj"
+			spec.Steps[0].Image = "ws-mz4c7"
+			spec.Steps[0].WorkingDir = "ws-mz4c7"
+			spec.Steps[0].Args = []string{"/workspace/myws"}
 
-		spec.Steps[1].VolumeMounts[0].Name = "ws-9l9zj"
-		spec.Steps[1].VolumeMounts[0].MountPath = "path/to//foo"
-		spec.Steps[1].VolumeMounts[0].SubPath = "ws-9l9zj"
+			spec.Steps[1].VolumeMounts[0].Name = "ws-9l9zj"
+			spec.Steps[1].VolumeMounts[0].MountPath = "path/to//foo"
+			spec.Steps[1].VolumeMounts[0].SubPath = "ws-9l9zj"
 
-		spec.Steps[2].Env[0].Value = "ws-9l9zj"
-		spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.LocalObjectReference.Name = "ws-9l9zj"
-		spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.Key = "ws-9l9zj"
-		spec.Steps[2].EnvFrom[0].Prefix = "ws-9l9zj"
-		spec.Steps[2].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name = "ws-9l9zj"
+			spec.Steps[2].Env[0].Value = "ws-9l9zj"
+			spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.LocalObjectReference.Name = "ws-9l9zj"
+			spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.Key = "ws-9l9zj"
+			spec.Steps[2].EnvFrom[0].Prefix = "ws-9l9zj"
+			spec.Steps[2].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name = "ws-9l9zj"
 
-		spec.Volumes[0].Name = "ws-9l9zj"
-		spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name = "ws-9l9zj"
-		spec.Volumes[1].VolumeSource.Secret.SecretName = "ws-9l9zj"
-		spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "ws-9l9zj"
-	})
-	w := []v1beta1.WorkspaceDeclaration{{
-		Name: "myws",
+			spec.Volumes[0].Name = "ws-9l9zj"
+			spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name = "ws-9l9zj"
+			spec.Volumes[1].VolumeSource.Secret.SecretName = "ws-9l9zj"
+			spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "ws-9l9zj"
+		}),
 	}, {
-		Name:      "otherws",
-		MountPath: "/foo",
-	}}
-	wb := []v1beta1.WorkspaceBinding{{
-		Name: "myws",
-		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-			ClaimName: "foo",
-		},
+		name: "optional-workspace-provided-variable-replacement",
+		spec: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "$(workspaces.ows.bound)" = "true" && echo "$(workspaces.ows.path)"`,
+		}}},
+		decls: []v1beta1.WorkspaceDeclaration{{
+			Name:     "ows",
+			Optional: true,
+		}},
+		binds: []v1beta1.WorkspaceBinding{{
+			Name:     "ows",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+		want: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "true" = "true" && echo "/workspace/ows"`,
+		}}},
 	}, {
-		Name:     "otherws",
-		EmptyDir: &corev1.EmptyDirVolumeSource{},
-	}}
-	got := resources.ApplyWorkspaces(ts, w, wb)
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("TestApplyWorkspaces() got diff %s", diff.PrintWantGot(d))
+		name: "optional-workspace-omitted-variable-replacement",
+		spec: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "$(workspaces.ows.bound)" = "true" && echo "$(workspaces.ows.path)"`,
+		}}},
+		decls: []v1beta1.WorkspaceDeclaration{{
+			Name:     "ows",
+			Optional: true,
+		}},
+		binds: []v1beta1.WorkspaceBinding{}, // intentionally omitted ows binding
+		want: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "false" = "true" && echo ""`,
+		}}},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resources.ApplyWorkspaces(tc.spec, tc.decls, tc.binds)
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("TestApplyWorkspaces() got diff %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -423,14 +423,16 @@ func (c *Reconciler) updateTaskRunWithDefaultWorkspaces(ctx context.Context, tr 
 		}
 		workspaceBindings := map[string]v1beta1.WorkspaceBinding{}
 		for _, tsWorkspace := range taskSpec.Workspaces {
-			workspaceBindings[tsWorkspace.Name] = v1beta1.WorkspaceBinding{
-				Name:                  tsWorkspace.Name,
-				SubPath:               defaultWS.SubPath,
-				VolumeClaimTemplate:   defaultWS.VolumeClaimTemplate,
-				PersistentVolumeClaim: defaultWS.PersistentVolumeClaim,
-				EmptyDir:              defaultWS.EmptyDir,
-				ConfigMap:             defaultWS.ConfigMap,
-				Secret:                defaultWS.Secret,
+			if !tsWorkspace.Optional {
+				workspaceBindings[tsWorkspace.Name] = v1beta1.WorkspaceBinding{
+					Name:                  tsWorkspace.Name,
+					SubPath:               defaultWS.SubPath,
+					VolumeClaimTemplate:   defaultWS.VolumeClaimTemplate,
+					PersistentVolumeClaim: defaultWS.PersistentVolumeClaim,
+					EmptyDir:              defaultWS.EmptyDir,
+					ConfigMap:             defaultWS.ConfigMap,
+					Secret:                defaultWS.Secret,
+				}
 			}
 		}
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2848,6 +2848,96 @@ func TestReconcileInvalidDefaultWorkspace(t *testing.T) {
 	}
 }
 
+// TestReconcileValidDefaultWorkspaceOmittedOptionalWorkspace tests a reconcile
+// of a TaskRun that has omitted a Workspace that the Task has marked as optional
+// with a Default TaskRun workspace defined. The default workspace should not be
+// injected in place of the omitted optional workspace.
+func TestReconcileValidDefaultWorkspaceOmittedOptionalWorkspace(t *testing.T) {
+	optionalWorkspaceMountPath := "/foo/bar/baz"
+	taskWithOptionalWorkspace := &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task-with-optional-workspace",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskSpec{
+			Workspaces: []v1beta1.WorkspaceDeclaration{{
+				Name:      "optional-ws",
+				MountPath: optionalWorkspaceMountPath,
+				Optional:  true,
+			}},
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Name:    "simple-step",
+				Image:   "foo",
+				Command: []string{"/mycmd"},
+			}}},
+		},
+	}
+	taskRunOmittingWorkspace := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-taskrun",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "test-task-with-optional-workspace",
+			},
+		},
+	}
+
+	d := test.Data{
+		Tasks:    []*v1beta1.Task{taskWithOptionalWorkspace},
+		TaskRuns: []*v1beta1.TaskRun{taskRunOmittingWorkspace},
+	}
+
+	d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.GetNamespace()},
+		Data: map[string]string{
+			"default-task-run-workspace-binding": "emptyDir: {}",
+		},
+	})
+	names.TestingSeed()
+	testAssets, cancel := getTaskRunController(t, d)
+	defer cancel()
+	clients := testAssets.Clients
+
+	t.Logf("Creating SA %s in %s", "default", "foo")
+	if _, err := clients.Kube.CoreV1().ServiceAccounts("default").Create(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "default",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRunOmittingWorkspace)); err != nil {
+		t.Errorf("Unexpected reconcile error for TaskRun %q: %v", taskRunOmittingWorkspace.Name, err)
+	}
+
+	tr, err := clients.Pipeline.TektonV1beta1().TaskRuns(taskRunOmittingWorkspace.Namespace).Get(taskRunOmittingWorkspace.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting TaskRun %q: %v", taskRunOmittingWorkspace.Name, err)
+	}
+
+	pod, err := clients.Kube.CoreV1().Pods(taskRunOmittingWorkspace.Namespace).Get(tr.Status.PodName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting Pod for TaskRun %q: %v", taskRunOmittingWorkspace.Name, err)
+	}
+	for _, c := range pod.Spec.Containers {
+		for _, vm := range c.VolumeMounts {
+			if vm.MountPath == optionalWorkspaceMountPath {
+				t.Errorf("Workspace with VolumeMount at %s should not have been found for Optional Workspace but was injected by Default TaskRun Workspace", optionalWorkspaceMountPath)
+			}
+		}
+	}
+
+	for _, c := range tr.Status.Conditions {
+		if c.Type == apis.ConditionSucceeded && c.Status == corev1.ConditionFalse {
+			t.Errorf("Unexpected unsuccessful condition for TaskRun %q:\n%#v", taskRunOmittingWorkspace.Name, tr.Status.Conditions)
+		}
+	}
+}
+
 func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 	for _, tt := range []struct {
 		desc             string

--- a/pkg/workspace/validate_test.go
+++ b/pkg/workspace/validate_test.go
@@ -58,6 +58,23 @@ func TestValidateBindingsValid(t *testing.T) {
 			Name:     "beth",
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		}},
+	}, {
+		name: "Included optional workspace",
+		declarations: []v1alpha1.WorkspaceDeclaration{{
+			Name:     "beth",
+			Optional: true,
+		}},
+		bindings: []v1alpha1.WorkspaceBinding{{
+			Name:     "beth",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+	}, {
+		name: "Omitted optional workspace",
+		declarations: []v1alpha1.WorkspaceDeclaration{{
+			Name:     "beth",
+			Optional: true,
+		}},
+		bindings: []v1alpha1.WorkspaceBinding{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := ValidateBindings(tc.declarations, tc.bindings); err != nil {

--- a/test/v1alpha1/workspace_test.go
+++ b/test/v1alpha1/workspace_test.go
@@ -161,7 +161,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
-	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline expects workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline requires workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
 		t.Fatalf("Failed to wait for PipelineRun %q to finish: %s", pipelineRunName, err)
 	}
 

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -231,7 +231,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
-	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline expects workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline requires workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
 		t.Fatalf("Failed to wait for PipelineRun %q to finish: %s", pipelineRunName, err)
 	}
 }


### PR DESCRIPTION
# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Initial design approved in [TEP 10](https://github.com/tektoncd/community/blob/master/teps/0010-optional-workspaces.md).

Prior to this commit any Workspaces declared by a Task are required to be provided by a TaskRun or Pipeline/Run.

This commit introduces the concept of Optional Workspaces: a Task may declare a Workspace as optional and a TaskRun may then omit that Workspace at runtime. Pipelines and PipelineRuns may do the same.

A new variable is introduced for workspaces, "bound", which interpolates to either "true" or "false" depending on whether a workspace binding is included in a TaskRun or not.

Default TaskRun Workspaces are _not_ injected in place of an omitted optional Workspace.

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Introduce optional workspaces: A Task or Pipeline may declare a workspace optional and conditionally change their behaviour based on its presence. A TaskRun or PipelineRun may omit that workspace and thereby modify the Task or Pipeline behaviour.
```