### PR TITLE
Add enforcement of TaskRun's timeout to step level

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -42,6 +42,7 @@ var (
 	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
 	waitPollingInterval = time.Second
 	timeout             = flag.String("timeout", "", "If specified, sets timeout for step")
+	taskRunDeadline     = flag.String("taskrun_deadline", "", "If specified, sets timeout for taskRun")
 )
 
 func cp(src, dst string) error {
@@ -106,9 +107,8 @@ func main() {
 		Results:         strings.Split(*results, ","),
 	}
 
-	if timeout != nil {
-		e.Timeout = *timeout
-	}
+	e.Timeout = *timeout
+	e.TaskRunDeadline = *taskRunDeadline
 
 	// Copy any creds injected by the controller into the $HOME directory of the current
 	// user so that they're discoverable by git / ssh.

--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -41,6 +41,7 @@ var (
 	terminationPath     = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
 	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
 	waitPollingInterval = time.Second
+	timeout             = flag.String("timeout", "", "If specified, sets timeout for step")
 )
 
 func cp(src, dst string) error {
@@ -103,6 +104,10 @@ func main() {
 		Runner:          &realRunner{},
 		PostWriter:      &realPostWriter{},
 		Results:         strings.Split(*results, ","),
+	}
+
+	if timeout != nil {
+		e.Timeout = *timeout
 	}
 
 	// Copy any creds injected by the controller into the $HOME directory of the current

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -89,7 +89,7 @@ func soonestTimeout(stepTimeout, taskRunDeadline string) time.Duration {
 
 	stepDuration, _ := time.ParseDuration(stepTimeout)
 
-	if stepTimeout == "" || taskRunEnd.Before(time.Now().Add(stepDuration)) {
+	if stepTimeout == "" || taskRunDeadline != "" && taskRunEnd.Before(time.Now().Add(stepDuration)) {
 		return taskRunDuration
 	}
 

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -55,15 +55,12 @@ func TestRealRunnerValidDeadline(t *testing.T) {
 // TestRealRunnerEmptyDeadline tests with valid Step timeout but empty TaskRun deadline.
 func TestRealRunnerEmptyDeadline(t *testing.T) {
 	rr := realRunner{}
-	timeout := "1ms"
+	timeout := "1s"
 	taskRunDeadline := ""
 	if err := rr.Run(timeout, taskRunDeadline, "sleep", "0.01"); err != nil {
-		if err != context.DeadlineExceeded {
-			t.Fatalf("unexpected error received: %v", err)
-		}
-	} else {
-		t.Fatalf("step didn't timeout")
+		t.Fatalf("unexpected error received: %v", err)
 	}
+	t.Logf("step finishes successfully")
 }
 
 // TestRealRunnerNegativeStepTimeout tests with negative Step timeout

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // TestRealRunnerSignalForwarding will artificially put an interrupt signal (SIGINT) in the rr.signals chan.
@@ -15,18 +16,76 @@ func TestRealRunnerSignalForwarding(t *testing.T) {
 	rr := realRunner{}
 	rr.signals = make(chan os.Signal, 1)
 	rr.signals <- syscall.SIGINT
-	if err := rr.Run("", "sleep", "3600"); err.Error() == "signal: interrupt" {
+	if err := rr.Run("", "", "sleep", "3600"); err.Error() == "signal: interrupt" {
 		t.Logf("SIGINT forwarded to Entrypoint")
 	} else {
 		t.Fatalf("Unexpected error received: %v", err)
 	}
+
 }
 
 // TestRealRunnerTimeout tests whether cmd is killed after a millisecond even though it's supposed to sleep for 10 milliseconds.
 func TestRealRunnerTimeout(t *testing.T) {
 	rr := realRunner{}
 	timeout := "1ms"
-	if err := rr.Run(timeout, "sleep", "0.01"); err != nil {
+	deadline := time.Now().Add(time.Second * 10)
+	if err := rr.Run(timeout, deadline.Format(time.UnixDate), "sleep", "0.01"); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error received: %v", err)
+		}
+	} else {
+		t.Fatalf("step didn't timeout")
+	}
+}
+
+// TestRealRunnerValidDeadline tests whether cmd is killed after nanosecond * 1000, set by TaskRun deadline, even though it's supposed to sleep for 10 milliseconds.
+func TestRealRunnerValidDeadline(t *testing.T) {
+	rr := realRunner{}
+	timeout := "1s"
+	taskRunDeadline := time.Now().Add(time.Nanosecond * 100).Format(time.UnixDate)
+	if err := rr.Run(timeout, taskRunDeadline, "sleep", "0.01"); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error received: %v", err)
+		}
+	} else {
+		t.Fatalf("step didn't timeout")
+	}
+}
+
+// TestRealRunnerEmptyDeadline tests with valid Step timeout but empty TaskRun deadline.
+func TestRealRunnerEmptyDeadline(t *testing.T) {
+	rr := realRunner{}
+	timeout := "1ms"
+	taskRunDeadline := ""
+	if err := rr.Run(timeout, taskRunDeadline, "sleep", "0.01"); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error received: %v", err)
+		}
+	} else {
+		t.Fatalf("step didn't timeout")
+	}
+}
+
+// TestRealRunnerNegativeStepTimeout tests with negative Step timeout
+func TestRealRunnerNegativeStepTimeout(t *testing.T) {
+	rr := realRunner{}
+	timeout := "-1ms"
+	taskRunDeadline := time.Now().Add(time.Nanosecond * 100).Format(time.UnixDate)
+	if err := rr.Run(timeout, taskRunDeadline, "sleep", "0.01"); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error received: %v", err)
+		}
+	} else {
+		t.Fatalf("step didn't timeout")
+	}
+}
+
+// TestRealRunnerEmptyStepTimeout tests with empty Step timeout and valid TaskRun deadline
+func TestRealRunnerEmptyStepTimeout(t *testing.T) {
+	rr := realRunner{}
+	timeout := ""
+	taskRunDeadline := time.Now().Add(time.Nanosecond * 100).Format(time.UnixDate)
+	if err := rr.Run(timeout, taskRunDeadline, "sleep", "0.01"); err != nil {
 		if err != context.DeadlineExceeded {
 			t.Fatalf("unexpected error received: %v", err)
 		}

--- a/cmd/entrypoint/runner_test.go
+++ b/cmd/entrypoint/runner_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"syscall"
 	"testing"
@@ -14,9 +15,22 @@ func TestRealRunnerSignalForwarding(t *testing.T) {
 	rr := realRunner{}
 	rr.signals = make(chan os.Signal, 1)
 	rr.signals <- syscall.SIGINT
-	if err := rr.Run("sleep", "3600"); err.Error() == "signal: interrupt" {
+	if err := rr.Run("", "sleep", "3600"); err.Error() == "signal: interrupt" {
 		t.Logf("SIGINT forwarded to Entrypoint")
 	} else {
 		t.Fatalf("Unexpected error received: %v", err)
+	}
+}
+
+// TestRealRunnerTimeout tests whether cmd is killed after a millisecond even though it's supposed to sleep for 10 milliseconds.
+func TestRealRunnerTimeout(t *testing.T) {
+	rr := realRunner{}
+	timeout := "1ms"
+	if err := rr.Run(timeout, "sleep", "0.01"); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatalf("unexpected error received: %v", err)
+		}
+	} else {
+		t.Fatalf("step didn't timeout")
 	}
 }

--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -40,6 +40,16 @@ data:
   # See https://github.com/tektoncd/pipeline/issues/2013 for more
   # info.
   disable-home-env-overwrite: "false"
+  # Setting this flag to "true" will enforce TaskRun's timeout
+  # check to Step level enforcement.
+  #
+  # The default behaviour currently is for the TaskRun's timeout
+  # check is done at TaskRun's reconciler level insteaf of at
+  # Step level.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/2559 for more
+  # info.
+  enforce-taskrun-timeouts-in-step-entrypoint: "false"
   # Setting this flag to "true" will prevent Tekton overriding your
   # Task container's working directory.
   #

--- a/docs/install.md
+++ b/docs/install.md
@@ -321,8 +321,14 @@ The default value is `false`, which causes Tekton to override the working direct
 for each `Step` that does not have its working directory explicitly set with `/workspace`.
 For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/1836).
 
