### PR TITLE
pkg/apis: refactor GetTaskRunSpecs function

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -425,20 +425,23 @@ type PipelineTaskRunSpec struct {
 	TaskPodTemplate        *PodTemplate `json:"taskPodTemplate,omitempty"`
 }
 
-// GetTaskRunSpecs returns the task specific spec for a given
+// GetTaskRunSpec returns the task specific spec for a given
 // PipelineTask if configured, otherwise it returns the PipelineRun's default.
-func (pr *PipelineRun) GetTaskRunSpecs(pipelineTaskName string) (string, *PodTemplate) {
-	serviceAccountName := pr.GetServiceAccountName(pipelineTaskName)
-	taskPodTemplate := pr.Spec.PodTemplate
+func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSpec {
+	s := PipelineTaskRunSpec{
+		PipelineTaskName:       pipelineTaskName,
+		TaskServiceAccountName: pr.GetServiceAccountName(pipelineTaskName),
+		TaskPodTemplate:        pr.Spec.PodTemplate,
+	}
 	for _, task := range pr.Spec.TaskRunSpecs {
 		if task.PipelineTaskName == pipelineTaskName {
 			if task.TaskPodTemplate != nil {
-				taskPodTemplate = task.TaskPodTemplate
+				s.TaskPodTemplate = task.TaskPodTemplate
 			}
 			if task.TaskServiceAccountName != "" {
-				serviceAccountName = task.TaskServiceAccountName
+				s.TaskServiceAccountName = task.TaskServiceAccountName
 			}
 		}
 	}
-	return serviceAccountName, taskPodTemplate
+	return s
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -385,9 +385,9 @@ func TestPipelineRunGetPodSpecSABackcompatibility(t *testing.T) {
 	} {
 		for taskName, expected := range tt.expectedSAs {
 			t.Run(tt.name, func(t *testing.T) {
-				sa, _ := tt.pr.GetTaskRunSpecs(taskName)
-				if expected != sa {
-					t.Errorf("wrong service account: got: %v, want: %v", sa, expected)
+				s := tt.pr.GetTaskRunSpec(taskName)
+				if expected != s.TaskServiceAccountName {
+					t.Errorf("wrong service account: got: %v, want: %v", s.TaskServiceAccountName, expected)
 				}
 			})
 		}
@@ -428,12 +428,12 @@ func TestPipelineRunGetPodSpec(t *testing.T) {
 	} {
 		for taskName, values := range tt.expectedPodTemplates {
 			t.Run(tt.name, func(t *testing.T) {
-				sa, taskPodTemplate := tt.pr.GetTaskRunSpecs(taskName)
-				if values[0] != taskPodTemplate.SchedulerName {
-					t.Errorf("wrong task podtemplate scheduler name: got: %v, want: %v", taskPodTemplate.SchedulerName, values[0])
+				s := tt.pr.GetTaskRunSpec(taskName)
+				if values[0] != s.TaskPodTemplate.SchedulerName {
+					t.Errorf("wrong task podtemplate scheduler name: got: %v, want: %v", s.TaskPodTemplate.SchedulerName, values[0])
 				}
-				if values[1] != sa {
-					t.Errorf("wrong service account: got: %v, want: %v", sa, values[1])
+				if values[1] != s.TaskServiceAccountName {
+					t.Errorf("wrong service account: got: %v, want: %v", s.TaskServiceAccountName, values[1])
 				}
 			})
 		}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Make it return an actual `PipelineTaskRunSpec` object, instead of
  multiple returns.
- Rename it to singular as it returns only one object.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
