### PR TITLE
fix cycle detection logic in dag

### DIFF
--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dag_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -479,7 +480,7 @@ func TestBuild_ConditionsParamsFromTaskResults(t *testing.T) {
 	assertSameDAG(t, expectedDAG, g)
 }
 
-func TestBuild_Invalid(t *testing.T) {
+func TestBuild_InvalidDAG(t *testing.T) {
 	a := v1beta1.PipelineTask{Name: "a"}
 	xDependsOnA := v1beta1.PipelineTask{
 		Name: "x",
@@ -539,37 +540,114 @@ func TestBuild_Invalid(t *testing.T) {
 			Resources:    []v1beta1.PipelineTaskInputResource{{From: []string{"none"}}},
 		}},
 	}
+	aRunsAfterE := v1beta1.PipelineTask{Name: "a", RunAfter: []string{"e"}}
+	bDependsOnA := v1beta1.PipelineTask{
+		Name: "b",
+		Resources: &v1beta1.PipelineTaskResources{
+			Inputs: []v1beta1.PipelineTaskInputResource{{From: []string{"a"}}},
+		},
+	}
+	cRunsAfterA := v1beta1.PipelineTask{
+		Name:     "c",
+		RunAfter: []string{"a"},
+	}
+	dDependsOnBAndC := v1beta1.PipelineTask{
+		Name: "d",
+		Resources: &v1beta1.PipelineTaskResources{
+			Inputs: []v1beta1.PipelineTaskInputResource{{From: []string{"b", "c"}}},
+		},
+	}
+	eRunsAfterD := v1beta1.PipelineTask{
+		Name:     "e",
+		RunAfter: []string{"d"},
+	}
+	fRunsAfterD := v1beta1.PipelineTask{
+		Name:     "f",
+		RunAfter: []string{"d"},
+	}
+	gDependsOnF := v1beta1.PipelineTask{
+		Name: "g",
+		Resources: &v1beta1.PipelineTaskResources{
+			Inputs: []v1beta1.PipelineTaskInputResource{{From: []string{"f"}}},
+		},
+	}
 
 	tcs := []struct {
 		name string
 		spec v1beta1.PipelineSpec
+		err  string
 	}{{
+		// a
+		// |
+		// a ("a" depends on resource from "a")
 		name: "self-link-from",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{selfLinkFrom}},
+		err:  "cycle detected",
 	}, {
+		// a
+		// |
+		// a ("a" runAfter "a")
 		name: "self-link-after",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{selfLinkAfter}},
+		err:  "cycle detected",
 	}, {
+		// a (also "a" depends on resource from "z")
+		// |
+		// x ("x" depends on resource from "a")
+		// |
+		// z ("z" depends on resource from "x")
 		name: "cycle-from",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{xDependsOnA, zDependsOnX, aDependsOnZ}},
+		err:  "cycle detected",
 	}, {
+		// a (also "a" runAfter "z")
+		// |
+		// x ("x" runAfter "a")
+		// |
+		// z ("z" runAfter "x")
 		name: "cycle-runAfter",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{xAfterA, zAfterX, aAfterZ}},
+		err:  "cycle detected",
 	}, {
+		// a (also "a" depends on resource from "z")
+		// |
+		// x ("x" depends on resource from "a")
+		// |
+		// z ("z" runAfter "x")
 		name: "cycle-both",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{xDependsOnA, zAfterX, aDependsOnZ}},
+		err:  "cycle detected",
+	}, {
+		// This test make sure we detect a cyclic branch in a DAG with multiple branches.
+		// The following DAG is having a cyclic branch with an additional dependency (a runAfter e)
+		//   a
+		//  / \
+		// b   c
+		//  \ /
+		//   d
+		//  / \
+		// e   f
+		//     |
+		//     g
+		name: "multiple-branches-with-one-cyclic-branch",
+		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{aRunsAfterE, bDependsOnA, cRunsAfterA, dDependsOnBAndC, eRunsAfterD, fRunsAfterD, gDependsOnF}},
+		err:  "cycle detected",
 	}, {
 		name: "duplicate-tasks",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{a, a}},
+		err:  "duplicate pipeline task",
 	}, {
 		name: "invalid-task-name-from",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{invalidTaskFrom}},
+		err:  "wasn't present in Pipeline",
 	}, {
 		name: "invalid-task-name-after",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{invalidTaskAfter}},
+		err:  "wasn't present in Pipeline",
 	}, {
 		name: "invalid-task-name-from-conditional",
 		spec: v1beta1.PipelineSpec{Tasks: []v1beta1.PipelineTask{invalidConditionalTask}},
+		err:  "wasn't present in Pipeline",
 	},
 	}
 	for _, tc := range tcs {
@@ -578,7 +656,8 @@ func TestBuild_Invalid(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: tc.name},
 				Spec:       tc.spec,
 			}
-			if _, err := dag.Build(v1beta1.PipelineTaskList(p.Spec.Tasks)); err == nil {
+			_, err := dag.Build(v1beta1.PipelineTaskList(p.Spec.Tasks))
+			if err == nil || !strings.Contains(err.Error(), tc.err) {
 				t.Errorf("expected to see an error for invalid DAG in pipeline %v but had none", tc.spec)
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`visited` map holds name of the nodes being visited as keys and `true` as value. This map is being updated with `currentName.HashKey` on every iteration which results in keys such as `a.d`, `b.d` where a, b, and d are nodes of a `dag`. But such keys are not utilized anywhere in the same `visit` function. `Visit` function checks existence of the node just
by the name without any string concatenation.

This extra addition in the map is causing severe delay for a graph with more than 60 nodes with distinct dependencies.

`visit` function is called on line 131 with all the parents of the existing `pipelineTask` to check if any of the parents exist in the `visited` map. `visit` function is then recursively called to check each parent's parent to see if any of them exist in the `visited` map, so on and so forth to detect a cycle.  

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
