### PR TITLE
Refresh list of s390x excluded test

### DIFF
--- a/examples/v1alpha1/pipelineruns/demo-optional-resources.yaml
+++ b/examples/v1alpha1/pipelineruns/demo-optional-resources.yaml
@@ -49,7 +49,7 @@ spec:
         optional: true
   steps:
     - name: build-an-image
-      image: "gcr.io/kaniko-project/executor:latest"
+      image: gcr.io/kaniko-project/executor:v1.3.0
       command:
         - /kaniko/executor
       args:

--- a/examples/v1alpha1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1alpha1/pipelineruns/pipelinerun.yaml
@@ -92,7 +92,7 @@ spec:
       type: image
   steps:
   - name: build-and-push
-    image: gcr.io/kaniko-project/executor:v0.17.1
+    image: gcr.io/kaniko-project/executor:v1.3.0
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     env:
     - name: "DOCKER_CONFIG"

--- a/examples/v1alpha1/taskruns/build-push-kaniko.yaml
+++ b/examples/v1alpha1/taskruns/build-push-kaniko.yaml
@@ -43,7 +43,7 @@ spec:
       type: image
   steps:
   - name: build-and-push
-    image: gcr.io/kaniko-project/executor:v0.17.1
+    image: gcr.io/kaniko-project/executor:v1.3.0
     # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
     env:
     - name: "DOCKER_CONFIG"

--- a/examples/v1beta1/pipelineruns/demo-optional-resources.yaml
+++ b/examples/v1beta1/pipelineruns/demo-optional-resources.yaml
@@ -51,7 +51,7 @@ spec:
         optional: true
   steps:
     - name: build-an-image
-      image: "gcr.io/kaniko-project/executor:latest"
+      image: gcr.io/kaniko-project/executor:v1.3.0
       command:
         - /kaniko/executor
       args:

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -140,7 +140,7 @@ spec:
     default: ""
   - name: BUILDER_IMAGE
     description: The image on which builds will run
-    default: gcr.io/kaniko-project/executor:latest
+    default: gcr.io/kaniko-project/executor:v1.3.0
   results:
   - name: IMAGE_DIGEST
     description: Digest of the image just built.

--- a/examples/v1beta1/taskruns/authenticating-git-commands.yaml
+++ b/examples/v1beta1/taskruns/authenticating-git-commands.yaml
@@ -165,7 +165,7 @@ spec:
         git commit -m "Test commit!"
         git push origin master
     - name: git-clone-and-check
-      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:mario
+      image: gcr.io/tekton-releases/dogfooding/alpine-git-nonroot:latest
       # Because this Step runs with a non-root security context, the creds-init
       # credentials will fail to copy into /tekton/home. This happens because
       # our previous step _already_ wrote to /tekton/home and ran as a root

