### PR TITLE
Don't fail immediately on missing resources.

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -148,6 +148,17 @@ func (trs *TaskRunStatus) MarkResourceNotConvertible(err *CannotConvertError) {
 	})
 }
 
+// MarkResourceOngoing sets the ConditionSucceeded condition to ConditionUnknown
+// with the reason and message.
+func (trs *TaskRunStatus) MarkResourceOngoing(reason TaskRunReason, message string) {
+	taskRunCondSet.Manage(trs).SetCondition(apis.Condition{
+		Type:    apis.ConditionSucceeded,
+		Status:  corev1.ConditionUnknown,
+		Reason:  reason.String(),
+		Message: message,
+	})
+}
+
 // MarkResourceFailed sets the ConditionSucceeded condition to ConditionFalse
 // based on an error that occurred and a reason
 func (trs *TaskRunStatus) MarkResourceFailed(reason TaskRunReason, err error) {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -338,6 +338,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun) err
 			// For newly created resources, don't fail immediately.
 			// Instead return an (non-permanent) error, which will prompt the
 			// controller to requeue the key with backoff.
+			logger.Warnf("References for pipelinerun %s not found: %v", pr.Name, err)
+			pr.Status.MarkRunning(ReasonCouldntGetResource,
+				"Unable to resolve dependencies for %q: %v", pr.Name, err)
 			return err
 		}
 		// This Run has failed, so we need to mark it as failed and stop reconciling it

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -196,7 +196,7 @@ func GetResourcesFromBindings(pr *v1beta1.PipelineRun, getResource resources.Get
 	for _, resource := range pr.Spec.Resources {
 		r, err := resources.GetResourceFromBinding(resource, getResource)
 		if err != nil {
-			return rs, fmt.Errorf("error following resource reference for %s: %w", resource.Name, err)
+			return rs, err
 		}
 		rs[resource.Name] = r
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -918,11 +918,13 @@ func TestGetResourcesFromBindings_Missing(t *testing.T) {
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))
 	getResource := func(name string) (*resourcev1alpha1.PipelineResource, error) {
-		return nil, fmt.Errorf("request for unexpected resource %s", name)
+		return nil, kerrors.NewNotFound(resourcev1alpha1.Resource("pipelineresources"), name)
 	}
 	_, err := GetResourcesFromBindings(pr, getResource)
 	if err == nil {
 		t.Fatalf("Expected error indicating `image-resource` was missing but got no error")
+	} else if !kerrors.IsNotFound(err) {
+		t.Fatalf("GetResourcesFromBindings() = %v, wanted IsNotFound", err)
 	}
 }
 

--- a/pkg/reconciler/resources.go
+++ b/pkg/reconciler/resources.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	// MinimumResourceAge is the age at which resources stop being IsYoungResource.
-	MinimumResourceAge = 30 * time.Second
+	// minimumResourceAge is the age at which resources stop being IsYoungResource.
+	minimumResourceAge = 30 * time.Second
 )
 
-// IsYoungResource checks whether the resource is younger than MinimumResourceAge, based on its creation timestamp.
+// IsYoungResource checks whether the resource is younger than minimumResourceAge, based on its creation timestamp.
 func IsYoungResource(obj kmeta.Accessor) bool {
-	return time.Now().Sub(obj.GetCreationTimestamp().Time) < MinimumResourceAge
+	return time.Now().Sub(obj.GetCreationTimestamp().Time) < minimumResourceAge
 }

--- a/pkg/reconciler/resources.go
+++ b/pkg/reconciler/resources.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"time"
+
+	"knative.dev/pkg/kmeta"
+)
+
+const (
+	// MinimumResourceAge is the age at which resources stop being IsYoungResource.
+	MinimumResourceAge = 30 * time.Second
+)
+
+// IsYoungResource checks whether the resource is younger than MinimumResourceAge, based on its creation timestamp.
+func IsYoungResource(obj kmeta.Accessor) bool {
+	return time.Now().Sub(obj.GetCreationTimestamp().Time) < MinimumResourceAge
+}

