### PR TITLE
Make the main releases multi-arch

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -23,8 +23,6 @@ spec:
     outputs:
     - name: bucket
       type: storage
-    - name: builtBaseImage
-      type: image
     - name: builtEntrypointImage
       type: image
     - name: builtNopImage

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -85,6 +85,22 @@ spec:
         inputs:
           - name: source
             resource: source-repo
+    - name: build-base-image
+      runAfter: [build, unit-tests]
+      taskRef:
+        name: build-multiarch-base-image
+      params:
+        - name: pathToProject
+          value: $(params.package)
+        - name: imageRegistry
+          value: $(params.imageRegistry)
+      resources:
+        inputs:
+          - name: source
+            resource: source-repo
+        outputs:
+          - name: builtBaseImage
+            resource: builtBaseImage
     - name: publish-images
       runAfter: [build, unit-tests]
       taskRef:
@@ -107,8 +123,6 @@ spec:
         outputs:
           - name: bucket
             resource: bucket
-          - name: builtBaseImage
-            resource: builtBaseImage
           - name: builtEntrypointImage
             resource: builtEntrypointImage
           - name: builtNopImage


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

With multi-arch builds, the base image is built by a dedicated
task and should not be in the list of outputs of the publish
task. Since the publish task is shared by nightly and full
releases, the solution is to turn the full releases to multi
arch as well.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>
/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Tekton full releases will be multi-arch as well
```