### PR TITLE
[cherry-pick] Only send cloud events when condition changes

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -51,6 +51,11 @@ retrieving those events using the `kubectl describe` command. Tekton can also em
 When you [configure a sink](install.md#configuring-cloudevents-notifications), Tekton emits
 events as described in the table below.
 
+Tekton sends cloud events in a parallel routine to allow for retries without blocking the
+reconciler. A routine is started every time the `Succeeded` condition changes - either state,
+reason or message. Retries are sent using an exponential back-off strategy. 
+Because of retries, events are not guaranteed to be sent to the target sink in the order they happened.
+
 Resource      |Event    |Event Type
 :-------------|:-------:|:----------------------------------------------------------
 `TaskRun`     | `Started` | `dev.tekton.event.taskrun.started.v1`

--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -58,9 +58,12 @@ func Emit(ctx context.Context, beforeCondition *apis.Condition, afterCondition *
 	sendKubernetesEvents(recorder, beforeCondition, afterCondition, object)
 
 	if sendCloudEvents {
-		err := cloudevent.SendCloudEventWithRetries(ctx, object)
-		if err != nil {
-			logger.Warnf("Failed to emit cloud events %v", err.Error())
+		// Only send events if the new condition represents a change
+		if !equality.Semantic.DeepEqual(beforeCondition, afterCondition) {
+			err := cloudevent.SendCloudEventWithRetries(ctx, object)
+			if err != nil {
+				logger.Warnf("Failed to emit cloud events %v", err.Error())
+			}
 		}
 	}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Change the logic for cloud events to be sent only if a change is
detected in the condition, specifically in state, message or reason.

Fixes #3336

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>
(cherry picked from commit 3d35b876e6e0967bc19b276eedc53c08e899bdcf)
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
Fixes issue with duplicate cloud events. Cloud events are now sent only if a change in condition happened.
```


/kind bug