### PR TITLE
Refresh list of s390x excluded tests

### DIFF
--- a/examples/v1beta1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1beta1/taskruns/authenticating-git-commands.yaml
@@ -62,7 +62,7 @@ spec:
       emptyDir: {}
     sidecars:
     - name: server
-      image: alpine/git:v2.24.3
+      image: alpine/git:v2.26.2
       securityContext:
         runAsUser: 0
       volumeMounts:
@@ -105,7 +105,7 @@ spec:
     - name: setup
       # This Step is only necessary as part of the test, it's not something you'll
       # ever need in a real-world scenario involving an external git repo.
-      image: alpine/git:v2.24.3
+      image: alpine/git:v2.26.2
       securityContext:
         runAsUser: 0
       volumeMounts:
@@ -124,7 +124,7 @@ spec:
           sleep 1
         done
     - name: git-clone-and-push
-      image: alpine/git:v2.24.3
+      image: alpine/git:v2.26.2
       securityContext:
         runAsUser: 0
       workingDir: /root

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -183,7 +183,7 @@ func getHelmDeployTask(namespace string) *v1beta1.Task {
 					"service.type=ClusterIP",
 				},
 			}}, {Container: corev1.Container{
-				Image:   "lachlanevenson/k8s-kubectl",
+				Image:   getTestImage(kubectlImage),
 				Command: []string{"kubectl"},
 				Args: []string{
 					"get",

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -36,6 +36,8 @@ const (
 	busyboxImage = iota
 	// Registry image
 	registryImage
+	//kubectl image
+	kubectlImage
 )
 
 func init() {
@@ -58,11 +60,13 @@ func initImageNames() map[int]string {
 		return map[int]string{
 			busyboxImage:  "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977",
 			registryImage: "ibmcom/registry:2.6.2.5",
+			kubectlImage:  "ibmcom/kubectl:v1.13.9",
 		}
 	}
 	return map[int]string{
 		busyboxImage:  "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
 		registryImage: "registry",
+		kubectlImage:  "lachlanevenson/k8s-kubectl",
 	}
 }
 
@@ -84,8 +88,10 @@ func getImagesMappingRE() map[*regexp.Regexp][]byte {
 func imageNamesMapping() map[string]string {
 	if getTestArch() == "s390x" {
 		return map[string]string{
-			"registry": getTestImage(registryImage),
-			"node":     "node:alpine3.11",
+			"registry":                   getTestImage(registryImage),
+			"node":                       "node:alpine3.11",
+			"lachlanevenson/k8s-kubectl": getTestImage(kubectlImage),
+			"gcr.io/cloud-builders/git":  "alpine/git:latest",
 		}
 	}
 
@@ -108,43 +114,16 @@ func initExcludedTests() sets.String {
 			"TestExamples/v1beta1/pipelineruns/pipelinerun",
 			"TestExamples/v1beta1/taskruns/build-gcs-zip",
 			"TestExamples/v1alpha1/taskruns/build-gcs-zip",
-			"TestExamples/v1alpha1/taskruns/git-volume",
-			"TestExamples/v1beta1/taskruns/git-volume",
 			"TestExamples/v1beta1/taskruns/docker-creds",
 			"TestExamples/v1alpha1/taskruns/docker-creds",
-			"TestExamples/v1beta1/taskruns/steps-run-in-order",
-			"TestExamples/v1alpha1/taskruns/steps-run-in-order",
-			"TestExamples/v1beta1/taskruns/step-by-digest",
-			"TestExamples/v1alpha1/taskruns/step-by-digest",
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/authenticating-git-commands",
 			"TestExamples/v1beta1/pipelineruns/pipelinerun-with-final-tasks",
-			"TestExamples/v1beta1/taskruns/pullrequest_input_copystep_output",
-			"TestExamples/v1alpha1/taskruns/pullrequest_input_copystep_output",
-			"TestExamples/v1beta1/taskruns/pullrequest",
-			"TestExamples/v1alpha1/taskruns/pullrequest",
-			"TestExamples/v1beta1/pipelineruns/conditional-pipelinerun",
-			"TestExamples/v1alpha1/pipelineruns/pipelinerun-with-resourcespec",
-			"TestExamples/v1beta1/pipelineruns/pipelinerun-with-resourcespec",
-			"TestExamples/v1beta1/taskruns/git-ssh-creds-without-known_hosts",
-			"TestExamples/v1alpha1/taskruns/optional-resources",
-			"TestExamples/v1beta1/taskruns/optional-resources",
-			"TestExamples/v1beta1/taskruns/task-output-image",
+			"TestExamples/v1beta1/taskruns/workspace-in-sidecar",
 			//e2e
-			"TestEntrypointRunningStepsInOrder",
-			"TestWorkingDirIgnoredNonSlashWorkspace",
-			"TestTaskRun_EmbeddedResource",
-			"TestTaskRunPipelineRunCancel",
-			"TestEntrypointRunningStepsInOrder",
-			"TestGitPipelineRun",
 			"TestHelmDeployPipelineRun",
 			"TestKanikoTaskRun",
-			"TestPipelineRun",
-			"TestSidecarTaskSupport",
-			"TestWorstkingDirCreated",
-			"TestWorkingDirIgnoredNonSlashWorkspace",
-			"TestWorkingDirCreated",
 			"TestPipelineRun/service_account_propagation_and_pipeline_param",
 			"TestPipelineRun/pipelinerun_succeeds_with_LimitRange_minimum_in_namespace",
 		)


### PR DESCRIPTION


# Changes
The list of s390x excluded tests is reduced with:
- bug fix https://github.com/tektoncd/pipeline/pull/3337
- bumping alpine-git version to the latest one to be able to use multi-arch image
- adding kubectl image replacement for s390x
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

