### PR TITLE
Add a clarifying comment to new workspace test

### DIFF
--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -236,6 +236,9 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 	}
 }
 
+// TestWorkspaceVolumeNameMatchesVolumeVariableReplacement checks that a workspace's
+// randomized volume name matches the workspaces.<name>.volume variable injected into
+// a user's task specs.
 func TestWorkspaceVolumeNameMatchesVolumeVariableReplacement(t *testing.T) {
 	c, namespace := setup(t)
 
@@ -311,6 +314,7 @@ func TestWorkspaceVolumeNameMatchesVolumeVariableReplacement(t *testing.T) {
 	volumeNames := []string{}
 	for _, volume := range p.Spec.Volumes {
 		if volume.Name == workspaceVariableValue {
+			// Success: the volume's generated name matches the workspace.<name>.volume variable.
 			return
 		}
 		volumeNames = append(volumeNames, volume.Name)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The purpose of a new workspace test was somewhat ambiguous.

This commit adds clarifying comments to help future readers of the test
code figure out what the meaning of the success condition is.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/kind documentation