### PR TITLE
Use dogfooding skopeo image for e2e and examples tests

### DIFF
--- a/examples/v1alpha1/taskruns/docker-creds.yaml
+++ b/examples/v1alpha1/taskruns/docker-creds.yaml
@@ -37,6 +37,6 @@ spec:
   taskSpec:
     steps:
     - name: test
-      image: quay.io/rhpipeline/skopeo:alpine
+      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
       # Test pulling a private builder container.
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/examples/v1alpha1/taskruns/pull-private-image.yaml
+++ b/examples/v1alpha1/taskruns/pull-private-image.yaml
@@ -46,5 +46,5 @@ spec:
     steps:
     - name: pull
       # Private image is just Ubuntu
-      image: quay.io/rhpipeline/skopeo:alpine
+      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/examples/v1beta1/taskruns/docker-creds.yaml
+++ b/examples/v1beta1/taskruns/docker-creds.yaml
@@ -37,6 +37,6 @@ spec:
   taskSpec:
     steps:
     - name: test
-      image: quay.io/rhpipeline/skopeo:alpine
+      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
       # Test pulling a private builder container.
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/examples/v1beta1/taskruns/pull-private-image.yaml
+++ b/examples/v1beta1/taskruns/pull-private-image.yaml
@@ -46,5 +46,5 @@ spec:
     steps:
     - name: pull
       # Private image is just Ubuntu
-      image: quay.io/rhpipeline/skopeo:alpine
+      image: gcr.io/tekton-releases/dogfooding/skopeo:latest
       script: skopeo copy docker://gcr.io/build-crd-testing/secret-sauce dir:///tmp/

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -108,8 +108,6 @@ func initExcludedTests() sets.String {
 			"TestExamples/v1alpha1/taskruns/build-gcs-targz",
 			"TestExamples/v1beta1/taskruns/build-gcs-targz",
 			"TestExamples/v1alpha1/taskruns/build-push-kaniko",
-			"TestExamples/v1alpha1/taskruns/pull-private-image",
-			"TestExamples/v1beta1/taskruns/pull-private-image",
 			"TestExamples/v1alpha1/pipelineruns/pipelinerun",
 			"TestExamples/v1beta1/pipelineruns/pipelinerun",
 			"TestExamples/v1beta1/taskruns/build-gcs-zip",
@@ -123,8 +121,6 @@ func initExcludedTests() sets.String {
 			//e2e
 			"TestHelmDeployPipelineRun",
 			"TestKanikoTaskRun",
-			"TestPipelineRun/service_account_propagation_and_pipeline_param",
-			"TestPipelineRun/pipelinerun_succeeds_with_LimitRange_minimum_in_namespace",
 		)
 	}
 	return sets.NewString()

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -110,7 +110,7 @@ func TestPipelineRun(t *testing.T) {
 					Steps: []v1beta1.Step{{
 						Container: corev1.Container{
 							Name:    "config-docker",
-							Image:   "quay.io/rhpipeline/skopeo:alpine",
+							Image:   "gcr.io/tekton-releases/dogfooding/skopeo:latest",
 							Command: []string{"skopeo"},
 							Args:    []string{"copy", "$(params.path)", "$(params.dest)"},
 						}},
@@ -186,7 +186,7 @@ func TestPipelineRun(t *testing.T) {
 					Steps: []v1beta1.Step{{
 						Container: corev1.Container{
 							Name:    "config-docker",
-							Image:   "quay.io/rhpipeline/skopeo:alpine",
+							Image:   "gcr.io/tekton-releases/dogfooding/skopeo:latest",
 							Command: []string{"skopeo"},
 							Args:    []string{"copy", "$(params.path)", "$(params.dest)"},
 						}},

--- a/test/v1alpha1/pipelinerun_test.go
+++ b/test/v1alpha1/pipelinerun_test.go
@@ -99,7 +99,7 @@ func TestPipelineRun(t *testing.T) {
 				tb.TaskInputs(tb.InputsParamSpec("path", v1alpha1.ParamTypeString),
 					tb.InputsParamSpec("dest", v1alpha1.ParamTypeString)),
 				// Reference build: https://github.com/knative/build/tree/master/test/docker-basic
-				tb.Step("quay.io/rhpipeline/skopeo:alpine", tb.StepName("config-docker"),
+				tb.Step("gcr.io/tekton-releases/dogfooding/skopeo:latest", tb.StepName("config-docker"),
 					tb.StepCommand("skopeo"),
 					tb.StepArgs("copy", "$(inputs.params.path)", "$(inputs.params.dest)"),
 				),


### PR DESCRIPTION
# Changes

Unify usage of skopeo image in the tests to the dogfooding one.
Also dogfooding skopeo image is multi-arched, so several tests are moved from skipped list for s390x.

/kind misc


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

