### PR TITLE
update submodules with --init flag

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -192,10 +192,7 @@ func SubmoduleFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 			return fmt.Errorf("failed to change directory with path %s; err: %w", spec.Path, err)
 		}
 	}
-	if _, err := run(logger, "", "submodule", "init"); err != nil {
-		return err
-	}
-	updateArgs := []string{"submodule", "update", "--recursive"}
+	updateArgs := []string{"submodule", "update", "--recursive", "--init"}
 	if spec.Depth > 0 {
 		updateArgs = append(updateArgs, fmt.Sprintf("--depth=%d", spec.Depth))
 	}


### PR DESCRIPTION
fixes #3320

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This updates `pkg/git`'s submodule updating to also `git submodule init` recursively.  This fixes #3320.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)

I don't know how to write the test.  ATM it does not test anything like that.  I am a novice in go though.

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)

not applicable.

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)

- [x] Release notes block has been filled in or deleted (only if no user facing changes)


## Reviewer Notes

There are no [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md).

# Release Notes

```release-note
Git-init can now clone recursive submodules.
```