### PR TITLE
Mark failure to copy cred to user home as warning

### DIFF
--- a/pkg/credentials/initialize.go
+++ b/pkg/credentials/initialize.go
@@ -95,7 +95,7 @@ func CopyCredsToHome(credPaths []string) error {
 		destination := filepath.Join(homepath, cred)
 		err := tryCopyCred(source, destination)
 		if err != nil {
-			log.Printf("unsuccessful cred copy: %q from %q to %q: %v", cred, pipeline.CredsDir, homepath, err)
+			log.Printf("warning: unsuccessful cred copy: %q from %q to %q: %v", cred, pipeline.CredsDir, homepath, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Contributes to https://github.com/tektoncd/pipeline/issues/3399

# Changes

Prior to this commit a message could be seen in step logs
when tekton failed to copy a credential from /tekton/creds
to /tekton/home or $HOME (if disable-home-override feature
flag is "true"). That message can be confusing because it
appears to be an error when in actual fact it's a warning.

The message appears when Steps inside a Task run with
varying UIDs - one UID may copy the credentials first
and then subsequent steps will attempt to copy over them.
If a Step running as root, for examples, copies creds
into /tekton/home, other non-root Steps will not be able
to utilize those credentials. Unfortunately this can manifest
in our own PipelineResources where the Steps they inject
use a mix of root & non-root base images.

The message can also appear if a user has explicltly
mounted credentials (via workspace or volumemount) in
/tekton/home and has _also_ attached a service account
to the task with creds-init credentials on it.

The message serves as an indicator of a potential problem but
not 100% guarantee that any issues in a Step are related to it.

This commit updates the message to include a "warning:"
prefix to indicate that it might (though not always)
be a potential source of issues in your Step.

This commit also adds documentation to docs/auth.md to help
users diagnose the impact of this message (including when
they can safely ignore it).

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
A message related to copying credentials has been more clearly marked as a warning to reduce confusion when it appears in Step logs.
```

/kind cleanup