### PR TITLE
Plumb the "TEKTON_RESOURCE_NAME" env var into the cluster and PR reso…

### DIFF
--- a/pkg/apis/resource/v1alpha1/cluster/cluster_resource.go
+++ b/pkg/apis/resource/v1alpha1/cluster/cluster_resource.go
@@ -166,7 +166,12 @@ func (s *Resource) GetOutputTaskModifier(_ *v1beta1.TaskSpec, _ string) (v1beta1
 
 // GetInputTaskModifier returns the TaskModifier to be used when this resource is an input.
 func (s *Resource) GetInputTaskModifier(ts *v1beta1.TaskSpec, path string) (v1beta1.TaskModifier, error) {
-	var envVars []corev1.EnvVar
+	envVars := []corev1.EnvVar{
+		{
+			Name:  "TEKTON_RESOURCE_NAME",
+			Value: s.Name,
+		},
+	}
 	for _, sec := range s.Secrets {
 		ev := corev1.EnvVar{
 			Name: strings.ToUpper(sec.FieldName),

--- a/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/cluster/cluster_resource_test.go
@@ -180,17 +180,22 @@ func TestClusterResource_GetInputTaskModifier(t *testing.T) {
 				Image:   "override-with-kubeconfig-writer:latest",
 				Command: []string{"/ko-app/kubeconfigwriter"},
 				Args:    []string{"-clusterConfig", `{"name":"test-cluster-resource","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","token":"","Insecure":false,"cadata":null,"clientKeyData":null,"clientCertificateData":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`},
-				Env: []corev1.EnvVar{{
-					Name: "CADATA",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "secret1",
-							},
-							Key: "cadatakey",
-						},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "TEKTON_RESOURCE_NAME",
+						Value: "test-cluster-resource",
 					},
-				}},
+					{
+						Name: "CADATA",
+						ValueFrom: &corev1.EnvVarSource{
+							SecretKeyRef: &corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "secret1",
+								},
+								Key: "cadatakey",
+							},
+						},
+					}},
 			},
 		},
 	}

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource.go
@@ -144,7 +144,12 @@ func (s *Resource) getSteps(mode string, sourcePath string) []pipelinev1beta1.St
 		args = append(args, "-disable-strict-json-comments=true")
 	}
 
-	evs := []corev1.EnvVar{}
+	evs := []corev1.EnvVar{
+		{
+			Name:  "TEKTON_RESOURCE_NAME",
+			Value: s.Name,
+		},
+	}
 	for _, sec := range s.Secrets {
 		if strings.EqualFold(sec.FieldName, authTokenField) {
 			ev := corev1.EnvVar{

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
@@ -87,7 +87,7 @@ func containerTestCases(mode string) []testcase {
 			WorkingDir: pipeline.WorkspaceDir,
 			Command:    []string{"/ko-app/pullrequest-init"},
 			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode},
-			Env:        []corev1.EnvVar{},
+			Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "nocreds"}},
 		}}},
 	}, {
 		in: &pullrequest.Resource{
@@ -108,17 +108,19 @@ func containerTestCases(mode string) []testcase {
 			WorkingDir: pipeline.WorkspaceDir,
 			Command:    []string{"/ko-app/pullrequest-init"},
 			Args:       []string{"-url", "https://example.com", "-path", "/workspace", "-mode", mode, "-provider", "github"},
-			Env: []corev1.EnvVar{{
-				Name: "AUTH_TOKEN",
-				ValueFrom: &corev1.EnvVarSource{
-					SecretKeyRef: &corev1.SecretKeySelector{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "github-creds",
+			Env: []corev1.EnvVar{
+				{Name: "TEKTON_RESOURCE_NAME", Value: "creds"},
+				{
+					Name: "AUTH_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "github-creds",
+							},
+							Key: "token",
 						},
-						Key: "token",
 					},
-				},
-			}},
+				}},
 		}}},
 	}, {
 		in: &pullrequest.Resource{
@@ -133,7 +135,7 @@ func containerTestCases(mode string) []testcase {
 			WorkingDir: pipeline.WorkspaceDir,
 			Command:    []string{"/ko-app/pullrequest-init"},
 			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode, "-insecure-skip-tls-verify=true"},
-			Env:        []corev1.EnvVar{},
+			Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "nocreds"}},
 		}}},
 	}, {
 		in: &pullrequest.Resource{
@@ -148,7 +150,7 @@ func containerTestCases(mode string) []testcase {
 			WorkingDir: pipeline.WorkspaceDir,
 			Command:    []string{"/ko-app/pullrequest-init"},
 			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode, "-disable-strict-json-comments=true"},
-			Env:        []corev1.EnvVar{},
+			Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "strict-json-comments"}},
 		}}},
 	}}
 }

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -848,6 +848,9 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 						Args: []string{
 							"-clusterConfig", `{"name":"cluster3","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"namespace1","token":"","Insecure":false,"cadata":"bXktY2EtY2VydAo=","clientKeyData":"Y2xpZW50LWtleS1kYXRh","clientCertificateData":"Y2xpZW50LWNlcnRpZmljYXRlLWRhdGE=","secrets":null}`,
 						},
+						Env: []corev1.EnvVar{
+							{Name: "TEKTON_RESOURCE_NAME", Value: "cluster3"},
+						},
 					},
 				},
 			},
@@ -900,17 +903,19 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 						Args: []string{
 							"-clusterConfig", `{"name":"cluster2","type":"cluster","url":"http://10.10.10.10","revision":"","username":"","password":"","namespace":"","token":"","Insecure":false,"cadata":null,"clientKeyData":null,"clientCertificateData":null,"secrets":[{"fieldName":"cadata","secretKey":"cadatakey","secretName":"secret1"}]}`,
 						},
-						Env: []corev1.EnvVar{{
-							ValueFrom: &corev1.EnvVarSource{
-								SecretKeyRef: &corev1.SecretKeySelector{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "secret1",
+						Env: []corev1.EnvVar{
+							{Name: "TEKTON_RESOURCE_NAME", Value: "cluster2"},
+							{
+								ValueFrom: &corev1.EnvVarSource{
+									SecretKeyRef: &corev1.SecretKeySelector{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: "secret1",
+										},
+										Key: "cadatakey",
 									},
-									Key: "cadatakey",
 								},
-							},
-							Name: "CADATA",
-						}},
+								Name: "CADATA",
+							}},
 					},
 				},
 			},


### PR DESCRIPTION
…urces.

# Changes

As part of TEP-0025 (hermetic builds), we need to know which containers/steps are part
of the "Tekton system" and which ones are part of the Task definition. This PR adds
the TEKTON_RESOURCE_NAME environment variable to the injected copy containers.

This variable is already used by several of the existing resources (git, image).

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
The TEKTON_RESOURCE_NAME environment variable is now set on the injected PR and cluster resource containers.
```
