### PR TITLE
Leverage logstream to get better e2e diagnostic logs.

### DIFF
--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestTaskRunPipelineRunCancel cancels a PipelineRun and verifies TaskRun statuses and Pod deletions.
@@ -49,9 +50,8 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
 
-			pipelineRunName := "cancel-me"
 			pipelineRun := &v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{Name: pipelineRunName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: helpers.ObjectNameForTest(t), Namespace: namespace},
 				Spec: v1beta1.PipelineRunSpec{
 					PipelineSpec: &v1beta1.PipelineSpec{
 						Tasks: []v1beta1.PipelineTask{{
@@ -72,21 +72,21 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 
 			t.Logf("Creating PipelineRun in namespace %s", namespace)
 			if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRunName, err)
+				t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 			}
 
-			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRunName, namespace)
-			if err := WaitForPipelineRunState(ctx, c, pipelineRunName, pipelineRunTimeout, Running(pipelineRunName), "PipelineRunRunning"); err != nil {
-				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRunName, err)
+			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
+			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
 			}
 
-			taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+			taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 			if err != nil {
-				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 			}
 
 			var wg sync.WaitGroup
-			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRunName, namespace)
+			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRun.Name, namespace)
 			for _, taskrunItem := range taskrunList.Items {
 				wg.Add(1)
 				go func(name string) {
@@ -99,9 +99,9 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			}
 			wg.Wait()
 
-			pr, err := c.PipelineRunClient.Get(ctx, pipelineRunName, metav1.GetOptions{})
+			pr, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRunName, err)
+				t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
 			}
 
 			patches := []jsonpatch.JsonPatchOperation{{
@@ -114,15 +114,15 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				t.Fatalf("failed to marshal patch bytes in order to cancel")
 			}
 			if _, err := c.PipelineRunClient.Patch(ctx, pr.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
-				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRunName, err)
+				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRun.Name, err)
 			}
 
-			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRunName, namespace)
-			if err := WaitForPipelineRunState(ctx, c, pipelineRunName, pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", pipelineRunName), "PipelineRunCancelled"); err != nil {
-				t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRunName, err)
+			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
+			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", pipelineRun.Name), "PipelineRunCancelled"); err != nil {
+				t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRun.Name, err)
 			}
 
-			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", pipelineRunName, namespace)
+			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
 			for _, taskrunItem := range taskrunList.Items {
 				wg.Add(1)
 				go func(name string) {
@@ -136,15 +136,15 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			wg.Wait()
 
 			var trName []string
-			taskrunList, err = c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRunName})
+			taskrunList, err = c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
 			if err != nil {
-				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRunName, err)
+				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
 			}
 			for _, taskrunItem := range taskrunList.Items {
 				trName = append(trName, taskrunItem.Name)
 			}
 
-			matchKinds := map[string][]string{"PipelineRun": {pipelineRunName}, "TaskRun": trName}
+			matchKinds := map[string][]string{"PipelineRun": {pipelineRun.Name}, "TaskRun": trName}
 			// Expected failure events: 1 for the pipelinerun cancel, 1 for each TaskRun
 			expectedNumberOfEvents := 1 + len(trName)
 			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)

