### PR TITLE
Base entrypoint image on distroless

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -4,11 +4,9 @@ baseImageOverrides:
   # They are produced from ./images/Dockerfile
   github.com/tektoncd/pipeline/cmd/creds-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
+
   # GCS fetcher needs root due to workspace permissions
   github.com/tektoncd/pipeline/vendor/github.com/GoogleCloudPlatform/cloud-builders/gcs-fetcher/cmd/gcs-fetcher: gcr.io/distroless/static:latest
   # PullRequest resource needs root because in output mode it needs to access pr.json
   # which might have been copied or written with any level of permissions.
   github.com/tektoncd/pipeline/cmd/pullrequest-init: gcr.io/distroless/static:latest
-
-  # Our entrypoint image does not need root, it simply needs to be able to 'cp' the binary into a shared location.
-  github.com/tektoncd/pipeline/cmd/entrypoint: gcr.io/distroless/base:debug-nonroot

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -42,12 +43,44 @@ var (
 	waitPollingInterval = time.Second
 )
 
+func cp(src, dst string) error {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	// Owner has permission to write and execute, and anybody has
+	// permission to execute.
+	d, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, 0311)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	_, err = io.Copy(d, s)
+	return err
+}
+
 func main() {
 	// Add credential flags originally used in creds-init.
 	gitcreds.AddFlags(flag.CommandLine)
 	dockercreds.AddFlags(flag.CommandLine)
 
 	flag.Parse()
+
+	// If invoked in "cp mode" (`entrypoint cp <src> <dst>`), simply copy
+	// the src path to the dst path. This is used to place the entrypoint
+	// binary in the tools directory, without requiring the cp command to
+	// exist in the base image.
+	if len(flag.Args()) == 3 && flag.Args()[0] == "cp" {
+		src, dst := flag.Args()[1], flag.Args()[2]
+		if err := cp(src, dst); err != nil {
+			log.Fatal(err)
+		}
+		log.Println("Copied", src, "to", dst)
+		return
+	}
 
 	// Copy creds-init credentials from secret volume mounts to /tekton/creds
 	// This is done to support the expansion of a variable, $(credentials.path), that

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -88,9 +88,11 @@ var (
 // TODO(#1605): Also use entrypoint injection to order sidecar start/stop.
 func orderContainers(entrypointImage string, extraEntrypointArgs []string, steps []corev1.Container, results []v1beta1.TaskResult) (corev1.Container, []corev1.Container, error) {
 	initContainer := corev1.Container{
-		Name:         "place-tools",
-		Image:        entrypointImage,
-		Command:      []string{"cp", "/ko-app/entrypoint", entrypointBinary},
+		Name:  "place-tools",
+		Image: entrypointImage,
+		// Invoke the entrypoint binary in "cp mode" to copy itself
+		// into the correct location for later steps.
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointBinary},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -98,7 +98,7 @@ func TestOrderContainers(t *testing.T) {
 	wantInit := corev1.Container{
 		Name:         "place-tools",
 		Image:        images.EntrypointImage,
-		Command:      []string{"cp", "/ko-app/entrypoint", entrypointBinary},
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointBinary},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 	if d := cmp.Diff(wantInit, gotInit); d != "" {

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -66,7 +66,7 @@ func TestPodBuild(t *testing.T) {
 	placeToolsInit := corev1.Container{
 		Name:         "place-tools",
 		Image:        images.EntrypointImage,
-		Command:      []string{"cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
 		VolumeMounts: []corev1.VolumeMount{toolsMount},
 	}
 	runtimeClassName := "gvisor"
@@ -772,7 +772,7 @@ script-heredoc-randomly-generated-78c5n
 				{
 					Name:         "place-tools",
 					Image:        images.EntrypointImage,
-					Command:      []string{"cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
+					Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
 					VolumeMounts: []corev1.VolumeMount{toolsMount},
 				}},
 			Containers: []corev1.Container{{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -220,7 +220,7 @@ var (
 
 	getPlaceToolsInitContainer = func(ops ...tb.ContainerOp) tb.PodSpecOp {
 		actualOps := []tb.ContainerOp{
-			tb.Command("cp", "/ko-app/entrypoint", entrypointLocation),
+			tb.Command("/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointLocation),
 			tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 			tb.Args(),
 		}


### PR DESCRIPTION
Reopening #2562 which for some reason GitHub/Prow won't let me reopen 🤷‍♂️ 

With [`ko` gaining multi-arch support](https://github.com/google/ko/pull/38), this change is becoming a bit more relevant, since it makes every TaskRun require a `cp` binary in the base image, which makes it harder to support multi-arch support in Tekton.

-----

The only reason it was based on busybox was to have access to `cp`,
which it used to copy its binary to /tekton/tools for use in later
steps.

Instead of relying on `cp`, this adds a "cp mode" to the entrypoint
binary itself. When invoked with the positional args `cp <src> <dst>`,
it copies src to dst using Go's os and io packages.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Base entrypoint image on distroless/static:nonroot and give it a mode to copy itself to the destination, instead of relying on cp being present in the base image.
```

cc @mattmoor @afrittoli @vdemeester 