### PR TITLE
[cherry-pick] config: fix runAsUser inconsistency with images 🍨

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -104,7 +104,8 @@ spec:
           value: tekton.dev/pipeline
         securityContext:
           allowPrivilegeEscalation: false
-          runAsUser: 1001
+          # User 65532 is the distroless nonroot user ID
+          runAsUser: 65532
       volumes:
         - name: config-logging
           configMap:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -82,7 +82,8 @@ spec:
           value: tekton.dev/pipeline
         securityContext:
           allowPrivilegeEscalation: false
-          runAsUser: 1001
+          # User 65532 is the distroless nonroot user ID
+          runAsUser: 65532
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

The distroless `nonroot` image define a user with the uid 65532 and
not 1001. The deployment should use that uid to make sure it works anywhere.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
(cherry picked from commit 4f5a71c6a2916b27fae917c05fa1ba20e505bf4e)
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fix inconsistent uid for the controller and webhook deployment, resulting in failure of installing tekton pipeline on minikube (and other platforms.)
```
