### PR TITLE
Drop default suffix.

### DIFF
--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -193,7 +193,7 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	taskName := "hello-world"
 	pipelineName := "hello-world-pipeline"
 	pipelineRunName := "hello-world-piplinerun"
-	repo := fmt.Sprintf("registry.%s.svc.cluster.local:5000/tektonbundlessimple", namespace)
+	repo := fmt.Sprintf("registry.%s.svc:5000/tektonbundlessimple", namespace)
 
 	ref, err := name.ParseReference(repo)
 	if err != nil {
@@ -333,7 +333,7 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	taskName := "hello-world-dne"
 	pipelineName := "hello-world-pipeline-dne"
 	pipelineRunName := "hello-world-piplinerun"
-	repo := fmt.Sprintf("registry.%s.svc.cluster.local:5000/tektonbundlesregularimage", namespace)
+	repo := fmt.Sprintf("registry.%s.svc:5000/tektonbundlesregularimage", namespace)
 
 	ref, err := name.ParseReference(repo)
 	if err != nil {
@@ -418,7 +418,7 @@ func TestTektonBundlesUsingImproperFormat(t *testing.T) {
 	taskName := "hello-world"
 	pipelineName := "hello-world-pipeline"
 	pipelineRunName := "hello-world-piplinerun"
-	repo := fmt.Sprintf("registry.%s.svc.cluster.local:5000/tektonbundlesimproperformat", namespace)
+	repo := fmt.Sprintf("registry.%s.svc:5000/tektonbundlesimproperformat", namespace)
 
 	ref, err := name.ParseReference(repo)
 	if err != nil {


### PR DESCRIPTION
This test assumes that the cluster is configured with `.svc.cluster.local`, which isn't always the case.  Downstream I'm testing against KinD with a randomized suffix and this blew up.

The simplest fix is to drop the `.cluster.local` and rely on the resolution to find the right thing.
/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
