### PR TITLE
Update PR template to try and avoid /kind being automatically set

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,11 @@
 Describe your changes here- ideally you can get that description straight from
 your descriptive commit message(s)! 
 
-In addition, categorize the changes you're making using the "/kind" Prow command, such as:
-/kind bug
-/kind documentation
-/kind feature
+In addition, categorize the changes you're making using the "/kind" Prow command, example:
+
+/kind <kind>
+
+Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
 -->
 
 # Submitter Checklist


### PR DESCRIPTION
We recently updated the PR template to include some useful examples of
the /kind command. Unfortunately Prow will see those even though they're
inside a comment and apply them to the PR.

This commit removes the valid kind examples and replaces them with some
more text hopefully explaining enough how to use them.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, such as:
/kind bug
/kind documentation
/kind feature
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```