### PR TITLE
Add variable expansion for ImagePullPolicy in Tasks. See #3423

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -127,6 +127,7 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | --- | ----- |
 | `Task` | `spec.steps[].name` |
 | `Task` | `spec.steps[].image` |
+| `Task` | `spec.steps[].imagePullPolicy` |
 | `Task` | `spec.steps[].env.value` |
 | `Task` | `spec.steps[].env.valuefrom.secretkeyref.name` |
 | `Task` | `spec.steps[].env.valuefrom.secretkeyref.key` |
@@ -150,6 +151,7 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `Task` | `spec.volumes[].csi.volumeattributes.* `|
 | `Task` | `spec.sidecars[].name` |
 | `Task` | `spec.sidecars[].image` |
+| `Task` | `spec.sidecars[].imagePullPolicy` |
 | `Task` | `spec.sidecars[].env.value` |
 | `Task` | `spec.sidecars[].env.valuefrom.secretkeyref.name` |
 | `Task` | `spec.sidecars[].env.valuefrom.secretkeyref.key` |

--- a/examples/v1beta1/taskruns/image-params.yaml
+++ b/examples/v1beta1/taskruns/image-params.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: image-params
+spec:
+  params:
+  - name: image
+    type: string
+    default: ubuntu
+  - name: imagePullPolicy
+    type: string
+    default: IfNotPresent
+  steps:
+  - image: $(params.image)
+    imagePullPolicy: $(params.imagePullPolicy)
+    script: echo hello
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: image-params-
+spec:
+  taskRef:
+    name: image-params
+    kind: ClusterTask

--- a/pkg/apis/pipeline/v1beta1/container_replacements.go
+++ b/pkg/apis/pipeline/v1beta1/container_replacements.go
@@ -24,6 +24,7 @@ import (
 func ApplyContainerReplacements(step *corev1.Container, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	step.Name = substitution.ApplyReplacements(step.Name, stringReplacements)
 	step.Image = substitution.ApplyReplacements(step.Image, stringReplacements)
+	step.ImagePullPolicy = corev1.PullPolicy(substitution.ApplyReplacements(string(step.ImagePullPolicy), stringReplacements))
 
 	// Use ApplyArrayReplacements here, as additional args may be added via an array parameter.
 	var newArgs []string

--- a/pkg/apis/pipeline/v1beta1/container_replacements_test.go
+++ b/pkg/apis/pipeline/v1beta1/container_replacements_test.go
@@ -34,11 +34,12 @@ func TestApplyContainerReplacements(t *testing.T) {
 	}
 
 	s := corev1.Container{
-		Name:       "$(replace.me)",
-		Image:      "$(replace.me)",
-		Command:    []string{"$(array.replace.me)"},
-		Args:       []string{"$(array.replace.me)"},
-		WorkingDir: "$(replace.me)",
+		Name:            "$(replace.me)",
+		Image:           "$(replace.me)",
+		ImagePullPolicy: "$(replace.me)",
+		Command:         []string{"$(array.replace.me)"},
+		Args:            []string{"$(array.replace.me)"},
+		WorkingDir:      "$(replace.me)",
 		EnvFrom: []corev1.EnvFromSource{{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -77,11 +78,12 @@ func TestApplyContainerReplacements(t *testing.T) {
 	}
 
 	expected := corev1.Container{
-		Name:       "replaced!",
-		Image:      "replaced!",
-		Command:    []string{"val1", "val2"},
-		Args:       []string{"val1", "val2"},
-		WorkingDir: "replaced!",
+		Name:            "replaced!",
+		Image:           "replaced!",
+		ImagePullPolicy: "replaced!",
+		Command:         []string{"val1", "val2"},
+		Args:            []string{"val1", "val2"},
+		WorkingDir:      "replaced!",
 		EnvFrom: []corev1.EnvFromSource{{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add variable expansion in Tasks for fields:
- `spec.steps[].imagePullPolicy`
- `spec.sidecar[].imagePullPolicy`

Closes #3423 

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Add variable expansion in Tasks for fields:
- `spec.steps[].imagePullPolicy`
- `spec.sidecar[].imagePullPolicy`
```
