### PR TITLE
Use PATCH to update ready annotation

### DIFF
--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -263,19 +263,18 @@ func TestUpdateReady(t *testing.T) {
 		desc            string
 		pod             corev1.Pod
 		wantAnnotations map[string]string
+		wantErr         bool
 	}{{
-		desc: "Pod without any annotations has it added",
+		desc: "Pod without any annotations fails",
 		pod: corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "pod",
 				Annotations: nil,
 			},
 		},
-		wantAnnotations: map[string]string{
-			readyAnnotation: readyAnnotationValue,
-		},
+		wantErr: true, // Nothing to replace.
 	}, {
-		desc: "Pod with existing annotations has it appended",
+		desc: "Pod without ready annotation adds it",
 		pod: corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod",
@@ -286,19 +285,36 @@ func TestUpdateReady(t *testing.T) {
 		},
 		wantAnnotations: map[string]string{
 			"something":     "else",
-			readyAnnotation: readyAnnotationValue,
+			readyAnnotation: "READY",
 		},
 	}, {
-		desc: "Pod with other annotation value has it updated",
+		desc: "Pod with empty annotation value has it replaced",
 		pod: corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod",
 				Annotations: map[string]string{
+					"something":     "else",
+					readyAnnotation: "",
+				},
+			},
+		},
+		wantAnnotations: map[string]string{
+			"something":     "else",
+			readyAnnotation: readyAnnotationValue,
+		},
+	}, {
+		desc: "Pod with other annotation value has it replaced",
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod",
+				Annotations: map[string]string{
+					"something":     "else",
 					readyAnnotation: "something else",
 				},
 			},
 		},
 		wantAnnotations: map[string]string{
+			"something":     "else",
 			readyAnnotation: readyAnnotationValue,
 		},
 	}} {
@@ -307,8 +323,8 @@ func TestUpdateReady(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			kubeclient := fakek8s.NewSimpleClientset(&c.pod)
-			if err := UpdateReady(ctx, kubeclient, c.pod); err != nil {
-				t.Errorf("UpdateReady: %v", err)
+			if err := UpdateReady(ctx, kubeclient, c.pod); (err != nil) != c.wantErr {
+				t.Errorf("UpdateReady (wantErr=%t): %v", c.wantErr, err)
 			}
 
 			got, err := kubeclient.CoreV1().Pods(c.pod.Namespace).Get(ctx, c.pod.Name, metav1.GetOptions{})


### PR DESCRIPTION
This should be faster and more reliable than the get-modify-write we use
today.

Closes #3310

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Use a PATCH to update pods to start running.
```