### PR TITLE
release: fix koparse behavior on finding images 🖌

### DIFF
--- a/tekton/koparse/koparse.py
+++ b/tekton/koparse/koparse.py
@@ -62,9 +62,13 @@ def parse_release(base: str, path: str) -> List[str]:
     images = []
     with open(path) as f:
         for line in f:
-            match = re.search(base + ".*" + DIGEST_MARKER + ":[0-9a-f]*", line)
-            if match:
-                images.append(match.group(0))
+            pattern = base + "[0-9a-z\-]+" + DIGEST_MARKER + ":[0-9a-f]*"
+            match = re.search(pattern, line)
+            while match is not None:
+                image = match.group(0)
+                images.append(image)
+                line = re.sub(image, "found", line)
+                match = re.search(pattern, line)
     return images
 
 

--- a/tekton/koparse/test_release.yaml
+++ b/tekton/koparse/test_release.yaml
@@ -326,16 +326,14 @@ spec:
         app: tekton-pipelines-controller
     spec:
       containers:
-      - args:
-        - -logtostderr
-        - -stderrthreshold
-        - INFO
-        - -kubeconfig-writer-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35
-        - -creds-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:67448da79e4731ab534b91df08da547bc434ab08e41d905858f2244e70290f48
-        - -git-image
-        - gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7d5520efa2d55e1346c424797988c541327ee52ef810a840b5c6f278a9de934a
+      - args: [
+        "-logtostderr",
+        "-stderrthreshold",
+        "INFO",
+        "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35", "-creds-ige", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:67448da79e4731ab534b91df08da547bc434ab08e41d905858f2244e70290f48",
+        "-git-image",
+        "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7d5520efa2d55e1346c424797988c541327ee52ef810a840b5c6f278a9de934a",
+      ]
         image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller@sha256:bdc6f22a44944c829983c30213091b60f490b41f89577e8492f6a2936be0df41
         name: tekton-pipelines-controller
         volumeMounts:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

Recent `ko` version *may* rework a bit the yaml and we *may* end up
in having multiple image to find on the same line. This would make the
release fail in those case.

This fixes that by looking multiple times for the regular expression
on a line.
It also changes a bit the regular expression to target images better.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @bobcatfish @ImJasonH @sbwsg @chmouel 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
