### PR TITLE
Add documents for conformance tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,9 @@ go test ./...
 
 # Integration tests (against your current kube cluster)
 go test -v -count=1 -tags=e2e -timeout=20m ./test
+
+#conformance tests  (against your current kube cluster)
+go test -v -count=1 -tags=conformance -timeout=10m ./test
 ```
 
 ## Unit tests
@@ -330,6 +333,21 @@ err = WaitForTaskRunState(c, hwTaskRunName, func(tr *v1alpha1.TaskRun) (bool, er
 
 _[Metrics will be emitted](https://github.com/knative/pkg/tree/master/test#emit-metrics)
 for these `Wait` methods tracking how long test poll for._
+
+## Conformance tests
+
+Conformance tests live in this directory. These tests are used to check [API specs](../docs/api-spec.md)
+of Pipelines. To run these tests, you must provide `go` with `-tags=conformance`. By default, the tests
+run against your current kubeconfig context, but you can change that and other settings with the flags like
+the end to end tests:
+
+```shell
+go test -v -count=1 -tags=conformace -timeout=10m ./test
+go test -v -count=1 -tags=conformace -timeout=10m ./test --kubeconfig ~/special/kubeconfig --cluster myspecialcluster
+```
+
+Flags that could be set in conformance tests are exactly the same as [flags in end to end tests](#flags).
+Just note that the build tags should be `-tags=conformance`.
 
 ## Presubmit tests
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a section in test/README.md for conformance tests.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