+- `enforce-taskrun-timeouts-in-step-entrypoint` - set this flag to `true` to enable 'TaskRun'
+timeout to apply at `Step` level.
+The default value is `false`, which causes Tekton follow the old timeout logic, which
+only applies from the reconciler level.
+For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/2559).
+
 - `running-in-environment-with-injected-sidecars`: set this flag to `"true"` to allow the
-Tekton controller to set the `tekton.dev/ready` annotation at pod creation time for 
+Tekton controller to set the `tekton.dev/ready` annotation at pod creation time for
 TaskRuns with no Sidecars specified. Enabling this option should decrease the time it takes for a TaskRun to
 start running. However, for clusters that use injected sidecars e.g. istio
 enabling this option can lead to unexpected behavior.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -12,6 +12,7 @@ weight: 1
   - [Defining `Steps`](#defining-steps)
     - [Reserved directories](#reserved-directories)
     - [Running scripts within `Steps`](#running-scripts-within-steps)
+    - [Specifying a timeout](#specifying-a-timeout)
   - [Specifying `Parameters`](#specifying-parameters)
   - [Specifying `Resources`](#specifying-resources)
   - [Specifying `Workspaces`](#specifying-workspaces)
@@ -241,7 +242,25 @@ steps:
     #!/usr/bin/env bash
     /bin/my-binary
 ```
+#### Specifying a timeout
 
+A `Step` can specify a `timeout` field. If the `Step` execution time exceeds the specified timeout, this `Step` and any subsequent `Steps` are canceled.
+Specifically, the running process spawned by the `Step` is killed.
+An accompanying log is output under the `status.conditions.message` field of the `TaskRun` YAML.
+
+The format for a timeout is a duration string as specified in the [Go time package](https://golang.org/pkg/time/#ParseDuration) (e.g. 1s or 1ms).
+
+The example `Step` below is supposed to sleep for 60 seconds but will be canceled by the specified 5 second timeout.
+```yaml
+steps:
+  - name: sleep-then-timeout
+    image: ubuntu
+    script: | 
+      #!/usr/bin/env bash
+      echo "I am supposed to sleep for 60 seconds!"
+      sleep 60
+    timeout: 5s
+``` 
 ### Specifying `Parameters`
 
 You can specify parameters, such as compilation flags or artifact names, that you want to supply to the `Task` at execution time.

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -28,11 +28,13 @@ const (
 	disableHomeEnvOverwriteKey              = "disable-home-env-overwrite"
 	disableWorkingDirOverwriteKey           = "disable-working-directory-overwrite"
 	disableAffinityAssistantKey             = "disable-affinity-assistant"
+	EnforceTaskrunTimeoutsInStepKey         = "enforce-taskrun-timeouts-in-step-entrypoint"
 	runningInEnvWithInjectedSidecarsKey     = "running-in-environment-with-injected-sidecars"
 	requireGitSSHSecretKnownHostsKey        = "require-git-ssh-secret-known-hosts" // nolint: gosec
 	DefaultDisableHomeEnvOverwrite          = false
 	DefaultDisableWorkingDirOverwrite       = false
 	DefaultDisableAffinityAssistant         = false
+	DefaultEnforceTaskrunTimeoutsInStep     = false
 	DefaultRunningInEnvWithInjectedSidecars = true
 	DefaultRequireGitSSHSecretKnownHosts    = false
 )
@@ -43,6 +45,7 @@ type FeatureFlags struct {
 	DisableHomeEnvOverwrite          bool
 	DisableWorkingDirOverwrite       bool
 	DisableAffinityAssistant         bool
+	EnforceTaskrunTimeoutsInStep     bool
 	RunningInEnvWithInjectedSidecars bool
 	RequireGitSSHSecretKnownHosts    bool
 }
@@ -79,6 +82,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setFeature(disableAffinityAssistantKey, DefaultDisableAffinityAssistant, &tc.DisableAffinityAssistant); err != nil {
+		return nil, err
+	}
+	if err := setFeature(EnforceTaskrunTimeoutsInStepKey, DefaultEnforceTaskrunTimeoutsInStep, &tc.EnforceTaskrunTimeoutsInStep); err != nil {
 		return nil, err
 	}
 	if err := setFeature(runningInEnvWithInjectedSidecarsKey, DefaultRunningInEnvWithInjectedSidecars, &tc.RunningInEnvWithInjectedSidecars); err != nil {

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -36,6 +36,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 		{
 			expectedConfig: &config.FeatureFlags{
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+				EnforceTaskrunTimeoutsInStep:     config.DefaultEnforceTaskrunTimeoutsInStep,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -44,6 +45,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				DisableHomeEnvOverwrite:          true,
 				DisableWorkingDirOverwrite:       true,
 				DisableAffinityAssistant:         true,
+				EnforceTaskrunTimeoutsInStep:     false,
 				RunningInEnvWithInjectedSidecars: false,
 				RequireGitSSHSecretKnownHosts:    true,
 			},
@@ -60,6 +62,7 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 	FeatureFlagsConfigEmptyName := "feature-flags-empty"
 	expectedConfig := &config.FeatureFlags{
 		RunningInEnvWithInjectedSidecars: true,
+		EnforceTaskrunTimeoutsInStep:     config.DefaultEnforceTaskrunTimeoutsInStep,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -125,10 +125,11 @@ type Step struct {
 	//
 	// If Script is not empty, the Step cannot have an Command or Args.
 	Script string `json:"script,omitempty"`
+	// If step times out after Timeout, pod is terminated
+	Timeout string `json:"timeout,omitempty"`
 }
 
-// Sidecar embeds the Container type, which allows it to include fields not
-// provided by Container.
+// Sidecar has nearly the same data structure as Step, consisting of a Container and an optional Script, but does not have the ability to timeout.
 type Sidecar struct {
 	corev1.Container `json:",inline"`
 

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/substitution"
@@ -157,6 +158,12 @@ func validateStep(s Step, names sets.String) (errs *apis.FieldError) {
 			})
 		}
 		names.Insert(s.Name)
+	}
+
+	if s.Timeout != "" {
+		if _, err := time.ParseDuration(s.Timeout); err != nil {
+			return apis.ErrInvalidValue(s.Timeout, "timeout")
+		}
 	}
 
 	for j, vm := range s.VolumeMounts {

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -66,6 +66,8 @@ type Entrypointer struct {
 	Results []string
 	//Timeout is an optional user-specified flag for timing out Steps
 	Timeout string
+	// TaskRunDeadline is the timeout deadline in Time for entire TaskRun
+	TaskRunDeadline string
 }
 
 // Waiter encapsulates waiting for files to exist.
@@ -76,7 +78,7 @@ type Waiter interface {
 
 // Runner encapsulates running commands.
 type Runner interface {
-	Run(timeout string, args ...string) error
+	Run(timeout string, taskRunDeadline string, args ...string) error
 }
 
 // PostWriter encapsulates writing a file when complete.
@@ -124,7 +126,7 @@ func (e Entrypointer) Go() error {
 		ResultType: v1beta1.InternalTektonResultType,
 	})
 
-	err := e.Runner.Run(e.Timeout, e.Args...)
+	err := e.Runner.Run(e.Timeout, e.TaskRunDeadline, e.Args...)
 	if err == context.DeadlineExceeded {
 		output = append(output, v1beta1.PipelineResourceResult{
 			Key:        "Reason",

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -214,7 +214,7 @@ func (f *fakeWaiter) Wait(file string, _ bool) error {
 
 type fakeRunner struct{ args *[]string }
 
-func (f *fakeRunner) Run(args ...string) error {
+func (f *fakeRunner) Run(timeout string, args ...string) error {
 	f.args = &args
 	return nil
 }
@@ -232,7 +232,7 @@ func (f *fakeErrorWaiter) Wait(file string, expectContent bool) error {
 
 type fakeErrorRunner struct{ args *[]string }
 
-func (f *fakeErrorRunner) Run(args ...string) error {
+func (f *fakeErrorRunner) Run(timeout string, args ...string) error {
 	f.args = &args
 	return errors.New("runner failed")
 }

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -214,7 +214,7 @@ func (f *fakeWaiter) Wait(file string, _ bool) error {
 
 type fakeRunner struct{ args *[]string }
 
-func (f *fakeRunner) Run(timeout string, args ...string) error {
+func (f *fakeRunner) Run(timeout string, taskRunDeadline string, args ...string) error {
 	f.args = &args
 	return nil
 }
@@ -232,7 +232,7 @@ func (f *fakeErrorWaiter) Wait(file string, expectContent bool) error {
 
 type fakeErrorRunner struct{ args *[]string }
 
-func (f *fakeErrorRunner) Run(timeout string, args ...string) error {
+func (f *fakeErrorRunner) Run(timeout string, taskRunDeadline string, args ...string) error {
 	f.args = &args
 	return errors.New("runner failed")
 }

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -88,7 +88,7 @@ func TestOrderContainers(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	gotInit, got, err := orderContainers(images.EntrypointImage, []string{}, steps, nil)
+	gotInit, got, err := orderContainers(images.EntrypointImage, []string{}, make([][]string, len(steps)), steps, nil)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestEntryPointResults(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, make([][]string, len(steps)), steps, results)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, make([][]string, len(steps)), steps, results)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}
@@ -244,7 +244,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
-	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, results)
+	_, got, err := orderContainers(images.EntrypointImage, []string{}, make([][]string, len(steps)), steps, results)
 	if err != nil {
 		t.Fatalf("orderContainers: %v", err)
 	}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -139,9 +139,11 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 		return nil, err
 	}
 
+	extraEntrypointArgs := returnTimeoutArgs(taskSpec.Steps)
+
 	// Rewrite steps with entrypoint binary. Append the entrypoint init
 	// container to place the entrypoint binary.
-	entrypointInit, stepContainers, err := orderContainers(b.Images.EntrypointImage, credEntrypointArgs, stepContainers, taskSpec.Results)
+	entrypointInit, stepContainers, err := orderContainers(b.Images.EntrypointImage, credEntrypointArgs, extraEntrypointArgs, stepContainers, taskSpec.Results)
 	if err != nil {
 		return nil, err
 	}
@@ -397,4 +399,15 @@ func shouldAddReadyAnnotationOnPodCreate(ctx context.Context, sidecars []v1beta1
 	// controllers.
 	cfg := config.FromContextOrDefaults(ctx)
 	return !cfg.FeatureFlags.RunningInEnvWithInjectedSidecars
+}
+
+// returnTimeoutArgs returns a string array of timeout arguments for steps
+func returnTimeoutArgs(steps []v1beta1.Step) [][]string {
+	stepTimeouts := make([][]string, len(steps))
+	for i, s := range steps {
+		if s.Timeout != "" {
+			stepTimeouts[i] = append(stepTimeouts[i], "-timeout", s.Timeout)
+		}
+	}
+	return stepTimeouts
 }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1084,7 +1084,54 @@ script-heredoc-randomly-generated-78c5n
 				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 				TerminationMessagePath: "/tekton/termination",
 			}},
-		}}} {
+		},
+	}, {
+		desc: "step-with-timeout",
+		ts: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				Name:    "name",
+				Image:   "image",
+				Command: []string{"cmd"}, // avoid entrypoint lookup.
+			},
+				Timeout: "1s",
+			}},
+		},
+		want: &corev1.PodSpec{
+			RestartPolicy:  corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{placeToolsInit},
+			Containers: []corev1.Container{{
+				Name:    "step-name",
+				Image:   "image",
+				Command: []string{"/tekton/tools/entrypoint"},
+				Args: []string{
+					"-wait_file",
+					"/tekton/downward/ready",
+					"-wait_file_content",
+					"-post_file",
+					"/tekton/tools/0",
+					"-termination_path",
+					"/tekton/termination",
+					"-timeout",
+					"1s",
+					"-entrypoint",
+					"cmd",
+					"--",
+				},
+				Env: implicitEnvVars,
+				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					Name:      "tekton-creds-init-home-9l9zj",
+					MountPath: "/tekton/creds",
+				}}, implicitVolumeMounts...),
+				WorkingDir:             pipeline.WorkspaceDir,
+				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
+				TerminationMessagePath: "/tekton/termination",
+			}},
+			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Name:         "tekton-creds-init-home-9l9zj",
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
+			}),
+		},
+	}} {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
 			store := config.NewStore(logtesting.TestLogger(t))

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -61,13 +61,13 @@ func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.
 	}
 
 	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, &placeScripts, "script")
-	// convertListOfSteps operates on overlapping fields across Step and Sidecar, hence a conversion
-	// from Sidecar into Step
+
 	sideCarSteps := []v1beta1.Step{}
 	for _, step := range sidecars {
 		sidecarStep := v1beta1.Step{
-			step.Container,
-			step.Script,
+			Container: step.Container,
+			Script:    step.Script,
+			Timeout:   "",
 		}
 		sideCarSteps = append(sideCarSteps, sidecarStep)
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -166,7 +166,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1beta1.TaskRun) pkg
 
 	// Check if the TaskRun has timed out; if it is, this will set its status
 	// accordingly.
-	if tr.HasTimedOut() {
+	if tr.HasTimedOut() && !podconvert.ShouldCheckTaskRunStepTimeout(ctx) {
 		message := fmt.Sprintf("TaskRun %q failed to finish within %q", tr.Name, tr.GetTimeout())
 		err := c.failTaskRun(ctx, tr, v1beta1.TaskRunReasonTimedOut, message)
 		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)

--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -210,6 +211,7 @@ func TestStepTimeout(t *testing.T) {
 			},
 		},
 	}
+
 	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", taskrunName, err)
 	}
@@ -294,6 +296,91 @@ func TestTaskRunTimeout(t *testing.T) {
 			t.Fatalf("-got, +want: %v", d)
 		}
 	}
+}
+
+// TestTaskRunStepTimeout is an integration test that will verify a Step can be timed out
+// due to TaskRun's timeout deadline.
+func TestTaskRunStepTimeout(t *testing.T) {
+	c, namespace := setup(t)
+	t.Parallel()
+
+	knativetest.CleanupOnInterrupt(func() { tearDown(t, c, namespace) }, t.Logf)
+	defer tearDown(t, c, namespace)
+
+	configMapData := map[string]string{
+		config.EnforceTaskrunTimeoutsInStepKey: "true",
+	}
+
+	// Update configMap to enforce TaskRun timeout to Step.
+	originalConfigMap, configMapErr := c.KubeClient.GetConfigMap("tekton-pipelines").Get(config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
+
+	if configMapErr != nil {
+		t.Fatalf("Failed to get configMap")
+	}
+
+	if err := updateConfigMap(c.KubeClient, "tekton-pipelines", config.GetFeatureFlagsConfigName(), configMapData); err != nil {
+		t.Fatalf("Failed updating configMap")
+	}
+
+	t.Logf("Creating Task with Step step-timeout, Step step-timeout, and Step step-canceled in namespace %s", namespace)
+
+	taskrunName := "taskrun-step-timeout"
+
+	t.Logf("Creating TaskRun %s in namespace %s", taskrunName, namespace)
+	taskRun := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: taskrunName, Namespace: namespace},
+		Spec: v1beta1.TaskRunSpec{
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1beta1.Step{{
+					Container: corev1.Container{
+						Name:  "timeout",
+						Image: "busybox",
+					},
+					Script:  "sleep 1",
+					Timeout: "2s",
+				}, {
+					Container: corev1.Container{
+						Name:  "canceled",
+						Image: "busybox",
+					},
+				},
+				},
+			},
+			Timeout: &metav1.Duration{Duration: 1 * time.Second},
+		},
+	}
+
+	if _, err := c.TaskRunClient.Create(taskRun); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", taskrunName, err)
+	}
+
+	failMsg := "\"step-timeout\" exited because the step exceeded the specified timeout limit"
+	t.Logf("Waiting for %s in namespace %s to time out", "taskrun-step-timeout", namespace)
+	if err := WaitForTaskRunState(c, taskrunName, FailedWithMessage(failMsg, "taskrun-step-timeout"), "StepTimeout"); err != nil {
+		t.Logf("Error in taskRun %s status: %s\n", taskrunName, err)
+		t.Errorf("Expected: %s", failMsg)
+	}
+
+	tr, err := c.TaskRunClient.Get(taskrunName, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Error getting Taskrun: %v", err)
+	}
+	if tr.Status.Steps[0].Terminated == nil {
+		if tr.Status.Steps[0].Terminated.Reason != "Completed" {
+			t.Errorf("step-timeout should not have been terminated")
+		}
+	}
+	if tr.Status.Steps[1].Terminated == nil {
+		t.Errorf("step-canceled should have been canceled after step-timeout timed out")
+	} else if exitcode := tr.Status.Steps[1].Terminated.ExitCode; exitcode != 1 {
+		t.Logf("step-canceled exited with exit code %d, expected exit code 1", exitcode)
+	}
+
+	// Resets configMap as it is shared across test cases.
+	if err := updateConfigMap(c.KubeClient, "tekton-pipelines", config.GetFeatureFlagsConfigName(), originalConfigMap.Data); err != nil {
+		t.Fatalf("Failed re-setting configMap")
+	}
+
 }
 
 func TestPipelineTaskTimeout(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enforces the TaskRun's timeout to step level and guard the feature with a feature flag. By default the new enforcement is disabled.

Added unit tests and integration tests along with the feature.

**NOTE: PR is based on another PR [#3087](https://github.com/tektoncd/pipeline/pull/3087). Will rebase once that is merged.**

Closes [#2559](https://github.com/tektoncd/pipeline/issues/2559)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

Enforces the TaskRun's timeout to step level and guard the feature with a feature flag. By default the new enforcement is disabled.

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
