### PR TITLE
Fix the logic for the disable-ha flag

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -84,7 +84,7 @@ func main() {
 	cfg.Burst = 2 * *burst
 
 	ctx := injection.WithNamespaceScope(signals.NewContext(), *namespace)
-	if !*disableHighAvailability {
+	if *disableHighAvailability {
 		ctx = sharedmain.WithHADisabled(ctx)
 	}
 	sharedmain.MainWithConfig(ctx, ControllerLogKey, cfg,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The tekton controller has a `disable-ha` flag that was introduced
in https://github.com/tektoncd/pipeline/pull/3156, which can be
used to disable support for leader-election-based HA.

The default for the disable flag is "false" i.e. support for HA
is meant to be enabled by default, however the current check on
the flag does the opposite of what it should, resulting in HA
being disabled by default.

This PR fixes the logic to restore the correct behaviour.

The new flag has been introduced in release v0.17.0 which has been released today.  We should include this in v0.17.1 to restore the existing default behaviour.

Fixes #3339 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Default behaviour for leader-election-ha has been restored to "enabled".
The controller flag `disable-ha` will now *disable* HA support when set to true.
```

/kind bug