### PR TITLE
Log cloud events to help debug issue 2992

### DIFF
--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -140,6 +140,7 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 	wasIn := make(chan error)
 	go func() {
 		wasIn <- nil
+		logger.Debugf("Sending cloudevent of type %q", event.Type())
 		if result := ceClient.Send(cloudevents.ContextWithRetriesExponentialBackoff(ctx, 10*time.Millisecond, 10), *event); !cloudevents.IsACK(result) {
 			logger.Warnf("Failed to send cloudevent: %s", result.Error())
 			recorder := controller.GetEventRecorder(ctx)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

This adds a log line to help debug future flakes in the TestReconcile_CloudEvents test for the TaskRun reconciler.

Prior to this commit, no messages are logged when the cloud
event controller is told to send an event by the TaskRun
reconciler.

Our working theory is that because we are delivering cloud events
from go routines (in order to support retries) the events may
end up sent in the wrong order, because the go routine scheduler
is not respecting the order they're created in.

So this commit adds a log entry from the cloud event controller in
order to help determine if the events are being sent out of order.

If the TestReconcile_CloudEvents unit test fails and the order
of sending doesn't appear to be incorrect then it may be that the events are
being retried and therefore pushed out of order.

Co-authored-by: christiewilson@google.com

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```