### PR TITLE
Implement Pending PipelineRun status (TEP-0015)

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -21,6 +21,7 @@ weight: 4
   - [Configuring a failure timeout](#configuring-a-failure-timeout)
 - [Monitoring execution status](#monitoring-execution-status)
 - [Cancelling a `PipelineRun`](#cancelling-a-pipelinerun)
+- [Pending `PipelineRuns`](#pending-pipelineruns)
 - [Events](events.md#pipelineruns)
 
 
@@ -527,6 +528,26 @@ spec:
   # […]
   status: "PipelineRunCancelled"
 ```
+
+## Pending `PipelineRuns`
+
+A `PipelineRun` can be created as a "pending" `PipelineRun` meaning that it will not actually be started until the pending status is cleared.
+
+Note that a `PipelineRun` can only be marked "pending" before it has started, this setting is invalid after the `PipelineRun` has been started.
+
+To mark a `PipelineRun` as pending, set `.spec.status` to `PipelineRunPending` when creating it:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "PipelineRunPending"
+```
+
+To start the PipelineRun, clear the `.spec.status` field. Alternatively, update the value to `PipelineRunCancelled` to cancel it.
 
 ---
 

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -114,9 +114,14 @@ func PipelineDescription(desc string) PipelineSpecOp {
 	}
 }
 
-// PipelineRunCancelled sets the status to cancel to the TaskRunSpec.
+// PipelineRunCancelled sets the status to cancel the PipelineRunSpec.
 func PipelineRunCancelled(spec *v1beta1.PipelineRunSpec) {
 	spec.Status = v1beta1.PipelineRunSpecStatusCancelled
+}
+
+// PipelineRunPending sets the status to pending to the PipelineRunSpec.
+func PipelineRunPending(spec *v1beta1.PipelineRunSpec) {
+	spec.Status = v1beta1.PipelineRunSpecStatusPending
 }
 
 // PipelineDeclaredResource adds a resource declaration to the Pipeline Spec,

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -108,6 +108,11 @@ func (pr *PipelineRun) GetTimeout(ctx context.Context) time.Duration {
 	return pr.Spec.Timeout.Duration
 }
 
+// IsPending returns true if the PipelineRun's spec status is set to Pending state
+func (pr *PipelineRun) IsPending() bool {
+	return pr.Spec.Status == PipelineRunSpecStatusPending
+}
+
 // GetNamespacedName returns a k8s namespaced name that identifies this PipelineRun
 func (pr *PipelineRun) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}
@@ -202,6 +207,8 @@ const (
 	// PipelineRunSpecStatusCancelled indicates that the user wants to cancel the task,
 	// if not already cancelled or terminated
 	PipelineRunSpecStatusCancelled = "PipelineRunCancelled"
+
+	PipelineRunSpecStatusPending = "PipelineRunPending"
 )
 
 // PipelineRef can be used to refer to a specific instance of a Pipeline.
@@ -243,6 +250,8 @@ const (
 	// This reason may be found with a corev1.ConditionFalse status, if the cancellation was processed successfully
 	// This reason may be found with a corev1.ConditionUnknown status, if the cancellation is being processed or failed
 	PipelineRunReasonCancelled PipelineRunReason = "Cancelled"
+	// PipelineRunReasonPending is the reason set when the PipelineRun is in the pending state
+	PipelineRunReasonPending PipelineRunReason = "PipelineRunPending"
 	// PipelineRunReasonTimedOut is the reason set when the PipelineRun has timed out
 	PipelineRunReasonTimedOut PipelineRunReason = "PipelineRunTimeout"
 	// PipelineRunReasonStopping indicates that no new Tasks will be scheduled by the controller, and the

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -92,7 +92,7 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 					Status: "PipelineRunCancell",
 				},
 			},
-			want: apis.ErrInvalidValue("PipelineRunCancell should be PipelineRunCancelled", "spec.status"),
+			want: apis.ErrInvalidValue("PipelineRunCancell should be PipelineRunCancelled or PipelineRunPending", "spec.status"),
 		}, {
 			name: "use of bundle without the feature flag set",
 			pr: v1beta1.PipelineRun{
@@ -137,6 +137,29 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 			},
 			want: apis.ErrInvalidValue("invalid bundle reference (could not parse reference: not a valid reference)", "spec.pipelineref.bundle"),
 			wc:   enableTektonOCIBundles(t),
+		},
+		{
+			name: "pipelinerun pending while running",
+			pr: v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pipelinerunname",
+				},
+				Spec: v1beta1.PipelineRunSpec{
+					Status: v1beta1.PipelineRunSpecStatusPending,
+					PipelineRef: &v1beta1.PipelineRef{
+						Name: "prname",
+					},
+				},
+				Status: v1beta1.PipelineRunStatus{
+					PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{time.Now()},
+					},
+				},
+			},
+			want: &apis.FieldError{
+				Message: "invalid value: PipelineRun cannot be Pending after it is started",
+				Paths:   []string{"spec.status"},
+			},
 		},
 	}
 
@@ -218,6 +241,19 @@ func TestPipelineRun_Validate(t *testing.T) {
 							}},
 						}},
 					}},
+				},
+			},
+		},
+	}, {
+		name: "pipelinerun pending",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinerunname",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				Status: v1beta1.PipelineRunSpecStatusPending,
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "prname",
 				},
 			},
 		},

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1161,6 +1161,43 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 	}
 }
 
+func TestReconcileOnPendingPipelineRun(t *testing.T) {
+	// TestReconcileOnPendingPipelineRun runs "Reconcile" on a PipelineRun that is pending.
+	// It verifies that reconcile is successful, the pipeline status updated and events generated.
+	prs := []*v1beta1.PipelineRun{tb.PipelineRun("test-pipeline-run-pending",
+		tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunSpec("test-pipeline", tb.PipelineRunServiceAccountName("test-sa"),
+			tb.PipelineRunPending,
+		),
+	)}
+	ps := []*v1beta1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
+		tb.PipelineTask("hello-world", "hello-world"),
+	))}
+	ts := []*v1beta1.Task{}
+	trs := []*v1beta1.TaskRun{}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+	}
+	prt := NewPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	wantEvents := []string{}
+	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-pending", wantEvents, false)
+
+	condition := reconciledRun.Status.GetCondition(apis.ConditionSucceeded)
+	if !condition.IsUnknown() || condition.Reason != ReasonPending {
+		t.Errorf("Expected PipelineRun condition to indicate the pending failed but reason was %s", condition.Reason)
+	}
+
+	if reconciledRun.Status.StartTime != nil {
+		t.Errorf("Start time should be nil, not: %s", reconciledRun.Status.StartTime)
+	}
+}
+
 func TestReconcileWithTimeout(t *testing.T) {
 	// TestReconcileWithTimeout runs "Reconcile" on a PipelineRun that has timed out.
 	// It verifies that reconcile is successful, the pipeline status updated and events generated.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implements the Pending PipelineRun status as described in [TEP-0015](https://github.com/tektoncd/community/blob/master/teps/0015-pending-pipeline.md). (based on https://github.com/tektoncd/pipeline/pull/3223)

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Added PipelineRunPending setting to PipelineRun Spec Status to allow creating PipelineRuns in a Pending state.
```