### PR TITLE
Check that events are at least expected ones

### DIFF
--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -144,23 +145,35 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			for _, taskrunItem := range taskrunList.Items {
 				trName = append(trName, taskrunItem.Name)
 			}
-			matchKinds := map[string][]string{"PipelineRun": {pipelineRunName}, "TaskRun": trName}
-			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
-			expectedNumberOfEvents := 1 + len(trName)
+			matchKinds := map[string][]string{"PipelineRun": {pipelineRunName}}
+			// Expected failure events: 1 for the pipelinerun cancel
+			expectedNumberOfEvents := 1
 			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)
 			events, err := collectMatchingEvents(ctx, c.KubeClient, namespace, matchKinds, "Failed")
 			if err != nil {
 				t.Fatalf("Failed to collect matching events: %q", err)
 			}
-			if len(events) != expectedNumberOfEvents {
-				collectedEvents := ""
-				for i, event := range events {
-					collectedEvents += fmt.Sprintf("%#v", event)
-					if i < (len(events) - 1) {
-						collectedEvents += ", "
-					}
+			if len(events) < expectedNumberOfEvents {
+				collectedEvents := make([]string, 0, len(events))
+				for _, event := range events {
+					collectedEvents = append(collectedEvents, fmt.Sprintf("%#v", event))
 				}
-				t.Fatalf("Expected %d number of successful events from pipelinerun and taskrun but got %d; list of received events : %#v", expectedNumberOfEvents, len(events), collectedEvents)
+				t.Fatalf("Expected %d number of failed events from pipelinerun but got %d; list of received events : %s", expectedNumberOfEvents, len(events), strings.Join(collectedEvents, ", "))
+			}
+			matchKinds = map[string][]string{"TaskRun": trName}
+			// Expected failure events: 1 for each TaskRun
+			expectedNumberOfEvents = len(trName)
+			t.Logf("Making sure %d events were created from taskruns with kinds %v", expectedNumberOfEvents, matchKinds)
+			events, err = collectMatchingEvents(ctx, c.KubeClient, namespace, matchKinds, "Failed")
+			if err != nil {
+				t.Fatalf("Failed to collect matching events: %q", err)
+			}
+			if len(events) < expectedNumberOfEvents {
+				collectedEvents := make([]string, 0, len(events))
+				for _, event := range events {
+					collectedEvents = append(collectedEvents, fmt.Sprintf("%#v", event))
+				}
+				t.Fatalf("Expected %d number of failed events from taskrun but got %d; list of received events : %s", expectedNumberOfEvents, len(events), strings.Join(collectedEvents, ", "))
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes #3374

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
