### PR TITLE
Run controller and webhook also as non-root group. Drop capabilities.

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -111,8 +111,12 @@ spec:
           value: tekton.dev/pipeline
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
           # User 65532 is the distroless nonroot user ID
           runAsUser: 65532
+          runAsGroup: 65532
         ports:
         - name: probes
           containerPort: 8080

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -102,8 +102,12 @@ spec:
           value: tekton.dev/pipeline
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
           # User 65532 is the distroless nonroot user ID
           runAsUser: 65532
+          runAsGroup: 65532
         ports:
         - name: metrics
           containerPort: 9090


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind misc
Containers running as root group or with excessive capabilities
have larger security impact if compromised. It is recommended
to run containers as non-root and drop unneeded capabilities.
Controller and Webhook are regular servers and don't need special
capabilities. This change is tested with master version on a GKE cluster.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).


```release-note
NONE
```