### PR TITLE
Add http and https proxy support for git-init

### DIFF
--- a/cmd/git-init/main.go
+++ b/cmd/git-init/main.go
@@ -36,6 +36,9 @@ func init() {
 	flag.StringVar(&fetchSpec.Refspec, "refspec", "", "The Git refspec to fetch the revision from (optional)")
 	flag.StringVar(&fetchSpec.Path, "path", "", "Path of directory under which Git repository will be copied")
 	flag.BoolVar(&fetchSpec.SSLVerify, "sslVerify", true, "Enable/Disable SSL verification in the git config")
+	flag.StringVar(&fetchSpec.HTTPProxy, "httpProxy", "", "Set an http proxy to use")
+	flag.StringVar(&fetchSpec.HTTPSProxy, "httpsProxy", "", "Set an https proxy to use")
+	flag.StringVar(&fetchSpec.HTTPSProxySSLCAInfo, "httpsCAInfo", "", "File containing the certificate bundle that should be used to verify the proxy with when using an HTTPS proxy")
 	flag.BoolVar(&fetchSpec.Submodules, "submodules", true, "Initialize and fetch Git submodules")
 	flag.UintVar(&fetchSpec.Depth, "depth", 1, "Perform a shallow clone to this depth")
 	flag.StringVar(&terminationMessagePath, "terminationMessagePath", "/tekton/termination", "Location of file containing termination message")
@@ -48,6 +51,18 @@ func main() {
 	defer func() {
 		_ = logger.Sync()
 	}()
+
+	if httpProxy := os.Getenv("HTTP_PROXY"); httpProxy != "" {
+		fetchSpec.HTTPProxy = httpProxy
+	}
+
+	if httpsProxy := os.Getenv("HTTPS_PROXY"); httpsProxy != "" {
+		fetchSpec.HTTPSProxy = httpsProxy
+	}
+
+	if sslCainfo := os.Getenv("GIT_PROXY_SSL_CAINFO"); sslCainfo != "" {
+		fetchSpec.HTTPSProxySSLCAInfo = sslCainfo
+	}
 
 	if err := git.Fetch(logger, fetchSpec); err != nil {
 		logger.Fatalf("Error fetching git repository: %s", err)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -139,7 +139,7 @@ see [`authenticating-git-commands`](../examples/v1beta1/taskruns/authenticating-
 ## Limiting `Secret` access to specific `Steps`
 
 As described earlier in this document, Tekton stores supported `Secrets` in
-`$HOME/tekton/home` and makes them available to all `Steps` within a `Task`. 
+`$HOME/tekton/home` and makes them available to all `Steps` within a `Task`.
 
 If you want to limit a `Secret` to only be accessible to specific `Steps` but not
 others, you must explicitly specify a `Volume` using the `Secret` definition and
@@ -332,10 +332,16 @@ directly in the `Steps` of a `Task`. Since `ssh` ignores the `$HOME` variable an
 user's home directory specified in `/etc/passwd`, each `Step` must symlink `/tekton/home/.ssh`
 to the home directory of its associated user.
 
-**Note:** This explicit symlinking is not necessary when using a `git` type `PipelineResource` or the
+:** This explicit symlinking is not necessary when using a `git` type `PipelineResource` or the
 [`git-clone` `Task`](https://github.com/tektoncd/catalog/tree/v1beta1/git) from Tekton Catalog.
 
 For example usage, see [`authenticating-git-commands`](../examples/v1beta1/taskruns/authenticating-git-commands.yaml).
+
+### Using Proxy with `git` type `Tasks`
+
+You can use an `http` or `https` proxy with the `git-clone` task [`git-clone`
+`Task`](https://github.com/tektoncd/catalog/tree/v1beta1/git) when passing the
+`http_proxy` or `https_proxy` argument.
 
 ## Configuring authentication for Docker
 
@@ -429,7 +435,7 @@ credentials from all specified `Secrets` but Tekton's `basic-auth` `Secret` over
 Kubernetes `Secrets`.
 
 1. Define a `Secret` based on your Docker client configuration file.
-   
+
    ```bash
    kubectl create secret generic regcred \
     --from-file=.dockerconfigjson=<path/to/.docker/config.json> \
@@ -512,7 +518,7 @@ https://user2:pass2@url2.com
 ### `ssh-auth` for Git
 
 Given hostnames, private keys, and `known_hosts` of the form: `url{n}.com`,
-`key{n}`, and `known_hosts{n}`, Tekton generates the following. 
+`key{n}`, and `known_hosts{n}`, Tekton generates the following.
 
 By default, if no value is specified for `known_hosts`, Tekton configures SSH to accept
 **any public key** returned by the server on first query. Tekton does this

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -59,16 +59,17 @@ func run(logger *zap.SugaredLogger, dir string, args ...string) (string, error) 
 
 // FetchSpec describes how to initialize and fetch from a Git repository.
 type FetchSpec struct {
-	URL        string
-	Revision   string
-	Refspec    string
-	Path       string
-	Depth      uint
-	Submodules bool
-	SSLVerify  bool
-	HTTPProxy  string
-	HTTPSProxy string
-	NOProxy    string
+	URL                 string
+	Revision            string
+	Refspec             string
+	Path                string
+	Depth               uint
+	Submodules          bool
+	SSLVerify           bool
+	HTTPProxy           string
+	HTTPSProxy          string
+	HTTPSProxySSLCAInfo string
+	NOProxy             string
 }
 
 // Fetch fetches the specified git repository at the revision into path, using the refspec to fetch if provided.
@@ -108,6 +109,22 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 		logger.Warnf("Failed to set http.sslVerify in git config: %s", err)
 		return err
 	}
+
+	if _, err := run(logger, "", "config", "--global", "http.proxy", spec.HTTPProxy); err != nil {
+		logger.Warnf("Failed to set http.proxy in git config: %s", err)
+		return err
+	}
+
+	if _, err := run(logger, "", "config", "--global", "http.proxySSLCAInfo", spec.HTTPSProxySSLCAInfo); err != nil {
+		logger.Warnf("Failed to set http.proxySSLCAInfo in git config: %s", err)
+		return err
+	}
+
+	if _, err := run(logger, "", "config", "--global", "https.proxy", spec.HTTPSProxy); err != nil {
+		logger.Warnf("Failed to set https.proxy in git config: %s", err)
+		return err
+	}
+
 	if spec.Revision == "" {
 		spec.Revision = "HEAD"
 		if _, err := run(logger, "", "symbolic-ref", spec.Revision, "refs/remotes/origin/HEAD"); err != nil {


### PR DESCRIPTION
# Changes

Let's set http and https proxy if we find the HTTP_PROXY and HTTPS_PROXY
environment variables or if the -httpProxy or -httpsProxy are passed.

Tested manually against a  [mitmproxy](http://mitm.it/) install which seems to works well : 

![image](https://user-images.githubusercontent.com/98980/98117200-aa46b900-1ea9-11eb-9033-8fbb004aba36.png)

Will be the tested functionally in a subsequent update to the git-clone catalog task.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [😿] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [👍🏼] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [👍🏼] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [👍🏼] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

# Release Notes

```release-note
Add http and https proxy support for git-init
```