--- a/test/e2e-common.sh
+++ b/test/e2e-common.sh
@@ -26,6 +26,8 @@ function install_pipeline_crd() {
       | sed -e 's%loglevel.webhook: "info"%loglevel.webhook: "debug"%' \
       | kubectl apply -f - || fail_test "Build pipeline installation failed"
   verify_pipeline_installation
+
+  export SYSTEM_NAMESPACE=tekton-pipelines
 }
 
 # Install the Tekton pipeline crd based on the release number

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -32,17 +32,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
-)
-
-const (
-	sourceResourceName        = "go-helloworld-git"
-	sourceImageName           = "go-helloworld-image"
-	createImageTaskName       = "create-image-task"
-	helmDeployTaskName        = "helm-deploy-task"
-	checkServiceTaskName      = "check-service-task"
-	helmDeployPipelineName    = "helm-deploy-pipeline"
-	helmDeployPipelineRunName = "helm-deploy-pipeline-run"
-	helmDeployServiceName     = "gohelloworld-chart"
+	"knative.dev/pkg/test/helpers"
 )
 
 var (
@@ -59,41 +49,51 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	c, namespace := setup(ctx, t)
 	setupClusterBindingForHelm(ctx, c, t, namespace)
 
+	var (
+		sourceResourceName        = helpers.ObjectNameForTest(t)
+		sourceImageName           = helpers.ObjectNameForTest(t)
+		createImageTaskName       = helpers.ObjectNameForTest(t)
+		helmDeployTaskName        = helpers.ObjectNameForTest(t)
+		checkServiceTaskName      = helpers.ObjectNameForTest(t)
+		helmDeployPipelineName    = helpers.ObjectNameForTest(t)
+		helmDeployPipelineRunName = helpers.ObjectNameForTest(t)
+	)
+
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
 	t.Logf("Creating Git PipelineResource %s", sourceResourceName)
-	if _, err := c.PipelineResourceClient.Create(ctx, getGoHelloworldGitResource(), metav1.CreateOptions{}); err != nil {
+	if _, err := c.PipelineResourceClient.Create(ctx, getGoHelloworldGitResource(sourceResourceName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceResourceName, err)
 	}
 
 	t.Logf("Creating Image PipelineResource %s", sourceImageName)
-	if _, err := c.PipelineResourceClient.Create(ctx, getHelmImageResource(repo), metav1.CreateOptions{}); err != nil {
+	if _, err := c.PipelineResourceClient.Create(ctx, getHelmImageResource(repo, sourceImageName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline Resource `%s`: %s", sourceImageName, err)
 	}
 
 	t.Logf("Creating Task %s", createImageTaskName)
-	if _, err := c.TaskClient.Create(ctx, getCreateImageTask(namespace), metav1.CreateOptions{}); err != nil {
+	if _, err := c.TaskClient.Create(ctx, getCreateImageTask(namespace, createImageTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", createImageTaskName, err)
 	}
 
 	t.Logf("Creating Task %s", helmDeployTaskName)
-	if _, err := c.TaskClient.Create(ctx, getHelmDeployTask(namespace), metav1.CreateOptions{}); err != nil {
+	if _, err := c.TaskClient.Create(ctx, getHelmDeployTask(namespace, helmDeployTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", helmDeployTaskName, err)
 	}
 
 	t.Logf("Creating Task %s", checkServiceTaskName)
-	if _, err := c.TaskClient.Create(ctx, getCheckServiceTask(namespace), metav1.CreateOptions{}); err != nil {
+	if _, err := c.TaskClient.Create(ctx, getCheckServiceTask(namespace, checkServiceTaskName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", checkServiceTaskName, err)
 	}
 
 	t.Logf("Creating Pipeline %s", helmDeployPipelineName)
-	if _, err := c.PipelineClient.Create(ctx, getHelmDeployPipeline(namespace), metav1.CreateOptions{}); err != nil {
+	if _, err := c.PipelineClient.Create(ctx, getHelmDeployPipeline(namespace, createImageTaskName, helmDeployTaskName, checkServiceTaskName, helmDeployPipelineName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", helmDeployPipelineName, err)
 	}
 
 	t.Logf("Creating PipelineRun %s", helmDeployPipelineRunName)
-	if _, err := c.PipelineRunClient.Create(ctx, getHelmDeployPipelineRun(namespace), metav1.CreateOptions{}); err != nil {
+	if _, err := c.PipelineRunClient.Create(ctx, getHelmDeployPipelineRun(namespace, sourceResourceName, sourceImageName, helmDeployPipelineRunName, helmDeployPipelineName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", helmDeployPipelineRunName, err)
 	}
 
@@ -108,14 +108,14 @@ func TestHelmDeployPipelineRun(t *testing.T) {
 	defer helmCleanup(ctx, c, t, namespace)
 }
 
-func getGoHelloworldGitResource() *v1alpha1.PipelineResource {
+func getGoHelloworldGitResource(sourceResourceName string) *v1alpha1.PipelineResource {
 	return tb.PipelineResource(sourceResourceName, tb.PipelineResourceSpec(
 		v1alpha1.PipelineResourceTypeGit,
 		tb.PipelineResourceSpecParam("url", "https://github.com/tektoncd/pipeline"),
 	))
 }
 
-func getHelmImageResource(dockerRepo string) *v1alpha1.PipelineResource {
+func getHelmImageResource(dockerRepo, sourceImageName string) *v1alpha1.PipelineResource {
 	imageName := fmt.Sprintf("%s/%s", dockerRepo, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(sourceImageName))
 
 	return tb.PipelineResource(sourceImageName, tb.PipelineResourceSpec(
@@ -124,7 +124,7 @@ func getHelmImageResource(dockerRepo string) *v1alpha1.PipelineResource {
 	))
 }
 
-func getCreateImageTask(namespace string) *v1beta1.Task {
+func getCreateImageTask(namespace, createImageTaskName string) *v1beta1.Task {
 	return &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: createImageTaskName, Namespace: namespace},
 		Spec: v1beta1.TaskSpec{
@@ -149,7 +149,7 @@ func getCreateImageTask(namespace string) *v1beta1.Task {
 	}
 }
 
-func getHelmDeployTask(namespace string) *v1beta1.Task {
+func getHelmDeployTask(namespace, helmDeployTaskName string) *v1beta1.Task {
 	empty := *v1beta1.NewArrayOrString("")
 	return &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: helmDeployTaskName, Namespace: namespace},
@@ -196,7 +196,7 @@ func getHelmDeployTask(namespace string) *v1beta1.Task {
 	}
 }
 
-func getCheckServiceTask(namespace string) *v1beta1.Task {
+func getCheckServiceTask(namespace, checkServiceTaskName string) *v1beta1.Task {
 	return &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: checkServiceTaskName, Namespace: namespace},
 		Spec: v1beta1.TaskSpec{
@@ -216,7 +216,7 @@ func getCheckServiceTask(namespace string) *v1beta1.Task {
 	}
 }
 
-func getHelmDeployPipeline(namespace string) *v1beta1.Pipeline {
+func getHelmDeployPipeline(namespace, createImageTaskName, helmDeployTaskName, checkServiceTaskName, helmDeployPipelineName string) *v1beta1.Pipeline {
 	return &v1beta1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{Name: helmDeployPipelineName, Namespace: namespace},
 		Spec: v1beta1.PipelineSpec{
@@ -258,7 +258,7 @@ func getHelmDeployPipeline(namespace string) *v1beta1.Pipeline {
 				Name:    "check-service",
 				TaskRef: &v1beta1.TaskRef{Name: checkServiceTaskName},
 				Params: []v1beta1.Param{{
-					Name: "serviceUrl", Value: *v1beta1.NewArrayOrString(fmt.Sprintf("http://%s:8080", helmDeployServiceName)),
+					Name: "serviceUrl", Value: *v1beta1.NewArrayOrString("http://gohelloworld-chart:8080"),
 				}},
 				RunAfter: []string{"helm-deploy"},
 			}},
@@ -266,7 +266,7 @@ func getHelmDeployPipeline(namespace string) *v1beta1.Pipeline {
 	}
 }
 
-func getHelmDeployPipelineRun(namespace string) *v1beta1.PipelineRun {
+func getHelmDeployPipelineRun(namespace, sourceResourceName, sourceImageName, helmDeployPipelineRunName, helmDeployPipelineName string) *v1beta1.PipelineRun {
 	return &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{Name: helmDeployPipelineRunName, Namespace: namespace},
 		Spec: v1beta1.PipelineRunSpec{

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -39,6 +39,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	knativetest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging" // Mysteriously by k8s libs, or they fail to create `KubeClient`s from config. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
+	"knative.dev/pkg/test/logstream"
 )
 
 var initMetrics sync.Once
@@ -55,6 +56,10 @@ func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testi
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
 
 	initializeLogsAndMetrics(t)
+
+	// Inline controller logs from SYSTEM_NAMESPACE into the t.Log output.
+	cancel := logstream.Start(t)
+	t.Cleanup(cancel)
 
 	c := newClients(t, knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster, namespace)
 	createNamespace(ctx, t, namespace, c.KubeClient)

--- a/vendor/knative.dev/pkg/test/helpers/dir.go
+++ b/vendor/knative.dev/pkg/test/helpers/dir.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const allUsersFullPermission = 0777
+
+// CreateDir creates dir if does not exist.
+// The created dir will have the permission bits as 0777, which means everyone can read/write/execute it.
+func CreateDir(dirPath string) error {
+	return CreateDirWithFileMode(dirPath, allUsersFullPermission)
+}
+
+// CreateDirWithFileMode creates dir if does not exist.
+// The created dir will have the permission bits as perm, which is the standard Unix rwxrwxrwx permissions.
+func CreateDirWithFileMode(dirPath string, perm os.FileMode) error {
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		if err = os.MkdirAll(dirPath, perm); err != nil {
+			return fmt.Errorf("error creating directory: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetRootDir gets directory of git root
+func GetRootDir() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// ChdirToRoot change directory to git root dir
+func ChdirToRoot() error {
+	d, err := GetRootDir()
+	if err != nil {
+		return err
+	}
+	return os.Chdir(d)
+}

--- a/vendor/knative.dev/pkg/test/helpers/dryrun.go
+++ b/vendor/knative.dev/pkg/test/helpers/dryrun.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"log"
+)
+
+// Run can run functions that needs dryrun support.
+func Run(message string, call func() error, dryrun bool) error {
+	if dryrun {
+		log.Printf("[dry run] %s", message)
+		return nil
+	}
+	log.Print(message)
+
+	return call()
+}

--- a/vendor/knative.dev/pkg/test/helpers/error.go
+++ b/vendor/knative.dev/pkg/test/helpers/error.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// error.go helps with error handling
+
+package helpers
+
+import (
+	"errors"
+	"strings"
+)
+
+// CombineErrors combines slice of errors and return a single error
+func CombineErrors(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	msgs := make([]string, 0)
+	for _, err := range errs {
+		if err != nil {
+			msgs = append(msgs, err.Error())
+		}
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(msgs, "\n"))
+}

--- a/vendor/knative.dev/pkg/test/helpers/name.go
+++ b/vendor/knative.dev/pkg/test/helpers/name.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"math/rand"
+	"strings"
+	"time"
+	"unicode"
+
+	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/test"
+)
+
+const (
+	letterBytes    = "abcdefghijklmnopqrstuvwxyz"
+	randSuffixLen  = 8
+	sep            = '-'
+	testNamePrefix = "Test"
+)
+
+func init() {
+	// Properly seed the random number generator so RandomString() is actually random.
+	// Otherwise, rerunning tests will generate the same names for the test resources, causing conflicts with
+	// already existing resources.
+	seed := time.Now().UTC().UnixNano()
+	rand.Seed(seed)
+}
+
+// ObjectPrefixForTest returns the name prefix for this test's random names.
+func ObjectPrefixForTest(t test.T) string {
+	return MakeK8sNamePrefix(strings.TrimPrefix(t.Name(), testNamePrefix))
+}
+
+// ObjectNameForTest generates a random object name based on the test name.
+func ObjectNameForTest(t test.T) string {
+	return kmeta.ChildName(ObjectPrefixForTest(t), string(sep)+RandomString())
+}
+
+// AppendRandomString will generate a random string that begins with prefix.
+// This is useful if you want to make sure that your tests can run at the same
+// time against the same environment without conflicting.
+// This method will use "-" as the separator between the prefix and
+// the random suffix.
+func AppendRandomString(prefix string) string {
+	return strings.Join([]string{prefix, RandomString()}, string(sep))
+}
+
+// RandomString will generate a random string.
+func RandomString() string {
+	suffix := make([]byte, randSuffixLen)
+
+	for i := range suffix {
+		suffix[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(suffix)
+}
+
+// MakeK8sNamePrefix converts each chunk of non-alphanumeric character into a single dash
+// and also convert camelcase tokens into dash-delimited lowercase tokens.
+func MakeK8sNamePrefix(s string) string {
+	var sb strings.Builder
+	newToken := false
+	for _, c := range s {
+		if !(unicode.IsLetter(c) || unicode.IsNumber(c)) {
+			newToken = true
+			continue
+		}
+		if sb.Len() > 0 && (newToken || unicode.IsUpper(c)) {
+			sb.WriteRune(sep)
+		}
+		sb.WriteRune(unicode.ToLower(c))
+		newToken = false
+	}
+	return sb.String()
+}
+
+// GetBaseFuncName returns the baseFuncName parsed from the fullFuncName.
+// eg. test/e2e.TestMain will return TestMain.
+func GetBaseFuncName(fullFuncName string) string {
+	name := fullFuncName
+	// Possibly there is no parent package, so only remove it from the name if '/' exists
+	if strings.ContainsRune(name, '/') {
+		name = name[strings.LastIndex(name, "/")+1:]
+	}
+	name = name[strings.LastIndex(name, ".")+1:]
+	return name
+}

--- a/vendor/knative.dev/pkg/test/logstream/README.md
+++ b/vendor/knative.dev/pkg/test/logstream/README.md
@@ -1,0 +1,46 @@
+# How to use logstream
+
+This is a guide to start using `logstream` in your e2e testing.
+
+## Requirements
+
+1. The `SYSTEM_NAMESPACE` environment variable must be configured. Many of the
+   knative test scripts already define this, and in some places (e.g. serving)
+   randomize it. However, to facilitate usage outside of CI, you should consider
+   including a package like
+   [this](https://github.com/knative/serving/blob/master/test/defaultsystem/system.go)
+   and linking it like
+   [this](https://github.com/knative/serving/blob/e797247322b5aa35001152d2a2715dbc20a86cc4/test/conformance.go#L20-L23)
+
+2) Test resources must be named with
+   [`test.ObjectNameForTest(t)`](https://github.com/knative/networking/blob/40ef99aa5db0d38730a89a1de7e5b28b8ef6eed5/vendor/knative.dev/pkg/test/helpers/name.go#L50)
+
+3. At the start of your test add: `t.Cleanup(logstream.Start(t))`
+
+With that, you will start getting logs from the processes in the system
+namespace interleaved into your test output via `t.Log`.
+
+## How it works
+
+In Knative we use `zap.Logger` for all of our logging, and most of those loggers
+(e.g. in the context of a reconcile) have been decorated with the "key" of the
+resource being processed. `logstream` simply decodes these structured log
+messages and when the `key` matches the naming prefix that `ObjectNameForTest`
+uses, it includes it into the test's output.
+
+## Integrating in Libraries.
+
+When a shared component is set up and called from reconciliation, it may have
+it's own logger. If that component is dealing with individual resources, it can
+scope individual log statements to that resource by decorating the logger with
+its key like so:
+
+```
+logger := logger.With(zap.String(logkey.Key, resourceKey))
+```
+
+Now, any log statements that the library prints through this logger will appear
+in the logstream!
+
+For an example of this pattern, see
+[the knative/networking prober library](https://github.com/knative/networking/blob/master/pkg/status/status.go).

--- a/vendor/knative.dev/pkg/test/logstream/doc.go
+++ b/vendor/knative.dev/pkg/test/logstream/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package logstream lets end-to-end tests incorporate controller logs
+// into the error output of tests.  It is enabled by setting the
+// SYSTEM_NAMESPACE environment variable, which tells this package
+// what namespace to stream logs from.
+package logstream

--- a/vendor/knative.dev/pkg/test/logstream/interface.go
+++ b/vendor/knative.dev/pkg/test/logstream/interface.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstream
+
+import (
+	"os"
+	"sync"
+
+	"knative.dev/pkg/system"
+	"knative.dev/pkg/test"
+)
+
+// Canceler is the type of a function returned when a logstream is started to be
+// deferred so that the logstream can be stopped when the test is complete.
+type Canceler func()
+
+// Start begins streaming the logs from system components with a `key:` matching
+// `test.ObjectNameForTest(t)` to `t.Log`.  It returns a Canceler, which must
+// be called before the test completes.
+func Start(t test.TLegacy) Canceler {
+	// Do this lazily to make import ordering less important.
+	once.Do(func() {
+		if ns := os.Getenv(system.NamespaceEnvKey); ns != "" {
+			// If SYSTEM_NAMESPACE is set, then start the stream.
+			stream = &kubelogs{namespace: ns}
+		} else {
+			// Otherwise set up a null stream.
+			stream = &null{}
+		}
+	})
+
+	return stream.Start(t)
+}
+
+type streamer interface {
+	Start(t test.TLegacy) Canceler
+}
+
+var (
+	stream streamer
+	once   sync.Once
+)

--- a/vendor/knative.dev/pkg/test/logstream/kubelogs.go
+++ b/vendor/knative.dev/pkg/test/logstream/kubelogs.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstream
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
+)
+
+type kubelogs struct {
+	namespace string
+	kc        *test.KubeClient
+
+	once sync.Once
+	m    sync.RWMutex
+	keys map[string]logger
+}
+
+type logger func(string, ...interface{})
+
+var _ streamer = (*kubelogs)(nil)
+
+// timeFormat defines a simple timestamp with millisecond granularity
+const timeFormat = "15:04:05.000"
+
+func (k *kubelogs) startForPod(pod *corev1.Pod) {
+	// Grab data from all containers in the pods.  We need this in case
+	// an envoy sidecar is injected for mesh installs.  This should be
+	// equivalent to --all-containers.
+	for _, container := range pod.Spec.Containers {
+		// Required for capture below.
+		psn, pn, cn := pod.Namespace, pod.Name, container.Name
+
+		handleLine := k.handleLine
+		if cn == "chaosduck" {
+			// Specialcase logs from chaosduck to be able to easily see when pods
+			// have been killed throughout all tests.
+			handleLine = k.handleGenericLine
+		}
+
+		go func() {
+			options := &corev1.PodLogOptions{
+				Container: cn,
+				// Follow directs the API server to continuously stream logs back.
+				Follow: true,
+				// Only return new logs (this value is being used for "epsilon").
+				SinceSeconds: ptr.Int64(1),
+			}
+
+			req := k.kc.Kube.CoreV1().Pods(psn).GetLogs(pn, options)
+			stream, err := req.Stream(context.Background())
+			if err != nil {
+				k.handleGenericLine([]byte(err.Error()), pn)
+				return
+			}
+			defer stream.Close()
+			// Read this container's stream.
+			scanner := bufio.NewScanner(stream)
+			for scanner.Scan() {
+				handleLine(scanner.Bytes(), pn)
+			}
+			// Pods get killed with chaos duck, so logs might end
+			// before the test does. So don't report an error here.
+		}()
+	}
+}
+
+func podIsReady(p *corev1.Pod) bool {
+	if p.Status.Phase == corev1.PodRunning && p.DeletionTimestamp == nil {
+		for _, cond := range p.Status.Conditions {
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (k *kubelogs) watchPods(t test.TLegacy) {
+	wi, err := k.kc.Kube.CoreV1().Pods(k.namespace).Watch(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Error("Logstream knative pod watch failed, logs might be missing", "error", err)
+		return
+	}
+	go func() {
+		watchedPods := sets.NewString()
+		for ev := range wi.ResultChan() {
+			p := ev.Object.(*corev1.Pod)
+			switch ev.Type {
+			case watch.Deleted:
+				watchedPods.Delete(p.Name)
+			case watch.Added, watch.Modified:
+				if watchedPods.Has(p.Name) {
+					continue
+				}
+				if podIsReady(p) {
+					watchedPods.Insert(p.Name)
+					k.startForPod(p)
+					continue
+				}
+			}
+		}
+	}()
+}
+
+func (k *kubelogs) init(t test.TLegacy) {
+	k.keys = make(map[string]logger, 1)
+
+	kc, err := test.NewKubeClient(test.Flags.Kubeconfig, test.Flags.Cluster)
+	if err != nil {
+		t.Error("Error loading client config", "error", err)
+		return
+	}
+	k.kc = kc
+
+	// watchPods will start logging for existing pods as well.
+	k.watchPods(t)
+}
+
+func (k *kubelogs) handleLine(l []byte, pod string) {
+	// This holds the standard structure of our logs.
+	var line struct {
+		Level      string    `json:"level"`
+		Timestamp  time.Time `json:"ts"`
+		Controller string    `json:"knative.dev/controller"`
+		Caller     string    `json:"caller"`
+		Key        string    `json:"knative.dev/key"`
+		Message    string    `json:"msg"`
+		Error      string    `json:"error"`
+
+		// TODO(mattmoor): Parse out more context.
+	}
+	if err := json.Unmarshal(l, &line); err != nil {
+		// Ignore malformed lines.
+		return
+	}
+	if line.Key == "" {
+		return
+	}
+
+	k.m.RLock()
+	defer k.m.RUnlock()
+
+	for name, logf := range k.keys {
+		// TODO(mattmoor): Do a slightly smarter match.
+		if !strings.Contains(line.Key, "/"+name) {
+			continue
+		}
+
+		// We also get logs not from controllers (activator, autoscaler).
+		// So replace controller string in them with their callsite.
+		site := line.Controller
+		if site == "" {
+			site = line.Caller
+		}
+		// E 15:04:05.000 webhook-699b7b668d-9smk2 [route-controller] [default/testroute-xyz] this is my message
+		msg := fmt.Sprintf("%s %s %s [%s] [%s] %s",
+			strings.ToUpper(string(line.Level[0])),
+			line.Timestamp.Format(timeFormat),
+			pod,
+			site,
+			line.Key,
+			line.Message)
+
+		if line.Error != "" {
+			msg += " err=" + line.Error
+		}
+
+		logf(msg)
+	}
+}
+
+// handleGenericLine prints the given logline to all active tests as it cannot be parsed
+// and/or doesn't contain any correlation data (like the chaosduck for example).
+func (k *kubelogs) handleGenericLine(l []byte, pod string) {
+	k.m.RLock()
+	defer k.m.RUnlock()
+
+	for _, logf := range k.keys {
+		// I 15:04:05.000 webhook-699b7b668d-9smk2 this is my message
+		logf("I %s %s %s", time.Now().Format(timeFormat), pod, string(l))
+	}
+}
+
+// Start implements streamer.
+func (k *kubelogs) Start(t test.TLegacy) Canceler {
+	k.once.Do(func() { k.init(t) })
+
+	name := helpers.ObjectPrefixForTest(t)
+
+	// Register a key
+	k.m.Lock()
+	defer k.m.Unlock()
+	k.keys[name] = t.Logf
+
+	// Return a function that unregisters that key.
+	return func() {
+		k.m.Lock()
+		defer k.m.Unlock()
+		delete(k.keys, name)
+	}
+}

--- a/vendor/knative.dev/pkg/test/logstream/null.go
+++ b/vendor/knative.dev/pkg/test/logstream/null.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logstream
+
+import "knative.dev/pkg/test"
+
+type null struct{}
+
+var _ streamer = (*null)(nil)
+
+// Start implements streamer
+func (*null) Start(t test.TLegacy) Canceler {
+	t.Log("logstream was requested, but SYSTEM_NAMESPACE was unset.")
+	return func() {}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1017,8 +1017,10 @@ knative.dev/pkg/signals
 knative.dev/pkg/system
 knative.dev/pkg/system/testing
 knative.dev/pkg/test
+knative.dev/pkg/test/helpers
 knative.dev/pkg/test/ingress
 knative.dev/pkg/test/logging
+knative.dev/pkg/test/logstream
 knative.dev/pkg/test/monitoring
 knative.dev/pkg/test/spoof
 knative.dev/pkg/test/zipkin


### PR DESCRIPTION
# Changes

`logstream` is a package that we use in knative to inline the system component logs relevant to a particular test into the test logs.  It relies on tests following the auto-naming convention we use with our helper method `helpers.ObjectNameForTest(t)`, which attaches a common prefix to resource names allowing logstream to filter the relevant log lines.

By virtue of using the `genreconciler` and other knative.dev/pkg controller infrastructure, each reconciler using `logging.FromContext(ctx)` on the context passed to `ReconcileKind` already gets a logger that's infused with the "key" being reconciled, but there may be other shared libraries that may require further instrumentation for this to reach its full potential.

I'm instrumenting several tests where I have seen downstream flakes as a start, and hopefully this illuminated why those tests are flaking by shining a light on controller activities during the test's execution.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

/assign @ImJasonH @vdemeester @afrittoli 