### PR TITLE
Replace variables in Sidecar Script block

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -158,6 +158,7 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `Task` | `spec.sidecars[].volumemounts.name` |
 | `Task` | `spec.sidecars[].volumemounts.mountpath` |
 | `Task` | `spec.sidecars[].volumemounts.subpath` |
+| `Task` | `spec.sidecars[].script` |
 | `Pipeline` | `spec.tasks[].params[].value` |
 | `Pipeline` | `spec.tasks[].conditions[].params[].value` |
 | `Pipeline` | `spec.results[].value` |

--- a/pkg/apis/pipeline/v1beta1/sidecar_replacements.go
+++ b/pkg/apis/pipeline/v1beta1/sidecar_replacements.go
@@ -1,0 +1,26 @@
+/*
+ Copyright 2020 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"github.com/tektoncd/pipeline/pkg/substitution"
+)
+
+func ApplySidecarReplacements(sidecar *Sidecar, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+	sidecar.Script = substitution.ApplyReplacements(sidecar.Script, stringReplacements)
+	ApplyContainerReplacements(&sidecar.Container, stringReplacements, arrayReplacements)
+}

--- a/pkg/apis/pipeline/v1beta1/sidecar_replacements_test.go
+++ b/pkg/apis/pipeline/v1beta1/sidecar_replacements_test.go
@@ -1,0 +1,131 @@
+/*
+ Copyright 2019 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestApplySidecarReplacements(t *testing.T) {
+	replacements := map[string]string{
+		"replace.me": "replaced!",
+	}
+
+	arrayReplacements := map[string][]string{
+		"array.replace.me": {"val1", "val2"},
+	}
+
+	s := v1beta1.Sidecar{
+		Script: "$(replace.me)",
+		Container: corev1.Container{
+			Name:       "$(replace.me)",
+			Image:      "$(replace.me)",
+			Command:    []string{"$(array.replace.me)"},
+			Args:       []string{"$(array.replace.me)"},
+			WorkingDir: "$(replace.me)",
+			EnvFrom: []corev1.EnvFromSource{{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "$(replace.me)",
+					},
+				},
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "$(replace.me)",
+					},
+				},
+			}},
+			Env: []corev1.EnvVar{{
+				Name:  "not_me",
+				Value: "$(replace.me)",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(replace.me)",
+						},
+						Key: "$(replace.me)",
+					},
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "$(replace.me)",
+						},
+						Key: "$(replace.me)",
+					},
+				},
+			}},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "$(replace.me)",
+				MountPath: "$(replace.me)",
+				SubPath:   "$(replace.me)",
+			}},
+		},
+	}
+
+	expected := v1beta1.Sidecar{
+		Script: "replaced!",
+		Container: corev1.Container{
+			Name:       "replaced!",
+			Image:      "replaced!",
+			Command:    []string{"val1", "val2"},
+			Args:       []string{"val1", "val2"},
+			WorkingDir: "replaced!",
+			EnvFrom: []corev1.EnvFromSource{{
+				ConfigMapRef: &corev1.ConfigMapEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "replaced!",
+					},
+				},
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "replaced!",
+					},
+				},
+			}},
+			Env: []corev1.EnvVar{{
+				Name:  "not_me",
+				Value: "replaced!",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "replaced!",
+						},
+						Key: "replaced!",
+					},
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "replaced!",
+						},
+						Key: "replaced!",
+					},
+				},
+			}},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:      "replaced!",
+				MountPath: "replaced!",
+				SubPath:   "replaced!",
+			}},
+		},
+	}
+	v1beta1.ApplySidecarReplacements(&s, replacements, arrayReplacements)
+	if d := cmp.Diff(s, expected); d != "" {
+		t.Errorf("Container replacements failed: %s", d)
+	}
+}

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -228,7 +228,7 @@ func ApplyReplacements(spec *v1beta1.TaskSpec, stringReplacements map[string]str
 	// Apply variable substitution to the sidecar definitions
 	sidecars := spec.Sidecars
 	for i := range sidecars {
-		v1beta1.ApplyContainerReplacements(&sidecars[i].Container, stringReplacements, arrayReplacements)
+		v1beta1.ApplySidecarReplacements(&sidecars[i], stringReplacements, arrayReplacements)
 	}
 
 	return spec


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A while ago we added Script block support to Sidecars but forgot
to perform variable replacement on them. We perform variable replacement
on pretty much every other important field in a Sidecar so we should
probably also do it in Scripts.

This commit applies variables used in Sidecar Script blocks and adds
a few tests for it (copied from the existing step_replacements func).


<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixed issue where script blocks in sidecars didn't have their variables replaced.
```

/kind bug