### PR TITLE
Add an unsuccessful TaskRun testcase in conformance tests

### DIFF
--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -20,14 +20,19 @@ package test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	knativetest "knative.dev/pkg/test"
 )
+
+type conditionFn func(name string) ConditionAccessorFn
 
 func TestTaskRun(t *testing.T) {
 	ctx := context.Background()
@@ -38,75 +43,156 @@ func TestTaskRun(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	trName := "echo-hello-task-run"
-	tr := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: trName, Namespace: namespace},
-		Spec: v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{Container: corev1.Container{
-					Image:   "busybox",
-					Command: []string{"echo", "\"hello\""},
-				}}},
+	fqImageName := getTestImage(busyboxImage)
+
+	for _, tc := range []struct {
+		name                    string
+		trName                  string
+		tr                      *v1beta1.TaskRun
+		fn                      conditionFn
+		expectedConditionStatus corev1.ConditionStatus
+		expectedStepState       []v1beta1.StepState
+	}{{
+		name:   "successful-task-run",
+		trName: "echo-hello-task-run",
+		tr: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "echo-hello-task-run", Namespace: namespace},
+			Spec: v1beta1.TaskRunSpec{
+				TaskSpec: &v1beta1.TaskSpec{
+					Steps: []v1beta1.Step{{Container: corev1.Container{
+						Image:   fqImageName,
+						Command: []string{"echo", "\"hello\""},
+					}}},
+				},
 			},
 		},
-	}
+		fn:                      TaskRunSucceed,
+		expectedConditionStatus: corev1.ConditionTrue,
+		expectedStepState: []v1beta1.StepState{{
+			ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 0,
+					Reason:   "Completed",
+				},
+			},
+		}},
+	}, {
+		name:   "failed-task-run",
+		trName: "failed-echo-hello-task-run",
+		tr: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "failed-echo-hello-task-run", Namespace: namespace},
+			Spec: v1beta1.TaskRunSpec{
+				TaskSpec: &v1beta1.TaskSpec{
+					Steps: []v1beta1.Step{{Container: corev1.Container{
+						Image:   fqImageName,
+						Command: []string{"/bin/sh"},
+						Args:    []string{"-c", "echo hello"},
+					}}, {Container: corev1.Container{
+						Image:   fqImageName,
+						Command: []string{"/bin/sh"},
+						Args:    []string{"-c", "exit 1"},
+					}}, {Container: corev1.Container{
+						Image:   fqImageName,
+						Command: []string{"/bin/sh"},
+						Args:    []string{"-c", "sleep 30s"},
+					}}},
+				},
+			},
+		},
+		fn:                      TaskRunFailed,
+		expectedConditionStatus: corev1.ConditionFalse,
+		expectedStepState: []v1beta1.StepState{{
+			ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 0,
+					Reason:   "Completed",
+				},
+			},
+		}, {
+			ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 1,
+					Reason:   "Error",
+				},
+			},
+		}, {
+			ContainerState: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					ExitCode: 1,
+					Reason:   "Error",
+				},
+			},
+		}},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Logf("Creating TaskRun %s", tc.trName)
+			if _, err := c.TaskRunClient.Create(ctx, tc.tr, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Failed to create TaskRun `%s`: %s", tc.trName, err)
+			}
 
-	t.Logf("Creating TaskRun %s", trName)
-	if _, err := c.TaskRunClient.Create(ctx, tr, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun `%s`: %s", trName, err)
-	}
+			if err := WaitForTaskRunState(ctx, c, tc.trName, tc.fn(tc.trName), "WaitTaskRunDone"); err != nil {
+				t.Errorf("Error waiting for TaskRun to finish: %s", err)
+				return
+			}
+			tr, err := c.TaskRunClient.Get(ctx, tc.trName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Failed to get TaskRun `%s`: %s", tc.trName, err)
+			}
 
-	if err := WaitForTaskRunState(ctx, c, trName, TaskRunSucceed(trName), "WaitTaskRunDone"); err != nil {
-		t.Errorf("Error waiting for TaskRun to finish: %s", err)
-		return
-	}
-	tr, err := c.TaskRunClient.Get(ctx, trName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get TaskRun `%s`: %s", trName, err)
-	}
+			// Check required fields in TaskRun ObjectMeta
+			if tr.ObjectMeta.Name == "" {
+				t.Errorf("TaskRun ObjectMeta doesn't have the Name.")
+			}
+			if len(tr.ObjectMeta.Labels) == 0 {
+				t.Errorf("TaskRun ObjectMeta doesn't have the Labels.")
+			}
+			if len(tr.ObjectMeta.Annotations) == 0 {
+				t.Errorf("TaskRun ObjectMeta doesn't have the Annotations.")
+			}
+			if tr.ObjectMeta.CreationTimestamp.IsZero() {
+				t.Errorf("TaskRun ObjectMeta doesn't have the CreationTimestamp.")
+			}
 
