### PR TITLE
Make t.Parallel() come first

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -38,11 +38,11 @@ import (
 // verify that pipelinerun timeout works and leads to the the correct TaskRun statuses
 // and pod deletions.
 func TestPipelineRunTimeout(t *testing.T) {
+	t.Parallel()
 	// cancel the context after we have waited a suitable buffer beyond the given deadline.
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)
@@ -171,10 +171,10 @@ func TestPipelineRunTimeout(t *testing.T) {
 
 // TestStepTimeout is an integration test that will verify a Step can be timed out.
 func TestStepTimeout(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)
@@ -242,11 +242,11 @@ func TestStepTimeout(t *testing.T) {
 
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
+	t.Parallel()
 	timeout := 30 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)
@@ -299,10 +299,10 @@ func TestTaskRunTimeout(t *testing.T) {
 }
 
 func TestPipelineTaskTimeout(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)

--- a/test/v1alpha1/timeout_test.go
+++ b/test/v1alpha1/timeout_test.go
@@ -37,10 +37,10 @@ import (
 // verify that pipelinerun timeout works and leads to the the correct TaskRun statuses
 // and pod deletions.
 func TestPipelineRunTimeout(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)
@@ -139,10 +139,10 @@ func TestPipelineRunTimeout(t *testing.T) {
 
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)
@@ -166,10 +166,10 @@ func TestTaskRunTimeout(t *testing.T) {
 }
 
 func TestPipelineTaskTimeout(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
 	defer cancel()
 	c, namespace := setup(ctx, t)
-	t.Parallel()
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)


### PR DESCRIPTION
# Changes

/kind bug

This makes the `t.Parallel()` call come first in the `timeout_test.go` tests, where I recently added `context.WithTimeout`.  When `t.Parallel()` is called, I believe it suspends the test and releases the blocking parent, and `-parallel=N` instances are allowed to proceed concurrently.  I *think* that in this case, we set up a timeout and then ~immediately suspend our thread! 
 So when things resume, our context is immediately cancelled 😬 

Here's what I'm seeing in my downstream testing (very intermittently):

```
--- FAIL: TestTaskRunTimeout (1.17s)
    init_test.go:132: Create namespace arendelle-cwq88 to deploy to
    init_test.go:148: Verify SA "default" is created in namespace "arendelle-cwq88"
    timeout_test.go:254: Creating Task and TaskRun in namespace arendelle-cwq88
    timeout_test.go:266: Failed to create Task `giraffe`: context deadline exceeded
    panic.go:636: ############################################
    panic.go:636: ### Dumping objects from arendelle-cwq88 ###
    panic.go:636: ############################################
    panic.go:636: 
    panic.go:636: #####################################################
    panic.go:636: ### Dumping logs from Pods in the arendelle-cwq88 ###
    panic.go:636: #####################################################
--- FAIL: TestStepTimeout (1.09s)
    init_test.go:132: Create namespace arendelle-lnzzk to deploy to
    init_test.go:148: Verify SA "default" is created in namespace "arendelle-lnzzk"
    timeout_test.go:182: Creating Task with Step step-no-timeout, Step step-timeout, and Step step-canceled in namespace arendelle-lnzzk
    timeout_test.go:186: Creating TaskRun run-timeout in namespace arendelle-lnzzk
    timeout_test.go:216: Failed to create TaskRun `run-timeout`: context deadline exceeded
    panic.go:636: ############################################
    panic.go:636: ### Dumping objects from arendelle-lnzzk ###
    panic.go:636: ############################################
    panic.go:636: 
    panic.go:636: #####################################################
    panic.go:636: ### Dumping logs from Pods in the arendelle-lnzzk ###
    panic.go:636: #####################################################
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```