### PR TITLE
Add a document to tell users how to configure Thread, QPS and Burst

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -363,6 +363,10 @@ data:
 
 To customize the behavior of HA for the Tekton Pipelines controller, please refer to the related [documentation](developers/enabling-ha.md).
 
+## Configuring tekton pipeline controller performance
+
+Out-of-the-box, Tekton Pipelines Controller is configured for relatively small-scale deployments but there have several options for configuring Pipelines' performance are available. See the [Performance Configuration](tekton-controller-performance-configuration.md) document which describes how to change the default ThreadsPerController, QPS and Burst settings to meet your requirements.
+
 ## Creating a custom release of Tekton Pipelines
 
 You can create a custom release of Tekton Pipelines by following and customizing the steps in [Creating an official release](https://github.com/tektoncd/pipeline/blob/master/tekton/README.md#create-an-official-release). For example, you might want to customize the container images built and used by Tekton Pipelines.

--- a/docs/tekton-controller-performance-configuration.md
+++ b/docs/tekton-controller-performance-configuration.md
@@ -1,0 +1,46 @@
+# Tekton Controller Performance Configuration
+Configure ThreadsPerController, QPS and Burst
+
+- [Overview](#overview)
+- [Performance Configuration](#performance-configuration)
+  - [Configure Thread, QPS and Burst](#configure-thread-qps-and-burst)
+
+## Overview
+
+---
+This document will show us how to configure [tekton-pipeline-controller](../../config/controller.yaml)'s performance. In general, there are mainly have three parameters will impact the performance of tekton controller, they are `ThreadsPerController`, `QPS` and `Burst`.
+
+- `ThreadsPerController`: Threads (goroutines) to create per controller. It's the number of threads to use when processing the controller's work queue.
+
+- `QPS`: Queries per Second. Maximum QPS to the master from this client.
+
+- `Burst`: Maximum burst for throttle.
+
+## Performance Configuration
+
+---
+#### Configure Thread, QPS and Burst
+
+---
+Default, the value of ThreadsPerController, QPS and Burst is [2](https://github.com/knative/pkg/blob/master/controller/controller.go#L58), [5.0](https://github.com/tektoncd/pipeline/blob/master/vendor/k8s.io/client-go/rest/config.go#L44) and [10](https://github.com/tektoncd/pipeline/blob/master/vendor/k8s.io/client-go/rest/config.go#L45) accordingly.
+
+Sometimes, above default values can't meet performance requirements, then you need to overwrite these values. You can modify them in the [tekton controller deployment](../../config/controller.yaml). You can specify these customized values in the `tekton-pipelines-controller` container via `threads-per-controller`, `kube-api-qps` and `kube-api-burst` flags accordingly. For example:
+
+```yaml
+spec:
+  serviceAccountName: tekton-pipelines-controller
+  containers:
+  - name: tekton-pipelines-controller
+    image: ko://github.com/tektoncd/pipeline/cmd/controller
+    args: [
+      "-kube-api-qps", "50",
+      "-kube-api-burst", "50",
+      "-threads-per-controller", "32",
+      # other flags defined here...
+    ]
+```
+
+Now, the ThreadsPerController, QPS and Burst have been changed to be `32`, `50` and `50`.
+
+**Note**:
+Although in above example, you set QPS and Burst to be `50` and `50`. However, the actual values of them are [multiplied by `2`](https://github.com/pierretasci/pipeline/blob/master/cmd/controller/main.go#L83-L84), so the actual QPS and Burst is `100` and `100`.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Follow up this [PR](https://github.com/tektoncd/pipeline/pull/3156). Especially for this [comment](https://github.com/tektoncd/pipeline/pull/3156#issuecomment-707008682).

This PR add a new document about how to configuring the ThreadPerController, QPS and Burst. The default ThreadPerController, QPS and Burst are `2`, `5.0` and `10` accordingly. Sometimes, users want to modify these default values. So a guidance is necessary. 

Beside, for QPS and Burst, the actual values of them are [multiplied by 2](https://github.com/pierretasci/pipeline/blob/master/cmd/controller/main.go#L83-L84), so the doc is more necessary. Because if a user isn't aware of this, then there will cause some misunderstand.

Fyi, @afrittoli 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
