### PR TITLE
Run enhancements

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -1,0 +1,321 @@
+# Tekton Pipelines API Specification
+
+<!-- toc -->
+- [Abstract](#abstract)
+- [Background](#background)
+- [Modifying This Specification](#modifying-this-specification)
+- [Resource Overview](#resource-overview)
+  * [`TaskRun`](#-taskrun-)
+- [Detailed Resources - v1beta1](#detailed-resources---v1beta1)
+  * [`TaskRun`](#-taskrun--1)
+    + [Metadata](#metadata)
+    + [Spec](#spec)
+    + [Status](#status)
+- [Status Signalling](#status-signalling)
+- [Listing Resources](#listing-resources)
+- [Detailed Resource Types - v1beta1](#detailed-resource-types---v1beta1)
+  * [`ArrayOrString`](#arrayorstring)
+  * [`ContainerStateRunning`](#containerstaterunning)
+  * [`ContainerStateWaiting`](#containerstatewaiting)
+  * [`ContainerStateTerminated`](#containerstateterminated)
+  * [`EnvVar`](#envvar)
+  * [`Param`](#param)
+  * [`ParamSpec`](#paramspec)
+  * [`Step`](#step)
+  * [`StepState`](#stepstate)
+  * [`TaskResult`](#taskresult)
+  * [`TaskRunResult`](#taskrunresult)
+  * [`TaskSpec`](#taskspec)
+  * [`WorkspaceBinding`](#workspacebinding)
+  * [`WorkspaceDeclaration`](#workspacedeclaration)
+<!-- /toc -->
+
+## Abstract
+
+The Tekton Pipelines platform provides common abstractions for describing and executing container-based, run-to-completion workflows, typipcally in service of CI/CD scenarios. This document describes the structure, lifecycle and management of Tekton resources in the context of the [Kubernetes Resource Model](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/resource-management.md). An understanding of the Kubernetes API interface and the capabilities of [Kubernetes Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) is assumed.
+
+This document does not define the [runtime contract](https://tekton.dev/docs/pipelines/container-contract/) nor prescribe specific implementations of supporting services such as access control, observability, or resource management.
+
+This document makes reference in a few places to different profiles for Tekton installations. A profile in this context is a set of operations, resources, and fields that are accessible to a developer interacting with a Tekton installation. Currently, only a single (minimal) profile for Tekton Pipelines is defined, but additional profiles may be defined in the future to standardize advanced functionality. A minimal profile is one that implements all of the “MUST”, “MUST NOT”, and “REQUIRED” conditions of this document.
+
+## Background
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
+
+There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.16 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
+
+## Modifying This Specification
+
+This spec is a living document, meaning new resources and fields may be added, and may transition from being OPTIONAL to RECOMMENDED to REQUIRED over time. In general a resource or field should not be added as REQUIRED directly, as this may cause unsuspecting previously-conformant implementations to suddenly no longer be conformant. These should be first OPTIONAL or RECOMMENDED, then change to be REQUIRED once a survey of conformant implementations indicates that doing so will not cause undue burden on any implementation.
+
+## Resource Overview
+
+The Tekton Pipelines API provides a set of API resources to manage run-to-completion workflows. Those are expressed as [Kubernetes Custom Resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/)
+
+### `TaskRun`
+
+A `TaskRun` represents an instantiation of a single execution of a `Task`. It can describe the steps of the Task directly.
+
+Its HTTP API endpoint is `/apis/tekton.dev/v1beta1/[parent]/taskruns`,  where  `[parent]` can refer to any string identifying a grouping of `TaskRun`s.
+
+For example, in the Kubernetes implementation `[parent]` refers to a Kubernetes namespace. Other implementations could interpret the string differently, including enabling hierarchies of resources containing `TaskRun`s, for example the API endpoint `/apis/tekton.dev/v1beta1/folders/my-folder/project/my-project/taskruns` could represent a hierarchy of "projects" that own `TaskRun`s.
+
+| HTTP Verb                 | Requirement      |
+|---------------------------|------------------|
+| Create (POST)             | REQUIRED         |
+| Patch (PATCH)*            | RECOMMENDED      |
+| Replace (PUT)**           | RECOMMENDED      |
+| Delete (DELETE)           | OPTIONAL         |
+| Read (GET)                | REQUIRED         |
+| List (GET)                | REQUIRED         |
+| Watch (GET)               | OPTIONAL         |
+| DeleteCollection (DELETE) | OPTIONAL         |
+
+\* Kubernetes only allows JSON merge patch for CRD types. It is recommended that if allowed, at least JSON Merge patch be made available. [JSON Merge Patch Spec (RFC 7386)](https://tools.ietf.org/html/rfc7386)
+
+\** NB: Support for cancellation depends on `Replace`.
+
+## Detailed Resources - v1beta1
+
+The following schema defines a set of REQUIRED or RECOMMENDED resource fields on the Tekton resource types. Whether a field is REQUIRED or RECOMMENDED is denoted in the "Requirement" column.
+
+Additional fields MAY be provided by particular implementations, however it is expected that most extension will be accomplished via the `metadata.labels` and `metadata.annotations` fields, as Tekton implementations MAY validate supplied resources against these fields and refuse resources which specify unknown fields.
+
+Tekton implementations MUST NOT require `spec` fields outside this implementation; to do so would break interoperability between such implementations and implementations which implement validation of field names.
+
+**NB:** All fields and resources not listed below are assumed to be **OPTIONAL**, not RECOMMENDED or REQUIRED. For example, at this time, support for `PipelineRun`s and for CRUD operations on `Task`s or `Pipeline`s is **OPTIONAL**.
+
+### `TaskRun`
+
+#### Metadata
+
+Standard Kubernetes [meta.v1/ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta) resource.
+
+| Field Name           | Field Type         | Requirement |
+|----------------------|--------------------|-------------|
+| `name`               | string             | REQUIRED    |
+| `labels`             | map<string,string> | REQUIRED    |
+| `annotations`        | map<string,string> | REQUIRED    |
+| `creationTimestamp`* | string             | REQUIRED    |
+| `uid`                | string             | RECOMMENDED |
+| `resourceVersion`    | string             | RECOMMENDED |
+| `generation`         | int64              | RECOMMENDED |
+| `namespace`          | string             | RECOMMENDED |
+| `generateName`**     | string             | RECOMMENDED |
+
+\* `creationTimestamp` MUST be populated by the implementation, in [RFC3339](https://tools.ietf.org/html/rfc3339).
+
+** If `generateName` is supported by the implementation, when it is specified at creation, it MUST be prepended to a random string and set as the `name`, and not set on the subsequent response.
+
+#### Spec
+
+| Field Name            | Field Type           | Requirement |
+|-----------------------|----------------------|-------------|
+| `params`              | `[]Param`            | REQUIRED    |
+| `taskSpec`            | `TaskSpec`           | REQUIRED    |
+| `workspaces`          | `[]WorkspaceBinding` | REQUIRED    |
+| `status`              | Enum:<br>- `""` (default)<br>- `"TaskRunCancelled"` | RECOMMENDED |
+| `timeout`             | string (duration)    | RECOMMENDED |
+| `serviceAccountName`^ | string               | RECOMMENDED |
+
+^ In the Kubernetes implementation, `serviceAccountName` refers to a Kubernetes `ServiceAccount` resource that is assumed to exist in the same namespace. Other implementations MAY interpret this string differently, and impose other requirements on specified values.
+
+#### Status
+
+| Field Name            | Field Type             | Requirement |
+|-----------------------|------------------------|-------------|
+| `conditions`          | see [#error-signaling] | REQUIRED    |
+| `startTime`           | string                 | REQUIRED    |
+| `completionTime`*     | string                 | REQUIRED    |
+| `steps`               | `[]StepState`          | REQUIRED    |
+| `observedGeneration`  | int64                  | RECOMMENDED |
+
+\* `startTime` and `completionTime` MUST be populated by the implementation, in [RFC3339](https://tools.ietf.org/html/rfc3339).
+
+## Status Signalling
+
+The Tekton Pipelines API uses the [Kubernetes Conditions convention](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties) to communicate status and errors to the user.
+
+`TaskRun`'s `status` field MUST have a `conditions` field, which must be a list of `Condition` objects of the following form:
+
+| Field                 | Type   | Requirement |
+|-----------------------|--------|-------------|
+| `type`                | string | REQUIRED    |
+| `status`              | Enum:<br>- `"True"`<br>- `"False"`<br>- `"Unknown"` (default) | REQUIRED |
+| `reason`              | string | REQUIRED    |
+| `message`             | string | REQUIRED    |
+| `severity`            | Enum:<br>- `""` (default)<br>- `"Warning"`<br>- `"Info"` | REQUIRED |
+| `lastTransitionTime`* | string | OPTIONAL    |
+
+\* If `lastTransitionTime` is populated by the implementation, it must be in [RFC3339](https://tools.ietf.org/html/rfc3339).
+
+Additionally, the resource's `status.conditions` field MUST be managed as follows to enable clients to present useful diagnostic and error information to the user.
+
+If a resource describes that it must report a Condition of the `type` `Succeeded`, then it must report it in the following manner:
+
+* If the `status` field is `"True"`, that means the execution finished successfully.
+* If the `status` field is `"False"`, that means the execution finished unsuccessfully -- the Condition's `reason` and `message` MUST include further diagnostic information.
+* If the `status` field is `"Unknown"`, that means the execution is still ongoing, and clients can check again later until the Condition's `status` reports either `"True"` or `"False"`.
+
+Resources MAY report Conditions with other `type`s, but none are REQUIRED or RECOMMENDED.
+
+## Listing Resources
+
+Requests to list resources specify the following fields (based on [`meta.v1/ListOptions`](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ListOptions)):
+
+| Field Name        | Field Type | Requirement |
+|-------------------|------------|-------------|
+| `continue`        | string     | REQUIRED    |
+| `limit`           | int64      | REQUIRED    |
+
+List responses have the following fields (based on [`meta.v1/ListMeta`](https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ListMeta)):
+
+| Field Name           | Field Type | Requirement |
+|----------------------|------------|-------------|
+| `continue`           | string     | REQUIRED    |
+| `items`              | `[]Object` | REQUIRED    |
+| `remainingItemCount` | int64      | REQUIRED    |
+| `apiVersion`         | string<br>(`"tekton.dev/v1beta1"`) | REQUIRED    |
+| `kind`               | string<br>(e.g., `"ObjectList"`)   | REQUIRED    |
+
+**NB:** All other fields inherited from [`ListOptions`] or [`ListMeta`]supported by the Kubernetes implementation (e.g., `fieldSelector`,  `labelSelector`) are **OPTIONAL** for the purposes of this spec.
+
+**NB:** The sort order of items returned by list requests is unspecified at this time.
+
+## Detailed Resource Types - v1beta1
+
+### `ArrayOrString`
+
+| Field Name  | Field Type | Requirement |
+|-------------|------------|-------------|
+| `type`      | Enum:<br>- `"string"` (default)<br>- `"array"` | REQUIRED |
+| `stringVal` | string     | REQUIRED    |
+| `arrayVal`  | []string   | REQUIRED    |
+
+### `ContainerStateRunning`
+
+| Field Name   | Field Type | Requirement |
+|--------------|------------|-------------|
+| `startedAt`* | string     | REQUIRED    |
+
+\* `startedAt` MUST be populated by the implementation, in [RFC3339](https://tools.ietf.org/html/rfc3339).
+
+### `ContainerStateWaiting`
+
+| Field Name | Field Type | Requirement |
+|------------|------------|-------------|
+| `reason`   | string     | REQUIRED    |
+| `message`  | string     | REQUIRED    |
+
+### `ContainerStateTerminated`
+
+| Field Name    | Field Type | Requirement |
+|---------------|------------|-------------|
+| `exitCode`    | int32      | REQUIRED    |
+| `reason`      | string     | REQUIRED    |
+| `message`     | string     | REQUIRED    |
+| `startedAt`*  | string     | REQUIRED    |
+| `finishedAt`* | string     | REQUIRED    |
+
+\* `startedAt` and `finishedAt` MUST be populated by the implementation, in [RFC3339](https://tools.ietf.org/html/rfc3339).
+
+### `EnvVar`
+
+| Field Name | Field Type | Requirement |
+|------------|------------|-------------|
+| `name`     | string     | REQUIRED    |
+| `value`    | string     | REQUIRED    |
+
+**NB:** All other [EnvVar](https://godoc.org/k8s.io/api/core/v1#EnvVar) types inherited from [core.v1/EnvVar](https://godoc.org/k8s.io/api/core/v1#EnvVar) and supported by the Kubernetes implementation (e.g., `valueFrom`) are **OPTIONAL** for the purposes of this spec.
+
+### `Param`
+
+| Field Name | Field Type      | Requirement |
+|------------|-----------------|-------------|
+| `name`     | string          | REQUIRED    |
+| `value`    | `ArrayOrString` | REQUIRED    |
+
+### `ParamSpec`
+
+| Field Name    | Field Type | Requirement |
+|---------------|------------|-------------|
+| `name`        | string     | REQUIRED    |
+| `description` | string     | REQUIRED    |
+| `type`        | Enum: <br>- `"string"` (default) <br>- `"array"` | REQUIRED |
+| `default`     | `ArrayOrString` | REQUIRED |
+
+### `Step`
+
+| Field Name   | Field Type | Requirement |
+|--------------|------------|-------------|
+| `name`       | string     | REQUIRED    |
+| `image`      | string     | REQUIRED    |
+| `args`       | []string   | REQUIRED    |
+| `command`    | []string   | REQUIRED    |
+| `workingDir` | []string   | REQUIRED    |
+| `env`        | `[]EnvVar` | REQUIRED    |
+| `script`     | string     | REQUIRED    |
+
+**NB:** All other fields inherited from the [core.v1/Container](https://godoc.org/k8s.io/api/core/v1#Container) type supported by the Kubernetes implementation are **OPTIONAL** for the purposes of this spec.
+
+### `StepState`
+
+| Field Name    | Field Type                 | Requirement |
+|---------------|----------------------------|-------------|
+| `name`        | string                     | REQUIRED    |
+| `imageID`     | string                     | REQUIRED    |
+| `waiting`*    | `ContainerStateWaiting`    | REQUIRED    |
+| `running`*    | `ContainerStateRunning`    | REQUIRED    |
+| `terminated`* | `ContainerStateTerminated` | REQUIRED    |
+| `taskResults` | `[]TaskRunResult`          | REQUIRED    |
+| `taskSpec`    | `TaskSpec`                 | REQUIRED    |
+
+\* Only one of `waiting`, `running` or `terminated` can be returned at a time.
+
+### `TaskResult`
+
+| Field Name   | Field Type | Requirement |
+|--------------|------------|-------------|
+| `name`        | string    | REQUIRED    |
+| `description` | string    | REQUIRED    |
+
+### `TaskRunResult`
+
+| Field Name | Field Type | Requirement |
+|------------|------------|-------------|
+| `name`     | string     | REQUIRED    |
+| `value`    | string     | REQUIRED    |
+
+### `TaskSpec`
+
+| Field Name    | Field Type               | Requirement |
+|---------------|--------------------------|-------------|
+| `params`      | `[]ParamSpec`            | REQUIRED    |
+| `steps`       | `[]Step`                 | REQUIRED    |
+| `results`     | `[]TaskResult`           | REQUIRED    |
+| `workspaces`  | `[]WorkspaceDeclaration` | REQUIRED    |
+| `description` | string                   | REQUIRED    |
+
+### `WorkspaceBinding`
+
+| Field Name | Field Type   | Requirement |
+|------------|--------------|-------------|
+| `name`     | string       | REQUIRED    |
+| `emptyDir` | empty struct | REQUIRED    |
+
+**NB:** All other Workspace types supported by the Kubernetes implementation are **OPTIONAL** for the purposes of this spec.
+
+### `WorkspaceDeclaration`
+
+  name	string
+  description	string
+  mountPath	string
+  readOnly	bool
+
+| Field Name    | Field Type | Requirement |
+|---------------|------------|-------------|
+| `name`        | string     | REQUIRED    |
+| `description` | string     | REQUIRED    |
+| `mountPath`   | string     | REQUIRED    |
+| `readOnly`    | boolean    | REQUIRED    |
+| `description` | string     | REQUIRED    |

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -504,9 +504,12 @@ https://user2:pass2@url2.com
 Given hostnames, private keys, and `known_hosts` of the form: `url{n}.com`,
 `key{n}`, and `known_hosts{n}`, Tekton generates the following. 
 
-If no value is specified for `known_hosts`, Tekton configures SSH to accept
+By default, if no value is specified for `known_hosts`, Tekton configures SSH to accept
 **any public key** returned by the server on first query. Tekton does this
 by setting Git's `core.sshCommand` variable to `ssh -o StrictHostKeyChecking=accept-new`.
+This behaviour can be prevented
+[using a feature-flag: `require-git-ssh-secret-known-hosts`](./install.md#customizing-the-pipelines-controller-behavior).
+Set this flag to `true` and all Git SSH Secrets _must_ include a `known_hosts`.
 
 ```
 === ~/.ssh/id_key1 ===

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -121,7 +121,7 @@ The following are considerations for executing `Runs` as a non-root user:
   Specifying a UID that has no valid home directory results in authentication failure.
 - Since SSH authentication ignores the `$HOME` environment variable, you must either move or symlink
   the appropriate `Secret` files from the `$HOME` directory defined by Tekton (`/tekton/home`) to
-  the the non-root user's valid home directory to use SSH authentication for either Git or Docker.
+  the non-root user's valid home directory to use SSH authentication for either Git or Docker.
 
 For an example of configuring SSH authentication in a non-root `securityContext`,
 see [`authenticating-git-commands`](../examples/v1beta1/taskruns/authenticating-git-commands.yaml).
@@ -147,7 +147,7 @@ This section describes how to configure the following authentication schemes for
 
 ### Configuring `basic-auth` authentication for Git
 
-This section descibes how to configure a `basic-auth` type `Secret` for use with Git. In the example below,
+This section describes how to configure a `basic-auth` type `Secret` for use with Git. In the example below,
 before executing any `Steps` in the `Run`, Tekton creates a `~/.gitconfig` file containing the credentials
 specified in the `Secret`. When the `Steps` execute, Tekton uses those credentials to retrieve
 `PipelineResources` specified in the `Run`.
@@ -218,7 +218,7 @@ specified in the `Secret`. When the `Steps` execute, Tekton uses those credentia
 
 ### Configuring `ssh-auth` authentication for Git
 
-This section descibes how to configure an `ssh-auth` type `Secret` for use with Git. In the example below,
+This section describes how to configure an `ssh-auth` type `Secret` for use with Git. In the example below,
 before executing any `Steps` in the `Run`, Tekton creates a `~/.ssh/config` file containing the SSH key
 specified in the `Secret`. When the `Steps` execute, Tekton uses this key to retrieve `PipelineResources`
 specified in the `Run`.

--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -28,7 +28,7 @@ embed a script within a `Step`, **do not** specify a `command` value. For exampl
 If you do not specify a `command` value, the Pipelines controller performs a lookup for
 the `entrypoint` value in the associated remote container registry. If the image is in
 a private registry, you must include an [`ImagePullSecret`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
-value in the the service account definition used by the `Task`.
+value in the service account definition used by the `Task`.
 The Pipelines controller uses this value unless the service account is not 
 defined, at which point it assumes the value of `default`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -327,6 +327,12 @@ TaskRuns with no Sidecars specified. Enabling this option should decrease the ti
 start running. However, for clusters that use injected sidecars e.g. istio
 enabling this option can lead to unexpected behavior.
 
+- `require-git-ssh-secret-known-hosts`: set this flag to `"true"` to require that
+Git SSH Secrets include a `known_hosts` field. This ensures that a git remote server's
+key is validated before data is accepted from it when authenticating over SSH. Secrets
+that don't include a `known_hosts` will result in the TaskRun failing validation and
+not running. 
+
 For example:
 
 ```yaml

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -15,6 +15,7 @@ This page documents the variable substitutions supported by `Tasks` and `Pipelin
 | -------- | ----------- |
 | `params.<param name>` | The value of the parameter at runtime. |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
+| `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.uid` | The uid of the `PipelineRun` that this `Pipeline` is running in. |
@@ -29,7 +30,8 @@ This page documents the variable substitutions supported by `Tasks` and `Pipelin
 | `resources.inputs.<resourceName>.path` | The path to the input resource's directory. |
 | `resources.outputs.<resourceName>.path` | The path to the output resource's directory. |
 | `results.<resultName>.path` | The path to the file where the `Task` writes its results data. |
-| `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. |
+| `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. Empty string if an optional `Workspace` has not been provided by the TaskRun. |
+| `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if an optional`Workspace` has not been provided by the TaskRun. |
 | `workspaces.<workspaceName>.claim` | The name of the `PersistentVolumeClaim` specified as a volume source for the `Workspace`. Empty string for other volume types. |
 | `workspaces.<workspaceName>.volume` | The name of the volume populating the `Workspace`. |
 | `credentials.path` | The path to credentials injected from Secrets with matching annotations. |

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -7,6 +7,7 @@ weight: 15
 # Variable Substitutions Supported by `Tasks` and `Pipelines`
 
 This page documents the variable substitutions supported by `Tasks` and `Pipelines`.
+**Note:** Tekton does not escape the contents of variables. Task authors are responsible for properly escaping a variable's value according to the shell, image or scripting language that the variable will be used in.
 
 ## Variables available in a `Pipeline`
 

--- a/examples/v1beta1/pipelineruns/optional-workspaces.yaml
+++ b/examples/v1beta1/pipelineruns/optional-workspaces.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-source-code-configmap
+data:
+  main.js: |
+    console.log("Hello, World!");
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-js
+spec:
+  workspaces:
+  - name: prelaunch
+    optional: true
+  - name: launch
+  steps:
+  - image: node:lts-alpine3.11
+    script: |
+      #!/usr/bin/env sh
+      if [ $(workspaces.prelaunch.bound) == "true" ] ; then
+        node "$(workspaces.prelaunch.path)/init.js"
+      else
+        echo "Skipping prelaunch."
+      fi
+      if [ -f "$(workspaces.launch.path)/main.js" ] ; then
+        node "$(workspaces.launch.path)/main.js"
+      else
+        echo "Error: missing main.js file in launch workspace!"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: echo
+spec:
+  params:
+  - name: values
+    type: array
+  steps:
+  - image: alpine
+    command: ["echo"]
+    args: ["$(params.values[*])"]
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: optional-workspaces-
+spec:
+  workspaces:
+  - name: launch
+    configMap:
+      name: example-source-code-configmap
+  pipelineSpec:
+    workspaces:
+    - name: launch
+      description: |
+        The program to run. Must provide a main.js at its root.
+    - name: prelaunch
+      optional: true
+      description: |
+        Prelaunch program to run before the launch program. Use this
+        to set up any environment-specific requirements. Must provide
+        an init.js file at its root.
+    tasks:
+    - name: print-bound-state
+      taskRef:
+        name: echo
+      params:
+      - name: values
+        value:
+        - "Was a prelaunch workspace provided? "
+        - $(workspaces.prelaunch.bound)
+        - "\n"
+        - "Was a launch workspace provided? "
+        - "$(workspaces.launch.bound)"
+        - "\n"
+    - name: run-js
+      runAfter: [print-bound-state]
+      workspaces:
+      - name: launch
+        workspace: launch
+      taskRef:
+        name: run-js

--- a/examples/v1beta1/taskruns/optional-workspaces.yaml
+++ b/examples/v1beta1/taskruns/optional-workspaces.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: optional-workspaces-
+spec:
+  workspaces:
+  - name: source-code
+    emptyDir: {}
+  taskSpec:
+    workspaces:
+    - name: source-code
+      optional: true
+    - name: extra-config
+      optional: true
+    steps:
+    - name: check-workspaces
+      image: alpine:3.12.0
+      script: |
+        if [ "$(workspaces.source-code.bound)" == "true" ]; then
+          printf "Source code workspace was provided at %s!\n" "$(workspaces.source-code.path)"
+        fi
+        if [ "$(workspaces.extra-config.bound)" == "true" ]; then
+          printf "Unexpected extra configuration mounted at %s\n" "$(workspaces.extra-config.path)"
+          exit 1
+        fi

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -168,3 +168,22 @@ status:
 		t.Fatalf("Diff(-want,+got): %s", d)
 	}
 }
+
+func TestEncodeDecodeExtraFields(t *testing.T) {
+	type Mystatus struct {
+		S string
+		I int
+	}
+	status := Mystatus{S: "one", I: 1}
+	r := &v1alpha1.RunStatus{}
+	if err := r.EncodeExtraFields(&status); err != nil {
+		t.Fatalf("EncodeExtraFields failed: %s", err)
+	}
+	newStatus := Mystatus{}
+	if err := r.DecodeExtraFields(&newStatus); err != nil {
+		t.Fatalf("DecodeExtraFields failed: %s", err)
+	}
+	if d := cmp.Diff(status, newStatus); d != "" {
+		t.Fatalf("Diff(-want,+got): %s", d)
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -36,6 +36,9 @@ type WorkspaceDeclaration struct {
 	// ReadOnly dictates whether a mounted volume is writable. By default this
 	// field is false and so mounted volumes are writable.
 	ReadOnly bool `json:"readOnly,omitempty"`
+	// Optional marks a Workspace as not being required in TaskRuns. By default
+	// this field is false and so declared workspaces are required.
+	Optional bool `json:"optional,omitempty"`
 }
 
 // GetMountPath returns the mountPath for w which is the MountPath if provided or the
@@ -91,6 +94,9 @@ type PipelineWorkspaceDeclaration struct {
 	// tasks are intended to have access to the data on the workspace.
 	// +optional
 	Description string `json:"description,omitempty"`
+	// Optional marks a Workspace as not being required in PipelineRuns. By default
+	// this field is false and so declared workspaces are required.
+	Optional bool `json:"optional,omitempty"`
 }
 
 // WorkspacePipelineTaskBinding describes how a workspace passed into the pipeline should be

--- a/pkg/controller/filter.go
+++ b/pkg/controller/filter.go
@@ -19,7 +19,10 @@ limitations under the License.
 package controller
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	listersalpha "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // FilterRunRef returns a filter that can be passed to a Run Informer, which
@@ -48,5 +51,41 @@ func FilterRunRef(apiVersion, kind string) func(interface{}) bool {
 		}
 
 		return r.Spec.Ref.APIVersion == apiVersion && r.Spec.Ref.Kind == v1alpha1.TaskKind(kind)
+	}
+}
+
+// FilterOwnerRunRef returns a filter that can be passed to an Informer for any runtime object, which
+// filters out objects that aren't controlled by a Run that references a particular apiVersion and kind.
+//
+// For example, a controller impl that wants to be notified of updates to TaskRuns that are controlled by
+// a Run which references a custom task with apiVersion "example.dev/v0" and kind "Example":
+//
+//     taskruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//       FilterFunc: FilterOwnerRunRef("example.dev/v0", "Example"),
+//       Handler:    controller.HandleAll(impl.Enqueue),
+//     })
+func FilterOwnerRunRef(runLister listersalpha.RunLister, apiVersion, kind string) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+		owner := metav1.GetControllerOf(object)
+		if owner == nil {
+			return false
+		}
+		if owner.APIVersion != v1alpha1.SchemeGroupVersion.String() || owner.Kind != pipeline.RunControllerName {
+			// Not owned by a Run
+			return false
+		}
+		run, err := runLister.Runs(object.GetNamespace()).Get(owner.Name)
+		if err != nil {
+			return false
+		}
+		if run.Spec.Ref == nil {
+			// These are invalid, but just in case they get created somehow, don't panic.
+			return false
+		}
+		return run.Spec.Ref.APIVersion == apiVersion && run.Spec.Ref.Kind == v1alpha1.TaskKind(kind)
 	}
 }

--- a/pkg/controller/filter_test.go
+++ b/pkg/controller/filter_test.go
@@ -19,14 +19,23 @@ package controller_test
 import (
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakeruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/run/fake"
 	"github.com/tektoncd/pipeline/pkg/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 const (
-	apiVersion = "example.dev/v0"
-	kind       = "Example"
+	apiVersion  = "example.dev/v0"
+	apiVersion2 = "example.dev/v1"
+	kind        = "Example"
+	kind2       = "SomethingCompletelyDifferent"
 )
+
+var trueB = true
 
 func TestFilterRunRef(t *testing.T) {
 	for _, c := range []struct {
@@ -99,6 +108,176 @@ func TestFilterRunRef(t *testing.T) {
 			got := controller.FilterRunRef(apiVersion, kind)(c.in)
 			if got != c.want {
 				t.Fatalf("FilterRunRef(%q, %q) got %t, want %t", apiVersion, kind, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFilterOwnerRunRef(t *testing.T) {
+	for _, c := range []struct {
+		desc  string
+		in    interface{}
+		owner *v1alpha1.Run
+		want  bool
+	}{{
+		desc: "Owner is a Run that references a matching apiVersion and kind",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-run",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-run",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       kind,
+				},
+			},
+		},
+		want: true,
+	}, {
+		desc: "Owner is a Run that references a non-matching apiversion",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-other-run",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-other-run",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion2, // different apiversion
+					Kind:       kind,
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Owner is a Run that references a non-matching kind",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-other-run2",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-other-run2",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       kind2, // different kind
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Owner is a Run that with a missing ref",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-strange-run",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-strange-run",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{}, // missing ref (illegal)
+		},
+		want: false,
+	}, {
+		desc: "Owner is not a Run",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.PipelineRunControllerName, // owned by PipelineRun, not Run
+					Name:       "some-pipelinerun",
+					Controller: &trueB,
+				}},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Object has no owner",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun-no-owner",
+				Namespace: "default",
+			},
+		},
+		want: false,
+	}, {
+		desc: "input is not a runtime Object",
+		in:   struct{}{},
+		want: false,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			runInformer := fakeruninformer.Get(ctx)
+			if c.owner != nil {
+				if err := runInformer.Informer().GetIndexer().Add(c.owner); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := controller.FilterOwnerRunRef(runInformer.Lister(), apiVersion, kind)(c.in)
+			if got != c.want {
+				t.Fatalf("FilterOwnerRunRef(%q, %q) got %t, want %t", apiVersion, kind, got, c.want)
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -387,6 +387,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 	// Apply parameter substitution from the PipelineRun
 	pipelineSpec = resources.ApplyParameters(pipelineSpec, pr)
 	pipelineSpec = resources.ApplyContexts(pipelineSpec, pipelineMeta.Name, pr)
+	pipelineSpec = resources.ApplyWorkspaces(pipelineSpec, pr)
 
 	// pipelineRunState holds a list of pipeline tasks after resolving conditions and pipeline resources
 	// pipelineRunState also holds a taskRun for each pipeline task after the taskRun is created

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -84,6 +84,20 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 	}
 }
 
+func ApplyWorkspaces(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
+	p = p.DeepCopy()
+	replacements := map[string]string{}
+	for _, declaredWorkspace := range p.Workspaces {
+		key := fmt.Sprintf("workspaces.%s.bound", declaredWorkspace.Name)
+		replacements[key] = "false"
+	}
+	for _, boundWorkspace := range pr.Spec.Workspaces {
+		key := fmt.Sprintf("workspaces.%s.bound", boundWorkspace.Name)
+		replacements[key] = "true"
+	}
+	return ApplyReplacements(p, replacements, map[string][]string{})
+}
+
 // ApplyReplacements replaces placeholders for declared parameters with the specified replacements.
 func ApplyReplacements(p *v1beta1.PipelineSpec, replacements map[string]string, arrayReplacements map[string][]string) *v1beta1.PipelineSpec {
 	p = p.DeepCopy()

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -255,8 +255,11 @@ func ValidateWorkspaceBindings(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun)
 	}
 
 	for _, ws := range p.Workspaces {
+		if ws.Optional {
+			continue
+		}
 		if _, ok := pipelineRunWorkspaces[ws.Name]; !ok {
-			return fmt.Errorf("pipeline expects workspace with name %q be provided by pipelinerun", ws.Name)
+			return fmt.Errorf("pipeline requires workspace with name %q be provided by pipelinerun", ws.Name)
 		}
 	}
 	return nil

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"github.com/tektoncd/pipeline/pkg/workspace"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -108,24 +109,37 @@ func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1bet
 	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
-// ApplyWorkspaces applies the substitution from paths that the workspaces in w are mounted to, the
-// volumes that wb are realized with in the task spec ts and the PersistentVolumeClaim names for the
+// ApplyWorkspaces applies the substitution from paths that the workspaces in declarations mounted to, the
+// volumes that bindings are realized with in the task spec and the PersistentVolumeClaim names for the
 // workspaces.
-func ApplyWorkspaces(spec *v1beta1.TaskSpec, w []v1beta1.WorkspaceDeclaration, wb []v1beta1.WorkspaceBinding) *v1beta1.TaskSpec {
+func ApplyWorkspaces(spec *v1beta1.TaskSpec, declarations []v1beta1.WorkspaceDeclaration, bindings []v1beta1.WorkspaceBinding) *v1beta1.TaskSpec {
 	stringReplacements := map[string]string{}
 
-	for _, ww := range w {
-		stringReplacements[fmt.Sprintf("workspaces.%s.path", ww.Name)] = ww.GetMountPath()
+	bindNames := sets.NewString()
+	for _, binding := range bindings {
+		bindNames.Insert(binding.Name)
 	}
-	v := workspace.GetVolumes(wb)
-	for name, vv := range v {
-		stringReplacements[fmt.Sprintf("workspaces.%s.volume", name)] = vv.Name
-	}
-	for _, w := range wb {
-		if w.PersistentVolumeClaim != nil {
-			stringReplacements[fmt.Sprintf("workspaces.%s.claim", w.Name)] = w.PersistentVolumeClaim.ClaimName
+
+	for _, declaration := range declarations {
+		prefix := fmt.Sprintf("workspaces.%s.", declaration.Name)
+		if declaration.Optional && !bindNames.Has(declaration.Name) {
+			stringReplacements[prefix+"bound"] = "false"
+			stringReplacements[prefix+"path"] = ""
 		} else {
-			stringReplacements[fmt.Sprintf("workspaces.%s.claim", w.Name)] = ""
+			stringReplacements[prefix+"bound"] = "true"
+			stringReplacements[prefix+"path"] = declaration.GetMountPath()
+		}
+	}
+
+	vols := workspace.GetVolumes(bindings)
+	for name, vol := range vols {
+		stringReplacements[fmt.Sprintf("workspaces.%s.volume", name)] = vol.Name
+	}
+	for _, binding := range bindings {
+		if binding.PersistentVolumeClaim != nil {
+			stringReplacements[fmt.Sprintf("workspaces.%s.claim", binding.Name)] = binding.PersistentVolumeClaim.ClaimName
+		} else {
+			stringReplacements[fmt.Sprintf("workspaces.%s.claim", binding.Name)] = ""
 		}
 	}
 	return ApplyReplacements(spec, stringReplacements, map[string][]string{})

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -708,49 +708,91 @@ func TestApplyWorkspaces(t *testing.T) {
 			},
 		}},
 	}
-	want := applyMutation(ts, func(spec *v1beta1.TaskSpec) {
-		spec.StepTemplate.Env[0].Value = "ws-9l9zj"
-		spec.StepTemplate.Env[1].Value = "foo"
-		spec.StepTemplate.Env[2].Value = ""
+	for _, tc := range []struct {
+		name  string
+		spec  *v1beta1.TaskSpec
+		decls []v1beta1.WorkspaceDeclaration
+		binds []v1beta1.WorkspaceBinding
+		want  *v1beta1.TaskSpec
+	}{{
+		name: "workspace-variable-replacement",
+		spec: ts.DeepCopy(),
+		decls: []v1beta1.WorkspaceDeclaration{{
+			Name: "myws",
+		}, {
+			Name:      "otherws",
+			MountPath: "/foo",
+		}},
+		binds: []v1beta1.WorkspaceBinding{{
+			Name: "myws",
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: "foo",
+			},
+		}, {
+			Name:     "otherws",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+		want: applyMutation(ts, func(spec *v1beta1.TaskSpec) {
+			spec.StepTemplate.Env[0].Value = "ws-9l9zj"
+			spec.StepTemplate.Env[1].Value = "foo"
+			spec.StepTemplate.Env[2].Value = ""
 
-		spec.Steps[0].Name = "ws-9l9zj"
-		spec.Steps[0].Image = "ws-mz4c7"
-		spec.Steps[0].WorkingDir = "ws-mz4c7"
-		spec.Steps[0].Args = []string{"/workspace/myws"}
+			spec.Steps[0].Name = "ws-9l9zj"
+			spec.Steps[0].Image = "ws-mz4c7"
+			spec.Steps[0].WorkingDir = "ws-mz4c7"
+			spec.Steps[0].Args = []string{"/workspace/myws"}
 
-		spec.Steps[1].VolumeMounts[0].Name = "ws-9l9zj"
-		spec.Steps[1].VolumeMounts[0].MountPath = "path/to//foo"
-		spec.Steps[1].VolumeMounts[0].SubPath = "ws-9l9zj"
+			spec.Steps[1].VolumeMounts[0].Name = "ws-9l9zj"
+			spec.Steps[1].VolumeMounts[0].MountPath = "path/to//foo"
+			spec.Steps[1].VolumeMounts[0].SubPath = "ws-9l9zj"
 
-		spec.Steps[2].Env[0].Value = "ws-9l9zj"
-		spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.LocalObjectReference.Name = "ws-9l9zj"
-		spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.Key = "ws-9l9zj"
-		spec.Steps[2].EnvFrom[0].Prefix = "ws-9l9zj"
-		spec.Steps[2].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name = "ws-9l9zj"
+			spec.Steps[2].Env[0].Value = "ws-9l9zj"
+			spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.LocalObjectReference.Name = "ws-9l9zj"
+			spec.Steps[2].Env[1].ValueFrom.SecretKeyRef.Key = "ws-9l9zj"
+			spec.Steps[2].EnvFrom[0].Prefix = "ws-9l9zj"
+			spec.Steps[2].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name = "ws-9l9zj"
 
-		spec.Volumes[0].Name = "ws-9l9zj"
-		spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name = "ws-9l9zj"
-		spec.Volumes[1].VolumeSource.Secret.SecretName = "ws-9l9zj"
-		spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "ws-9l9zj"
-	})
-	w := []v1beta1.WorkspaceDeclaration{{
-		Name: "myws",
+			spec.Volumes[0].Name = "ws-9l9zj"
+			spec.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name = "ws-9l9zj"
+			spec.Volumes[1].VolumeSource.Secret.SecretName = "ws-9l9zj"
+			spec.Volumes[2].VolumeSource.PersistentVolumeClaim.ClaimName = "ws-9l9zj"
+		}),
 	}, {
-		Name:      "otherws",
-		MountPath: "/foo",
-	}}
-	wb := []v1beta1.WorkspaceBinding{{
-		Name: "myws",
-		PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-			ClaimName: "foo",
-		},
+		name: "optional-workspace-provided-variable-replacement",
+		spec: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "$(workspaces.ows.bound)" = "true" && echo "$(workspaces.ows.path)"`,
+		}}},
+		decls: []v1beta1.WorkspaceDeclaration{{
+			Name:     "ows",
+			Optional: true,
+		}},
+		binds: []v1beta1.WorkspaceBinding{{
+			Name:     "ows",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+		want: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "true" = "true" && echo "/workspace/ows"`,
+		}}},
 	}, {
-		Name:     "otherws",
-		EmptyDir: &corev1.EmptyDirVolumeSource{},
-	}}
-	got := resources.ApplyWorkspaces(ts, w, wb)
-	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("TestApplyWorkspaces() got diff %s", diff.PrintWantGot(d))
+		name: "optional-workspace-omitted-variable-replacement",
+		spec: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "$(workspaces.ows.bound)" = "true" && echo "$(workspaces.ows.path)"`,
+		}}},
+		decls: []v1beta1.WorkspaceDeclaration{{
+			Name:     "ows",
+			Optional: true,
+		}},
+		binds: []v1beta1.WorkspaceBinding{}, // intentionally omitted ows binding
+		want: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Script: `test "false" = "true" && echo ""`,
+		}}},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resources.ApplyWorkspaces(tc.spec, tc.decls, tc.binds)
+			if d := cmp.Diff(tc.want, got); d != "" {
+				t.Errorf("TestApplyWorkspaces() got diff %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -423,14 +423,16 @@ func (c *Reconciler) updateTaskRunWithDefaultWorkspaces(ctx context.Context, tr 
 		}
 		workspaceBindings := map[string]v1beta1.WorkspaceBinding{}
 		for _, tsWorkspace := range taskSpec.Workspaces {
-			workspaceBindings[tsWorkspace.Name] = v1beta1.WorkspaceBinding{
-				Name:                  tsWorkspace.Name,
-				SubPath:               defaultWS.SubPath,
-				VolumeClaimTemplate:   defaultWS.VolumeClaimTemplate,
-				PersistentVolumeClaim: defaultWS.PersistentVolumeClaim,
-				EmptyDir:              defaultWS.EmptyDir,
-				ConfigMap:             defaultWS.ConfigMap,
-				Secret:                defaultWS.Secret,
+			if !tsWorkspace.Optional {
+				workspaceBindings[tsWorkspace.Name] = v1beta1.WorkspaceBinding{
+					Name:                  tsWorkspace.Name,
+					SubPath:               defaultWS.SubPath,
+					VolumeClaimTemplate:   defaultWS.VolumeClaimTemplate,
+					PersistentVolumeClaim: defaultWS.PersistentVolumeClaim,
+					EmptyDir:              defaultWS.EmptyDir,
+					ConfigMap:             defaultWS.ConfigMap,
+					Secret:                defaultWS.Secret,
+				}
 			}
 		}
 

--- a/pkg/workspace/validate_test.go
+++ b/pkg/workspace/validate_test.go
@@ -58,6 +58,23 @@ func TestValidateBindingsValid(t *testing.T) {
 			Name:     "beth",
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		}},
+	}, {
+		name: "Included optional workspace",
+		declarations: []v1alpha1.WorkspaceDeclaration{{
+			Name:     "beth",
+			Optional: true,
+		}},
+		bindings: []v1alpha1.WorkspaceBinding{{
+			Name:     "beth",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+	}, {
+		name: "Omitted optional workspace",
+		declarations: []v1alpha1.WorkspaceDeclaration{{
+			Name:     "beth",
+			Optional: true,
+		}},
+		bindings: []v1alpha1.WorkspaceBinding{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := ValidateBindings(tc.declarations, tc.bindings); err != nil {

--- a/test/v1alpha1/workspace_test.go
+++ b/test/v1alpha1/workspace_test.go
@@ -161,7 +161,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
-	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline expects workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline requires workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
 		t.Fatalf("Failed to wait for PipelineRun %q to finish: %s", pipelineRunName, err)
 	}
 

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -231,7 +231,7 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 		t.Fatalf("Failed to create PipelineRun: %s", err)
 	}
 
-	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline expects workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
+	if err := WaitForPipelineRunState(c, pipelineRunName, 10*time.Second, FailedWithMessage(`pipeline requires workspace with name "foo" be provided by pipelinerun`, pipelineRunName), "PipelineRunHasCondition"); err != nil {
 		t.Fatalf("Failed to wait for PipelineRun %q to finish: %s", pipelineRunName, err)
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR contains a number of small enhancements related to the new `Run` type. I am building a custom controller to handle `Run`s. I found these enhancements to be helpful in building it.

* Add a status field to the `Run` spec to support requesting cancellation of the `Run`
* Add helper functions (`MarkRunFailed`, etc.) to update the Run status condition, similar to ones in `pipelinerun_types.go` and `taskrun_types.go`
* Add helper functions to serialize and deserialize a `Run`'s `extraFields`
* Add a filter function that can be used when creating an event handler to notify your custom controller when an object owned by a `Run` is modified

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
