### PR TITLE
set task as failed 

### DIFF
--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -272,7 +272,7 @@ func extractStartedAtTimeFromResults(results []v1beta1.PipelineResourceResult) (
 func updateCompletedTaskRunStatus(logger *zap.SugaredLogger, trs *v1beta1.TaskRunStatus, pod *corev1.Pod) {
 	if DidTaskRunFail(pod) {
 		msg := getFailureMessage(logger, pod)
-		MarkStatusFailure(trs, msg)
+		MarkStatusFailure(trs, v1beta1.TaskRunReasonFailed.String(), msg)
 	} else {
 		MarkStatusSuccess(trs)
 	}
@@ -286,19 +286,14 @@ func updateIncompleteTaskRunStatus(trs *v1beta1.TaskRunStatus, pod *corev1.Pod) 
 	case corev1.PodRunning:
 		MarkStatusRunning(trs, v1beta1.TaskRunReasonRunning.String(), "Not all Steps in the Task have finished executing")
 	case corev1.PodPending:
-		var reason, msg string
 		switch {
 		case IsPodExceedingNodeResources(pod):
-			reason = ReasonExceededNodeResources
-			msg = "TaskRun Pod exceeded available resources"
+			MarkStatusRunning(trs, ReasonExceededNodeResources, "TaskRun Pod exceeded available resources")
 		case IsPodHitConfigError(pod):
-			reason = ReasonCreateContainerConfigError
-			msg = getWaitingMessage(pod)
+			MarkStatusFailure(trs, ReasonCreateContainerConfigError, "Failed to create pod due to config error")
 		default:
-			reason = ReasonPending
-			msg = getWaitingMessage(pod)
+			MarkStatusRunning(trs, ReasonPending, getWaitingMessage(pod))
 		}
-		MarkStatusRunning(trs, reason, msg)
 	}
 }
 
@@ -383,7 +378,7 @@ func IsPodExceedingNodeResources(pod *corev1.Pod) bool {
 // IsPodHitConfigError returns true if the Pod's status undicates there are config error raised
 func IsPodHitConfigError(pod *corev1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "CreateContainerConfigError" {
+		if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == ReasonCreateContainerConfigError {
 			return true
 		}
 	}
@@ -427,12 +422,12 @@ func MarkStatusRunning(trs *v1beta1.TaskRunStatus, reason, message string) {
 	})
 }
 
-// MarkStatusFailure sets taskrun status to failure
-func MarkStatusFailure(trs *v1beta1.TaskRunStatus, message string) {
+// MarkStatusFailure sets taskrun status to failure with specified reason
+func MarkStatusFailure(trs *v1beta1.TaskRunStatus, reason string, message string) {
 	trs.SetCondition(&apis.Condition{
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionFalse,
-		Reason:  v1beta1.TaskRunReasonFailed.String(),
+		Reason:  reason,
 		Message: message,
 	})
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Set task as failed when the pod encounters `CreateContainerConfigError`. TaskRun status is now set to `false` instead of `unknown` with the same reason `CreateContainerConfigError`.

Before this change, `taskRun` status had the same reason `CreateContainerConfigError` but status was set to `unknown` which means task is still running in turn pipeline is still running until it hits the timeout.

PR #1907 tried to fix this issue which was also reported in issue #1902. 

Fixes #3412 

/cc @vdemeester @vincent-pli @afrittoli @chmouel 

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
Declare task failure when it hits `CreateContainerConfigError` instead of setting it to unknown i.e. running.
```
