### PR TITLE
perf: create (pipeline|task)run timeout checks in background

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -87,7 +87,7 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 		})
 
 		timeoutHandler.SetCallbackFunc(impl.EnqueueKey)
-		timeoutHandler.CheckTimeouts(ctx, namespace, kubeclientset, pipelineclientset)
+		go timeoutHandler.CheckTimeouts(ctx, namespace, kubeclientset, pipelineclientset)
 
 		logger.Info("Setting up event handlers")
 		pipelineRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -88,7 +88,7 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 		})
 
 		timeoutHandler.SetCallbackFunc(impl.EnqueueKey)
-		timeoutHandler.CheckTimeouts(ctx, namespace, kubeclientset, pipelineclientset)
+		go timeoutHandler.CheckTimeouts(ctx, namespace, kubeclientset, pipelineclientset)
 
 		logger.Info("Setting up event handlers")
 		taskRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/timeout/handler_test.go
+++ b/pkg/timeout/handler_test.go
@@ -111,7 +111,7 @@ func TestTaskRunCheckTimeouts(t *testing.T) {
 	}
 
 	th.SetCallbackFunc(f)
-	th.CheckTimeouts(context.Background(), testNs, c.Kube, c.Pipeline)
+	go th.CheckTimeouts(context.Background(), testNs, c.Kube, c.Pipeline)
 
 	for _, tc := range []struct {
 		name           string
@@ -203,7 +203,7 @@ func TestTaskRunSingleNamespaceCheckTimeouts(t *testing.T) {
 	// Note that since f843899a11d5d09b29fac750f72f4a7e4882f615 CheckTimeouts is always called
 	// with a namespace so there is no reason to maintain all namespaces functionality;
 	// however in #2905 we should remove CheckTimeouts completely
-	th.CheckTimeouts(context.Background(), "", c.Kube, c.Pipeline)
+	go th.CheckTimeouts(context.Background(), "", c.Kube, c.Pipeline)
 
 	for _, tc := range []struct {
 		name           string
@@ -316,7 +316,7 @@ func TestPipelinRunCheckTimeouts(t *testing.T) {
 	}
 
 	th.SetCallbackFunc(f)
-	th.CheckTimeouts(context.Background(), allNs, c.Kube, c.Pipeline)
+	go th.CheckTimeouts(context.Background(), allNs, c.Kube, c.Pipeline)
 	for _, tc := range []struct {
 		name           string
 		pr             *v1beta1.PipelineRun
@@ -395,7 +395,7 @@ func TestWithNoFunc(t *testing.T) {
 			t.Fatal("Expected CheckTimeouts function not to panic")
 		}
 	}()
-	testHandler.CheckTimeouts(context.Background(), allNs, c.Kube, c.Pipeline)
+	go testHandler.CheckTimeouts(context.Background(), allNs, c.Kube, c.Pipeline)
 
 }
 


### PR DESCRIPTION
Both the pipelinerun and taskrun controllers start timeout checks at
startup. They do this by iterating though each namespace and spawning a
go routine for each pipelinerun/taskrun to run the check in the
background. Although each timeout check is done in a go routine, the
iteration through namespaces and creation of the timeout checks is done
in a blocking manner. This adds significant latency at startup when the
number of namespaces is large. Ultimately, this causes a delay in how
fast each controllers can actually start reconciling resources. To
speed up the startup time, this changes the logic so that the iteration
through namespaces is done in the background. The timeout checks were
already carried out in separate go routines and were therefore safe to
use in a concurrent context, so no extra logic was needed to make this
change work in a concurrent context.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
controller and startup time is improved when lots of namespaces are being managed
```