### PR TITLE
Document usage of chown on /tekton as another cause of error

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -580,6 +580,11 @@ Multiple Steps with different users / UIDs are trying to initialize docker
 or git credentials in the same Task. If those Steps need access to the
 credentials then they may fail as they might not have permission to access them.
 
+This happens because, by default, `/tekton/home` is set to be a Step user's home
+directory and Tekton makes this directory a shared volume that all Steps in a
+Task have access to. Any credentials initialized by one Step are overwritten
+by subsequent Steps also initializing credentials.
+
 If the Steps reporting this warning do not use the credentials mentioned
 in the message then you can safely ignore it.
 
@@ -604,6 +609,14 @@ credentials that Tekton will try to initialize.
 
 The simplest solution to this problem is to not mix credentials mounted via
 Workspace with those initialized using the process described in this document.
+
+#### The contents of `$HOME` are `chown`ed to a different user
+
+A Task Step that modifies the ownership of files in the user home directory
+may prevent subsequent Steps from initializing credentials in that same home
+directory. The simplest solution to this problem is to avoid running chown
+on files and directories under `/tekton`. Another option is to run all Steps
+with the same UID.
 
 #### The Step is named `image-digest-exporter`
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


In a prior commit we documented reasons that a warning may be
printed while initializing credentials. There is another possible
cause of these warnings that was not included at that time.

This commit adds another possible cause of the warning message
appearing: Steps that `chown` the contents of /tekton to be a UID
that subsequent Steps are not running as.

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)


```release-note
NONE
```