### PR TITLE
Pass test ctx to taskrun reconciler instead of background ctx

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2566,7 +2566,7 @@ func TestReconcileValidDefaultWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := testAssets.Controller.Reconciler.Reconcile(context.Background(), getRunName(taskRun)); err != nil {
+	if err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, getRunName(taskRun)); err != nil {
 		t.Errorf("Expected no error reconciling valid TaskRun but got %v", err)
 	}
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Trying to fix https://github.com/tektoncd/pipeline/issues/3444

Prior to this commit the test reconciler was being passed a background
context to its Reconciler method in TestReconcileValidDefaultWorkspace.

This commit passes the test assets context instead which will hopefully
be immediately up-to-date with configmap changes like the Default
TaskRun Workspace Binding config.

/kind flake

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

```release-note
NONE
```