### PR TITLE
Fix the pipelinerun docs about completion time

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -440,7 +440,8 @@ taskRuns:
           startedAt: "2020-05-04T02:06:24Z"
   ```
 
-The following tables shows how to read the overall status of a `PipelineRun`:
+The following tables shows how to read the overall status of a `PipelineRun`.
+Completion time is set once a `PipelineRun` reaches status `True` or `False`:
 
 `status`|`reason`|`completionTime` is set|Description
 :-------|:-------|:---------------------:|--------------:
@@ -450,7 +451,6 @@ Unknown|PipelineRunCancelled|No|The user requested the PipelineRun to be cancell
 True|Succeeded|Yes|The `PipelineRun` completed successfully.
 True|Completed|Yes|The `PipelineRun` completed successfully, one or more Tasks were skipped.
 False|Failed|Yes|The `PipelineRun` failed because one of the `TaskRuns` failed.
-False|\[Error message\]|No|The `PipelineRun` encountered an non-permanent error, but it's still running and it may ultimately succeed.
 False|\[Error message\]|Yes|The `PipelineRun` failed with a permanent error (usually validation).
 False|PipelineRunCancelled|Yes|The `PipelineRun` was cancelled successfully.
 False|PipelineRunTimeout|Yes|The `PipelineRun` timed out.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Completion time is only set once a pipelinerun reaches status
true or false. Once the status is set, it's irreversible.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fixed incorrect documentation about pipeline run completion time and status.
```

/kind documentation