### PR TITLE
Add e2e-kind.sh

### DIFF
--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a cop y of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script calls out to scripts in tektoncd/plumbing to setup a cluster
+# and deploy Tekton Pipelines to it for running integration tests.
+
+source $(git rev-parse --show-toplevel)/test/e2e-common.sh
+
+# Script entry point.
+
+initialize $@ --cloud-provider kind
+
+header "Setting up environment"
+
+install_pipeline_crd
+
+failed=0
+
+# Run the integration tests
+header "Running Go e2e tests"
+go_test_e2e -timeout=40m ./test/... -run="TestTaskRunPipelineRunCancel|TestDAGPipelineRun" || failed=1
+
+# Run these _after_ the integration tests b/c they don't quite work all the way
+# and they cause a lot of noise in the logs, making it harder to debug integration
+# test failures.
+go_test_e2e -tags=examples -timeout=40m ./test/ || failed=1
+
+(( failed )) && fail_test
+success

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -31,7 +31,7 @@ failed=0
 
 # Run the integration tests
 header "Running Go e2e tests"
-go_test_e2e -timeout=40m ./test/... -run="TestTaskRunPipelineRunCancel|TestDAGPipelineRun" || failed=1
+go_test_e2e -timeout=40m ./test/... || failed=1
 (( failed )) && fail_test
 
 # Run these _after_ the integration tests b/c they don't quite work all the way

--- a/test/e2e-kind.sh
+++ b/test/e2e-kind.sh
@@ -32,11 +32,12 @@ failed=0
 # Run the integration tests
 header "Running Go e2e tests"
 go_test_e2e -timeout=40m ./test/... -run="TestTaskRunPipelineRunCancel|TestDAGPipelineRun" || failed=1
+(( failed )) && fail_test
 
 # Run these _after_ the integration tests b/c they don't quite work all the way
 # and they cause a lot of noise in the logs, making it harder to debug integration
 # test failures.
 go_test_e2e -tags=examples -timeout=40m ./test/ || failed=1
-
 (( failed )) && fail_test
+
 success


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR adds a script which runs e2e tests locally by using kind. Depends on plumbing PR https://github.com/tektoncd/plumbing/pull/639.

/kind feature

-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Add a script which runs e2e tests locally by using kind
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
