### PR TITLE
[cherry-pick] Avoid dangling symlinks in git-init

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -206,9 +206,11 @@ func SubmoduleFetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 	return nil
 }
 
+// ensureHomeEnv works around an issue where ssh doesn't respect the HOME env variable. If HOME is set and
+// different from the user's detected home directory then symlink .ssh from the home directory to the HOME env
+// var. This way ssh will see the .ssh directory in the user's home directory even though it ignores
+// the HOME env var.
 func ensureHomeEnv(logger *zap.SugaredLogger) error {
-	// HACK: This is to get git+ssh to work since ssh doesn't respect the HOME
-	// env variable.
 	homepath, err := homedir.Dir()
 	if err != nil {
 		logger.Errorf("Unexpected error: getting the user home directory: %v", err)
@@ -216,23 +218,32 @@ func ensureHomeEnv(logger *zap.SugaredLogger) error {
 	}
 	homeenv := os.Getenv("HOME")
 	euid := os.Geteuid()
-	// Special case the root user/directory
+	if _, err := os.Stat(filepath.Join(homeenv, ".ssh")); err != nil {
+		// There's no $HOME/.ssh directory to access or the user doesn't have permissions
+		// to read it, or something else; in any event there's no need to try creating a
+		// symlink to it.
+		return nil
+	}
 	if euid == 0 {
-		if err := os.Symlink(homeenv+"/.ssh", "/root/.ssh"); err != nil {
-			// Only do a warning, in case we don't have a real home
-			// directory writable in our image
-			logger.Warnf("Unexpected error: creating symlink: %v", err)
-		}
-	} else if homeenv != "" && homeenv != homepath {
-		if _, err := os.Stat(homepath + "/.ssh"); os.IsNotExist(err) {
-			if err := os.Symlink(homeenv+"/.ssh", homepath+"/.ssh"); err != nil {
+		ensureHomeEnvSSHLinkedFromPath(logger, homeenv, "/root")
+	} else if homeenv != "" {
+		ensureHomeEnvSSHLinkedFromPath(logger, homeenv, homepath)
+	}
+	return nil
+}
+
+func ensureHomeEnvSSHLinkedFromPath(logger *zap.SugaredLogger, homeenv string, homepath string) {
+	if filepath.Clean(homeenv) != filepath.Clean(homepath) {
+		homeEnvSSH := filepath.Join(homeenv, ".ssh")
+		homePathSSH := filepath.Join(homepath, ".ssh")
+		if _, err := os.Stat(homePathSSH); os.IsNotExist(err) {
+			if err := os.Symlink(homeEnvSSH, homePathSSH); err != nil {
 				// Only do a warning, in case we don't have a real home
 				// directory writable in our image
 				logger.Warnf("Unexpected error: creating symlink: %v", err)
 			}
 		}
 	}
-	return nil
 }
 
 func userHasKnownHostsFile(logger *zap.SugaredLogger) (bool, error) {


### PR DESCRIPTION
When the following conditions are met:

1. the feature flag disable-home-env-overwrite is "true"
2. the container user is root
3. no git / ssh secret is attached to a taskrun service account
4. user is running new-ish version of catalog git-clone task with git-init v0.15.2+

git-init will error out in the git-clone task because we create a circular symlink
from /root/.ssh to itself and then try to look up /root/.ssh/known_hosts.

This commit adds a check to avoid this from happening:

If the user's $HOME/.ssh directory doesn't exist or if they aren't able to access it
for any reason, then we don't try to create a symlink to it at all since we can trust that
the user is incapable of utilizing the credential.

This commit also expands an existing check to see if the $HOME/.ssh directory is
the same as the user's home directory + '.ssh'. This was originally only checked if
the user was nonroot, but now this is also checked if the user is root too.

(cherry picked from commit 1160686e9b0e9d63bd3596786724dd541bb868e2)
Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug
/cc @sbwsg @bobcatfish @afrittoli

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fixed a bug in `git-init` that allowed a circular symlink to be created from `/root/.ssh` to itself if no SSH credentials are present in the service account and the `disable-home-env-overwrite` flag is set to `"true"`.
```
