### PR TITLE
tests: fix potential races with t.Parallel and loops ➿

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -247,6 +247,7 @@ func TestApplyParameters(t *testing.T) {
 			}},
 		},
 	}} {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			run := &v1beta1.PipelineRun{

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -41,6 +41,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 	// on failure, to ensure that cancelling the PipelineRun doesn't cause
 	// the retrying TaskRun to retry.
 	for _, numRetries := range []int{0, 1} {
+		numRetries := numRetries // capture range variable
 		t.Run(fmt.Sprintf("retries=%d", numRetries), func(t *testing.T) {
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -218,6 +218,7 @@ func TestExamples(t *testing.T) {
 
 	t.Parallel()
 	for _, path := range getExamplePaths(t, baseDir) {
+		path := path // capture range variable
 		testName := extractTestName(baseDir, path)
 		waitValidateFunc := waitValidatePipelineRunDone
 		kind := "pipelinerun"

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -96,6 +96,7 @@ func TestGitPipelineRun(t *testing.T) {
 		repo:     "https://github.com/spring-projects/spring-petclinic",
 		revision: "main",
 	}} {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -182,6 +183,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 		name:       "invalid httpsproxy",
 		httpsproxy: "invalid.https.proxy.example.com",
 	}} {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -207,9 +207,9 @@ func TestPipelineRun(t *testing.T) {
 	}}
 
 	for i, td := range tds {
+		i := i   // capture range variable
+		td := td // capture range variable
 		t.Run(td.name, func(t *testing.T) {
-			td := td
-
 			t.Parallel()
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)

--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -41,6 +41,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 	// on failure, to ensure that cancelling the PipelineRun doesn't cause
 	// the retrying TaskRun to retry.
 	for _, numRetries := range []int{0, 1} {
+		numRetries := numRetries // capture range variable
 		t.Run(fmt.Sprintf("retries=%d", numRetries), func(t *testing.T) {
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)

--- a/test/v1alpha1/git_checkout_test.go
+++ b/test/v1alpha1/git_checkout_test.go
@@ -94,6 +94,7 @@ func TestGitPipelineRun(t *testing.T) {
 		repo:     "https://github.com/spring-projects/spring-petclinic",
 		revision: "main",
 	}} {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -180,6 +181,7 @@ func TestGitPipelineRunFail(t *testing.T) {
 		name:       "invalid httpsproxy",
 		httpsproxy: "invalid.https.proxy.example.com",
 	}} {
+		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/test/v1alpha1/pipelinerun_test.go
+++ b/test/v1alpha1/pipelinerun_test.go
@@ -145,8 +145,9 @@ func TestPipelineRun(t *testing.T) {
 	}}
 
 	for i, td := range tds {
+		i := i   // capture range variable
+		td := td // capture range variable
 		t.Run(td.name, func(t *testing.T) {
-			td := td
 			t.Parallel()
 			ctx := context.Background()
 			ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Following the CommonMistake[1] in Go, for loop and go routines can be
a big racey problem. This happens quite easily when using `t.Parallel`
in for loop with tests.

This fixes possible races by adding a "shadow" var that is evaluated
at each iteration and placed on the stack for the goroutine, so each
slice element is available to the goroutine when it is eventually
executed.

[1]: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug
/area testing

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
