### PR TITLE
Add a short example of using optional workspaces in when expressions

### DIFF
--- a/examples/v1beta1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
@@ -1,0 +1,66 @@
+# This example demonstrates using the workspaces.<name>.bound variable
+# in a when expression to selectively run different portions of a Pipeline
+# based on the presence of an optional workspace.
+#
+# In the PipelineRun below an optional message-of-the-day workspace is accepted
+# by the Pipeline. If that workspace is provided then the print-motd task is
+# executed. If that workspace is not provided then a print-default-motd task
+# is run instead. We supply a ConfigMap for the workspace and so the print-motd
+# task ends up running and printing the contents of each entry in the ConfigMap.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-motd
+data:
+  message_1: "Hello, good morning!"
+  message_2: "Hello, good evening!"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: optional-workspace-when-
+spec:
+  serviceAccountName: 'default'
+  workspaces:
+  - name: message-of-the-day
+    configMap:
+      name: test-motd
+  pipelineSpec:
+    workspaces:
+    - name: message-of-the-day
+      optional: true
+      description: |
+        If a workspace is provided here then every file at the root of the workspace
+        will be printed.
+    tasks:
+    - name: print-motd
+      when:
+      - input: "$(workspaces.message-of-the-day.bound)"
+        operator: in
+        values: ["true"]
+      workspaces:
+      - name: message-of-the-day
+        workspace: message-of-the-day
+      taskSpec:
+        workspaces:
+        - name: message-of-the-day
+        steps:
+        - image: alpine
+          script: |
+            #!/usr/bin/env ash
+            for f in "$(workspaces.message-of-the-day.path)"/* ; do
+              echo "Message from $f:"
+              cat "$f"
+              echo "" # add newline
+            done
+    - name: print-default-motd
+      when:
+      - input: "$(workspaces.message-of-the-day.bound)"
+        operator: in
+        values: ["false"]
+      taskSpec:
+        steps:
+        - name: print-default
+          image: alpine
+          script: |
+            echo "No message-of-the-day workspace was provided. This is the default MOTD instead!"


### PR DESCRIPTION
We've just added support for optional workspaces but I forgot to include
an example showing how to use them as part of a When Expression.

This commit adds a PipelineRun example YAML showing use of a
workspaces.\<name>.bound variable in a when expression.

I've also added a line to the pipelines.md file mentioning that you
can use a when expression to evaluate whether an optional workspace was
bound or not.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)


# Release Notes

```release-note
Added a short example of using optional workspaces in when expressions.
```