--- a/pkg/reconciler/resources.go
+++ b/pkg/reconciler/resources.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	// minimumResourceAge is the age at which resources stop being IsYoungResource.
-	minimumResourceAge = 30 * time.Second
+	minimumResourceAge = 5 * time.Second
 )
 
 // IsYoungResource checks whether the resource is younger than minimumResourceAge, based on its creation timestamp.

--- a/pkg/reconciler/resources_test.go
+++ b/pkg/reconciler/resources_test.go
@@ -36,7 +36,7 @@ func TestIsYoungResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.Time{
 					// The age is Min-1 seconds
-					Time: time.Now().Add(-MinimumResourceAge + 1*time.Second),
+					Time: time.Now().Add(-minimumResourceAge + 1*time.Second),
 				},
 			},
 		},
@@ -47,7 +47,7 @@ func TestIsYoungResource(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				CreationTimestamp: metav1.Time{
 					// The age is Min+1 seconds
-					Time: time.Now().Add(-MinimumResourceAge - 1*time.Second),
+					Time: time.Now().Add(-minimumResourceAge - 1*time.Second),
 				},
 			},
 		},

--- a/pkg/reconciler/resources_test.go
+++ b/pkg/reconciler/resources_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
+)
+
+func TestIsYoungResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource kmeta.Accessor
+		want     bool
+	}{{
+		name: "young",
+		resource: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{
+					// The age is Min-1 seconds
+					Time: time.Now().Add(-MinimumResourceAge + 1*time.Second),
+				},
+			},
+		},
+		want: true,
+	}, {
+		name: "old",
+		resource: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				CreationTimestamp: metav1.Time{
+					// The age is Min+1 seconds
+					Time: time.Now().Add(-MinimumResourceAge - 1*time.Second),
+				},
+			},
+		},
+		want: false,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := IsYoungResource(test.resource)
+			if got != test.want {
+				t.Errorf("IsYoungResource() = %v, wanted %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/resources/taskresourceresolution.go
+++ b/pkg/reconciler/taskrun/resources/taskresourceresolution.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -57,7 +56,7 @@ func ResolveTaskResources(ts *v1beta1.TaskSpec, taskName string, kind v1beta1.Ta
 	for _, r := range inputs {
 		rr, err := GetResourceFromBinding(r.PipelineResourceBinding, gr)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't retrieve referenced input PipelineResource: %w", err)
+			return nil, err
 		}
 
 		rtr.Inputs[r.Name] = rr
@@ -67,7 +66,7 @@ func ResolveTaskResources(ts *v1beta1.TaskSpec, taskName string, kind v1beta1.Ta
 		rr, err := GetResourceFromBinding(r.PipelineResourceBinding, gr)
 
 		if err != nil {
-			return nil, fmt.Errorf("couldn't retrieve referenced output PipelineResource: %w", err)
+			return nil, err
 		}
 
 		rtr.Outputs[r.Name] = rr

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -289,6 +289,9 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 			// For newly created resources, don't fail immediately.
 			// Instead return an (non-permanent) error, which will prompt the
 			// controller to requeue the key with backoff.
+			logger.Warnf("References for taskrun %s not found: %v", tr.Name, err)
+			tr.Status.MarkResourceOngoing(podconvert.ReasonFailedResolution,
+				fmt.Sprintf("Unable to resolve dependencies for %q: %v", tr.Name, err))
 			return nil, nil, err
 		}
 		logger.Errorf("Failed to resolve references for taskrun %s: %v", tr.Name, err)


### PR DESCRIPTION
# Changes

As the PipelineRun reconciler executes, it resolves resources using the informer's lister cache.  Currently, when that cache is behind the pipeline run will immediately fail.  This change builds in a buffer of `resources.MinimumAge` and a helper `resources.IsYoung` that elide this check, returning the error to the controller framework to requeue the key for later processing (with backoff).

Fixes: https://github.com/tektoncd/pipeline/issues/3378

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Add a grace period for resources to appear before failing *Runs
```
