### PR TITLE
refactoring pipelinerunstate - no logic changed at all

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -32,6 +32,7 @@ import (
 // state of the PipelineRun.
 type PipelineRunState []*ResolvedPipelineRunTask
 
+// PipelineRunFacts is a collection of list of ResolvedPipelineTask, graph of DAG tasks, and graph of finally tasks
 type PipelineRunFacts struct {
 	State           PipelineRunState
 	TasksGraph      *dag.Graph
@@ -57,10 +58,62 @@ func (state PipelineRunState) IsBeforeFirstTaskRun() bool {
 	return true
 }
 
-// GetNextTasks returns a list of tasks which should be executed next i.e.
+// GetTaskRunsStatus returns a map of taskrun name and the taskrun
+// ignore a nil taskrun in pipelineRunState, otherwise, capture taskrun object from PipelineRun Status
+// update taskrun status based on the pipelineRunState before returning it in the map
+func (state PipelineRunState) GetTaskRunsStatus(pr *v1beta1.PipelineRun) map[string]*v1beta1.PipelineRunTaskRunStatus {
+	status := make(map[string]*v1beta1.PipelineRunTaskRunStatus)
+	for _, rprt := range state {
+		if rprt.TaskRun == nil && rprt.ResolvedConditionChecks == nil {
+			continue
+		}
+
+		var prtrs *v1beta1.PipelineRunTaskRunStatus
+		if rprt.TaskRun != nil {
+			prtrs = pr.Status.TaskRuns[rprt.TaskRun.Name]
+		}
+		if prtrs == nil {
+			prtrs = &v1beta1.PipelineRunTaskRunStatus{
+				PipelineTaskName: rprt.PipelineTask.Name,
+			}
+		}
+
+		if rprt.TaskRun != nil {
+			prtrs.Status = &rprt.TaskRun.Status
+		}
+
+		if len(rprt.ResolvedConditionChecks) > 0 {
+			cStatus := make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
+			for _, c := range rprt.ResolvedConditionChecks {
+				cStatus[c.ConditionCheckName] = &v1beta1.PipelineRunConditionCheckStatus{
+					ConditionName: c.ConditionRegisterName,
+				}
+				if c.ConditionCheck != nil {
+					cStatus[c.ConditionCheckName].Status = c.NewConditionCheckStatus()
+				}
+			}
+			prtrs.ConditionChecks = cStatus
+			if rprt.ResolvedConditionChecks.IsDone() && !rprt.ResolvedConditionChecks.IsSuccess() {
+				if prtrs.Status == nil {
+					prtrs.Status = &v1beta1.TaskRunStatus{}
+				}
+				prtrs.Status.SetCondition(&apis.Condition{
+					Type:    apis.ConditionSucceeded,
+					Status:  corev1.ConditionFalse,
+					Reason:  ReasonConditionCheckFailed,
+					Message: fmt.Sprintf("ConditionChecks failed for Task %s in PipelineRun %s", rprt.TaskRunName, pr.Name),
+				})
+			}
+		}
+		status[rprt.TaskRunName] = prtrs
+	}
+	return status
+}
+
+// getNextTasks returns a list of tasks which should be executed next i.e.
 // a list of tasks from candidateTasks which aren't yet indicated in state to be running and
 // a list of cancelled/failed tasks from candidateTasks which haven't exhausted their retries
-func (state PipelineRunState) GetNextTasks(candidateTasks sets.String) []*ResolvedPipelineRunTask {
+func (state PipelineRunState) getNextTasks(candidateTasks sets.String) []*ResolvedPipelineRunTask {
 	tasks := []*ResolvedPipelineRunTask{}
 	for _, t := range state {
 		if _, ok := candidateTasks[t.PipelineTask.Name]; ok && t.TaskRun == nil {
@@ -96,50 +149,7 @@ func (facts *PipelineRunFacts) IsStopping() bool {
 	return false
 }
 
-// SuccessfulOrSkippedTasks returns a list of the names of all of the PipelineTasks in state
-// which have successfully completed or skipped
-func (facts *PipelineRunFacts) SuccessfulOrSkippedDAGTasks() []string {
-	tasks := []string{}
-	for _, t := range facts.State {
-		if facts.isDAGTask(t.PipelineTask.Name) {
-			if t.IsSuccessful() || t.Skip(facts) {
-				tasks = append(tasks, t.PipelineTask.Name)
-			}
-		}
-	}
-	return tasks
-}
-
-// checkTasksDone returns true if all tasks from the specified graph are finished executing
-// a task is considered done if it has failed/succeeded/skipped
-func (facts *PipelineRunFacts) checkTasksDone(d *dag.Graph) bool {
-	for _, t := range facts.State {
-		if isTaskInGraph(t.PipelineTask.Name, d) {
-			if t.TaskRun == nil {
-				// this task might have skipped if taskRun is nil
-				// continue and ignore if this task was skipped
-				// skipped task is considered part of done
-				if t.Skip(facts) {
-					continue
-				}
-				return false
-			}
-			if !t.IsDone() {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func (facts *PipelineRunFacts) CheckDAGTasksDone() bool {
-	return facts.checkTasksDone(facts.TasksGraph)
-}
-
-func (facts *PipelineRunFacts) CheckFinalTasksDone() bool {
-	return facts.checkTasksDone(facts.FinalTasksGraph)
-}
-
+// DAGExecutionQueue returns a list of DAG tasks which needs to be scheduled next
 func (facts *PipelineRunFacts) DAGExecutionQueue() (PipelineRunState, error) {
 	tasks := PipelineRunState{}
 	// when pipeline run is stopping, do not schedule any new task and only
@@ -147,11 +157,11 @@ func (facts *PipelineRunFacts) DAGExecutionQueue() (PipelineRunState, error) {
 	if !facts.IsStopping() {
 		// candidateTasks is initialized to DAG root nodes to start pipeline execution
 		// candidateTasks is derived based on successfully finished tasks and/or skipped tasks
-		candidateTasks, err := dag.GetSchedulable(facts.TasksGraph, facts.SuccessfulOrSkippedDAGTasks()...)
+		candidateTasks, err := dag.GetSchedulable(facts.TasksGraph, facts.successfulOrSkippedDAGTasks()...)
 		if err != nil {
 			return tasks, err
 		}
-		tasks = facts.State.GetNextTasks(candidateTasks)
+		tasks = facts.State.getNextTasks(candidateTasks)
 	}
 	return tasks, nil
 }
@@ -164,14 +174,14 @@ func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
 	finalCandidates := sets.NewString()
 	// check either pipeline has finished executing all DAG pipelineTasks
 	// or any one of the DAG pipelineTask has failed
-	if facts.CheckDAGTasksDone() {
+	if facts.checkDAGTasksDone() {
 		// return list of tasks with all final tasks
 		for _, t := range facts.State {
 			if facts.isFinalTask(t.PipelineTask.Name) && !t.IsSuccessful() {
 				finalCandidates.Insert(t.PipelineTask.Name)
 			}
 		}
-		tasks = facts.State.GetNextTasks(finalCandidates)
+		tasks = facts.State.getNextTasks(finalCandidates)
 	}
 	return tasks
 }
@@ -256,7 +266,7 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(pr *v1beta1.PipelineRu
 	// transition pipeline into stopping state when one of the tasks(dag/final) cancelled or one of the dag tasks failed
 	// for a pipeline with final tasks, single dag task failure does not transition to interim stopping state
 	// pipeline stays in running state until all final tasks are done before transitioning to failed state
-	if cancelledTasks > 0 || (failedTasks > 0 && facts.CheckFinalTasksDone()) {
+	if cancelledTasks > 0 || (failedTasks > 0 && facts.checkFinalTasksDone()) {
 		reason = v1beta1.PipelineRunReasonStopping.String()
 	} else {
 		reason = v1beta1.PipelineRunReasonRunning.String()
@@ -280,55 +290,53 @@ func (facts *PipelineRunFacts) GetSkippedTasks() []v1beta1.SkippedTask {
 	return skipped
 }
 
-func (state PipelineRunState) GetTaskRunsStatus(pr *v1beta1.PipelineRun) map[string]*v1beta1.PipelineRunTaskRunStatus {
-	status := make(map[string]*v1beta1.PipelineRunTaskRunStatus)
-	for _, rprt := range state {
-		if rprt.TaskRun == nil && rprt.ResolvedConditionChecks == nil {
-			continue
-		}
-
-		var prtrs *v1beta1.PipelineRunTaskRunStatus
-		if rprt.TaskRun != nil {
-			prtrs = pr.Status.TaskRuns[rprt.TaskRun.Name]
-		}
-		if prtrs == nil {
-			prtrs = &v1beta1.PipelineRunTaskRunStatus{
-				PipelineTaskName: rprt.PipelineTask.Name,
+// successfulOrSkippedTasks returns a list of the names of all of the PipelineTasks in state
+// which have successfully completed or skipped
+func (facts *PipelineRunFacts) successfulOrSkippedDAGTasks() []string {
+	tasks := []string{}
+	for _, t := range facts.State {
+		if facts.isDAGTask(t.PipelineTask.Name) {
+			if t.IsSuccessful() || t.Skip(facts) {
+				tasks = append(tasks, t.PipelineTask.Name)
 			}
 		}
-
-		if rprt.TaskRun != nil {
-			prtrs.Status = &rprt.TaskRun.Status
-		}
-
-		if len(rprt.ResolvedConditionChecks) > 0 {
-			cStatus := make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
-			for _, c := range rprt.ResolvedConditionChecks {
-				cStatus[c.ConditionCheckName] = &v1beta1.PipelineRunConditionCheckStatus{
-					ConditionName: c.ConditionRegisterName,
-				}
-				if c.ConditionCheck != nil {
-					cStatus[c.ConditionCheckName].Status = c.NewConditionCheckStatus()
-				}
-			}
-			prtrs.ConditionChecks = cStatus
-			if rprt.ResolvedConditionChecks.IsDone() && !rprt.ResolvedConditionChecks.IsSuccess() {
-				if prtrs.Status == nil {
-					prtrs.Status = &v1beta1.TaskRunStatus{}
-				}
-				prtrs.Status.SetCondition(&apis.Condition{
-					Type:    apis.ConditionSucceeded,
-					Status:  corev1.ConditionFalse,
-					Reason:  ReasonConditionCheckFailed,
-					Message: fmt.Sprintf("ConditionChecks failed for Task %s in PipelineRun %s", rprt.TaskRunName, pr.Name),
-				})
-			}
-		}
-		status[rprt.TaskRunName] = prtrs
 	}
-	return status
+	return tasks
 }
 
+// checkTasksDone returns true if all tasks from the specified graph are finished executing
+// a task is considered done if it has failed/succeeded/skipped
+func (facts *PipelineRunFacts) checkTasksDone(d *dag.Graph) bool {
+	for _, t := range facts.State {
+		if isTaskInGraph(t.PipelineTask.Name, d) {
+			if t.TaskRun == nil {
+				// this task might have skipped if taskRun is nil
+				// continue and ignore if this task was skipped
+				// skipped task is considered part of done
+				if t.Skip(facts) {
+					continue
+				}
+				return false
+			}
+			if !t.IsDone() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// check if all DAG tasks done executing (succeeded, failed, or skipped)
+func (facts *PipelineRunFacts) checkDAGTasksDone() bool {
+	return facts.checkTasksDone(facts.TasksGraph)
+}
+
+// check if all finally tasks done executing (succeeded or failed)
+func (facts *PipelineRunFacts) checkFinalTasksDone() bool {
+	return facts.checkTasksDone(facts.FinalTasksGraph)
+}
+
+// check if a specified pipelineTask is defined under tasks(DAG) section
 func (facts *PipelineRunFacts) isDAGTask(pipelineTaskName string) bool {
 	if _, ok := facts.TasksGraph.Nodes[pipelineTaskName]; ok {
 		return true
@@ -336,6 +344,7 @@ func (facts *PipelineRunFacts) isDAGTask(pipelineTaskName string) bool {
 	return false
 }
 
+// check if a specified pipelineTask is defined under finally section
 func (facts *PipelineRunFacts) isFinalTask(pipelineTaskName string) bool {
 	if _, ok := facts.FinalTasksGraph.Nodes[pipelineTaskName]; ok {
 		return true

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -293,7 +293,7 @@ func TestGetNextTasks(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			next := tc.state.GetNextTasks(tc.candidates)
+			next := tc.state.getNextTasks(tc.candidates)
 			if d := cmp.Diff(next, tc.expectedNext); d != "" {
 				t.Errorf("Didn't get expected next Tasks %s", diff.PrintWantGot(d))
 			}
@@ -399,7 +399,7 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			next := tc.state.GetNextTasks(tc.candidates)
+			next := tc.state.getNextTasks(tc.candidates)
 			if d := cmp.Diff(next, tc.expectedNext); d != "" {
 				t.Errorf("Didn't get expected next Tasks %s", diff.PrintWantGot(d))
 			}
@@ -466,7 +466,7 @@ func TestPipelineRunState_SuccessfulOrSkippedDAGTasks(t *testing.T) {
 				TasksGraph:      d,
 				FinalTasksGraph: &dag.Graph{},
 			}
-			names := facts.SuccessfulOrSkippedDAGTasks()
+			names := facts.successfulOrSkippedDAGTasks()
 			if d := cmp.Diff(names, tc.expectedNames); d != "" {
 				t.Errorf("Expected to get completed names %v but got something different %s", tc.expectedNames, diff.PrintWantGot(d))
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a "pure" refactoring i.e. no logic changes at all. 

- Converting exported methods into unexported local methods since they are being called from the same file/package to avoid direct access.
- Grouping exported and unexported (local) methods
- Adding comments to those methods

[Diff](https://github.com/tektoncd/pipeline/pull/3326/files?diff=split&w=1) with hiding spaces renders much better 🙏  

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/kind cleanup
