### PR TITLE
Make ConditionCheck container names DNS-safe

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -96,7 +97,7 @@ func (state TaskConditionCheckState) IsSuccess() bool {
 // ConditionToTaskSpec creates a TaskSpec from a given Condition
 func (rcc *ResolvedConditionCheck) ConditionToTaskSpec() (*v1beta1.TaskSpec, error) {
 	if rcc.Condition.Spec.Check.Name == "" {
-		rcc.Condition.Spec.Check.Name = unnamedCheckNamePrefix + rcc.Condition.Name
+		rcc.Condition.Spec.Check.Name = names.SimpleNameGenerator.RestrictLength(unnamedCheckNamePrefix + rcc.Condition.Name)
 	}
 
 	t := &v1beta1.TaskSpec{

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution_test.go
@@ -216,6 +216,18 @@ func TestResolvedConditionCheck_ConditionToTaskSpec(t *testing.T) {
 			}}},
 		},
 	}, {
+		name: "default-container-name",
+		cond: tbv1alpha1.Condition("very-very-very-very-very-very-very-very-very-very-very-long-name", tbv1alpha1.ConditionSpec(
+			tbv1alpha1.ConditionSpecCheck("", "ubuntu"),
+		)),
+		want: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{Container: corev1.Container{
+				// Shortened via: names.SimpleNameGenerator.RestrictLength
+				Name:  "condition-check-very-very-very-very-very-very-very-very-very-ve",
+				Image: "ubuntu",
+			}}},
+		},
+	}, {
 		name: "with-input-params",
 		cond: tbv1alpha1.Condition("bar", tbv1alpha1.ConditionSpec(
 			tbv1alpha1.ConditionSpecCheck("$(params.name)", "$(params.img)",


### PR DESCRIPTION
# Changes

My recent change uncovered a latent bug where especially long test names result in especially long container names, which fails certain validations.  Unfortunately it slipped in because the test was expected to fail.

This leverages an upstream helper we created to solve ~exactly this problem.  You get DNS-safe short names based on an input name and a suffix, which are deterministic, and are friendly for suitably short inputs.

Fixes: https://github.com/tektoncd/pipeline/issues/3393

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fixes a bug where condition validation may fail with long condition names.
```

/kind bug