### PR TITLE
Add docs demonstrating how to share a Workspace with Sidecars

### DIFF
--- a/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
@@ -1,0 +1,44 @@
+# This example TaskRun demonstrates how to share a Workspace between Steps
+# and a Sidecar. The Sidecar must be explicitly configured to mount the
+# volume backing a Workspace so that it has access to it.
+#
+# The Step writes a file to the Workspace and then waits for the Sidecar
+# to respond. The Sidecar sees the Step's file and writes its response.
+# The Step sees the response and exits.
+kind: TaskRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: workspace-in-sidecar-
+spec:
+  timeout: 30s
+  workspaces:
+  - name: signals
+    emptyDir: {}
+  taskSpec:
+    workspaces:
+    - name: signals
+    steps:
+    - image: alpine:3.12.0
+      script: |
+        #!/usr/bin/env ash
+        echo "foo" > "$(workspaces.signals.path)"/bar
+        echo "Wrote bar file"
+        while [ ! -f "$(workspaces.signals.path)"/ready ] ; do
+          echo "Waiting for $(workspaces.signals.path)/ready"
+          sleep 1
+        done
+        echo "Saw ready file"
+    sidecars:
+    - image: alpine:3.12.0
+      # Note: must explicitly add volumeMount to gain access to Workspace in sidecar
+      volumeMounts:
+      - name: $(workspaces.signals.volume)
+        mountPath: $(workspaces.signals.path)
+      script: |
+        #!/usr/bin/env ash
+        while [ ! -f "$(workspaces.signals.path)"/bar ] ; do
+          echo "Waiting for $(workspaces.signals.path)/bar"
+          sleep 1
+        done
+        touch "$(workspaces.signals.path)"/ready
+        echo "Wrote ready file"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit we didn't have any documentation showing how to share
a Workspace between Steps of a Task and the Task's Sidecars. In fact
there were two bugs that prevented this from working correctly. Those
bugs have since been squashed.

This commit adds documentation and an example yaml showing how to share a
Workspace between a Task's Steps and its Sidecars.



<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Added an example and documentation showing how to share a Workspace between Steps and Sidecars in a Task.
```

/kind documentation