### PR TITLE
Don't "Follow" when dumping test pod logs.

### DIFF
--- a/test/build_logs.go
+++ b/test/build_logs.go
@@ -57,7 +57,10 @@ func getContainersLogsFromPod(ctx context.Context, c kubernetes.Interface, pod, 
 
 func getContainerLogsFromPod(ctx context.Context, c kubernetes.Interface, pod, container, namespace string) (string, error) {
 	sb := strings.Builder{}
-	req := c.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{Follow: true, Container: container})
+	// Do not follow, which will block until the Pod terminates, and potentially deadlock the test.
+	// If done in the wrong order, this could actually block things and prevent the Pod from being
+	// deleted at all.
+	req := c.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{Follow: false, Container: container})
 	rc, err := req.Stream(ctx)
 	if err != nil {
 		return "", err

--- a/test/v1alpha1/build_logs.go
+++ b/test/v1alpha1/build_logs.go
@@ -57,7 +57,10 @@ func getContainersLogsFromPod(ctx context.Context, c kubernetes.Interface, pod, 
 
 func getContainerLogsFromPod(ctx context.Context, c kubernetes.Interface, pod, container, namespace string) (string, error) {
 	sb := strings.Builder{}
-	req := c.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{Follow: true, Container: container})
+	// Do not follow, which will block until the Pod terminates, and potentially deadlock the test.
+	// If done in the wrong order, this could actually block things and prevent the Pod from being
+	// deleted at all.
+	req := c.CoreV1().Pods(namespace).GetLogs(pod, &corev1.PodLogOptions{Follow: false, Container: container})
 	rc, err := req.Stream(ctx)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
"Follow" is for watching for *additional* logs and printing them as they appear (e.g. `tail -f`), it only stops when the Pod itself goes away.  This is inappropriate for the type of post-mortem log dumping we are doing here.

I've seen a number of `timeout_test.go` stack traces still after my `context.WithTimeout` changes, which trace back to this line.  Things are deadlocked on this line until the test times out.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
