### PR TITLE
Add logstream to v1alpha1 timeout_test.go

### DIFF
--- a/test/v1alpha1/init_test.go
+++ b/test/v1alpha1/init_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	knativetest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
+	"knative.dev/pkg/test/logstream"
 
 	// Mysteriously by k8s libs, or they fail to create `KubeClient`s from config. Apparently just importing it is enough. @_@ side effects @_@. https://github.com/kubernetes/client-go/issues/242
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -56,6 +57,10 @@ func setup(ctx context.Context, t *testing.T, fn ...func(context.Context, *testi
 	namespace := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix("arendelle")
 
 	initializeLogsAndMetrics(t)
+
+	// Inline controller logs from SYSTEM_NAMESPACE into the t.Log output.
+	cancel := logstream.Start(t)
+	t.Cleanup(cancel)
 
 	c := newClients(t, knativetest.Flags.Kubeconfig, knativetest.Flags.Cluster, namespace)
 	createNamespace(ctx, t, namespace, c.KubeClient)


### PR DESCRIPTION
# Changes

/kind cleanup

This instruments `./test/v1alpha1/timeout_test.go` with logstream.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
