### PR TITLE
Do not allow use of deprecated Conditions with custom tasks

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -972,6 +972,8 @@ Pipelines do not directly support passing the following items to custom tasks:
 * Service account name
 * Pod templates
 
+A pipeline task that references a custom task cannot reference `Conditions`.
+`Conditions` are deprecated.  Use [`WhenExpressions`](#guard-task-execution-using-whenexpressions) instead.
 
 ## Code examples
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -144,6 +144,11 @@ func validatePipelineTask(ctx context.Context, t PipelineTask, taskNames sets.St
 		if t.TaskRef.Kind == "" {
 			errs = errs.Also(apis.ErrInvalidValue("custom task ref must specify kind", "taskRef.kind"))
 		}
+		// Conditions are deprecated so the effort to support them with custom tasks is not justified.
+		// When expressions should be used instead.
+		if len(t.Conditions) > 0 {
+			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support conditions - use when expressions instead", "conditions"))
+		}
 		// TODO(#3133): Support these features if possible.
 		if t.Retries > 0 {
 			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support retries", "retries"))

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -583,6 +583,20 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 		},
 		wc: enableFeature(t, "enable-custom-tasks"),
 	}, {
+		name: "pipelinetask custom task doesn't support conditions",
+		tasks: []PipelineTask{{
+			Name: "foo",
+			Conditions: []PipelineTaskCondition{{
+				ConditionRef: "some-condition",
+			}},
+			TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example"},
+		}},
+		expectedError: apis.FieldError{
+			Message: `invalid value: custom tasks do not support conditions - use when expressions instead`,
+			Paths:   []string{"tasks[0].conditions"},
+		},
+		wc: enableFeature(t, "enable-custom-tasks"),
+	}, {
 		name: "pipelinetask custom task doesn't support retries",
 		tasks: []PipelineTask{{
 			Name:    "foo",


### PR DESCRIPTION
# Changes

Fixes #3592

During discussion of #3463 it was agreed to not support Conditions with custom tasks since they are deprecated.  This adds code to enforce that decision.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Disallow use of Conditions in pipeline tasks that reference custom tasks
```
