### PR TITLE
Change the webhook name to pipeline-webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -232,7 +232,10 @@ func main() {
 		log.Fatal(http.ListenAndServe(":"+port, mux))
 	}()
 
-	sharedmain.WebhookMainWithConfig(ctx, "webhook",
+	// NOTE(afrittoli) - we should have the name "webhook-pipeline"
+	// configurable. Once the change is done on knative/pkg side
+	// knative/eventing#4530 we can inherit it from it
+	sharedmain.WebhookMainWithConfig(ctx, "webhook-pipeline",
 		sharedmain.ParseAndGetConfigOrDie(),
 		certificates.NewController,
 		newDefaultingAdmissionController,


### PR DESCRIPTION
# Changes

The "webhook" name is too generic and it creates conflicts on leases
when other services (like triggers) that use leader election run in
same namespace but with different configuration.

Fixes #3529

Co-authored-by: Matt Moore <mattmoor@vmware.com>

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fix an issue that caused the webhook, under certain conditions,  to fail to acquire a lease and not function correctly as a result. 
```
