### PR TITLE
access execution status of any task in finally

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -820,6 +820,44 @@ Overall, `PipelineRun` state transitioning is explained below for respective sce
 Please refer to the [table](pipelineruns.md#monitoring-execution-status) under Monitoring Execution Status to learn about
 what kind of events are triggered based on the `Pipelinerun` status.
 
+
+### Using Execution `Status` of `pipelineTask`
+
+Finally Task can utilize execution status of any of the `pipelineTasks` under `tasks` section using param:
+
+```yaml
+    finally:
+    - name: finaltask
+      params:
+        - name: task1Status
+          value: "$(tasks.task1.status)"
+      taskSpec:
+        params:
+          - name: task1Status
+        steps:
+          - image: ubuntu
+            name: print-task-status
+            script: |
+              if [ $(params.task1Status) == "Failed" ]
+              then
+                echo "Task1 has failed, continue processing the failure"
+              fi
+```
+
+This kind of variable can have any one of the values from the following table:
+
+| Status | Description |
+| ------- | -----------|
+| Succeeded | `taskRun` for the `pipelineTask` completed successfully |
+| Failed | `taskRun` for the `pipelineTask` completed with a failure or cancelled by the user |
+| None | the `pipelineTask` has been skipped or no execution information available for the `pipelineTask` |
+
+For an end-to-end example, see [`status` in a `PipelineRun`](../examples/v1beta1/pipelineruns/pipelinerun-task-execution-status.yaml).
+
+**Note:** `$(tasks.<pipelineTask>.status)` is instantiated and available at runtime and must be used as a param value
+as is without concatenating it with any other param or string, for example, this kind of usage is not validated/supported
+`task status is $(tasks.<pipelineTask>.status)`.
+
 ### Known Limitations
 
 ### Specifying `Resources` in Final Tasks

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -23,6 +23,7 @@ For instructions on using variable substitutions see the relevant section of [th
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.uid` | The uid of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipeline.name` | The name of this `Pipeline` . |
+| `tasks.<pipelineTaskName>.status` | The execution status of the specified `pipelineTask`, only available in `finally` tasks. |
 
 
 ## Variables available in a `Task`

--- a/examples/v1beta1/pipelineruns/pipelinerun-task-execution-status.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-task-execution-status.yaml
@@ -1,0 +1,44 @@
+kind: PipelineRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: pr-execution-status-
+spec:
+  serviceAccountName: 'default'
+  pipelineSpec:
+    tasks:
+    - name: task1 # successful task
+      taskSpec:
+        steps:
+        - image: ubuntu
+          name: hello
+          script: |
+            echo "Hello World!"
+    - name: task2 # skipped task
+      when:
+        - input: "true"
+          operator: "notin"
+          values: ["true"]
+      taskSpec:
+        steps:
+          - image: ubuntu
+            name: success
+            script: |
+              exit 0
+    finally:
+    - name: task3 # this task verifies the status of dag tasks, it fails if verification fails
+      params:
+        - name: task1Status
+          value: "$(tasks.task1.status)"
+        - name: task2Status
+          value: "$(tasks.task2.status)"
+      taskSpec:
+        params:
+          - name: task1Status
+          - name: task2Status
+        steps:
+          - image: alpine
+            name: verify-dag-task-status
+            script: |
+              if [[ $(params.task1Status) != "Succeeded" ||  $(params.task2Status) != "None" ]]; then
+                exit 1;
+              fi

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -581,7 +581,12 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 	pipelineRunFacts.ResetSkippedCache()
 
 	// GetFinalTasks only returns tasks when a DAG is complete
-	nextRprts = append(nextRprts, pipelineRunFacts.GetFinalTasks()...)
+	fnextRprts := pipelineRunFacts.GetFinalTasks()
+	if len(fnextRprts) != 0 {
+		// apply the runtime context just before creating taskRuns for final tasks in queue
+		resources.ApplyPipelineTaskContext(fnextRprts, pipelineRunFacts.GetPipelineTaskStatus(ctx))
+		nextRprts = append(nextRprts, fnextRprts...)
+	}
 
 	for _, rprt := range nextRprts {
 		if rprt == nil || rprt.Skip(pipelineRunFacts) {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -87,6 +87,17 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 	}
 }
 
+//ApplyPipelineTaskContext replaces context variables referring to execution status with the specified status
+func ApplyPipelineTaskContext(state PipelineRunState, replacements map[string]string) {
+	for _, resolvedPipelineRunTask := range state {
+		if resolvedPipelineRunTask.PipelineTask != nil {
+			pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
+			pipelineTask.Params = replaceParamValues(pipelineTask.Params, replacements, nil)
+			resolvedPipelineRunTask.PipelineTask = pipelineTask
+		}
+	}
+}
+
 // ApplyWorkspaces replaces workspace variables in the given pipeline spec with their
 // concrete values.
 func ApplyWorkspaces(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -882,4 +882,42 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 			}
 		})
 	}
