### PR TITLE
TestSidecarTaskSupport e2e test case fix for custom base image

### DIFF
--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -48,7 +48,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 	}{{
 		desc:           "A sidecar that runs forever is terminated when Steps complete",
 		stepCommand:    []string{"echo", "\"hello world\""},
-		sidecarCommand: []string{"sh", "-c", "while [[ true ]] ; do echo \"hello from sidecar\" ; done"},
+		sidecarCommand: []string{"sh", "-c", "while [[ true ]] ; do echo \"hello from sidecar\" ; [[ -f /ko-app/nop ]] && break; done; ./ko-app/nop"},
 	}, {
 		desc:           "A sidecar that terminates early does not cause problems running Steps",
 		stepCommand:    []string{"echo", "\"hello world\""},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This PR resolves #1253 `TestSidecarTaskSupport` e2e test. When a base image of nop contains the command sidecar is executing, sidecar is not terminated. The detailed cause is already discussed at #1347. I faced the exact same issue when I used `registry.access.redhat.com/ubi8/ubi:latest` as base for nop image. There is already a merged PR #1464 which documents this behavior. 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
TestSidecarTaskSupport e2e test will execute successfully when base image of nop contains the command sidecar is trying to execute
```

