### PR TITLE
Use os.Stat when checking existence of .ssh/known_hosts

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -252,15 +252,14 @@ func userHasKnownHostsFile(logger *zap.SugaredLogger) (bool, error) {
 		logger.Errorf("Unexpected error: getting the user home directory: %v", err)
 		return false, err
 	}
-	f, err := os.Open(filepath.Join(homepath, sshKnownHostsUserPath))
+	f, err := os.Stat(filepath.Join(homepath, sshKnownHostsUserPath))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
 		return false, err
 	}
-	f.Close()
-	return true, nil
+	return !f.IsDir(), nil
 }
 
 func validateGitAuth(logger *zap.SugaredLogger, url string) {


### PR DESCRIPTION
# Changes

`os.Open` will fail when home directory has no `.ssh` directory, so replaced with `os.Stat`

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```