### PR TITLE
Fix bug where PipelineRun emits task results that were never produced

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -604,6 +604,20 @@ references the `outputValue` `Result` emitted by the `calculate-sum` `Task`.
 
 For an end-to-end example, see [`Results` in a `PipelineRun`](../examples/v1beta1/pipelineruns/pipelinerun-results.yaml).
 
+A `Pipeline Result` is not emitted if any of the following are true:
+- A `PipelineTask` referenced by the `Pipeline Result` failed. The `PipelineRun` will also
+have failed.
+- A `PipelineTask` referenced by the `Pipeline Result` was skipped.
+- A `PipelineTask` referenced by the `Pipeline Result` didn't emit the referenced `Task Result`. This
+should be considered a bug in the `Task` and [may fail a `PipelineTask` in future](https://github.com/tektoncd/pipeline/issues/3497).
+- The `Pipeline Result` uses a variable that doesn't point to an actual `PipelineTask`. This will
+result in an `InvalidTaskResultReference` validation error during `PipelineRun` execution.
+- The `Pipeline Result` uses a variable that doesn't point to an actual result in a `PipelineTask`.
+This will cause an `InvalidTaskResultReference` validation error during `PipelineRun` execution.
+
+**Note:** Since a `Pipeline Result` can contain references to multiple `Task Results`, if any of those
+`Task Result` references are invalid the entire `Pipeline Result` is not emitted.
+
 ## Configuring the `Task` execution order
 
 You can connect `Tasks` in a `Pipeline` so that they execute in a Directed Acyclic Graph (DAG).

--- a/pkg/reconciler/pipelinerun/resources/conditionresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/conditionresolution.go
@@ -177,6 +177,8 @@ func (rcc *ResolvedConditionCheck) NewConditionCheckStatus() *v1beta1.ConditionC
 	}
 }
 
+// ToTaskResourceBindings converts pipeline resources in a ResolvedConditionCheck to a list of TaskResourceBinding
+// and returns them.
 func (rcc *ResolvedConditionCheck) ToTaskResourceBindings() []v1beta1.TaskResourceBinding {
 	var trb []v1beta1.TaskResourceBinding
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3465

Prior to this commit a Pipeline Result that references a Task Result of a failed TaskRun would end up with a value of the literal variable. For example: if Task "foo" failed, a Pipeline Result with value of "$(tasks.foo.results.bar)" would end up in the PipelineRun.Status.Results list with the literal value, "$(tasks.foo.results.bar)". It was therefore difficult to assess programatically whether results were populated correctly or were the result of some invalid TaskRun condition.

This commit fixes the bug by filtering out PipelineRun Results that reference failed TaskRuns. It was quite difficult to follow the flow of execution wrt PipelineRun Results and so ultimately I had to refactor the whole lot to figure out where the bug was. The final code is quite a bit shorter than the original and has improved test coverage to more robustly exercise the behaviour of PipelineResults in various failure scenarios.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

```release-note
Fix bug where PipelineRun emits task results that were never produced. Previously a Pipeline Result that contained an invalid variable would be added to the PipelineRun with that unreplaced variable intact. Now a Pipeline Result that contains an invalid variable will not be emitted by the PipelineRun at all.
```