### PR TITLE
Update bundle tests to use IP of service to avoid cluster domain rules

### DIFF
--- a/test/registry_test.go
+++ b/test/registry_test.go
@@ -92,3 +92,13 @@ func getRegistryService(namespace string) *corev1.Service {
 		},
 	}
 }
+
+// getRegistryServiceIP fetches the registry service's current IP.
+func getRegistryServiceIP(ctx context.Context, t *testing.T, c *clients, namespace string) string {
+	t.Helper()
+	svc, err := c.KubeClient.Kube.CoreV1().Services(namespace).Get(ctx, "registry", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to lookup registry service: %q", err)
+	}
+	return svc.Spec.ClusterIP
+}

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -193,7 +193,7 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	taskName := "hello-world"
 	pipelineName := "hello-world-pipeline"
 	pipelineRunName := "hello-world-piplinerun"
-	repo := fmt.Sprintf("registry.%s.svc.cluster.local:5000/tektonbundlessimple", namespace)
+	repo := fmt.Sprintf("%s:5000/tektonbundlessimple", getRegistryServiceIP(ctx, t, c, namespace))
 
 	ref, err := name.ParseReference(repo)
 	if err != nil {
@@ -333,7 +333,7 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	taskName := "hello-world-dne"
 	pipelineName := "hello-world-pipeline-dne"
 	pipelineRunName := "hello-world-piplinerun"
-	repo := fmt.Sprintf("registry.%s.svc.cluster.local:5000/tektonbundlesregularimage", namespace)
+	repo := fmt.Sprintf("%s:5000/tektonbundlesregularimage", getRegistryServiceIP(ctx, t, c, namespace))
 
 	ref, err := name.ParseReference(repo)
 	if err != nil {
@@ -418,7 +418,7 @@ func TestTektonBundlesUsingImproperFormat(t *testing.T) {
 	taskName := "hello-world"
 	pipelineName := "hello-world-pipeline"
 	pipelineRunName := "hello-world-piplinerun"
-	repo := fmt.Sprintf("registry.%s.svc.cluster.local:5000/tektonbundlesimproperformat", namespace)
+	repo := fmt.Sprintf("%s:5000/tektonbundlesimproperformat", getRegistryServiceIP(ctx, t, c, namespace))
 
 	ref, err := name.ParseReference(repo)
 	if err != nil {


### PR DESCRIPTION
# Changes

Fixes a regression (#3429) introduced in the Tekton Bundle tests that depended on accessing the in-cluster registry via the `.cluster.local` DNS syntax. This was to workaround a go-containerregistry limitation which automatically treats `.local` addresses as `HTTP`. Instead, this change uses the Service's IP in the cluster which go-containerregistry also recognizes as a situation where it should automatically use `HTTP`.

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind failing-test

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
