### PR TITLE
Closes #3262: Modify unnecessarily exported methods to unexported

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/conversion_error.go
+++ b/pkg/apis/pipeline/v1alpha1/conversion_error.go
@@ -35,5 +35,5 @@ type CannotConvertError = v1beta1.CannotConvertError
 
 var _ error = (*CannotConvertError)(nil)
 
-// ConvertErrorf creates a CannotConvertError from the field name and format string.
-var ConvertErrorf = v1beta1.ConvertErrorf
+// convertErrorf creates a CannotConvertError from the field name and format string.
+var convertErrorf = v1beta1.ConvertErrorf

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -102,7 +102,7 @@ func (sink *PipelineSpec) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 	}
 	// finally clause was introduced in v1beta1 and not available in v1alpha1
 	if len(source.Finally) > 0 {
-		return ConvertErrorf(FinallyFieldName, ConversionErrorFieldNotAvailableMsg)
+		return convertErrorf(FinallyFieldName, ConversionErrorFieldNotAvailableMsg)
 	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -43,7 +43,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrMissingField("steps"))
 	}
 	errs = errs.Also(ValidateVolumes(ts.Volumes).ViaField("volumes"))
-	errs = errs.Also(ValidateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
+	errs = errs.Also(validateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
 	mergedSteps, err := MergeStepsWithStepTemplate(ts.StepTemplate, ts.Steps)
 	if err != nil {
 		errs = errs.Also(&apis.FieldError{
@@ -79,7 +79,7 @@ func (tr TaskResult) Validate(_ context.Context) *apis.FieldError {
 
 // a mount path which conflicts with any other declared workspaces, with the explicitly
 // declared volume mounts, or with the stepTemplate. The names must also be unique.
-func ValidateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step, stepTemplate *corev1.Container) (errs *apis.FieldError) {
+func validateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step, stepTemplate *corev1.Container) (errs *apis.FieldError) {
 	mountPaths := sets.NewString()
 	for _, step := range steps {
 		for _, vm := range step.VolumeMounts {

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -54,7 +54,7 @@ var (
 	}
 	defaultStorageClass   *string
 	customStorageClass    = "custom-storage-class"
-	persistentVolumeClaim = GetPersistentVolumeClaim(config.DefaultPVCSize, defaultStorageClass)
+	persistentVolumeClaim = getPersistentVolumeClaim(config.DefaultPVCSize, defaultStorageClass)
 	quantityComparer      = cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0
 	})
@@ -99,7 +99,7 @@ var (
 	}
 )
 
-func GetPersistentVolumeClaim(size string, storageClassName *string) *corev1.PersistentVolumeClaim {
+func getPersistentVolumeClaim(size string, storageClassName *string) *corev1.PersistentVolumeClaim {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: pipelinerun.Namespace, OwnerReferences: []metav1.OwnerReference{pipelinerun.GetOwnerReference()}},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -156,7 +156,7 @@ func TestNeedsPVC(t *testing.T) {
 				ArtifactBucket: artifactBucket,
 			}
 			ctx := config.ToContext(context.Background(), &configs)
-			needed := NeedsPVC(ctx)
+			needed := needsPVC(ctx)
 			if needed != c.pvcNeeded {
 				t.Fatalf("Expected that ConfigMapNeedsPVC would be %t, but was %t", c.pvcNeeded, needed)
 			}
@@ -179,7 +179,7 @@ func TestInitializeArtifactStorage(t *testing.T) {
 		storagetype: "pvc",
 		expectedArtifactStorage: &storage.ArtifactPVC{
 			Name:                  "pipelineruntest",
-			PersistentVolumeClaim: GetPersistentVolumeClaim("10Gi", defaultStorageClass),
+			PersistentVolumeClaim: getPersistentVolumeClaim("10Gi", defaultStorageClass),
 			ShellImage:            "busybox",
 		},
 	}, {
@@ -190,7 +190,7 @@ func TestInitializeArtifactStorage(t *testing.T) {
 		storagetype: "pvc",
 		expectedArtifactStorage: &storage.ArtifactPVC{
 			Name:                  "pipelineruntest",
-			PersistentVolumeClaim: GetPersistentVolumeClaim("5Gi", &customStorageClass),
+			PersistentVolumeClaim: getPersistentVolumeClaim("5Gi", &customStorageClass),
 			ShellImage:            "busybox",
 		},
 	}, {
@@ -445,7 +445,7 @@ func TestCleanupArtifactStorage(t *testing.T) {
 		storageConfig: map[string]string{},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			fakekubeclient := fakek8s.NewSimpleClientset(GetPVCSpec(pipelinerun, persistentVolumeClaim.Spec.Resources.Requests["storage"], defaultStorageClass))
+			fakekubeclient := fakek8s.NewSimpleClientset(getPVCSpec(pipelinerun, persistentVolumeClaim.Spec.Resources.Requests["storage"], defaultStorageClass))
 			ab, err := config.NewArtifactBucketFromMap(c.storageConfig)
 			if err != nil {
 				t.Fatalf("Error getting an ArtifactBucket from data %s, %s", c.storageConfig, err)

--- a/pkg/contexts/contexts.go
+++ b/pkg/contexts/contexts.go
@@ -18,23 +18,6 @@ package contexts
 
 import "context"
 
-// hdcnKey is used as the key for associating information
-// with a context.Context.
-type hdcnKey struct{}
-
-// withDefaultConfigurationName notes on the context for nested validation
-// that there is a default configuration name, which affects how an empty
-// configurationName is validated.
-func withDefaultConfigurationName(ctx context.Context) context.Context {
-	return context.WithValue(ctx, hdcnKey{}, struct{}{})
-}
-
-// hasDefaultConfigurationName checks to see whether the given context has
-// been marked as having a default configurationName.
-func hasDefaultConfigurationName(ctx context.Context) bool {
-	return ctx.Value(hdcnKey{}) != nil
-}
-
 // lemonadeKey is used as the key for associating information
 // with a context.Context. This variable doesn't really matter, so it's
 // a total random name (for history purpose, used lemonade as it was written

--- a/pkg/contexts/contexts.go
+++ b/pkg/contexts/contexts.go
@@ -22,16 +22,16 @@ import "context"
 // with a context.Context.
 type hdcnKey struct{}
 
-// WithDefaultConfigurationName notes on the context for nested validation
+// withDefaultConfigurationName notes on the context for nested validation
 // that there is a default configuration name, which affects how an empty
 // configurationName is validated.
-func WithDefaultConfigurationName(ctx context.Context) context.Context {
+func withDefaultConfigurationName(ctx context.Context) context.Context {
 	return context.WithValue(ctx, hdcnKey{}, struct{}{})
 }
 
-// HasDefaultConfigurationName checks to see whether the given context has
+// hasDefaultConfigurationName checks to see whether the given context has
 // been marked as having a default configurationName.
-func HasDefaultConfigurationName(ctx context.Context) bool {
+func hasDefaultConfigurationName(ctx context.Context) bool {
 	return ctx.Value(hdcnKey{}) != nil
 }
 

--- a/pkg/contexts/contexts_test.go
+++ b/pkg/contexts/contexts_test.go
@@ -29,16 +29,6 @@ func TestContexts(t *testing.T) {
 		check func(context.Context) bool
 		want  bool
 	}{{
-		name:  "has default config name",
-		ctx:   withDefaultConfigurationName(ctx),
-		check: hasDefaultConfigurationName,
-		want:  true,
-	}, {
-		name:  "doesn't have default config name",
-		ctx:   ctx,
-		check: hasDefaultConfigurationName,
-		want:  false,
-	}, {
 		name:  "are upgrading via defaulting",
 		ctx:   WithUpgradeViaDefaulting(ctx),
 		check: IsUpgradeViaDefaulting,

--- a/pkg/contexts/contexts_test.go
+++ b/pkg/contexts/contexts_test.go
@@ -30,13 +30,13 @@ func TestContexts(t *testing.T) {
 		want  bool
 	}{{
 		name:  "has default config name",
-		ctx:   WithDefaultConfigurationName(ctx),
-		check: HasDefaultConfigurationName,
+		ctx:   withDefaultConfigurationName(ctx),
+		check: hasDefaultConfigurationName,
 		want:  true,
 	}, {
 		name:  "doesn't have default config name",
 		ctx:   ctx,
-		check: HasDefaultConfigurationName,
+		check: hasDefaultConfigurationName,
 		want:  false,
 	}, {
 		name:  "are upgrading via defaulting",

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -162,13 +162,13 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 	if err != nil {
 		return err
 	}
-	ref, err := ShowRef(logger, "HEAD", spec.Path)
+	ref, err := showRef(logger, "HEAD", spec.Path)
 	if err != nil {
 		return err
 	}
 	logger.Infof("Successfully cloned %s @ %s (%s) in path %s", trimmedURL, commit, ref, spec.Path)
 	if spec.Submodules {
-		if err := SubmoduleFetch(logger, spec); err != nil {
+		if err := submoduleFetch(logger, spec); err != nil {
 			return err
 		}
 	}
@@ -183,7 +183,7 @@ func ShowCommit(logger *zap.SugaredLogger, revision, path string) (string, error
 	return strings.TrimSuffix(output, "\n"), nil
 }
 
-func ShowRef(logger *zap.SugaredLogger, revision, path string) (string, error) {
+func showRef(logger *zap.SugaredLogger, revision, path string) (string, error) {
 	output, err := run(logger, path, "show", "-q", "--pretty=format:%D", revision)
 	if err != nil {
 		return "", err
@@ -191,7 +191,7 @@ func ShowRef(logger *zap.SugaredLogger, revision, path string) (string, error) {
 	return strings.TrimSuffix(output, "\n"), nil
 }
 
-func SubmoduleFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
+func submoduleFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 	if spec.Path != "" {
 		if err := os.Chdir(spec.Path); err != nil {
 			return fmt.Errorf("failed to change directory with path %s; err: %w", spec.Path, err)
@@ -270,7 +270,7 @@ func validateGitAuth(logger *zap.SugaredLogger, credsDir, url string) {
 	if _, err := os.Stat(credsDir + "/.ssh"); os.IsNotExist(err) {
 		sshCred = false
 	}
-	urlSSHFormat := ValidateGitSSHURLFormat(url)
+	urlSSHFormat := validateGitSSHURLFormat(url)
 	if sshCred && !urlSSHFormat {
 		logger.Warnf("SSH credentials have been provided but the URL(%q) is not a valid SSH URL. This warning can be safely ignored if the URL is for a public repo or you are using basic auth", url)
 	} else if !sshCred && urlSSHFormat {
@@ -278,8 +278,8 @@ func validateGitAuth(logger *zap.SugaredLogger, credsDir, url string) {
 	}
 }
 
-// ValidateGitSSHURLFormat validates the given URL format is SSH or not
-func ValidateGitSSHURLFormat(url string) bool {
+// validateGitSSHURLFormat validates the given URL format is SSH or not
+func validateGitSSHURLFormat(url string) bool {
 	if sshURLRegexFormat.MatchString(url) {
 		return true
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -107,7 +107,7 @@ func TestValidateGitSSHURLFormat(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := ValidateGitSSHURLFormat(tt.url)
+		got := validateGitSSHURLFormat(tt.url)
 		if got != tt.want {
 			t.Errorf("Validate URL(%v)'s SSH format got %v, want %v", tt.url, got, tt.want)
 		}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -277,7 +277,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 				*metav1.NewControllerRef(taskRun, groupVersionKind),
 			},
 			Annotations: podAnnotations,
-			Labels:      MakeLabels(taskRun),
+			Labels:      makeLabels(taskRun),
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:                corev1.RestartPolicyNever,
@@ -302,8 +302,8 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	}, nil
 }
 
-// MakeLabels constructs the labels we will propagate from TaskRuns to Pods.
-func MakeLabels(s *v1beta1.TaskRun) map[string]string {
+// makeLabels constructs the labels we will propagate from TaskRuns to Pods.
+func makeLabels(s *v1beta1.TaskRun) map[string]string {
 	labels := make(map[string]string, len(s.ObjectMeta.Labels)+1)
 	// NB: Set this *before* passing through TaskRun labels. If the TaskRun
 	// has a managed-by label, it should override this default.

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1264,7 +1264,7 @@ func TestMakeLabels(t *testing.T) {
 		"foo":           "bar",
 		"hello":         "world",
 	}
-	got := MakeLabels(&v1beta1.TaskRun{
+	got := makeLabels(&v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: taskRunName,
 			Labels: map[string]string{

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -61,7 +61,7 @@ const (
 	ReasonPodCreationFailed = "PodCreationFailed"
 
 	// ReasonPending indicates that the pod is in corev1.Pending, and the reason is not
-	// ReasonExceededNodeResources or IsPodHitConfigError
+	// ReasonExceededNodeResources or isPodHitConfigError
 	ReasonPending = "Pending"
 
 	//timeFormat is RFC3339 with millisecond
@@ -100,7 +100,7 @@ func MakeTaskRunStatus(logger *zap.SugaredLogger, tr v1beta1.TaskRun, pod *corev
 	trs := &tr.Status
 	if trs.GetCondition(apis.ConditionSucceeded) == nil || trs.GetCondition(apis.ConditionSucceeded).Status == corev1.ConditionUnknown {
 		// If the taskRunStatus doesn't exist yet, it's because we just started running
-		MarkStatusRunning(trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
+		markStatusRunning(trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
 	}
 
 	sortPodContainerStatuses(pod.Status.ContainerStatuses, pod.Spec.Containers)
@@ -271,9 +271,9 @@ func extractStartedAtTimeFromResults(results []v1beta1.PipelineResourceResult) (
 func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1beta1.TaskRunStatus, pod *corev1.Pod) {
 	if DidTaskRunFail(pod) {
 		msg := getFailureMessage(logger, pod)
-		MarkStatusFailure(trs, v1beta1.TaskRunReasonFailed.String(), msg)
+		markStatusFailure(trs, v1beta1.TaskRunReasonFailed.String(), msg)
 	} else {
-		MarkStatusSuccess(trs)
+		markStatusSuccess(trs)
 	}
 
 	// update tr completed time
@@ -283,15 +283,15 @@ func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1beta1.TaskRu
 func updateIncompleteTaskRunStatus(trs *v1beta1.TaskRunStatus, pod *corev1.Pod) {
 	switch pod.Status.Phase {
 	case corev1.PodRunning:
-		MarkStatusRunning(trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
+		markStatusRunning(trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
 	case corev1.PodPending:
 		switch {
 		case IsPodExceedingNodeResources(pod):
-			MarkStatusRunning(trs, ReasonExceededNodeResources, "TaskRun Pod exceeded available resources")
-		case IsPodHitConfigError(pod):
-			MarkStatusFailure(trs, ReasonCreateContainerConfigError, "Failed to create pod due to config error")
+			markStatusRunning(trs, ReasonExceededNodeResources, "TaskRun Pod exceeded available resources")
+		case isPodHitConfigError(pod):
+			markStatusFailure(trs, ReasonCreateContainerConfigError, "Failed to create pod due to config error")
 		default:
-			MarkStatusRunning(trs, ReasonPending, getWaitingMessage(pod))
+			markStatusRunning(trs, ReasonPending, getWaitingMessage(pod))
 		}
 	}
 }
@@ -374,8 +374,8 @@ func IsPodExceedingNodeResources(pod *corev1.Pod) bool {
 	return false
 }
 
-// IsPodHitConfigError returns true if the Pod's status undicates there are config error raised
-func IsPodHitConfigError(pod *corev1.Pod) bool {
+// isPodHitConfigError returns true if the Pod's status undicates there are config error raised
+func isPodHitConfigError(pod *corev1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == ReasonCreateContainerConfigError {
 			return true
@@ -411,8 +411,8 @@ func getWaitingMessage(pod *corev1.Pod) string {
 	return "Pending"
 }
 
-// MarkStatusRunning sets taskrun status to running
-func MarkStatusRunning(trs *v1beta1.TaskRunStatus, reason, message string) {
+// markStatusRunning sets taskrun status to running
+func markStatusRunning(trs *v1beta1.TaskRunStatus, reason, message string) {
 	trs.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionUnknown,
@@ -421,8 +421,8 @@ func MarkStatusRunning(trs *v1beta1.TaskRunStatus, reason, message string) {
 	})
 }
 
-// MarkStatusFailure sets taskrun status to failure with specified reason
-func MarkStatusFailure(trs *v1beta1.TaskRunStatus, reason string, message string) {
+// markStatusFailure sets taskrun status to failure with specified reason
+func markStatusFailure(trs *v1beta1.TaskRunStatus, reason string, message string) {
 	trs.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionFalse,
@@ -431,8 +431,8 @@ func MarkStatusFailure(trs *v1beta1.TaskRunStatus, reason string, message string
 	})
 }
 
-// MarkStatusSuccess sets taskrun status to success
-func MarkStatusSuccess(trs *v1beta1.TaskRunStatus) {
+// markStatusSuccess sets taskrun status to success
+func markStatusSuccess(trs *v1beta1.TaskRunStatus) {
 	trs.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionTrue,

--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -1098,7 +1098,7 @@ func TestSidecarsReady(t *testing.T) {
 
 func TestMarkStatusRunning(t *testing.T) {
 	trs := v1beta1.TaskRunStatus{}
-	MarkStatusRunning(&trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
+	markStatusRunning(&trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
 
 	expected := &apis.Condition{
 		Type:    apis.ConditionSucceeded,
@@ -1114,7 +1114,7 @@ func TestMarkStatusRunning(t *testing.T) {
 
 func TestMarkStatusFailure(t *testing.T) {
 	trs := v1beta1.TaskRunStatus{}
-	MarkStatusFailure(&trs, v1beta1.TaskRunReasonFailed.String(), "failure message")
+	markStatusFailure(&trs, v1beta1.TaskRunReasonFailed.String(), "failure message")
 
 	expected := &apis.Condition{
 		Type:    apis.ConditionSucceeded,
@@ -1130,7 +1130,7 @@ func TestMarkStatusFailure(t *testing.T) {
 
 func TestMarkStatusSuccess(t *testing.T) {
 	trs := v1beta1.TaskRunStatus{}
-	MarkStatusSuccess(&trs)
+	markStatusSuccess(&trs)
 
 	expected := &apis.Condition{
 		Type:    apis.ConditionSucceeded,
@@ -1146,19 +1146,19 @@ func TestMarkStatusSuccess(t *testing.T) {
 
 func statusRunning() duckv1beta1.Status {
 	var trs v1beta1.TaskRunStatus
-	MarkStatusRunning(&trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
+	markStatusRunning(&trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
 	return trs.Status
 }
 
 func statusFailure(reason, message string) duckv1beta1.Status {
 	var trs v1beta1.TaskRunStatus
-	MarkStatusFailure(&trs, reason, message)
+	markStatusFailure(&trs, reason, message)
 	return trs.Status
 }
 
 func statusSuccess() duckv1beta1.Status {
 	var trs v1beta1.TaskRunStatus
-	MarkStatusSuccess(&trs)
+	markStatusSuccess(&trs)
 	return trs.Status
 }
 

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -76,7 +76,7 @@ func SendCloudEvents(tr *v1beta1.TaskRun, ceclient CEClient, logger *zap.Sugared
 	logger = logger.With(zap.String("taskrun", tr.Name))
 
 	// Make the event we would like to send:
-	event, err := EventForTaskRun(tr)
+	event, err := eventForTaskRun(tr)
 	if err != nil || event == nil {
 		logger.With(zap.Error(err)).Error("failed to produce a cloudevent from TaskRun.")
 		return err
@@ -132,7 +132,7 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 	if ceClient == nil {
 		return errors.New("No cloud events client found in the context")
 	}
-	event, err := EventForObjectWithCondition(o)
+	event, err := eventForObjectWithCondition(o)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -138,7 +138,7 @@ func TestSendCloudEvents(t *testing.T) {
 			successfulBehaviour := FakeClientBehaviour{
 				SendSuccessfully: true,
 			}
-			err := SendCloudEvents(tc.taskRun, NewFakeClient(&successfulBehaviour), logger)
+			err := SendCloudEvents(tc.taskRun, newFakeClient(&successfulBehaviour), logger)
 			if err != nil {
 				t.Fatalf("Unexpected error sending cloud events: %v", err)
 			}
@@ -196,7 +196,7 @@ func TestSendCloudEventsErrors(t *testing.T) {
 			unsuccessfulBehaviour := FakeClientBehaviour{
 				SendSuccessfully: false,
 			}
-			err := SendCloudEvents(tc.taskRun, NewFakeClient(&unsuccessfulBehaviour), logger)
+			err := SendCloudEvents(tc.taskRun, newFakeClient(&unsuccessfulBehaviour), logger)
 			if err == nil {
 				t.Fatalf("Unexpected success sending cloud events: %v", err)
 			}

--- a/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -77,8 +77,8 @@ type TektonCloudEventData struct {
 	PipelineRun *v1beta1.PipelineRun `json:"pipelineRun,omitempty"`
 }
 
-// NewTektonCloudEventData returns a new instance of TektonCloudEventData
-func NewTektonCloudEventData(runObject objectWithCondition) TektonCloudEventData {
+// newTektonCloudEventData returns a new instance of TektonCloudEventData
+func newTektonCloudEventData(runObject objectWithCondition) TektonCloudEventData {
 	tektonCloudEventData := TektonCloudEventData{}
 	switch v := runObject.(type) {
 	case *v1beta1.TaskRun:
@@ -89,9 +89,9 @@ func NewTektonCloudEventData(runObject objectWithCondition) TektonCloudEventData
 	return tektonCloudEventData
 }
 
-// EventForObjectWithCondition creates a new event based for a objectWithCondition,
+// eventForObjectWithCondition creates a new event based for a objectWithCondition,
 // or return an error if not possible.
-func EventForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Event, error) {
+func eventForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Event, error) {
 	event := cloudevents.NewEvent()
 	event.SetID(uuid.New().String())
 	event.SetSubject(runObject.GetObjectMeta().GetName())
@@ -116,30 +116,30 @@ func EventForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Ev
 	}
 	event.SetType(eventType.String())
 
-	if err := event.SetData(cloudevents.ApplicationJSON, NewTektonCloudEventData(runObject)); err != nil {
+	if err := event.SetData(cloudevents.ApplicationJSON, newTektonCloudEventData(runObject)); err != nil {
 		return nil, err
 	}
 	return &event, nil
 }
 
-// EventForTaskRun will create a new event based on a TaskRun,
+// eventForTaskRun will create a new event based on a TaskRun,
 // or return an error if not possible.
-func EventForTaskRun(taskRun *v1beta1.TaskRun) (*cloudevents.Event, error) {
+func eventForTaskRun(taskRun *v1beta1.TaskRun) (*cloudevents.Event, error) {
 	// Check if the TaskRun is defined
 	if taskRun == nil {
 		return nil, errors.New("Cannot send an event for an empty TaskRun")
 	}
-	return EventForObjectWithCondition(taskRun)
+	return eventForObjectWithCondition(taskRun)
 }
 
-// EventForPipelineRun will create a new event based on a PipelineRun,
+// eventForPipelineRun will create a new event based on a PipelineRun,
 // or return an error if not possible.
-func EventForPipelineRun(pipelineRun *v1beta1.PipelineRun) (*cloudevents.Event, error) {
+func eventForPipelineRun(pipelineRun *v1beta1.PipelineRun) (*cloudevents.Event, error) {
 	// Check if the TaskRun is defined
 	if pipelineRun == nil {
 		return nil, errors.New("Cannot send an event for an empty PipelineRun")
 	}
-	return EventForObjectWithCondition(pipelineRun)
+	return eventForObjectWithCondition(pipelineRun)
 }
 
 func getEventType(runObject objectWithCondition) (*TektonEventType, error) {

--- a/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -123,7 +123,7 @@ func TestEventForTaskRun(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
 
-			got, err := EventForTaskRun(c.taskRun)
+			got, err := eventForTaskRun(c.taskRun)
 			if err != nil {
 				t.Fatalf("I did not expect an error but I got %s", err)
 			} else {
@@ -134,7 +134,7 @@ func TestEventForTaskRun(t *testing.T) {
 				if d := cmp.Diff(string(c.wantEventType), got.Type()); d != "" {
 					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
 				}
-				wantData := NewTektonCloudEventData(c.taskRun)
+				wantData := newTektonCloudEventData(c.taskRun)
 				gotData := TektonCloudEventData{}
 				if err := got.DataAs(&gotData); err != nil {
 					t.Errorf("Unexpected error from DataAsl; %s", err)
@@ -182,7 +182,7 @@ func TestEventForPipelineRun(t *testing.T) {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
 
-			got, err := EventForPipelineRun(c.pipelineRun)
+			got, err := eventForPipelineRun(c.pipelineRun)
 			if err != nil {
 				t.Fatalf("I did not expect an error but I got %s", err)
 			} else {
@@ -193,7 +193,7 @@ func TestEventForPipelineRun(t *testing.T) {
 				if d := cmp.Diff(string(c.wantEventType), got.Type()); d != "" {
 					t.Errorf("Wrong Event Type %s", diff.PrintWantGot(d))
 				}
-				wantData := NewTektonCloudEventData(c.pipelineRun)
+				wantData := newTektonCloudEventData(c.pipelineRun)
 				gotData := TektonCloudEventData{}
 				if err := got.DataAs(&gotData); err != nil {
 					t.Errorf("Unexpected error from DataAsl; %s", err)

--- a/pkg/reconciler/events/cloudevent/cloudeventsfakeclient.go
+++ b/pkg/reconciler/events/cloudevent/cloudeventsfakeclient.go
@@ -39,8 +39,8 @@ type FakeClient struct {
 	Events chan string
 }
 
-// NewFakeClient is a FakeClient factory, it returns a client for the target
-func NewFakeClient(behaviour *FakeClientBehaviour) cloudevents.Client {
+// newFakeClient is a FakeClient factory, it returns a client for the target
+func newFakeClient(behaviour *FakeClientBehaviour) cloudevents.Client {
 	return FakeClient{
 		behaviour: behaviour,
 		Events:    make(chan string, bufferSize),
@@ -74,5 +74,5 @@ func (c FakeClient) StartReceiver(ctx context.Context, fn interface{}) error {
 
 // WithClient adds to the context a fake client with the desired behaviour
 func WithClient(ctx context.Context, behaviour *FakeClientBehaviour) context.Context {
-	return context.WithValue(ctx, CECKey{}, NewFakeClient(behaviour))
+	return context.WithValue(ctx, CECKey{}, newFakeClient(behaviour))
 }

--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -106,7 +106,7 @@ func EmitError(c record.EventRecorder, err error, object runtime.Object) {
 	}
 }
 
-// EmitEvent emits an event for object if afterCondition is different from beforeCondition
+// emitEvent emits an event for object if afterCondition is different from beforeCondition
 //
 // Status "ConditionUnknown":
 //   beforeCondition == nil, emit EventReasonStarted
@@ -115,12 +115,12 @@ func EmitError(c record.EventRecorder, err error, object runtime.Object) {
 //  Status "ConditionTrue": emit EventReasonSucceded
 //  Status "ConditionFalse": emit EventReasonFailed
 // Deprecated: use Emit
-func EmitEvent(ctx context.Context, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
+func emitEvent(ctx context.Context, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
 	Emit(ctx, beforeCondition, afterCondition, object)
 }
 
-// EmitErrorEvent emits a failure associated to an error
+// emitErrorEvent emits a failure associated to an error
 // Deprecated: use EmitError instead
-func EmitErrorEvent(c record.EventRecorder, err error, object runtime.Object) {
+func emitErrorEvent(c record.EventRecorder, err error, object runtime.Object) {
 	EmitError(c, err, object)
 }

--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -105,22 +105,3 @@ func EmitError(c record.EventRecorder, err error, object runtime.Object) {
 		c.Event(object, corev1.EventTypeWarning, EventReasonError, err.Error())
 	}
 }
-
-// emitEvent emits an event for object if afterCondition is different from beforeCondition
-//
-// Status "ConditionUnknown":
-//   beforeCondition == nil, emit EventReasonStarted
-//   beforeCondition != nil, emit afterCondition.Reason
-//
-//  Status "ConditionTrue": emit EventReasonSucceded
-//  Status "ConditionFalse": emit EventReasonFailed
-// Deprecated: use Emit
-func emitEvent(ctx context.Context, beforeCondition *apis.Condition, afterCondition *apis.Condition, object runtime.Object) {
-	Emit(ctx, beforeCondition, afterCondition, object)
-}
-
-// emitErrorEvent emits a failure associated to an error
-// Deprecated: use EmitError instead
-func emitErrorEvent(c record.EventRecorder, err error, object runtime.Object) {
-	EmitError(c, err, object)
-}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -370,7 +370,7 @@ func TestReconcile(t *testing.T) {
 		ClusterTasks:      clusterTasks,
 		PipelineResources: rs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -608,7 +608,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
 				ConfigMaps:   cms,
 			}
-			prt := NewPipelineRunTest(d, t)
+			prt := newPipelineRunTest(d, t)
 			defer prt.Cancel()
 
 			wantEvents := []string{
@@ -675,7 +675,7 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 		PipelineRuns: prs,
 		Pipelines:    ps,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -916,7 +916,7 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 				Pipelines:    ps,
 				Tasks:        ts,
 			}
-			prt := NewPipelineRunTest(d, t)
+			prt := newPipelineRunTest(d, t)
 			defer prt.Cancel()
 
 			wantEvents := append(tc.wantEvents, "Warning InternalError 1 error occurred")
@@ -1323,7 +1323,7 @@ func TestReconcileOnCompletedPipelineRun(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1407,7 +1407,7 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1446,7 +1446,7 @@ func TestReconcileOnPendingPipelineRun(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{}
@@ -1484,7 +1484,7 @@ func TestReconcileWithTimeout(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1533,7 +1533,7 @@ func TestReconcileWithoutPVC(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run", []string{}, false)
@@ -1648,7 +1648,7 @@ func TestReconcileCancelledPipelineRun(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -1708,7 +1708,7 @@ func TestReconcilePropagateLabels(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-with-labels", []string{}, false)
@@ -1746,7 +1746,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -1828,7 +1828,7 @@ func TestReconcileCustomTasksWithDifferentServiceAccounts(t *testing.T) {
 		Pipelines:    ps,
 		ConfigMaps:   cms,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -1922,7 +1922,7 @@ func TestReconcileWithTimeoutAndRetry(t *testing.T) {
 				Tasks:        ts,
 				TaskRuns:     trs,
 			}
-			prt := NewPipelineRunTest(d, t)
+			prt := newPipelineRunTest(d, t)
 			defer prt.Cancel()
 
 			reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-retry-run-with-timeout", []string{}, false)
@@ -1957,7 +1957,7 @@ func TestReconcilePropagateAnnotations(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-with-annotations", []string{}, false)
@@ -2112,7 +2112,7 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
@@ -2190,7 +2190,7 @@ func TestReconcileCustomTasksWithTaskRunSpec(t *testing.T) {
 		Pipelines:    ps,
 		ConfigMaps:   cms,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
@@ -2261,7 +2261,7 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 		Tasks:        ts,
 		Conditions:   conditions,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2373,7 +2373,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		TaskRuns:     trs,
 		Conditions:   conditions,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2479,7 +2479,7 @@ func TestReconcileWithWhenExpressionsWithParameters(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2619,7 +2619,7 @@ func TestReconcileWithWhenExpressionsWithTaskResults(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -2734,7 +2734,7 @@ func TestReconcileWithAffinityAssistantStatefulSet(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -2826,7 +2826,7 @@ func TestReconcileWithVolumeClaimTemplateWorkspace(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -2902,7 +2902,7 @@ func TestReconcileWithVolumeClaimTemplateWorkspaceUsingSubPaths(t *testing.T) {
 		Pipelines:    ps,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run", []string{}, false)
@@ -3028,7 +3028,7 @@ func TestReconcileWithTaskResults(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -3099,7 +3099,7 @@ func TestReconcileWithTaskResultsEmbeddedNoneStarted(t *testing.T) {
 		PipelineRuns: prs,
 		Tasks:        ts,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -3207,7 +3207,7 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
@@ -3464,7 +3464,7 @@ func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 		Runs:         runs,
 		ConfigMaps:   cms,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", prOutOfSync.Name, []string{}, false)
@@ -3606,7 +3606,7 @@ func TestUpdatePipelineRunStatusFromInformer(t *testing.T) {
 	d := test.Data{
 		PipelineRuns: []*v1beta1.PipelineRun{pr},
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -4310,7 +4310,7 @@ func TestReconcilePipeline_FinalTasks(t *testing.T) {
 				Tasks:        tt.ts,
 				TaskRuns:     tt.trs,
 			}
-			prt := NewPipelineRunTest(d, t)
+			prt := newPipelineRunTest(d, t)
 			defer prt.Cancel()
 
 			reconciledRun, clients := prt.reconcileRun("foo", tt.pipelineRunName, []string{}, false)
@@ -4461,7 +4461,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		Tasks:        ts,
 		ConfigMaps:   cms,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -4532,7 +4532,7 @@ func TestReconcilePipeline_TaskSpecMetadata(t *testing.T) {
 		PipelineRuns: prs,
 		Pipelines:    ps,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-success", []string{}, false)
@@ -4641,7 +4641,7 @@ func TestReconciler_ReconcileKind_PipelineTaskContext(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	_, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
@@ -4868,7 +4868,7 @@ func TestReconcileWithTaskResultsInFinalTasks(t *testing.T) {
 		Tasks:        ts,
 		TaskRuns:     trs,
 	}
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-final-task-results", []string{}, false)
@@ -4937,9 +4937,9 @@ func TestReconcileWithTaskResultsInFinalTasks(t *testing.T) {
 	}
 }
 
-// NewPipelineRunTest returns PipelineRunTest with a new PipelineRun controller created with specified state through data
+// newPipelineRunTest returns PipelineRunTest with a new PipelineRun controller created with specified state through data
 // This PipelineRunTest can be reused for multiple PipelineRuns by calling reconcileRun for each pipelineRun
-func NewPipelineRunTest(data test.Data, t *testing.T) *PipelineRunTest {
+func newPipelineRunTest(data test.Data, t *testing.T) *PipelineRunTest {
 	t.Helper()
 	testAssets, cancel := getPipelineRunController(t, data)
 	return &PipelineRunTest{
@@ -5051,7 +5051,7 @@ func TestReconcile_RemotePipelineRef(t *testing.T) {
 		ConfigMaps: cms,
 	}
 
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	wantEvents := []string{
@@ -5165,7 +5165,7 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 		}},
 	}
 
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-success", nil, false)
@@ -5345,7 +5345,7 @@ func TestReconcile_DependencyValidationsImmediatelyFailPipelineRun(t *testing.T)
 		}},
 	}
 
-	prt := NewPipelineRunTest(d, t)
+	prt := newPipelineRunTest(d, t)
 	defer prt.Cancel()
 
 	run1, _ := prt.reconcileRun("foo", "pipelinerun-param-invalid-result-variable", nil, true)

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -115,7 +115,7 @@ func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() (*v1beta1.TaskSpec, err
 	}
 
 	convertParamTemplates(&t.Steps[0], rcc.Condition.Spec.Params)
-	err := ApplyResourceSubstitution(&t.Steps[0], rcc.ResolvedResources, rcc.Condition.Spec.Resources, rcc.images)
+	err := applyResourceSubstitution(&t.Steps[0], rcc.ResolvedResources, rcc.Condition.Spec.Resources, rcc.images)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to replace resource template strings %w", err)
@@ -135,9 +135,9 @@ func convertParamTemplates(step *v1beta1.Step, params []v1beta1.ParamSpec) {
 	v1beta1.ApplyStepReplacements(step, replacements, map[string][]string{})
 }
 
-// ApplyResourceSubstitution applies the substitution from values in resources which are referenced
+// applyResourceSubstitution applies the substitution from values in resources which are referenced
 // in spec as subitems of the replacementStr.
-func ApplyResourceSubstitution(step *v1beta1.Step, resolvedResources map[string]*resourcev1alpha1.PipelineResource, conditionResources []v1beta1.ResourceDeclaration, images pipeline.Images) error {
+func applyResourceSubstitution(step *v1beta1.Step, resolvedResources map[string]*resourcev1alpha1.PipelineResource, conditionResources []v1beta1.ResourceDeclaration, images pipeline.Images) error {
 	replacements := make(map[string]string)
 	for _, cr := range conditionResources {
 		if rSpec, ok := resolvedResources[cr.Name]; ok {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -363,7 +363,7 @@ func ResolvePipelineRunTask(
 		rprt.PipelineTask.TaskRef.APIVersion != "" && rprt.PipelineTask.TaskRef.Kind != ""
 
 	if rprt.IsCustomTask() {
-		rprt.RunName = GetRunName(pipelineRun.Status.Runs, task.Name, pipelineRun.Name)
+		rprt.RunName = getRunName(pipelineRun.Status.Runs, task.Name, pipelineRun.Name)
 		run, err := getRun(rprt.RunName)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, fmt.Errorf("error retrieving Run %s: %w", rprt.RunName, err)
@@ -450,9 +450,9 @@ func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus,
 	return names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%s", prName, ptName))
 }
 
-// GetRunName should return a unique name for a `Run` if one has not already
+// getRunName should return a unique name for a `Run` if one has not already
 // been defined, and the existing one otherwise.
-func GetRunName(runsStatus map[string]*v1beta1.PipelineRunRunStatus, ptName, prName string) string {
+func getRunName(runsStatus map[string]*v1beta1.PipelineRunRunStatus, ptName, prName string) string {
 	for k, v := range runsStatus {
 		if v.PipelineTaskName == ptName {
 			return k

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -396,7 +396,7 @@ func ResolvePipelineRunTask(
 			spec = task.TaskSpec.TaskSpec
 		}
 		spec.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
-		rtr, err := ResolvePipelineTaskResources(task, &spec, taskName, kind, providedResources)
+		rtr, err := resolvePipelineTaskResources(task, &spec, taskName, kind, providedResources)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't match referenced resources with declared resources: %w", err)
 		}
@@ -510,9 +510,9 @@ func resolveConditionChecks(pt *v1beta1.PipelineTask, taskRunStatus map[string]*
 	return rccs, nil
 }
 
-// ResolvePipelineTaskResources matches PipelineResources referenced by pt inputs and outputs with the
+// resolvePipelineTaskResources matches PipelineResources referenced by pt inputs and outputs with the
 // providedResources and returns an instance of ResolvedTaskResources.
-func ResolvePipelineTaskResources(pt v1beta1.PipelineTask, ts *v1beta1.TaskSpec, taskName string, kind v1beta1.TaskKind, providedResources map[string]*resourcev1alpha1.PipelineResource) (*resources.ResolvedTaskResources, error) {
+func resolvePipelineTaskResources(pt v1beta1.PipelineTask, ts *v1beta1.TaskSpec, taskName string, kind v1beta1.TaskKind, providedResources map[string]*resourcev1alpha1.PipelineResource) (*resources.ResolvedTaskResources, error) {
 	rtr := resources.ResolvedTaskResources{
 		TaskName: taskName,
 		TaskSpec: ts,

--- a/pkg/reconciler/testing/logger.go
+++ b/pkg/reconciler/testing/logger.go
@@ -23,7 +23,7 @@ import (
 
 // SetupFakeContext sets up the the Context and the fake filtered informers for the tests.
 func SetupFakeContext(t *testing.T) (context.Context, []controller.Informer) {
-	ctx, _, informer := SetupFakeContextWithLabelKey(t)
+	ctx, _, informer := setupFakeContextWithLabelKey(t)
 	cloudEventClientBehaviour := cloudevent.FakeClientBehaviour{
 		SendSuccessfully: true,
 	}
@@ -42,9 +42,9 @@ func TestLogger(t *testing.T) *zap.SugaredLogger {
 	return logger.Sugar().Named(t.Name())
 }
 
-// SetupFakeContextWithLabelKey sets up the the Context and the fake informers for the tests
+// setupFakeContextWithLabelKey sets up the the Context and the fake informers for the tests
 // The provided context includes the FilteredInformerFactory LabelKey.
-func SetupFakeContextWithLabelKey(t zaptest.TestingT) (context.Context, context.CancelFunc, []controller.Informer) {
+func setupFakeContextWithLabelKey(t zaptest.TestingT) (context.Context, context.CancelFunc, []controller.Informer) {
 	ctx, c := context.WithCancel(logtesting.TestContextWithLogger(t))
 	ctx = controller.WithEventRecorder(ctx, record.NewFakeRecorder(1000))
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This is for issue #3262.

Only `ConvertErrorf` is kept as it is in v1beta1 because the function is imported in v1alpha1.

```
$ grep -r ConvertErrorf *pkg/apis/pipeline/v1alpha1/conversion_error.go:39:var convertErrorf = v1beta1.ConvertErrorf
pkg/apis/pipeline/v1beta1/conversion_error.go:45:// ConvertErrorf creates a CannotConvertError from the field name and format string.
pkg/apis/pipeline/v1beta1/conversion_error.go:46:func ConvertErrorf(field, msg string, args ...interface{}) error {
$
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
