### PR TITLE
pkg/apis: use pod.Template instead of v1beta1.PodTemplate

### DIFF
--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -527,7 +528,7 @@ func PipelineRunNilTimeout(prs *v1beta1.PipelineRunSpec) {
 func PipelineRunNodeSelector(values map[string]string) PipelineRunSpecOp {
 	return func(prs *v1beta1.PipelineRunSpec) {
 		if prs.PodTemplate == nil {
-			prs.PodTemplate = &v1beta1.PodTemplate{}
+			prs.PodTemplate = &pod.Template{}
 		}
 		prs.PodTemplate.NodeSelector = values
 	}

--- a/internal/builder/v1beta1/pipeline_test.go
+++ b/internal/builder/v1beta1/pipeline_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -282,7 +283,7 @@ func TestPipelineRunWithPodTemplate(t *testing.T) {
 					Name: "my-special-resource",
 				},
 			}},
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				NodeSelector: map[string]string{
 					"label": "value",
 				},

--- a/internal/builder/v1beta1/task.go
+++ b/internal/builder/v1beta1/task.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -451,7 +452,7 @@ func TaskRunNilTimeout(spec *v1beta1.TaskRunSpec) {
 func TaskRunNodeSelector(values map[string]string) TaskRunSpecOp {
 	return func(spec *v1beta1.TaskRunSpec) {
 		if spec.PodTemplate == nil {
-			spec.PodTemplate = &v1beta1.PodTemplate{}
+			spec.PodTemplate = &pod.Template{}
 		}
 		spec.PodTemplate.NodeSelector = values
 	}
@@ -720,7 +721,7 @@ func TaskResourceBindingPaths(paths ...string) TaskResourceBindingOp {
 }
 
 // TaskRunPodTemplate add a custom PodTemplate to the TaskRun
-func TaskRunPodTemplate(podTemplate *v1beta1.PodTemplate) TaskRunSpecOp {
+func TaskRunPodTemplate(podTemplate *pod.Template) TaskRunSpecOp {
 	return func(spec *v1beta1.TaskRunSpec) {
 		spec.PodTemplate = podTemplate
 	}

--- a/internal/builder/v1beta1/task_test.go
+++ b/internal/builder/v1beta1/task_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -401,7 +402,7 @@ func TestTaskRunWithPodTemplate(t *testing.T) {
 						}}},
 				},
 			},
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				NodeSelector: map[string]string{
 					"label": "value",
 				},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/contexts"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -66,7 +67,7 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 		{
 			desc: "pod template is not nil",
 			prs: &v1beta1.PipelineRunSpec{
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
 					},
@@ -75,7 +76,7 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			want: &v1beta1.PipelineRunSpec{
 				ServiceAccountName: config.DefaultServiceAccountValue,
 				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
 					},
@@ -215,7 +216,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
 					},
@@ -241,7 +242,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 		in: &v1beta1.PipelineRun{
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label2": "value2",
 					},
@@ -253,7 +254,7 @@ func TestPipelineRunDefaulting(t *testing.T) {
 				PipelineRef:        &v1beta1.PipelineRef{Name: "foo"},
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label2": "value2",
 					},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -405,17 +406,17 @@ func TestPipelineRunGetPodSpec(t *testing.T) {
 			pr: &v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Name: "pr"},
 				Spec: v1beta1.PipelineRunSpec{
-					PodTemplate:        &v1beta1.PodTemplate{SchedulerName: "scheduleTest"},
+					PodTemplate:        &pod.Template{SchedulerName: "scheduleTest"},
 					PipelineRef:        &v1beta1.PipelineRef{Name: "prs"},
 					ServiceAccountName: "defaultSA",
 					TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
 						PipelineTaskName:       "taskNameOne",
 						TaskServiceAccountName: "TaskSAOne",
-						TaskPodTemplate:        &v1beta1.PodTemplate{SchedulerName: "scheduleTestOne"},
+						TaskPodTemplate:        &pod.Template{SchedulerName: "scheduleTestOne"},
 					}, {
 						PipelineTaskName:       "taskNameTwo",
 						TaskServiceAccountName: "newTaskTwo",
-						TaskPodTemplate:        &v1beta1.PodTemplate{SchedulerName: "scheduleTestTwo"},
+						TaskPodTemplate:        &pod.Template{SchedulerName: "scheduleTestTwo"},
 					}},
 				},
 			},

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/contexts"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -82,7 +83,7 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 	}, {
 		desc: "pod template is not nil",
 		trs: &v1beta1.TaskRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				NodeSelector: map[string]string{
 					"label": "value",
 				},
@@ -91,7 +92,7 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 		want: &v1beta1.TaskRunSpec{
 			ServiceAccountName: config.DefaultServiceAccountValue,
 			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				NodeSelector: map[string]string{
 					"label": "value",
 				},
@@ -319,7 +320,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
 					},
