### PR TITLE
Do not set the gitconfig option globally

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -98,13 +98,13 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 		return fmt.Errorf("error checking for known_hosts file: %w", err)
 	}
 	if !hasKnownHosts {
-		if _, err := run(logger, "", "config", "--global", "core.sshCommand", sshMissingKnownHostsSSHCommand); err != nil {
+		if _, err := run(logger, "", "config", "core.sshCommand", sshMissingKnownHostsSSHCommand); err != nil {
 			err = fmt.Errorf("error disabling strict host key checking: %w", err)
 			logger.Warnf(err.Error())
 			return err
 		}
 	}
-	if _, err := run(logger, "", "config", "--global", "http.sslVerify", strconv.FormatBool(spec.SSLVerify)); err != nil {
+	if _, err := run(logger, "", "config", "http.sslVerify", strconv.FormatBool(spec.SSLVerify)); err != nil {
 		logger.Warnf("Failed to set http.sslVerify in git config: %s", err)
 		return err
 	}


### PR DESCRIPTION
# Changes

When we are in the git-init binary we are launching the `git config` commands
with the option `--global`.

When a developer run the tests with the newly added tests for git-init it would
modify the developer .gitconfig which can be pretty bad. (i.e: it would add
`http.sslverify=False` to the developer gitconfig file)

We do not need to modify the gitconfig globally even if we are outside the context of runnin the tests, we can use the `.git/config` from the repository.

Let's remove this switch then.

/kind misc

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->



<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```