### PR TITLE
Add feature flag to disable creds-init

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -50,6 +50,20 @@ data:
   # See https://github.com/tektoncd/pipeline/issues/1836 for more
   # info.
   disable-working-directory-overwrite: "false"
+  # Setting this flag to "true" will prevent Tekton scanning attached
+  # service accounts and injecting any credentials it finds into your
+  # Steps.
+  #
+  # The default behaviour currently is for Tekton to search service
+  # accounts for secrets matching a specified format and automatically
+  # mount those into your Steps.
+  #
+  # Note: setting this to "true" will prevent PipelineResources from
+  # working.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/1836 for more
+  # info.
+  disable-creds-init: "false"
   # This option should be set to false when Pipelines is running in a
   # cluster that does not use injected sidecars such as Istio. Setting
   # it to false should decrease the time it takes for a TaskRun to start

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -33,6 +33,10 @@ refers to `TaskRuns` and `PipelineRuns` as `Runs` for the sake of brevity.
       - [A Workspace or Volume is also Mounted for the same credentials](#a-workspace-or-volume-is-also-mounted-for-the-same-credentials)
       - [A Task employes a read-only-Workspace or Volume for `$HOME`](#a-task-employs-a-read-only-workspace-or-volume-for-home)
       - [The Step is named `image-digest-exporter`](#the-step-is-named-image-digest-exporter)
+- [Disabling Tekton's Built-In Auth](#disabling-tektons-build-in-auth)
+  - [Why would an organization want to do this?](#why-would-an-organization-want-to-do-this)
+  - [What are the effects of making this change?](#what-are-the-effects-of-making-this-change)
+  - [How to disable the built-in auth](#how-to-disable-the-build-in-auth)
 
 ## Overview
 
@@ -587,6 +591,11 @@ This can most easily be resolved by ensuring that each Step executing in your
 Task and TaskRun runs with the same UID. A blanket UID can be set with [a
 TaskRun's `Pod template` field](./taskruns.md#specifying-a-pod-template).
 
+If you require Steps to run with different UIDs then you should disable
+Tekton's built-in credential initialization and use Workspaces to mount
+credentials from Secrets instead. See [the section on disabling Tekton's
+credential initialization](#disabling-tektons-build-in-auth).
+
 #### A Workspace or Volume is also Mounted for the same credentials
 
 A Task has mounted both a Workspace (or Volume) for credentials and the TaskRun
@@ -595,6 +604,7 @@ try to initialize.
 
 The simplest solution to this problem is to not mix credentials mounted via
 Workspace with those initialized using the process described in this document.
+See [the section on disabling Tekton's credential initialization](#disabling-tektons-build-in-auth).
 
 #### A Task employs a read-only Workspace or Volume for `$HOME`
 
@@ -604,6 +614,7 @@ credentials that Tekton will try to initialize.
 
 The simplest solution to this problem is to not mix credentials mounted via
 Workspace with those initialized using the process described in this document.
+See [the section on disabling Tekton's credential initialization](#disabling-tektons-build-in-auth).
 
 #### The Step is named `image-digest-exporter`
 
@@ -614,6 +625,35 @@ that can differ from those of the Steps in the Task. The Step does not use
 these credentials.
 
 ---
+
+## Disabling Tekton's Built-In Auth
+
+### Why would an organization want to do this?
+
+There are a number of reasons that an organization may want to disable
+Tekton's built-in credential handling:
+
+1. The mechanism can be quite difficult to debug.
+2. There are an extremely limited set of supported credential types.
+3. Tasks with Steps that have different UIDs can break if multiple Steps
+are trying to share access to the same credentials.
+4. Tasks with Steps that have different UIDs can log more warning messages,
+creating more noise in TaskRun logs. Again this is because multiple Steps
+with differing UIDs cannot share access to the same credential files.
+
+
+### What are the effects of making this change?
+
+1. Credentials must now be passed explicitly to Tasks either with [Workspaces](./workspaces.md#using-workspaces-in-tasks),
+environment variables (using [`envFrom`](https://kubernetes.io/docs/concepts/configuration/secret/#use-case-as-container-environment-variables) in your Steps and a Task param to
+specify a Secret), or a custom volume and volumeMount definition.
+2. Git PipelineResources may not work or may only work with public repositories.
+
+### How to disable the built-in auth
+
+To disable Tekton's built-in auth, edit the `feature-flag` `ConfigMap` in the
+`tekton-pipelines` namespace and update the value of `disable-creds-init`
+from `"false"` to `"true"`.
 
 Except as otherwise noted, the content of this page is licensed under the
 [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/),

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -28,11 +28,13 @@ const (
 	disableHomeEnvOverwriteKey              = "disable-home-env-overwrite"
 	disableWorkingDirOverwriteKey           = "disable-working-directory-overwrite"
 	disableAffinityAssistantKey             = "disable-affinity-assistant"
+	disableCredsInitKey                     = "disable-creds-init"
 	runningInEnvWithInjectedSidecarsKey     = "running-in-environment-with-injected-sidecars"
 	requireGitSSHSecretKnownHostsKey        = "require-git-ssh-secret-known-hosts" // nolint: gosec
 	DefaultDisableHomeEnvOverwrite          = false
 	DefaultDisableWorkingDirOverwrite       = false
 	DefaultDisableAffinityAssistant         = false
+	DefaultDisableCredsInit                 = false
 	DefaultRunningInEnvWithInjectedSidecars = true
 	DefaultRequireGitSSHSecretKnownHosts    = false
 )
@@ -43,6 +45,7 @@ type FeatureFlags struct {
 	DisableHomeEnvOverwrite          bool
 	DisableWorkingDirOverwrite       bool
 	DisableAffinityAssistant         bool
+	DisableCredsInit                 bool
 	RunningInEnvWithInjectedSidecars bool
 	RequireGitSSHSecretKnownHosts    bool
 }
@@ -79,6 +82,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setFeature(disableAffinityAssistantKey, DefaultDisableAffinityAssistant, &tc.DisableAffinityAssistant); err != nil {
+		return nil, err
+	}
+	if err := setFeature(disableCredsInitKey, DefaultDisableCredsInit, &tc.DisableCredsInit); err != nil {
 		return nil, err
 	}
 	if err := setFeature(runningInEnvWithInjectedSidecarsKey, DefaultRunningInEnvWithInjectedSidecars, &tc.RunningInEnvWithInjectedSidecars); err != nil {


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/2791

Prior to this commit Tekton scans service accounts attached to taskruns
and mounts secrets matching a specific format into all the Steps of a
Task. Then the entrypoint goes through those secrets and copies them
to the user's home directory so they can be used by `git`, `docker`, etc

This commit adds a feature-flag, `disable-creds-init`, that lets users
turn off the service account scanning behaviour. The default is "false"
so the creds-init behaviour remains enabled. Disabling creds-init can be
desirable for a lot of reasons:

1. The process is opaque and difficult to debug
2. It's not particularly well suited for non-root, multi-UID tasks.
3. Only a limited set of credential types are supported

Warning: Disabling creds-init will probably break PipelineResources.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

# Release Notes

```release-note
Tekton's built-in credential mechanism can now be disabled by setting the `disable-creds-init` feature-flag to "true".
```