### PR TITLE
pkg/apis: rename {Task,Pipeline}Interface into *Object

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
@@ -56,6 +56,6 @@ func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
-func (t *ClusterTask) Copy() TaskInterface {
+func (t *ClusterTask) Copy() TaskObject {
 	return t.DeepCopy()
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_interface.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_interface.go
@@ -18,9 +18,9 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// PipelineInterface is implemented by Pipeline and ClusterPipeline
-type PipelineInterface interface {
+// PipelineObject is implemented by Pipeline and ClusterPipeline
+type PipelineObject interface {
 	PipelineMetadata() metav1.ObjectMeta
 	PipelineSpec() PipelineSpec
-	Copy() PipelineInterface
+	Copy() PipelineObject
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -97,7 +97,7 @@ func (p *Pipeline) PipelineSpec() PipelineSpec {
 	return p.Spec
 }
 
-func (p *Pipeline) Copy() PipelineInterface {
+func (p *Pipeline) Copy() PipelineObject {
 	return p.DeepCopy()
 }
 

--- a/pkg/apis/pipeline/v1alpha1/task_interface.go
+++ b/pkg/apis/pipeline/v1alpha1/task_interface.go
@@ -18,9 +18,9 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// TaskInterface is implemented by Task and ClusterTask
-type TaskInterface interface {
+// TaskObject is implemented by Task and ClusterTask
+type TaskObject interface {
 	TaskMetadata() metav1.ObjectMeta
 	TaskSpec() TaskSpec
-	Copy() TaskInterface
+	Copy() TaskObject
 }

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -39,7 +39,7 @@ func (t *Task) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
-func (t *Task) Copy() TaskInterface {
+func (t *Task) Copy() TaskObject {
 	return t.DeepCopy()
 }
 

--- a/pkg/apis/pipeline/v1beta1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_types.go
@@ -56,6 +56,6 @@ func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
-func (t *ClusterTask) Copy() TaskInterface {
+func (t *ClusterTask) Copy() TaskObject {
 	return t.DeepCopy()
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_interface.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_interface.go
@@ -18,9 +18,9 @@ package v1beta1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// PipelineInterface is implemented by Pipeline and ClusterPipeline
-type PipelineInterface interface {
+// PipelineObject is implemented by Pipeline and ClusterPipeline
+type PipelineObject interface {
 	PipelineMetadata() metav1.ObjectMeta
 	PipelineSpec() PipelineSpec
-	Copy() PipelineInterface
+	Copy() PipelineObject
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -47,7 +47,7 @@ func (p *Pipeline) PipelineSpec() PipelineSpec {
 	return p.Spec
 }
 
-func (p *Pipeline) Copy() PipelineInterface {
+func (p *Pipeline) Copy() PipelineObject {
 	return p.DeepCopy()
 }
 

--- a/pkg/apis/pipeline/v1beta1/task_interface.go
+++ b/pkg/apis/pipeline/v1beta1/task_interface.go
@@ -18,9 +18,9 @@ package v1beta1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// TaskInterface is implemented by Task and ClusterTask
-type TaskInterface interface {
+// TaskObject is implemented by Task and ClusterTask
+type TaskObject interface {
 	TaskMetadata() metav1.ObjectMeta
 	TaskSpec() TaskSpec
-	Copy() TaskInterface
+	Copy() TaskObject
 }

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -60,7 +60,7 @@ func (t *Task) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
-func (t *Task) Copy() TaskInterface {
+func (t *Task) Copy() TaskObject {
 	return t.DeepCopy()
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -40,8 +40,8 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 	switch {
 	case cfg.FeatureFlags.EnableTektonOCIBundles && pr != nil && pr.Bundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
-		// casting it to a PipelineInterface.
-		return func(ctx context.Context, name string) (v1beta1.PipelineInterface, error) {
+		// casting it to a PipelineObject.
+		return func(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
 			// If there is a bundle url at all, construct an OCI resolver to fetch the pipeline.
 			kc, err := k8schain.New(ctx, k8s, k8schain.Options{
 				Namespace:          namespace,
@@ -56,7 +56,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 			if err != nil {
 				return nil, err
 			}
-			if pipeline, ok := obj.(v1beta1.PipelineInterface); ok {
+			if pipeline, ok := obj.(v1beta1.PipelineObject); ok {
 				return pipeline, nil
 			}
 
@@ -86,7 +86,7 @@ type LocalPipelineRefResolver struct {
 
 // GetPipeline will resolve a Pipeline from the local cluster using a versioned Tekton client. It will
 // return an error if it can't find an appropriate Pipeline for any reason.
-func (l *LocalPipelineRefResolver) GetPipeline(ctx context.Context, name string) (v1beta1.PipelineInterface, error) {
+func (l *LocalPipelineRefResolver) GetPipeline(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {
 		return nil, fmt.Errorf("Must specify namespace to resolve reference to pipeline %s", name)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -319,7 +319,7 @@ func ResolvePipelineRunTask(
 
 	// Find the Task that this PipelineTask is using
 	var (
-		t        v1beta1.TaskInterface
+		t        v1beta1.TaskObject
 		err      error
 		spec     v1beta1.TaskSpec
 		taskName string

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -985,7 +985,7 @@ func TestResolvePipelineRun(t *testing.T) {
 	}
 	// The Task "task" doesn't actually take any inputs or outputs, but validating
 	// that is not done as part of Run resolution
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
 
@@ -1063,7 +1063,7 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 	}}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
 	pr := v1beta1.PipelineRun{
@@ -1104,7 +1104,7 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
 	// Return an error when the Task is retrieved, as if it didn't exist
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) {
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
 		return nil, kerrors.NewNotFound(v1beta1.Resource("task"), name)
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) {
@@ -1150,7 +1150,7 @@ func TestResolvePipelineRun_ResourceBindingsDontExist(t *testing.T) {
 	}}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return &trs[0], nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) {
 		return nil, nil
@@ -1211,7 +1211,7 @@ func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 
 	// The Task "task" doesn't actually take any inputs or outputs, but validating
 	// that is not done as part of Run resolution
-	getTask := func(_ context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(_ context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return nil, nil }
 	resolvedTask, err := ResolvePipelineRunTask(context.Background(), pr, getTask, getTaskRun, getCondition, p.Spec.Tasks[0], providedResources)
@@ -1262,7 +1262,7 @@ func TestResolvedPipelineRun_PipelineTaskHasOptionalResources(t *testing.T) {
 		},
 	}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) {
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
 		return taskWithOptionalResourcesDeprecated, nil
 	}
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
@@ -1314,7 +1314,7 @@ func TestResolveConditionChecks(t *testing.T) {
 	}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(_ context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(_ context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return &condition, nil }
 	pr := v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1425,7 +1425,7 @@ func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 	}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(_ context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(_ context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return &condition, nil }
 	pr := v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1497,7 +1497,7 @@ func TestResolveConditionChecks_ConditionDoesNotExist(t *testing.T) {
 	}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) {
 		if name == ccName {
 			return nil, fmt.Errorf("should not be called")
@@ -1551,7 +1551,7 @@ func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 	}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) {
 		if name == ccName {
 			return cc, nil
@@ -1626,7 +1626,7 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 		Conditions: []v1beta1.PipelineTaskCondition{ptc},
 	}
 
-	getTask := func(ctx context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return nil, nil }
 
 	// This err result is required to satisfy the type alias on this function, but it triggers
@@ -1945,7 +1945,7 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
-	getTask := func(_ context.Context, name string) (v1beta1.TaskInterface, error) { return task, nil }
+	getTask := func(_ context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
 	getCondition := func(name string) (*v1alpha1.Condition, error) { return &condition, nil }
 	pr := v1beta1.PipelineRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec.go
@@ -25,7 +25,7 @@ import (
 )
 
 // GetPipeline is a function used to retrieve Pipelines.
-type GetPipeline func(context.Context, string) (v1beta1.PipelineInterface, error)
+type GetPipeline func(context.Context, string) (v1beta1.PipelineObject, error)
 
 // GetPipelineData will retrieve the Pipeline metadata and Spec associated with the
 // provided PipelineRun. This can come from a reference Pipeline or from the PipelineRun's

--- a/pkg/reconciler/pipelinerun/resources/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinespec_test.go
@@ -49,7 +49,7 @@ func TestGetPipelineSpec_Ref(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineInterface, error) { return pipeline, nil }
+	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, error) { return pipeline, nil }
 	pipelineMeta, pipelineSpec, err := GetPipelineData(context.Background(), pr, gt)
 
 	if err != nil {
@@ -81,7 +81,7 @@ func TestGetPipelineSpec_Embedded(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineInterface, error) {
+	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, error) {
 		return nil, errors.New("shouldn't be called")
 	}
 	pipelineMeta, pipelineSpec, err := GetPipelineData(context.Background(), pr, gt)
@@ -105,7 +105,7 @@ func TestGetPipelineSpec_Invalid(t *testing.T) {
 			Name: "mypipelinerun",
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineInterface, error) {
+	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, error) {
 		return nil, errors.New("shouldn't be called")
 	}
 	_, _, err := GetPipelineData(context.Background(), tr, gt)
@@ -125,7 +125,7 @@ func TestGetPipelineSpec_Error(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.PipelineInterface, error) {
+	gt := func(ctx context.Context, n string) (v1beta1.PipelineObject, error) {
 		return nil, errors.New("something went wrong")
 	}
 	_, _, err := GetPipelineData(context.Background(), tr, gt)

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -45,8 +45,8 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 	switch {
 	case cfg.FeatureFlags.EnableTektonOCIBundles && tr != nil && tr.Bundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
-		// casting it to a TaskInterface.
-		return func(ctx context.Context, name string) (v1beta1.TaskInterface, error) {
+		// casting it to a TaskObject.
+		return func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
 			// If there is a bundle url at all, construct an OCI resolver to fetch the task.
 			kc, err := k8schain.New(ctx, k8s, k8schain.Options{
 				Namespace:          namespace,
@@ -65,8 +65,8 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			}
 
 			// If the resolved object is already a v1beta1.{Cluster}Task, it should be returnable as a
-			// v1beta1.TaskInterface.
-			if ti, ok := obj.(v1beta1.TaskInterface); ok {
+			// v1beta1.TaskObject.
+			if ti, ok := obj.(v1beta1.TaskObject); ok {
 				return ti, nil
 			}
 
@@ -105,7 +105,7 @@ type LocalTaskRefResolver struct {
 
 // GetTask will resolve either a Task or ClusterTask from the local cluster using a versioned Tekton client. It will
 // return an error if it can't find an appropriate Task for any reason.
-func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (v1beta1.TaskInterface, error) {
+func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (v1beta1.TaskObject, error) {
 	if l.Kind == v1beta1.ClusterTaskKind {
 		task, err := l.Tektonclient.TektonV1beta1().ClusterTasks().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -26,11 +26,11 @@ import (
 )
 
 // GetTask is a function used to retrieve Tasks.
-type GetTask func(context.Context, string) (v1beta1.TaskInterface, error)
+type GetTask func(context.Context, string) (v1beta1.TaskObject, error)
 type GetTaskRun func(string) (*v1beta1.TaskRun, error)
 
 // GetClusterTask is a function that will retrieve the Task from name and namespace.
-type GetClusterTask func(name string) (v1beta1.TaskInterface, error)
+type GetClusterTask func(name string) (v1beta1.TaskObject, error)
 
 // GetTaskData will retrieve the Task metadata and Spec associated with the
 // provided TaskRun. This can come from a reference Task or from the TaskRun's

--- a/pkg/reconciler/taskrun/resources/taskspec_test.go
+++ b/pkg/reconciler/taskrun/resources/taskspec_test.go
@@ -47,7 +47,7 @@ func TestGetTaskSpec_Ref(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskInterface, error) { return task, nil }
+	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, error) { return task, nil }
 	taskMeta, taskSpec, err := GetTaskData(context.Background(), tr, gt)
 
 	if err != nil {
@@ -76,7 +76,7 @@ func TestGetTaskSpec_Embedded(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskInterface, error) {
+	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, error) {
 		return nil, errors.New("shouldn't be called")
 	}
 	taskMeta, taskSpec, err := GetTaskData(context.Background(), tr, gt)
@@ -100,7 +100,7 @@ func TestGetTaskSpec_Invalid(t *testing.T) {
 			Name: "mytaskrun",
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskInterface, error) {
+	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, error) {
 		return nil, errors.New("shouldn't be called")
 	}
 	_, _, err := GetTaskData(context.Background(), tr, gt)
@@ -120,7 +120,7 @@ func TestGetTaskSpec_Error(t *testing.T) {
 			},
 		},
 	}
-	gt := func(ctx context.Context, n string) (v1beta1.TaskInterface, error) {
+	gt := func(ctx context.Context, n string) (v1beta1.TaskObject, error) {
 		return nil, errors.New("something went wrong")
 	}
 	_, _, err := GetTaskData(context.Background(), tr, gt)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The main reason for rename this interface is because the code
generation also generates a `TaskInterface` and `PipelineInterface`
that are related to kubernetes clients. It tends to be a bit confusing
when looking at code on which we are referring to.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
