### PR TITLE
adding unit tests for pipelineTaskList.Deps

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -181,7 +181,6 @@ func (pt PipelineTask) Deps() []string {
 			continue
 		}
 		uniqueDeps.Insert(w)
-
 	}
 
 	return uniqueDeps.List()
@@ -236,30 +235,24 @@ func (pt PipelineTask) resourceDeps() []string {
 
 func (pt PipelineTask) orderingDeps() []string {
 	orderingDeps := []string{}
-	resourceDeps := pt.resourceDeps()
 	for _, runAfter := range pt.RunAfter {
-		if !contains(runAfter, resourceDeps) {
-			orderingDeps = append(orderingDeps, runAfter)
-		}
+		orderingDeps = append(orderingDeps, runAfter)
 	}
 	return orderingDeps
 }
 
-func contains(s string, arr []string) bool {
-	for _, elem := range arr {
-		if elem == s {
-			return true
-		}
-	}
-	return false
-}
-
 type PipelineTaskList []PipelineTask
 
+// Deps returns a map with key as name of a pipelineTask and value as a list of its dependencies
 func (l PipelineTaskList) Deps() map[string][]string {
 	deps := map[string][]string{}
 	for _, pt := range l {
-		deps[pt.HashKey()] = pt.Deps()
+		// get the list of deps for this pipelineTask
+		d := pt.Deps()
+		// add the pipelineTask into the map if it has any deps
+		if len(d) > 0 {
+			deps[pt.HashKey()] = d
+		}
 	}
 	return deps
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -39,3 +39,182 @@ func TestPipelineTaskList_Names(t *testing.T) {
 		t.Fatalf("Failed to get list of pipeline task names, diff: %s", diff.PrintWantGot(d))
 	}
 }
+
+func TestPipelineTaskList_Deps(t *testing.T) {
+	pipelines := []struct {
+		name         string
+		tasks        PipelineTaskList
+		expectedDeps map[string][]string
+	}{{
+		name: "valid pipeline without any deps",
+		tasks: []PipelineTask{
+			{Name: "task-1"},
+			{Name: "task-2"},
+		},
+		expectedDeps: map[string][]string{},
+	}, {
+		name: "valid pipeline with ordering deps - runAfter",
+		tasks: []PipelineTask{
+			{Name: "task-1"},
+			{Name: "task-2", RunAfter: []string{"task-1"}},
+		},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+		},
+	}, {
+		name: "valid pipeline with resource deps - Inputs",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2",
+		}, {
+			Name: "task-3",
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					From: []string{"task-1", "task-2"},
+				}},
+			}},
+		},
+		expectedDeps: map[string][]string{
+			"task-3": {"task-1", "task-2"},
+		},
+	}, {
+		name: "valid pipeline with resource deps - Task Results",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2",
+			Params: []Param{{
+				Value: ArrayOrString{
+					Type:      "string",
+					StringVal: "$(tasks.task-1.results.result)",
+				}},
+			}},
+		},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+		},
+	}, {
+		name: "valid pipeline with resource deps - When Expressions",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2",
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.task-1.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+		},
+	}, {
+		name: "valid pipeline with ordering deps and resource deps",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2", RunAfter: []string{"task-1"},
+		}, {
+			Name:     "task-3",
+			RunAfter: []string{"task-1"},
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					From: []string{"task-1", "task-2"},
+				}},
+			},
+		}, {
+			Name:     "task-4",
+			RunAfter: []string{"task-1"},
+			Params: []Param{{
+				Value: ArrayOrString{
+					Type:      "string",
+					StringVal: "$(tasks.task-3.results.result)",
+				}},
+			},
+		}, {
+			Name:     "task-5",
+			RunAfter: []string{"task-1"},
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.task-4.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+			"task-3": {"task-1", "task-2"},
+			"task-4": {"task-1", "task-3"},
+			"task-5": {"task-1", "task-4"},
+		},
+	}, {
+		name: "valid pipeline with ordering deps and resource deps - verify unique dependencies",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2", RunAfter: []string{"task-1"},
+		}, {
+			Name:     "task-3",
+			RunAfter: []string{"task-1"},
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					From: []string{"task-1", "task-2"},
+				}},
+			},
+		}, {
+			Name:     "task-4",
+			RunAfter: []string{"task-1", "task-3"},
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					From: []string{"task-1", "task-2"},
+				}},
+			},
+			Params: []Param{{
+				Value: ArrayOrString{
+					Type:      "string",
+					StringVal: "$(tasks.task-2.results.result)",
+				}}, {
+				Value: ArrayOrString{
+					Type:      "string",
+					StringVal: "$(tasks.task-3.results.result)",
+				}},
+			},
+		}, {
+			Name:     "task-5",
+			RunAfter: []string{"task-1", "task-2", "task-3", "task-4"},
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					From: []string{"task-1", "task-2"},
+				}},
+			},
+			Params: []Param{{
+				Value: ArrayOrString{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result)",
+				}},
+			},
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.task-3.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}, {
+				Input:    "$(tasks.task-4.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+			"task-3": {"task-1", "task-2"},
+			"task-4": {"task-1", "task-2", "task-3"},
+			"task-5": {"task-1", "task-2", "task-3", "task-4"},
+		},
+	}}
+	for _, tc := range pipelines {
+		t.Run(tc.name, func(t *testing.T) {
+			if d := cmp.Diff(tc.expectedDeps, tc.tasks.Deps()); d != "" {
+				t.Fatalf("Failed to get the right set of dependencies, diff: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adding unit tests to validate `pipelineTaskList.Deps()` returning correct dependencies.

Changing `orderingDeps()` to avoid calling `resourceDeps()` and checking for duplicates since `pipelineTaskList.Dep()` returns a unique set of dependencies (using `sets`) for all `pipelineTask`s.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