-	// check required fields in TaskRun ObjectMeta
-	if tr.ObjectMeta.Name == "" {
-		t.Errorf("TaskRun ObjectMeta doesn't have the Name.")
-	}
-	if len(tr.ObjectMeta.Labels) == 0 {
-		t.Errorf("TaskRun ObjectMeta doesn't have the Labels.")
-	}
-	if len(tr.ObjectMeta.Annotations) == 0 {
-		t.Errorf("TaskRun ObjectMeta doesn't have the Annotations.")
-	}
-	if tr.ObjectMeta.CreationTimestamp.IsZero() {
-		t.Errorf("TaskRun ObjectMeta doesn't have the CreationTimestamp.")
-	}
+			// Check required fields in TaskRun Status
+			if len(tr.Status.Conditions) == 0 {
+				t.Errorf("TaskRun Status doesn't have the Conditions.")
+			}
+			if tr.Status.StartTime.IsZero() {
+				t.Errorf("TaskRun Status doesn't have the StartTime.")
+			}
+			if tr.Status.CompletionTime.IsZero() {
+				t.Errorf("TaskRun Status doesn't have the CompletionTime.")
+			}
+			if len(tr.Status.Steps) == 0 {
+				t.Errorf("TaskRun Status doesn't have the Steps.")
+			}
 
-	// check required fields in TaskRun Status
-	if len(tr.Status.Conditions) == 0 {
-		t.Errorf("TaskRun Status doesn't have the Conditions.")
-	}
-	if tr.Status.StartTime.IsZero() {
-		t.Errorf("TaskRun Status doesn't have the StartTime.")
-	}
-	if tr.Status.CompletionTime.IsZero() {
-		t.Errorf("TaskRun Status doesn't have the CompletionTime.")
-	}
-	if len(tr.Status.Steps) == 0 {
-		t.Errorf("TaskRun Status doesn't have the Steps.")
-	}
+			condition := tr.Status.GetCondition(apis.ConditionSucceeded)
+			if condition == nil {
+				t.Errorf("Expected a succeeded Condition but got nil.")
+			}
+			if condition.Status != tc.expectedConditionStatus {
+				t.Errorf("TaskRun Status Condition doesn't have the right Status.")
+			}
+			if condition.Reason == "" {
+				t.Errorf("TaskRun Status Condition doesn't have the Reason.")
+			}
+			if condition.Message == "" {
+				t.Errorf("TaskRun Status Condition doesn't have the Message.")
+			}
+			if condition.Severity != apis.ConditionSeverityError && condition.Severity != apis.ConditionSeverityWarning && condition.Severity != apis.ConditionSeverityInfo {
+				t.Errorf("TaskRun Status Condition doesn't have the right Severity.")
+			}
 
-	condition := tr.Status.GetCondition(apis.ConditionSucceeded)
-	if condition == nil {
-		t.Errorf("Expected a succeeded Condition but got nil.")
-	}
-	if condition.Status != corev1.ConditionTrue {
-		t.Errorf("TaskRun Status Condition doesn't have the right Status.")
-	}
-	if condition.Reason == "" {
-		t.Errorf("TaskRun Status Condition doesn't have the Reason.")
-	}
-	if condition.Message == "" {
-		t.Errorf("TaskRun Status Condition doesn't have the Message.")
-	}
-	if condition.Severity != apis.ConditionSeverityError && condition.Severity != apis.ConditionSeverityWarning && condition.Severity != apis.ConditionSeverityInfo {
-		t.Errorf("TaskRun Status Condition doesn't have the right Severity.")
+			ignoreTerminatedFields := cmpopts.IgnoreFields(corev1.ContainerStateTerminated{}, "StartedAt", "FinishedAt", "ContainerID")
+			ignoreStepFields := cmpopts.IgnoreFields(v1beta1.StepState{}, "ImageID", "Name", "ContainerName")
+			if d := cmp.Diff(tr.Status.Steps, tc.expectedStepState, ignoreTerminatedFields, ignoreStepFields); d != "" {
+				t.Fatalf("-got, +want: %v", d)
+			}
+			// Note(chmouel): Sometime we have docker-pullable:// or docker.io/library as prefix, so let only compare the suffix
+			if !strings.HasSuffix(tr.Status.Steps[0].ImageID, fqImageName) {
+				t.Fatalf("`ImageID: %s` does not end with `%s`", tr.Status.Steps[0].ImageID, fqImageName)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add an unsuccessful TaskRun testcase in conformance tests

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
```release-note
NONE
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
