### PR TITLE
Move the High Availability doc out of the developers subdirectory

### DIFF
--- a/docs/enabling-ha.md
+++ b/docs/enabling-ha.md
@@ -1,4 +1,4 @@
-# HA support for Tekton Pipeline controllers
+# HA Support for Tekton Pipeline Controllers
 
 - [Overview](#overview)
 - [Configuring HA](#configuring-ha)
@@ -11,7 +11,7 @@
 ## Overview
 
 ---
-This document is aimed at helping maintainers/developers when configuring High Availability(HA) support for the Tekton Pipeline [controller deployment](../../config/controller.yaml).
+This document is aimed at helping Cluster Admins when configuring High Availability(HA) support for the Tekton Pipeline [controller deployment](../../config/controller.yaml).
 
 HA support allows components to remain operational when a disruption occurs. This is achieved by following an active/active model, where all replicas of the Tekton controller can receive workload. In this HA approach the reconcile space is distributed across buckets, where each replica owns a subset of those buckets and can process the load if the given replica is the leader of that bucket.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,6 +7,8 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 * [Installing Tekton Pipelines on OpenShift](#installing-tekton-pipelines-on-openshift)
 * [Configuring PipelineResource storage](#configuring-pipelineresource-storage)
 * [Customizing basic execution parameters](#customizing-basic-execution-parameters)
+* [Configuring High Availability](#configuring-high-availability)
+* [Configuring tekton pipeline controller performance](#configuring-tekton-pipeline-controller-performance)
 * [Creating a custom release of Tekton Pipelines](#creating-a-custom-release-of-tekton-pipelines)
 * [Next steps](#next-steps)
 
@@ -359,9 +361,18 @@ data:
   disable-working-directory-overwrite: "true" # Tekton will not override the working directory for individual Steps.
 ```
 
-### Customizing High Availability for the Pipelines Controller
+## Configuring High Availability
 
-To customize the behavior of HA for the Tekton Pipelines controller, please refer to the related [documentation](developers/enabling-ha.md).
+If you want to run Tekton Pipelines in a way so that webhooks are resiliant against failures and support
+high concurrency scenarios, you need to run a [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in
+your Kubernetes cluster. This is required by the [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+to compute replica count. 
+
+See [HA Support for Tekton Pipeline Controllers](./enabling-ha.md) for instructions on configuring
+High Availability in the Tekton Pipelines Controller.
+
+The default configuration is defined in [webhook-hpa.yaml](./../config/webhook-hpa.yaml) which can be customized
+to better fit specific usecases.
 
 ## Configuring tekton pipeline controller performance
 
@@ -370,12 +381,6 @@ Out-of-the-box, Tekton Pipelines Controller is configured for relatively small-s
 ## Creating a custom release of Tekton Pipelines
 
 You can create a custom release of Tekton Pipelines by following and customizing the steps in [Creating an official release](https://github.com/tektoncd/pipeline/blob/master/tekton/README.md#create-an-official-release). For example, you might want to customize the container images built and used by Tekton Pipelines.
-
-## Configuring High Availability
-
-If you want to run Tekton Pipelines in a way so that webhooks are resiliant against failures and support high concurrency scenarios, you need to run a [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in your Kubernetes cluster. This is required by the [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) to compute the replica count. 
-
-**Note:** The default configuration is defined in [webhook-hpa.yaml](./../config/webhook-hpa.yaml) which could be customized to better fit a  specific usecase.
 
 ## Next steps
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Our docs/developers subdirectory is intended for documentation for maintainers and
developers of the Tekotn Pipelines project. The HA doc that was added previously
has a wider audience than this - it's intended for cluster administrators managing
a Tekton Pipelines deployment.

This commit moves the ha doc out of the docs/developers subdirectory and puts it
in the docs directory. Links are updated to in the install doc and text is
reformatted to consolidate the multiple HA configuration sections we have in that
doc.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
