### PR TITLE
Run enhancements

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -168,3 +168,22 @@ status:
 		t.Fatalf("Diff(-want,+got): %s", d)
 	}
 }
+
+func TestEncodeDecodeExtraFields(t *testing.T) {
+	type Mystatus struct {
+		S string
+		I int
+	}
+	status := Mystatus{S: "one", I: 1}
+	r := &v1alpha1.RunStatus{}
+	if err := r.EncodeExtraFields(&status); err != nil {
+		t.Fatalf("EncodeExtraFields failed: %s", err)
+	}
+	newStatus := Mystatus{}
+	if err := r.DecodeExtraFields(&newStatus); err != nil {
+		t.Fatalf("DecodeExtraFields failed: %s", err)
+	}
+	if d := cmp.Diff(status, newStatus); d != "" {
+		t.Fatalf("Diff(-want,+got): %s", d)
+	}
+}

--- a/pkg/controller/filter.go
+++ b/pkg/controller/filter.go
@@ -19,7 +19,10 @@ limitations under the License.
 package controller
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	listersalpha "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // FilterRunRef returns a filter that can be passed to a Run Informer, which
@@ -48,5 +51,41 @@ func FilterRunRef(apiVersion, kind string) func(interface{}) bool {
 		}
 
 		return r.Spec.Ref.APIVersion == apiVersion && r.Spec.Ref.Kind == v1alpha1.TaskKind(kind)
+	}
+}
+
+// FilterOwnerRunRef returns a filter that can be passed to an Informer for any runtime object, which
+// filters out objects that aren't controlled by a Run that references a particular apiVersion and kind.
+//
+// For example, a controller impl that wants to be notified of updates to TaskRuns that are controlled by
+// a Run which references a custom task with apiVersion "example.dev/v0" and kind "Example":
+//
+//     taskruninformer.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+//       FilterFunc: FilterOwnerRunRef("example.dev/v0", "Example"),
+//       Handler:    controller.HandleAll(impl.Enqueue),
+//     })
+func FilterOwnerRunRef(runLister listersalpha.RunLister, apiVersion, kind string) func(interface{}) bool {
+	return func(obj interface{}) bool {
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+		owner := metav1.GetControllerOf(object)
+		if owner == nil {
+			return false
+		}
+		if owner.APIVersion != v1alpha1.SchemeGroupVersion.String() || owner.Kind != pipeline.RunControllerName {
+			// Not owned by a Run
+			return false
+		}
+		run, err := runLister.Runs(object.GetNamespace()).Get(owner.Name)
+		if err != nil {
+			return false
+		}
+		if run.Spec.Ref == nil {
+			// These are invalid, but just in case they get created somehow, don't panic.
+			return false
+		}
+		return run.Spec.Ref.APIVersion == apiVersion && run.Spec.Ref.Kind == v1alpha1.TaskKind(kind)
 	}
 }

--- a/pkg/controller/filter_test.go
+++ b/pkg/controller/filter_test.go
@@ -19,14 +19,23 @@ package controller_test
 import (
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakeruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1alpha1/run/fake"
 	"github.com/tektoncd/pipeline/pkg/controller"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 const (
-	apiVersion = "example.dev/v0"
-	kind       = "Example"
+	apiVersion  = "example.dev/v0"
+	apiVersion2 = "example.dev/v1"
+	kind        = "Example"
+	kind2       = "SomethingCompletelyDifferent"
 )
+
+var trueB = true
 
 func TestFilterRunRef(t *testing.T) {
 	for _, c := range []struct {
@@ -99,6 +108,176 @@ func TestFilterRunRef(t *testing.T) {
 			got := controller.FilterRunRef(apiVersion, kind)(c.in)
 			if got != c.want {
 				t.Fatalf("FilterRunRef(%q, %q) got %t, want %t", apiVersion, kind, got, c.want)
+			}
+		})
+	}
+}
+
+func TestFilterOwnerRunRef(t *testing.T) {
+	for _, c := range []struct {
+		desc  string
+		in    interface{}
+		owner *v1alpha1.Run
+		want  bool
+	}{{
+		desc: "Owner is a Run that references a matching apiVersion and kind",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-run",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-run",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       kind,
+				},
+			},
+		},
+		want: true,
+	}, {
+		desc: "Owner is a Run that references a non-matching apiversion",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-other-run",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-other-run",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion2, // different apiversion
+					Kind:       kind,
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Owner is a Run that references a non-matching kind",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-other-run2",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-other-run2",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1alpha1.TaskRef{
+					APIVersion: apiVersion,
+					Kind:       kind2, // different kind
+				},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Owner is a Run that with a missing ref",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.RunControllerName,
+					Name:       "some-strange-run",
+					Controller: &trueB,
+				}},
+			},
+		},
+		owner: &v1alpha1.Run{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: v1alpha1.SchemeGroupVersion.String(),
+				Kind:       pipeline.RunControllerName,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-strange-run",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.RunSpec{}, // missing ref (illegal)
+		},
+		want: false,
+	}, {
+		desc: "Owner is not a Run",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: v1alpha1.SchemeGroupVersion.String(),
+					Kind:       pipeline.PipelineRunControllerName, // owned by PipelineRun, not Run
+					Name:       "some-pipelinerun",
+					Controller: &trueB,
+				}},
+			},
+		},
+		want: false,
+	}, {
+		desc: "Object has no owner",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-taskrun-no-owner",
+				Namespace: "default",
+			},
+		},
+		want: false,
+	}, {
+		desc: "input is not a runtime Object",
+		in:   struct{}{},
+		want: false,
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			ctx, _ := rtesting.SetupFakeContext(t)
+			runInformer := fakeruninformer.Get(ctx)
+			if c.owner != nil {
+				if err := runInformer.Informer().GetIndexer().Add(c.owner); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := controller.FilterOwnerRunRef(runInformer.Lister(), apiVersion, kind)(c.in)
+			if got != c.want {
+				t.Fatalf("FilterOwnerRunRef(%q, %q) got %t, want %t", apiVersion, kind, got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR contains a number of small enhancements related to the new Run type. I am building a custom controller to handle Runs. I found these enhancements to be helpful in building it.

* Add a status field to the Run spec to support requesting cancellation of the Run
* Add helper functions (MarkRunFailed, etc.) to update the Run status condition, similar to ones in pipelinerun_types.go and taskrun_types.go
* Add helper functions to serialize and deserialize a Run's extraFields
* Add a filter function that can be used when creating an event handler to notify your custom controller when an object owned by a Run is modified

Hopefully I have all the commit messages right this time.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```