### PR TITLE
Enhance v1beta1 validation code for pipelinerun 🍸

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -36,19 +36,15 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 		want *apis.FieldError
 	}{
 		{
-			name: "invalid pipelinerun",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "prmetaname",
-				},
-			},
-			want: apis.ErrMissingField("spec"),
-		},
-		{
 			name: "invalid pipelinerun metadata",
 			pr: v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pipelinerun.name",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: "prname",
+					},
 				},
 			},
 			want: &apis.FieldError{
@@ -155,15 +151,11 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 		spec    v1beta1.PipelineRunSpec
 		wantErr *apis.FieldError
 	}{{
-		name:    "Empty pipelineSpec",
-		spec:    v1beta1.PipelineRunSpec{},
-		wantErr: apis.ErrMissingField("spec"),
-	}, {
 		name: "pipelineRef without Pipeline Name",
 		spec: v1beta1.PipelineRunSpec{
 			PipelineRef: &v1beta1.PipelineRef{},
 		},
-		wantErr: apis.ErrMissingField("spec.pipelineref.name", "spec.pipelinespec"),
+		wantErr: apis.ErrMissingField("pipelineref.name", "pipelinespec"),
 	}, {
 		name: "pipelineRef and pipelineSpec together",
 		spec: v1beta1.PipelineRunSpec{
@@ -178,7 +170,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 					},
 				}}},
 		},
-		wantErr: apis.ErrDisallowedFields("spec.pipelinespec", "spec.pipelineref"),
+		wantErr: apis.ErrDisallowedFields("pipelinespec", "pipelineref"),
 	}, {
 		name: "workspaces may only appear once",
 		spec: v1beta1.PipelineRunSpec{
@@ -195,7 +187,7 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 		},
 		wantErr: &apis.FieldError{
 			Message: `workspace "ws" provided by pipelinerun more than once, at index 0 and 1`,
-			Paths:   []string{"spec.workspaces"},
+			Paths:   []string{"workspaces[1].name"},
 		},
 	}, {
 		name: "workspaces must contain a valid volume config",
@@ -210,11 +202,11 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 		wantErr: &apis.FieldError{
 			Message: "expected exactly one, got neither",
 			Paths: []string{
-				"spec.workspaces[0].configmap",
-				"spec.workspaces[0].emptydir",
-				"spec.workspaces[0].persistentvolumeclaim",
-				"spec.workspaces[0].secret",
-				"spec.workspaces[0].volumeclaimtemplate",
+				"workspaces[0].configmap",
+				"workspaces[0].emptydir",
+				"workspaces[0].persistentvolumeclaim",
+				"workspaces[0].secret",
+				"workspaces[0].volumeclaimtemplate",
 			},
 		},
 	}}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This make a better use of knative.dev/pkg apis errors package in order
to make the code simpler, *and* the report better.

- This allows reporting multiple validation error at once — so, one
  failure message (webhook error) would be more useful to the user.
- This reduce `if err != nil` path, simplifying the code.

This commit tackles `PipelineRun` 🙃

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @pritidesai @jerop @bobcatfish @sbwsg @savitaashture @ImJasonH

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
PipelineRun validation now reports all the error at once, and is a bit more detailed.
```