--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -138,7 +138,7 @@ func getCreateImageTask(namespace, createImageTaskName string) *v1beta1.Task {
 			},
 			Steps: []v1beta1.Step{{Container: corev1.Container{
 				Name:  "kaniko",
-				Image: "gcr.io/kaniko-project/executor:v0.17.1",
+				Image: getTestImage(kanikoImage),
 				Args: []string{
 					"--dockerfile=/workspace/gitsource/test/gohelloworld/Dockerfile",
 					"--context=/workspace/gitsource/",
@@ -167,7 +167,7 @@ func getHelmDeployTask(namespace, helmDeployTaskName string) *v1beta1.Task {
 				Name: "chartname", Type: v1beta1.ParamTypeString, Default: &empty,
 			}},
 			Steps: []v1beta1.Step{{Container: corev1.Container{
-				Image: "alpine/helm:3.1.2",
+				Image: getTestImage(helmImage),
 				Args: []string{
 					"upgrade",
 					"--wait",
@@ -328,7 +328,7 @@ func removeAllHelmReleases(ctx context.Context, c *clients, t *testing.T, namesp
 		Spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{Container: corev1.Container{
 				Name:    "helm-remove-all",
-				Image:   "alpine/helm:3.1.2",
+				Image:   getTestImage(helmImage),
 				Command: []string{"/bin/sh"},
 				Args:    []string{"-c", fmt.Sprintf("helm ls --short --all --namespace %s | xargs -n1 helm delete --namespace %s", namespace, namespace)},
 			}}},

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -163,7 +163,7 @@ func getTask(repo, namespace string) *v1beta1.Task {
 			},
 			Steps: []v1beta1.Step{{Container: corev1.Container{
 				Name:  "kaniko",
-				Image: "gcr.io/kaniko-project/executor:v0.17.1",
+				Image: getTestImage(kanikoImage),
 				Args: []string{
 					"--dockerfile=/workspace/gitsource/integration/dockerfiles/Dockerfile_test_label",
 					fmt.Sprintf("--destination=%s", repo),

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -38,6 +38,10 @@ const (
 	registryImage
 	//kubectl image
 	kubectlImage
+	//helm image
+	helmImage
+	//kaniko executor image
+	kanikoImage
 )
 
 func init() {
@@ -61,12 +65,16 @@ func initImageNames() map[int]string {
 			busyboxImage:  "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977",
 			registryImage: "ibmcom/registry:2.6.2.5",
 			kubectlImage:  "ibmcom/kubectl:v1.13.9",
+			helmImage:     "ibmcom/alpine-helm-s390x:latest",
+			kanikoImage:   "gcr.io/kaniko-project/executor:s390x-9ed158c1f63a059cde4fd5f8b95af51d452d9aa7",
 		}
 	}
 	return map[int]string{
 		busyboxImage:  "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
 		registryImage: "registry",
 		kubectlImage:  "lachlanevenson/k8s-kubectl",
+		helmImage:     "alpine/helm:3.1.2",
+		kanikoImage:   "gcr.io/kaniko-project/executor:v1.3.0",
 	}
 }
 
@@ -88,10 +96,15 @@ func getImagesMappingRE() map[*regexp.Regexp][]byte {
 func imageNamesMapping() map[string]string {
 	if getTestArch() == "s390x" {
 		return map[string]string{
-			"registry":                   getTestImage(registryImage),
-			"node":                       "node:alpine3.11",
-			"lachlanevenson/k8s-kubectl": getTestImage(kubectlImage),
-			"gcr.io/cloud-builders/git":  "alpine/git:latest",
+			"registry":                              getTestImage(registryImage),
+			"node":                                  "node:alpine3.11",
+			"lachlanevenson/k8s-kubectl":            getTestImage(kubectlImage),
+			"gcr.io/cloud-builders/git":             "alpine/git:latest",
+			"docker:dind":                           "ibmcom/docker-s390x:dind",
+			"docker":                                "docker:18.06.3",
+			"mikefarah/yq":                          "danielxlee/yq:2.4.0",
+			"stedolan/jq":                           "ibmcom/jq-s390x:latest",
+			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
 		}
 	}
 
@@ -103,24 +116,15 @@ func initExcludedTests() sets.String {
 	if getTestArch() == "s390x" {
 		return sets.NewString(
 			//examples
-			"TestExamples/v1alpha1/taskruns/dind-sidecar",
-			"TestExamples/v1beta1/taskruns/dind-sidecar",
 			"TestExamples/v1alpha1/taskruns/build-gcs-targz",
 			"TestExamples/v1beta1/taskruns/build-gcs-targz",
-			"TestExamples/v1alpha1/taskruns/build-push-kaniko",
-			"TestExamples/v1alpha1/pipelineruns/pipelinerun",
-			"TestExamples/v1beta1/pipelineruns/pipelinerun",
 			"TestExamples/v1beta1/taskruns/build-gcs-zip",
 			"TestExamples/v1alpha1/taskruns/build-gcs-zip",
-			"TestExamples/v1beta1/taskruns/docker-creds",
-			"TestExamples/v1alpha1/taskruns/docker-creds",
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
-			"TestExamples/v1beta1/taskruns/authenticating-git-commands",
-			"TestExamples/v1beta1/taskruns/workspace-in-sidecar",
+			"TestExamples/v1beta1/pipelineruns/pipelinerun",
 			//e2e
 			"TestHelmDeployPipelineRun",
-			"TestKanikoTaskRun",
 		)
 	}
 	return sets.NewString()

--- a/test/v1alpha1/kaniko_task_test.go
+++ b/test/v1alpha1/kaniko_task_test.go
@@ -161,7 +161,7 @@ func getTask(repo, namespace string) *v1alpha1.Task {
 		),
 		tb.StepSecurityContext(&corev1.SecurityContext{RunAsUser: &root}),
 	}
-	step := tb.Step("gcr.io/kaniko-project/executor:v0.17.1", stepOps...)
+	step := tb.Step("gcr.io/kaniko-project/executor:v1.3.0", stepOps...)
 	taskSpecOps = append(taskSpecOps, step)
 	sidecar := tb.Sidecar("registry", "registry")
 	taskSpecOps = append(taskSpecOps, sidecar)


### PR DESCRIPTION
# Changes
The list of s390x excluded tests is reduced with:
- unify amd64 kaniko image name and use available one for s390x
- use latest alpine-git-nonroot dogfooding image (multi-arch)
- add several specific images to use for tests on s390x architecture

/kind misc


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
NONE
```
