### PR TITLE
Use dogfooding buildx image for multi-arch builds

### DIFF
--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -16,7 +16,7 @@ spec:
     - name: builtBaseImage
       type: image
   steps:
-  - image: gcr.io/google.com/cloudsdktool/cloud-sdk
+  - image: gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest
     name: build-image
     env:
     # Connect to the sidecar over TCP, with TLS.
@@ -39,13 +39,10 @@ spec:
         # Setup docker-auth
         gcloud auth configure-docker
 
+        ln -s /root/.docker/cli-plugins ~/.docker/cli-plugins
+
         # add qemu bins
         docker run --rm --privileged tonistiigi/binfmt:latest --install all
-
-        #install buildx
-        mkdir -p ~/.docker/cli-plugins
-        curl -fsSL https://github.com/docker/buildx/releases/download/v0.4.2/buildx-v0.4.2.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
-        chmod u+x ~/.docker/cli-plugins/docker-buildx
 
         #create docker context
         docker context create context1


### PR DESCRIPTION
# Changes

Replace default gcloud image with the dogfooding one, where buildx is already installed

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

