### PR TITLE
Add ability to replace image names for examples tests based on arch

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -66,8 +66,9 @@ func waitValidateTaskRunDone(t *testing.T, c *clients, taskRunName string) {
 }
 
 // substituteEnv substitutes docker repos and bucket paths from the system
-// environment for input to allow tests on local clusters. It also unsets the
-// namespace for ServiceAccounts so that they work under test.
+// environment for input to allow tests on local clusters. It unsets the
+// namespace for ServiceAccounts so that they work under test. It also
+// replaces image names to arch specific ones, based on provided mapping.
 func substituteEnv(input []byte, namespace string) ([]byte, error) {
 	// Replace the placeholder image repo with the value of the
 	// KO_DOCKER_REPO env var.
@@ -81,6 +82,10 @@ func substituteEnv(input []byte, namespace string) ([]byte, error) {
 	// the test namespace using `ko create -n`
 	output = defaultNamespaceRE.ReplaceAll(output, []byte("namespace: "+namespace))
 
+	// Replace image names to arch specific ones, where it's necessary
+	for existingImage, archSpecificImage := range imagesMappingRE {
+		output = existingImage.ReplaceAll(output, archSpecificImage)
+	}
 	return output, nil
 }
 

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"os"
+	"regexp"
 	"runtime"
 	"testing"
 
@@ -25,8 +26,9 @@ import (
 )
 
 var (
-	imageNames    = initImageNames()
-	excludedTests = initExcludedTests()
+	imageNames      = initImageNames()
+	excludedTests   = initExcludedTests()
+	imagesMappingRE map[*regexp.Regexp][]byte
 )
 
 const (
@@ -36,7 +38,11 @@ const (
 	registryImage
 )
 
-// return architecture of the cluster where test suites will be executed.
+func init() {
+	imagesMappingRE = getImagesMappingRE()
+}
+
+// getTestArch returns architecture of the cluster where test suites will be executed.
 // default value is similar to build architecture, TEST_RUNTIME_ARCH is used when test target cluster has another architecture
 func getTestArch() string {
 	val, ok := os.LookupEnv("TEST_RUNTIME_ARCH")
@@ -46,6 +52,7 @@ func getTestArch() string {
 	return runtime.GOARCH
 }
 
+// initImageNames returns the map with arch dependent image names for e2e tests
 func initImageNames() map[int]string {
 	if getTestArch() == "s390x" {
 		return map[int]string{
@@ -59,6 +66,33 @@ func initImageNames() map[int]string {
 	}
 }
 
+// getImagesMappingRE generates the map ready to search and replace image names with regexp for examples files.
+// search is done using "image: <name>" pattern.
+func getImagesMappingRE() map[*regexp.Regexp][]byte {
+	imageNamesMapping := imageNamesMapping()
+	imageMappingRE := make(map[*regexp.Regexp][]byte, len(imageNamesMapping))
+
+	for existingImage, archSpecificImage := range imageNamesMapping {
+		imageMappingRE[regexp.MustCompile("(?im)image: "+existingImage+"$")] = []byte("image: " + archSpecificImage)
+	}
+
+	return imageMappingRE
+}
+
+// imageNamesMapping provides mapping between image name in the examples yaml files and desired image name for specific arch.
+// by default empty map is returned.
+func imageNamesMapping() map[string]string {
+	if getTestArch() == "s390x" {
+		return map[string]string{
+			"registry": getTestImage(registryImage),
+			"node":     "node:alpine3.11",
+		}
+	}
+
+	return make(map[string]string)
+}
+
+// initExcludedTests provides list of excluded tests for e2e and exanples tests
 func initExcludedTests() sets.String {
 	if getTestArch() == "s390x" {
 		return sets.NewString(
@@ -90,8 +124,6 @@ func initExcludedTests() sets.String {
 			"TestExamples/v1alpha1/taskruns/pullrequest_input_copystep_output",
 			"TestExamples/v1beta1/taskruns/pullrequest",
 			"TestExamples/v1alpha1/taskruns/pullrequest",
-			"TestExamples/v1beta1/taskruns/step-script",
-			"TestExamples/v1alpha1/taskruns/step-script",
 			"TestExamples/v1beta1/pipelineruns/conditional-pipelinerun",
 			"TestExamples/v1alpha1/pipelineruns/pipelinerun-with-resourcespec",
 			"TestExamples/v1beta1/pipelineruns/pipelinerun-with-resourcespec",
@@ -120,12 +152,12 @@ func initExcludedTests() sets.String {
 	return sets.NewString()
 }
 
-// get test image based on unique id
+// getTestImage gets test image based on unique id
 func getTestImage(image int) string {
 	return imageNames[image]
 }
 
-// check if test name is in the excluded list and skip it
+// skipIfExcluded checks if test name is in the excluded list and skip it
 func skipIfExcluded(t *testing.T) {
 	if excludedTests.Has(t.Name()) {
 		t.Skipf("skip for %s architecture", getTestArch())


### PR DESCRIPTION
# Changes

Some images which are used to run the examples tests are amd64 only.
To run the examples tests for other architectures it makes sense to replace the
amd64 image names to arch-specific ones at runtime.

- add code to search and replace image names based on architecture in the
examples yaml files at runtime.
- provide mapping between amd64 and s390x image names.
- remove several tests from excluded list for s390x.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```
