### PR TITLE
pkg/git: fix ssh credentials detection 🦀

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"go.uber.org/zap"
 )
 
@@ -261,9 +262,8 @@ func userHasKnownHostsFile(logger *zap.SugaredLogger) (bool, error) {
 }
 
 func validateGitAuth(logger *zap.SugaredLogger, url string) {
-	homeenv := os.Getenv("HOME")
 	sshCred := true
-	if _, err := os.Stat(homeenv + "/.ssh"); os.IsNotExist(err) {
+	if _, err := os.Stat(pipeline.CredsDir + "/.ssh"); os.IsNotExist(err) {
 		sshCred = false
 	}
 	urlSSHFormat := ValidateGitSSHURLFormat(url)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

To detect ssh cerdentials (and validate the git clone url with
cerdentials), we do check if there is a `$HOME/.ssh` folder. With
`disable-home-env-overwrite` we do not overwrite `$HOME` env anymore,
and thus we have *no* control where `$HOME` is and wether the image
ships it with a `.ssh` or not.

This fixes it by looking at a path we control no matter how the
controller is configured : `pipeline.CredsDir` (`/tekton/creds`).

Fixes  #3481

/kind bug
/cc @afrittoli @sbwsg @FogDong @bobcatfish @pritidesai 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
fix ssh credential wrong detection in git-init
```
