### PR TITLE
Derive cancel patch bytes once at controller startup

### DIFF
--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -19,37 +19,44 @@ package pipelinerun
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
-	"go.uber.org/zap"
-	jsonpatch "gomodules.xyz/jsonpatch/v2"
-
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 )
 
+var cancelPatchBytes []byte
+
+func init() {
+	var err error
+	cancelPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/status",
+		Value:     v1beta1.TaskRunSpecStatusCancelled,
+	}})
+	if err != nil {
+		log.Fatalf("failed to marshal cancel patch bytes: %v", err)
+	}
+}
+
 // cancelPipelineRun marks the PipelineRun as cancelled and any resolved TaskRun(s) too.
 func cancelPipelineRun(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface) error {
 	errs := []string{}
-
-	// Use Patch to update the TaskRuns since the TaskRun controller may be operating on the
-	// TaskRuns at the same time and trying to update the entire object may cause a race
-	b, err := getCancelPatch()
-	if err != nil {
-		return fmt.Errorf("couldn't make patch to update TaskRun cancellation: %v", err)
-	}
 
 	// Loop over the TaskRuns in the PipelineRun status.
 	// If a TaskRun is not in the status yet we should not cancel it anyways.
 	for taskRunName := range pr.Status.TaskRuns {
 		logger.Infof("cancelling TaskRun %s", taskRunName)
 
-		if _, err := clientSet.TektonV1beta1().TaskRuns(pr.Namespace).Patch(taskRunName, types.JSONPatchType, b, ""); err != nil {
+		if _, err := clientSet.TektonV1beta1().TaskRuns(pr.Namespace).Patch(taskRunName, types.JSONPatchType, cancelPatchBytes, ""); err != nil {
 			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %s", taskRunName, err).Error())
 			continue
 		}
@@ -76,17 +83,4 @@ func cancelPipelineRun(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clien
 		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
 	}
 	return nil
-}
-
-func getCancelPatch() ([]byte, error) {
-	patches := []jsonpatch.JsonPatchOperation{{
-		Operation: "add",
-		Path:      "/spec/status",
-		Value:     v1beta1.TaskRunSpecStatusCancelled,
-	}}
-	patchBytes, err := json.Marshal(patches)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal patch bytes in order to cancel: %v", err)
-	}
-	return patchBytes, nil
 }


### PR DESCRIPTION
This avoids JSON marshaling the same object every time a PipelineRun is
cancelled, and marshals the object once at startup. If for some reason
marshaling that object fails (which it should never do), the controller
will exit and restart.

Failure to marshal this object should only be caused by a bug in our
code, since the object isn't derived from anything related to user
requests. If we have a bug in our cancel patch generation, we'd rather
find out by having the controller crashloop than find out by having
PipelineRuns be uncancellable, which might be harder to detect.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fail more loudly at controller startup when we fail to marshal the JSON Patch request to cancel TaskRuns owned by cancelled PipelineRuns.
```

cc @ywluogg since I think we should also generate patch bytes like this for updating annotations (#3310)