### PR TITLE
Initialize load testing

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -1,4 +1,4 @@
-// +build conformance e2e examples
+// +build conformance e2e examples load
 
 /*
 Copyright 2019 The Tekton Authors

--- a/test/load-test.sh
+++ b/test/load-test.sh
@@ -45,7 +45,7 @@ function success() {
   exit 0
 }
 
-TIMEOUT="5m"
+TIMEOUT="10m"
 TASKRUN_NUM=50
 
 while [[ $# -ne 0 ]]; do

--- a/test/load-test.sh
+++ b/test/load-test.sh
@@ -63,7 +63,7 @@ done
 # Script entry point.
 header "Running load tests"
 
-report_go_test -tags load -timeout ${TIMEOUT} -taskrun-num ${TASKRUN_NUM} ./test/... || failed=1
+report_go_test -tags load -timeout ${TIMEOUT} ./test/ -taskrun-num ${TASKRUN_NUM}  || failed=1
 
 (( failed )) && fail_test
 success

--- a/test/load-test.sh
+++ b/test/load-test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script calls out to scripts in tektoncd/plumbing to setup a cluster
+# and deploy Tekton Pipelines to it for running integration tests.
+
+source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+
+function fail_test() {
+  echo "***************************************"
+  echo "***        LOAD TESTS FAILED        ***"
+  echo "***    Start of information dump    ***"
+  echo "***************************************"
+  echo ">>> All resources:"
+  kubectl get all --all-namespaces
+  echo ">>> Services:"
+  kubectl get services --all-namespaces
+  echo ">>> Events:"
+  kubectl get events --all-namespaces
+  function_exists dump_extra_cluster_state && dump_extra_cluster_state
+  echo "***************************************"
+  echo "***        LOAD TESTS FAILED        ***"
+  echo "***     End of information dump     ***"
+  echo "***************************************"
+  exit 1
+}
+
+function success() {
+  echo "**************************************"
+  echo "***       LOAD TESTS PASSED        ***"
+  echo "**************************************"
+  exit 0
+}
+
+TIMEOUT="5m"
+TASKRUN_NUM=50
+
+while [[ $# -ne 0 ]]; do
+  parameter=$1
+  [[ $# -ge 2 ]] || abort "missing parameter after $1"
+  shift
+  case ${parameter} in
+    --timeout) TIMEOUT=$1 ;;
+    --taskrun-num) TASKRUN_NUM=$1 ;;
+    *) abort "unknown option ${parameter}" ;;
+  esac
+  shift
+done
+
+# Script entry point.
+header "Running load tests"
+
+report_go_test -tags load -timeout ${TIMEOUT} -taskrun-num ${TASKRUN_NUM} ./test/... || failed=1
+
+(( failed )) && fail_test
+success


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR initializes load testing. It starts multiple taskruns and sees if they could
complete in defined time.

It also provides a script to run load testing. Users can use flag `--taskrun-num`
and `--timeout` to specify the amount of taskruns they want to run and the time
in which taskruns should complete.

To run the load testing:

`./test/load-test.sh --taskrun-num 50 --timeout 10m`

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Initialize load testing
```