@@ -345,7 +346,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 		in: &v1beta1.TaskRun{
 			Spec: v1beta1.TaskRunSpec{
 				TaskRef: &v1beta1.TaskRef{Name: "foo"},
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label2": "value2",
 					},
@@ -360,7 +361,7 @@ func TestTaskRunDefaulting(t *testing.T) {
 				TaskRef:            &v1beta1.TaskRef{Name: "foo", Kind: v1beta1.NamespacedTaskKind},
 				Timeout:            &metav1.Duration{Duration: 5 * time.Minute},
 				ServiceAccountName: "tekton",
-				PodTemplate: &v1beta1.PodTemplate{
+				PodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label2": "value2",
 					},

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	"github.com/tektoncd/pipeline/pkg/version"
@@ -210,7 +211,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	}
 
 	// By default, use an empty pod template and take the one defined in the task run spec if any
-	podTemplate := v1beta1.PodTemplate{}
+	podTemplate := pod.Template{}
 
 	if taskRun.Spec.PodTemplate != nil {
 		podTemplate = *taskRun.Spec.PodTemplate

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/system"
 	"github.com/tektoncd/pipeline/pkg/version"
@@ -238,7 +239,7 @@ func TestPodBuild(t *testing.T) {
 			}}},
 		},
 		trs: v1beta1.TaskRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				SecurityContext: &corev1.PodSecurityContext{
 					Sysctls: []corev1.Sysctl{
 						{Name: "net.ipv4.tcp_syncookies", Value: "1"},
@@ -880,7 +881,7 @@ script-heredoc-randomly-generated-78c5n
 			},
 		},
 		trs: v1beta1.TaskRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				SchedulerName: "there-scheduler",
 			},
 		},
@@ -932,7 +933,7 @@ script-heredoc-randomly-generated-78c5n
 			},
 		},
 		trs: v1beta1.TaskRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "imageSecret"}},
 			},
 		},
@@ -983,7 +984,7 @@ script-heredoc-randomly-generated-78c5n
 			},
 		},
 		trs: v1beta1.TaskRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				HostNetwork: true,
 			},
 		},
@@ -1038,7 +1039,7 @@ script-heredoc-randomly-generated-78c5n
 			"pipeline.tekton.dev/affinity-assistant": "random-name-123",
 		},
 		trs: v1beta1.TaskRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{},
+			PodTemplate: &pod.Template{},
 		},
 		want: &corev1.PodSpec{
 			Affinity: &corev1.Affinity{

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/system"
 	corev1 "k8s.io/api/core/v1"
@@ -89,7 +90,7 @@ func TestThatCustomTolerationsAndNodeSelectorArePropagatedToAffinityAssistant(t 
 			Name: "pipelinerun-with-custom-podtemplate",
 		},
 		Spec: v1beta1.PipelineRunSpec{
-			PodTemplate: &v1beta1.PodTemplate{
+			PodTemplate: &pod.Template{
 				Tolerations: []corev1.Toleration{{
 					Key:      "key",
 					Operator: "Equal",

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -33,6 +33,7 @@ import (
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -1744,7 +1745,7 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 			tb.PipelineTaskRunSpecs([]v1beta1.PipelineTaskRunSpec{{
 				PipelineTaskName:       "hello-world-1",
 				TaskServiceAccountName: "custom-sa",
-				TaskPodTemplate: &v1beta1.PodTemplate{
+				TaskPodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"workloadtype": "tekton",
 					},
@@ -1784,7 +1785,7 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("hello-world"),
 			tb.TaskRunServiceAccountName("custom-sa"),
-			tb.TaskRunPodTemplate(&v1beta1.PodTemplate{
+			tb.TaskRunPodTemplate(&pod.Template{
 				NodeSelector: map[string]string{
 					"workloadtype": "tekton",
 				},

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
@@ -780,7 +781,7 @@ func storeTaskSpec(ctx context.Context, tr *v1beta1.TaskRun, ts *v1beta1.TaskSpe
 // willOverwritePodSetAffinity returns a bool indicating whether the
 // affinity for pods will be overwritten with affinity assistant.
 func willOverwritePodSetAffinity(taskRun *v1beta1.TaskRun) bool {
-	var podTemplate v1beta1.PodTemplate
+	var podTemplate pod.Template
 	if taskRun.Spec.PodTemplate != nil {
 		podTemplate = *taskRun.Spec.PodTemplate
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -33,6 +33,7 @@ import (
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
@@ -3334,7 +3335,7 @@ func TestWillOverwritePodAffinity(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := &v1beta1.TaskRun{
 				Spec: v1beta1.TaskRunSpec{
-					PodTemplate: &v1beta1.PodTemplate{},
+					PodTemplate: &pod.Template{},
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: tc.annotations,

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -271,7 +272,7 @@ func TestPipelineRunWithServiceAccountNameAndTaskRunSpec(t *testing.T) {
 			ServiceAccountName: "sa1",
 			TaskRunSpecs: []v1beta1.PipelineTaskRunSpec{{
 				PipelineTaskName: "task1",
-				TaskPodTemplate: &v1beta1.PodTemplate{
+				TaskPodTemplate: &pod.Template{
 					DNSPolicy: &dnsPolicy,
 				},
 			}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`v1beta1.PodTemplate` is just an alias to `pod.Template`. We should
tend to prefer using `pod.Template` than `v1beta1.PodTemplate` as much
as we can — end goal being to remove `v1beta1.PodTemplate`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
