### PR TITLE
Update the revision used with kaniko.

### DIFF
--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -40,8 +40,8 @@ const (
 	kanikoTaskRunName       = "kanikotask-run"
 	kanikoGitResourceName   = "go-example-git"
 	kanikoImageResourceName = "go-example-image"
-	// This is a random revision chosen on 10/11/2019
-	revision = "1c9d566ecd13535f93789595740f20932f655905"
+	// This is a random revision chosen on 2020/10/09
+	revision = "a310cc6d1cd449f95cedd23393de766fdc649651"
 )
 
 // TestTaskRun is an integration test that will verify a TaskRun using kaniko

--- a/test/v1alpha1/kaniko_task_test.go
+++ b/test/v1alpha1/kaniko_task_test.go
@@ -38,8 +38,8 @@ const (
 	kanikoTaskRunName       = "kanikotask-run"
 	kanikoGitResourceName   = "go-example-git"
 	kanikoImageResourceName = "go-example-image"
-	// This is a random revision chosen on 10/11/2019
-	revision = "1c9d566ecd13535f93789595740f20932f655905"
+	// This is a random revision chosen on 2020/10/09
+	revision = "a310cc6d1cd449f95cedd23393de766fdc649651"
 )
 
 // TestTaskRun is an integration test that will verify a TaskRun using kaniko


### PR DESCRIPTION
# Changes

Running the e2e tests on KinD w/o GCP auth configured I am getting authentication errors in the kaniko step:

```
        >>> Container step-kaniko:
        INFO[0000] Resolved base name gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0 to gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
        INFO[0000] Resolved base name gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0 to gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
        INFO[0000] Retrieving image manifest gcr.io/google-appengine/debian9@sha256:1d6a9a6d106bd795098f60f4abb7083626354fa6735e81743c7f8cfca11259f0
        error building image: error getting credentials - err: exit status 1, out: `docker-credential-gcr/helper: could not retrieve GCR's access token: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.`
```

I noticed that at HEAD kaniko us using DockerHub, so it felt like the simplest change to get things passing.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
