### PR TITLE
tracker: use TrackReference instead of deprecated Track function

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
@@ -143,16 +142,6 @@ type PipelineRunList struct {
 // task has the potential to succeed or fail (based on the exit code)
 // and produces logs.
 type PipelineTaskRun = v1beta1.PipelineTaskRun
-
-// GetTaskRunRef for pipelinerun
-func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
-	return corev1.ObjectReference{
-		APIVersion: SchemeGroupVersion.String(),
-		Kind:       "TaskRun",
-		Namespace:  pr.Namespace,
-		Name:       pr.Name,
-	}
-}
 
 // GetOwnerReference gets the pipeline run as owner reference for any related objects
 func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types_test.go
@@ -63,26 +63,6 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 	}
 }
 
-func TestPipelineRun_TaskRunref(t *testing.T) {
-	p := &v1alpha1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-name",
-			Namespace: "test-ns",
-		},
-	}
-
-	expectTaskRunRef := corev1.ObjectReference{
-		APIVersion: "tekton.dev/v1alpha1",
-		Kind:       "TaskRun",
-		Namespace:  p.Namespace,
-		Name:       p.Name,
-	}
-
-	if d := cmp.Diff(p.GetTaskRunRef(), expectTaskRunRef); d != "" {
-		t.Fatalf("Taskrun reference mismatch; diff %s", diff.PrintWantGot(d))
-	}
-}
-
 func TestInitializeConditions(t *testing.T) {
 	p := &v1alpha1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -23,7 +23,6 @@ import (
 	apisconfig "github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
@@ -168,16 +167,6 @@ type TaskRunList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []TaskRun `json:"items"`
-}
-
-// GetBuildPodRef for task
-func (tr *TaskRun) GetBuildPodRef() corev1.ObjectReference {
-	return corev1.ObjectReference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Namespace:  tr.Namespace,
-		Name:       tr.Name,
-	}
 }
 
 // GetOwnerReference gets the task run as owner reference for any related objects

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types_test.go
@@ -31,18 +31,6 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-func TestTaskRun_GetBuildPodRef(t *testing.T) {
-	tr := tb.TaskRun("taskrunname", tb.TaskRunNamespace("testns"))
-	if d := cmp.Diff(tr.GetBuildPodRef(), corev1.ObjectReference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Namespace:  "testns",
-		Name:       "taskrunname",
-	}); d != "" {
-		t.Fatalf("taskrun build pod ref mismatch %s", diff.PrintWantGot(d))
-	}
-}
-
 func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -64,16 +64,6 @@ func (pr *PipelineRun) GetName() string {
 	return pr.ObjectMeta.GetName()
 }
 
-// GetTaskRunRef for pipelinerun
-func (pr *PipelineRun) GetTaskRunRef() corev1.ObjectReference {
-	return corev1.ObjectReference{
-		APIVersion: SchemeGroupVersion.String(),
-		Kind:       "TaskRun",
-		Namespace:  pr.Namespace,
-		Name:       pr.Name,
-	}
-}
-
 // GetStatusCondition returns the task run status as a ConditionAccessor
 func (pr *PipelineRun) GetStatusCondition() apis.ConditionAccessor {
 	return &pr.Status

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -61,26 +61,6 @@ func TestPipelineRunStatusConditions(t *testing.T) {
 	}
 }
 
-func TestPipelineRun_TaskRunref(t *testing.T) {
-	p := &v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-name",
-			Namespace: "test-ns",
-		},
-	}
-
-	expectTaskRunRef := corev1.ObjectReference{
-		APIVersion: "tekton.dev/v1beta1",
-		Kind:       "TaskRun",
-		Namespace:  p.Namespace,
-		Name:       p.Name,
-	}
-
-	if d := cmp.Diff(p.GetTaskRunRef(), expectTaskRunRef); d != "" {
-		t.Fatalf("Taskrun reference mismatch; diff %s", diff.PrintWantGot(d))
-	}
-}
-
 func TestInitializePipelineRunConditions(t *testing.T) {
 	p := &v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -351,16 +351,6 @@ type TaskRunList struct {
 	Items           []TaskRun `json:"items"`
 }
 
-// GetBuildPodRef for task
-func (tr *TaskRun) GetBuildPodRef() corev1.ObjectReference {
-	return corev1.ObjectReference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Namespace:  tr.Namespace,
-		Name:       tr.Name,
-	}
-}
-
 // GetPipelineRunPVCName for taskrun gets pipelinerun
 func (tr *TaskRun) GetPipelineRunPVCName() string {
 	if tr == nil {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -31,23 +31,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-func TestTaskRun_GetBuildPodRef(t *testing.T) {
-	tr := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "testns",
-			Name:      "taskrunname",
-		},
-	}
-	if d := cmp.Diff(tr.GetBuildPodRef(), corev1.ObjectReference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Namespace:  "testns",
-		Name:       "taskrunname",
-	}); d != "" {
-		t.Fatalf("taskrun build pod ref mismatch: %s", diff.PrintWantGot(d))
-	}
-}
-
 func TestTaskRun_GetPipelineRunPVCName(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -203,7 +203,12 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 	}
 
-	if err := c.tracker.Track(pr.GetTaskRunRef(), pr); err != nil {
+	if err := c.tracker.TrackReference(tracker.Reference{
+		APIVersion: v1beta1.SchemeGroupVersion.String(),
+		Kind:       "TaskRun",
+		Namespace:  pr.GetNamespace(),
+		Name:       pr.GetName(),
+	}, pr); err != nil {
 		logger.Errorf("Failed to create tracker for TaskRuns for PipelineRun %s: %v", pr.Name, err)
 		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -426,7 +426,12 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 		}
 	}
 
-	if err := c.tracker.Track(tr.GetBuildPodRef(), tr); err != nil {
+	if err := c.tracker.TrackReference(tracker.Reference{
+		APIVersion: "v1",
+		Kind:       "Pod",
+		Namespace:  tr.Namespace,
+		Name:       tr.Name,
+	}, tr); err != nil {
 		logger.Errorf("Failed to create tracker for build pod %q for taskrun %q: %v", tr.Name, tr.Name, err)
 		return err
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This changes remove the use of `Track` function on the tracker and use
`TrackReference` instead. The main reason is that `Track` is
deprecated.

This also remove `GetBuildPodRef` from TaskRun type and
`GetTaskRunRef` from PipelineRun type as they are only used once.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
