### PR TITLE
Fix the regex to match image in koparse

### DIFF
--- a/tekton/koparse/koparse.py
+++ b/tekton/koparse/koparse.py
@@ -60,7 +60,7 @@ def parse_release(base: str, path: str) -> List[str]:
         list of the images parsed from the file
     """
     images = []
-    pattern = re.compile(base + r"[0-9a-z\-]+" + DIGEST_MARKER + r":[0-9a-f]*")
+    pattern = re.compile(base + r"[0-9a-z\-/]+(?::[0-9a-z]+)?" + DIGEST_MARKER + r":[0-9a-f]+")
     with open(path) as f:
         for line in f:
             found = re.findall(pattern, line)

--- a/tekton/koparse/test_koparse.py
+++ b/tekton/koparse/test_koparse.py
@@ -12,14 +12,14 @@ PATH_TO_TEST_RELEASE_YAML = os.path.join(os.path.dirname(
 PATH_TO_WRONG_FILE = os.path.join(os.path.dirname(
     os.path.abspath(__file__)), "koparse.py")
 BUILT_IMAGES = [
-    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35",
+    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:withtag@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:67448da79e4731ab534b91df08da547bc434ab08e41d905858f2244e70290f48",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7d5520efa2d55e1346c424797988c541327ee52ef810a840b5c6f278a9de934a",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller@sha256:bdc6f22a44944c829983c30213091b60f490b41f89577e8492f6a2936be0df41",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook@sha256:cca7069a11aaf0d9d214306d456bc40b2e33e5839429bf07c123ad964d495d8a",
 ]
 EXPECTED_IMAGES = [
-    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter",
+    "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:withtag",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init",
     "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller",

--- a/tekton/koparse/test_release.yaml
+++ b/tekton/koparse/test_release.yaml
@@ -330,7 +330,7 @@ spec:
         "-logtostderr",
         "-stderrthreshold",
         "INFO",
-        "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35", "-creds-ige", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:67448da79e4731ab534b91df08da547bc434ab08e41d905858f2244e70290f48",
+        "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:withtag@sha256:68453f5bb4b76c0eab98964754114d4f79d3a50413872520d8919a6786ea2b35", "-creds-ige", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/creds-init@sha256:67448da79e4731ab534b91df08da547bc434ab08e41d905858f2244e70290f48",
         "-git-image",
         "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:7d5520efa2d55e1346c424797988c541327ee52ef810a840b5c6f278a9de934a",
       ]


### PR DESCRIPTION
# Changes

The regex to parse images does not include '/' after the base
registry. We should not require passing the registry with a
trailing '/', so adding it in the regex instead.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```