### PR TITLE
Add a short note documenting the new git ssh secret feature flag

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -504,9 +504,12 @@ https://user2:pass2@url2.com
 Given hostnames, private keys, and `known_hosts` of the form: `url{n}.com`,
 `key{n}`, and `known_hosts{n}`, Tekton generates the following. 
 
-If no value is specified for `known_hosts`, Tekton configures SSH to accept
+By default, if no value is specified for `known_hosts`, Tekton configures SSH to accept
 **any public key** returned by the server on first query. Tekton does this
 by setting Git's `core.sshCommand` variable to `ssh -o StrictHostKeyChecking=accept-new`.
+This behaviour can be prevented
+[using a feature-flag: `require-git-ssh-secret-known-hosts`](./install.md#customizing-the-pipelines-controller-behavior).
+Set this flag to `true` and all Git SSH Secrets _must_ include a `known_hosts`.
 
 ```
 === ~/.ssh/id_key1 ===

--- a/docs/install.md
+++ b/docs/install.md
@@ -327,6 +327,12 @@ TaskRuns with no Sidecars specified. Enabling this option should decrease the ti
 start running. However, for clusters that use injected sidecars e.g. istio
 enabling this option can lead to unexpected behavior.
 
+- `require-git-ssh-secret-known-hosts`: set this flag to `"true"` to require that
+Git SSH Secrets include a `known_hosts` field. This ensures that a git remote server's
+key is validated before data is accepted from it when authenticating over SSH. Secrets
+that don't include a `known_hosts` will result in the TaskRun failing validation and
+not running. 
+
 For example:
 
 ```yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We recently added a new feature flag to prevent git ssh secrets from omitting
the known_hosts field.

This commit adds a short description of the new flag to the install.md doc and
also to auth.md.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