+
+}
+
+func TestApplyTaskRunContext(t *testing.T) {
+	r := map[string]string{
+		"tasks.task1.status": "succeeded",
+		"tasks.task3.status": "none",
+	}
+	state := PipelineRunState{{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "task4",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+			Params: []v1beta1.Param{{
+				Name:  "task1",
+				Value: *v1beta1.NewArrayOrString("$(tasks.task1.status)"),
+			}, {
+				Name:  "task3",
+				Value: *v1beta1.NewArrayOrString("$(tasks.task3.status)"),
+			}},
+		},
+	}}
+	expectedState := PipelineRunState{{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "task4",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+			Params: []v1beta1.Param{{
+				Name:  "task1",
+				Value: *v1beta1.NewArrayOrString("succeeded"),
+			}, {
+				Name:  "task3",
+				Value: *v1beta1.NewArrayOrString("none"),
+			}},
+		},
+	}}
+	ApplyPipelineTaskContext(state, r)
+	if d := cmp.Diff(expectedState, state); d != "" {
+		t.Fatalf("ApplyTaskRunContext() %s", diff.PrintWantGot(d))
+	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -132,6 +132,18 @@ func (t ResolvedPipelineRunTask) IsStarted() bool {
 	return t.TaskRun != nil && t.TaskRun.Status.GetCondition(apis.ConditionSucceeded) != nil
 }
 
+// IsConditionStatusFalse returns true when a task has succeeded condition with status set to false
+// it includes task failed after retries are exhausted, cancelled tasks, and time outs
+func (t ResolvedPipelineRunTask) IsConditionStatusFalse() bool {
+	if t.IsStarted() {
+		if t.IsCustomTask() {
+			return t.Run.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
+		}
+		return t.TaskRun.Status.GetCondition(apis.ConditionSucceeded).IsFalse()
+	}
+	return false
+}
+
 func (t *ResolvedPipelineRunTask) checkParentsDone(facts *PipelineRunFacts) bool {
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -60,6 +60,22 @@ func ValidateVariableP(value, prefix string, vars sets.String) *apis.FieldError 
 	return nil
 }
 
+func ValidateVariablePS(value, prefix string, suffix string, vars sets.String) *apis.FieldError {
+	if vs, present := extractVariablesFromString(value, prefix); present {
+		for _, v := range vs {
+			v = strings.TrimSuffix(v, suffix)
+			if !vars.Has(v) {
+				return &apis.FieldError{
+					Message: fmt.Sprintf("non-existent variable in %q", value),
+					// Empty path is required to make the `ViaField`, … work
+					Paths: []string{""},
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // Verifies that variables matching the relevant string expressions do not reference any of the names present in vars.
 func ValidateVariableProhibited(name, value, prefix, locationName, path string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Introducing a variable which can be used to access the execution status of any `pipelineTask` in a `pipeline`. This can be used in any `finally` task (and limited to `finally` tasks for the first iteration).

Use `$(tasks.<pipelineTask>.status)` as param value which resolves to the status, one of, `Succeeded`, `Failed`, and `None`.

E.g.:

```yaml
    finally:
    - name: finaltask
      params:
        - name: task1Status
          value: "$(tasks.task1.status)"
      taskSpec:
        params:
          - name: task1Status
        steps:
          - image: ubuntu
            name: print-task-status
            script: |
              if [ $(params.task1Status) == "Failed" ]
              then
                echo "Task1 has failed, now process this failure"
              fi
```


Partially Closes #1020 
Implements TEP [#0028](https://github.com/tektoncd/community/blob/master/teps/0028-task-execution-status-at-runtime.md)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Introducing a variable $(tasks.<taskName>.status) to access execution status of any non finally pipelineTask in finally.
```

/kind feature