### PR TITLE
Updates to the HA document

### DIFF
--- a/config/config-leader-election.yaml
+++ b/config/config-leader-election.yaml
@@ -22,7 +22,6 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 data:
   # An inactive but valid configuration follows; see example.
-  resourceLock: "leases"
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"

--- a/docs/enabling-ha.md
+++ b/docs/enabling-ha.md
@@ -36,10 +36,12 @@ The leader election can be configured via the [config-leader-election.yaml](../.
 
 | Parameter            | Default  |
 | -------------------- | -------- |
-| `data.resourceLock`  | "leases" |
+| `data.buckets`       | 1        |
 | `data.leaseDuration` | 15s      |
 | `data.renewDeadline` | 10s      |
 | `data.retryPeriod`   | 2s       |
+
+_Note_: When setting `data.buckets`, the underlying Knative library only allows a value between 1 and 10, making 10 the maximum number of allowed buckets.
 
 ## Disabling leader election
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Enhance enabling-ha.md doc
- This document was missing the `data.buckets` configurable parameter for the leader election.
Remove references to `data.resourceLock` for HA config
- While enhancing the HA document, we realized that the `resourceLock` field is not configurable in the Knative side, but rather hardcoded. You can see in https://github.com/knative/pkg/blob/master/leaderelection/config.go#L74-L87
, where the Config object is defined, that this field is not included. Also, the value for it seems to be hardcoded to "leases", as seen in https://github.com/knative/pkg/blob/master/leaderelection/config.go#L38

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Update enabling-ha.md document, to highlight the usage of buckets for the HA solution in the pipeline controller.
```