### PR TITLE
Provide configuration option to disallow omitting known_hosts

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -58,3 +58,9 @@ data:
   #
   # See https://github.com/tektoncd/pipeline/issues/2080 for more info.
   running-in-environment-with-injected-sidecars: "true"
+  # Setting this flag to "true" will require that any Git SSH Secret
+  # offered to Tekton must have known_hosts included.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2981 for more
+  # info.
+  require-git-ssh-secret-known-hosts: "false"

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -29,10 +29,12 @@ const (
 	disableWorkingDirOverwriteKey           = "disable-working-directory-overwrite"
 	disableAffinityAssistantKey             = "disable-affinity-assistant"
 	runningInEnvWithInjectedSidecarsKey     = "running-in-environment-with-injected-sidecars"
+	requireGitSSHSecretKnownHostsKey        = "require-git-ssh-secret-known-hosts" // nolint: gosec
 	DefaultDisableHomeEnvOverwrite          = false
 	DefaultDisableWorkingDirOverwrite       = false
 	DefaultDisableAffinityAssistant         = false
 	DefaultRunningInEnvWithInjectedSidecars = true
+	DefaultRequireGitSSHSecretKnownHosts    = false
 )
 
 // FeatureFlags holds the features configurations
@@ -42,6 +44,7 @@ type FeatureFlags struct {
 	DisableWorkingDirOverwrite       bool
 	DisableAffinityAssistant         bool
 	RunningInEnvWithInjectedSidecars bool
+	RequireGitSSHSecretKnownHosts    bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -79,6 +82,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setFeature(runningInEnvWithInjectedSidecarsKey, DefaultRunningInEnvWithInjectedSidecars, &tc.RunningInEnvWithInjectedSidecars); err != nil {
+		return nil, err
+	}
+	if err := setFeature(requireGitSSHSecretKnownHostsKey, DefaultRequireGitSSHSecretKnownHosts, &tc.RequireGitSSHSecretKnownHosts); err != nil {
 		return nil, err
 	}
 	return &tc, nil

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -45,6 +45,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				DisableWorkingDirOverwrite:       true,
 				DisableAffinityAssistant:         true,
 				RunningInEnvWithInjectedSidecars: false,
+				RequireGitSSHSecretKnownHosts:    true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -22,3 +22,4 @@ data:
   disable-working-directory-overwrite: "true"
   disable-affinity-assistant: "true"
   running-in-environment-with-injected-sidecars: "false"
+  require-git-ssh-secret-known-hosts: "true"

--- a/pkg/apis/config/testdata/feature-flags.yaml
+++ b/pkg/apis/config/testdata/feature-flags.yaml
@@ -22,3 +22,4 @@ data:
   disable-working-directory-overwrite: "false"
   disable-affinity-assistant: "false"
   running-in-environment-with-injected-sidecars: "true"
+  require-git-ssh-secret-known-hosts: "false"

--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -30,7 +31,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const credsInitHomeMountPrefix = "tekton-creds-init-home"
+const (
+	credsInitHomeMountPrefix = "tekton-creds-init-home"
+	sshKnownHosts            = "known_hosts"
+)
 
 // credsInit reads secrets available to the given service account and
 // searches for annotations matching a specific format (documented in
@@ -43,7 +47,7 @@ const credsInitHomeMountPrefix = "tekton-creds-init-home"
 // Any errors encountered during this process are returned to the
 // caller. If no matching annotated secrets are found, nil lists with a
 // nil error are returned.
-func credsInit(serviceAccountName, namespace string, kubeclient kubernetes.Interface) ([]string, []corev1.Volume, []corev1.VolumeMount, error) {
+func credsInit(ctx context.Context, serviceAccountName, namespace string, kubeclient kubernetes.Interface) ([]string, []corev1.Volume, []corev1.VolumeMount, error) {
 	// service account if not specified in pipeline/task spec, read it from the ConfigMap
 	// and defaults to `default` if its missing from the ConfigMap as well
 	if serviceAccountName == "" {
@@ -63,6 +67,10 @@ func credsInit(serviceAccountName, namespace string, kubeclient kubernetes.Inter
 	for _, secretEntry := range sa.Secrets {
 		secret, err := kubeclient.CoreV1().Secrets(namespace).Get(secretEntry.Name, metav1.GetOptions{})
 		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if err := checkGitSSHSecret(ctx, secret); err != nil {
 			return nil, nil, nil, err
 		}
 
@@ -114,4 +122,18 @@ func getCredsInitVolume() (corev1.Volume, corev1.VolumeMount) {
 		MountPath: pipeline.CredsDir,
 	}
 	return v, vm
+}
+
+// checkGitSSHSecret requires `known_host` field must be included in Git SSH Secret when feature flag
+// `require-git-ssh-secret-known-hosts` is true.
+func checkGitSSHSecret(ctx context.Context, secret *corev1.Secret) error {
+	cfg := config.FromContextOrDefaults(ctx)
+
+	if secret.Type == corev1.SecretTypeSSHAuth && cfg.FeatureFlags.RequireGitSSHSecretKnownHosts {
+		if _, ok := secret.Data[sshKnownHosts]; !ok {
+			return fmt.Errorf("TaskRun validation failed. Git SSH Secret must have \"known_hosts\" included " +
+				"when feature flag \"require-git-ssh-secret-known-hosts\" is set to true")
+		}
+	}
+	return nil
 }

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -106,7 +106,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	// Create Volumes and VolumeMounts for any credentials found in annotated
 	// Secrets, along with any arguments needed by Step entrypoints to process
 	// those secrets.
-	credEntrypointArgs, credVolumes, credVolumeMounts, err := credsInit(taskRun.Spec.ServiceAccountName, taskRun.Namespace, b.KubeClient)
+	credEntrypointArgs, credVolumes, credVolumeMounts, err := credsInit(ctx, taskRun.Spec.ServiceAccountName, taskRun.Namespace, b.KubeClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2119,6 +2119,12 @@ func TestHandlePodCreationError(t *testing.T) {
 		expectedStatus: corev1.ConditionUnknown,
 		expectedReason: podconvert.ReasonExceededResourceQuota,
 	}, {
+		description:    "taskrun validation failed",
+		err:            errors.New("TaskRun validation failed"),
+		expectedType:   apis.ConditionSucceeded,
+		expectedStatus: corev1.ConditionFalse,
+		expectedReason: podconvert.ReasonFailedValidation,
+	}, {
 		description:    "errors other than exceeded quota fail the taskrun",
 		err:            errors.New("this is a fatal error"),
 		expectedType:   apis.ConditionSucceeded,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit closes tektoncd#2981

Prior to this commit when a Git SSH secret does not include a known_hosts field, Tekton will accept any public key that an SSH/Git server returns. This could be a security concern and may not be an organization's desired behavior.

This commit introduces a feature flag `require-git-ssh-secret-known-hosts`: the default value is false. When the flag is true, `known_host` field must be included in Git SSH Secret.

`checkGitSSHSecret()` will check the type of every secrets. If the type of the secret is `kubernetes.io/ssh-auth` and `require-git-ssh-secret-known-hosts` is true, `checkGitSSHSecret` will validate whether `known_hosts` field is in the secret data. If `known_hosts` is not found, it will emit an error which ceases the creation of the pod.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
Provide configuration option to disallow omitting known_hosts in Git SSH Secret.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
