### PR TITLE
Clarify input and output resource usage with PVC

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -33,10 +33,41 @@ the persistent volume can fail.
 ## How are inputs handled
 
 Input resources, like source code (git) or artifacts, are dumped at path
-`/workspace/task_resource_name`. Resource definition in task can have custom
-target directory. If `targetPath` is mentioned in task input then the
-controllers are responsible for adding container definitions to create
-directories and also to fetch the versioned artifacts into that directory.
+`/workspace/task_resource_name`. 
+
+- If input resource is declared as below, then resource will be copied to
+ `/workspace/task_resource_name` directory `from` depended task PVC directory
+ `/pvc/previous_task/resource_name`.
+ 
+  ```yaml
+  kind: Task
+  metadata:
+    name: get-gcs-task
+    namespace: default
+  spec:
+    resources:
+      inputs:
+        - name: gcs-workspace
+          type: storage
+  ```
+
+- Resource definition in task can have custom target directory. 
+If `targetPath` is mentioned in task input resource as below then resource will be 
+copied to `/workspace/outputstuff` directory `from` depended task PVC directory
+ `/pvc/previous_task/resource_name`.
+
+  ```yaml
+  kind: Task
+  metadata:
+    name: get-gcs-task
+    namespace: default
+  spec:
+    resources:
+      inputs:
+        - name: gcs-workspace
+          type: storage
+          targetPath: /workspace/outputstuff
+  ```
 
 ## How are outputs handled
 
@@ -48,7 +79,7 @@ expected in directory path `/workspace/output/resource_name`.
 - If there is PVC volume present (TaskRun holds owner reference to PipelineRun)
   then copy step is added as well.
 
-- If the resource is declared only in output but not in input for task then the
+- If the output resource is declared as below then the
   copy step includes resource being copied to PVC to path
   `/pvc/task_name/resource_name` from `/workspace/output/resource_name` like the
   following example.
@@ -65,10 +96,9 @@ expected in directory path `/workspace/output/resource_name`.
           type: storage
   ```
 
-- If the resource is declared only in output but not in input for task and the
-  resource defined with `TargetPath` then the copy step includes resource being
-  copied to PVC to path `/pvc/task_name/resource_name` from
-  `/workspace/outputstuff` like the following example.
+- Same as input, if the output resource is declared with `TargetPath` then the copy step 
+includes resource being copied to PVC to path `/pvc/task_name/resource_name` 
+from `/workspace/outputstuff` like the following example.
 
   ```yaml
   kind: Task
@@ -81,48 +111,6 @@ expected in directory path `/workspace/output/resource_name`.
         - name: gcs-workspace
           type: storage
           targetPath: /workspace/outputstuff
-  ```
-
-- If the resource is declared both in input and output for task the then copy
-  step includes resource being copied to PVC to path
-  `/pvc/task_name/resource_name` from `/workspace/random-space/` if input
-  resource has custom target directory (`random-space`) declared like the
-  following example.
-
-  ```yaml
-  kind: Task
-  metadata:
-    name: get-gcs-task
-    namespace: default
-  spec:
-    resources:
-      inputs:
-        - name: gcs-workspace
-          type: storage
-          targetPath: random-space
-      outputs:
-        - name: gcs-workspace
-          type: storage
-  ```
-
-- If resource is declared both in input and output for task without custom
-  target directory then copy step includes resource being copied to PVC to
-  path `/pvc/task_name/resource_name` from `/workspace/resource_name/` like
-  the following example.
-
-  ```yaml
-  kind: Task
-  metadata:
-    name: get-gcs-task
-    namespace: default
-  spec:
-    resources:
-      inputs:
-        - name: gcs-workspace
-          type: storage
-      outputs:
-        - name: gcs-workspace
-          type: storage
   ```
 
 ## Entrypoint rewriting and step ordering


### PR DESCRIPTION


# Changes

The description for the copy direction and path between pvc and task container is quite confusing, especially mention a lot about the input resource in the output related section.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
/kind documentation
