### PR TITLE
[cherry-pick] Fix json annotations in WhenExpression

### DIFF
--- a/pkg/apis/pipeline/v1beta1/when_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/when_validation_test.go
@@ -99,6 +99,30 @@ func TestWhenExpressions_Invalid(t *testing.T) {
 			Values:   []string{"bar"},
 		}},
 	}, {
+		name: "multiple inputs",
+		wes: []WhenExpression{{
+			Input:           "foo",
+			DeprecatedInput: "nay",
+			Operator:        selection.In,
+			Values:          []string{"bar"},
+		}},
+	}, {
+		name: "multiple operators",
+		wes: []WhenExpression{{
+			Input:              "foo",
+			Operator:           selection.In,
+			DeprecatedOperator: selection.NotIn,
+			Values:             []string{"bar"},
+		}},
+	}, {
+		name: "multiple values",
+		wes: []WhenExpression{{
+			Input:            "foo",
+			Operator:         selection.In,
+			Values:           []string{"bar"},
+			DeprecatedValues: []string{"bar"},
+		}},
+	}, {
 		name: "missing when expression",
 		wes:  []WhenExpression{{}},
 	}}

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1750,6 +1750,11 @@ func (in *WhenExpression) DeepCopyInto(out *WhenExpression) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DeprecatedValues != nil {
+		in, out := &in.DeprecatedValues, &out.DeprecatedValues
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -186,7 +186,7 @@ func convertWhenExpressions(whenExpressions []v1beta1.WhenExpression, pipelineRu
 		if ok {
 			resolvedResultRefs, err := extractResultRefs(expressions, pipelineRunState)
 			if err != nil {
-				return nil, fmt.Errorf("unable to find result referenced by when expression with input %q in task %q: %w", whenExpression.Input, name, err)
+				return nil, fmt.Errorf("unable to find result referenced by when expression with input %q in task %q: %w", whenExpression.GetInput(), name, err)
 			}
 			if resolvedResultRefs != nil {
 				resolvedWhenExpressions = append(resolvedWhenExpressions, resolvedResultRefs...)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a pipeline with when expressions is created in v0.16.* then it is
run in a pipelinerun in v0.17.0 or v0.17.1, a pipeline validation error
about missing fields would be thrown -- as reported in #3382

That happened because json annotations were added to when expressions
type in v0.17.0 so that the fields would have lowercase, such as in the
code completion in tekton intellij plugin as described in
redhat-developer/intellij-tekton#223

Without the json annotations, the fields were stored with first letters
capitalized, that is Input, Operator and Values. With the json
annotations, the fields were expected to be lowercase, that is input,
operator and values, causing the missing fields error in pipeline
validation

As such, users would have to reapply pipelines definitions created in
previous versions to make them work in v0.17.0 or v0.17.1 -- to remove
this requirement, we need to support both the uppercase and lowercase
first letters for the annotations

Fixes #3382

(cherry picked from commit 4edcbc19ee96d5adf9098143677a4bbd697ed0e4)
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug
/cc @jerop @pritidesai @afrittoli @sbwsg @bobcatfish 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
pipelines with when expressions created in v0.16.3 can be run
```
