### PR TITLE
Add some more release process details 🤓

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -6,13 +6,20 @@ the pipelines repo, a terminal window and a text editor.
 
 1. `cd` to root of Pipelines git checkout.
 
-2. Point `kubectl` at dogfooding cluster.
+1. Configure `kubectl` to use the  dogfooding cluster
+   [as the default context](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/)
+   (**in the final step we will configure the default context to point to something else; until then be aware
+    that any kubctl commands you run will act on the dogfooding cluster**)
 
     ```bash
     gcloud container clusters get-credentials dogfooding --zone us-central1-a --project tekton-releases
     ```
 
-3. Create PipelineResource for new version. e.g.
+1. Select the commit you would like to build the release from, most likely the
+   most recent commit at https://github.com/tektoncd/pipeline/commits/master
+   and note the commit's hash.
+
+1. Create a `.yaml` file containing PipelineResource for new version. e.g.
 
     ```yaml
     apiVersion: tekton.dev/v1alpha1
@@ -25,26 +32,26 @@ the pipelines repo, a terminal window and a text editor.
       - name: url
         value: https://github.com/tektoncd/pipeline
       - name: revision
-        value: # Example: 33e0847e67fc9804689e50371746c3cdad4b0a9d
+        value: # The commmit you selected in the last step, e.g. 33e0847e67fc9804689e50371746c3cdad4b0a9d
     ```
 
-4. `kubectl apply -f tekton/resources.yaml`
+1. Apply file you just made to the dogfooding cluster: `kubectl apply -f your-pipeline-resource-file.yaml`
 
-5. Create environment variables for bash scripts in later steps.
+1. Create environment variables for bash scripts in later steps.
 
     ```bash
-    TEKTON_VERSION=# Example: v0.11.2
-    TEKTON_RELEASE_GIT_RESOURCE=# Example: tekton-pipelines-v0-11-2
-    TEKTON_IMAGE_REGISTRY=gcr.io/tekton-releases
+    TEKTON_VERSION=# Example: v0.11.0
+    TEKTON_RELEASE_GIT_RESOURCE=# Name of the resource you created, e.g.: tekton-pipelines-v0-11-0
+    TEKTON_IMAGE_REGISTRY=gcr.io/tekton-releases # only change if you want to publish to a different registry
     ```
 
-6. Confirm commit SHA matches what you want to release.
+1. Confirm commit SHA matches what you want to release.
 
     ```bash
     kubectl get pipelineresource "$TEKTON_RELEASE_GIT_RESOURCE" -o=jsonpath="{'Target Revision: '}{.spec.params[?(@.name == 'revision')].value}{'\n'}"
     ```
 
-7. Execute the release pipeline.
+1. Execute the release pipeline.
 
     **If you are backporting include this flag: `--param=releaseAsLatest="false"`**
 
@@ -70,19 +77,22 @@ the pipelines repo, a terminal window and a text editor.
     pipeline-release
     ```
 
-8. Watch logs of pipeline-release.
+1. Watch logs of pipeline-release.
 
-9. The YAMLs are now released! Anyone installing Tekton Pipelines will now get the new version. Time to create a new GitHub release announcement:
+1. The YAMLs are now released! Anyone installing Tekton Pipelines will now get the new version. Time to create a new GitHub release announcement:
+
+    1. Choose a name for the new release! The usual pattern is "< cat breed > < famous robot >" e.g. "Ragdoll Norby".
+       (Check the previous releases to avoid repetition: https://github.com/tektoncd/pipeline/releases.)
 
     1. Create additional environment variables
 
     ```bash
     TEKTON_OLD_VERSION=# Example: v0.11.1
-    TEKTON_RELEASE_NAME=# Example: "Ragdoll Norby"
+    TEKTON_RELEASE_NAME=# The release name you just chose, e.g.: "Ragdoll Norby"
     TEKTON_PACKAGE=tektoncd/pipeline
     ```
 
-    2. Execute the Draft Release task.
+    1. Execute the Draft Release task.
 
     ```bash
     tkn task start \
@@ -95,26 +105,30 @@ the pipelines repo, a terminal window and a text editor.
       create-draft-release
     ```
 
-    4. Watch logs of create-draft-release
+    1. Watch logs of create-draft-release
 
-    5. On successful completion, a URL will be logged. Visit that URL and sort the
-    release notes. **Double-check that the list of commits here matches your expectations
-    for the release.** You might need to remove incorrect commits or copy/paste commits
-    from the release branch. Refer to previous releases to confirm the expected format.
+    1. On successful completion, a URL will be logged. Visit that URL and sort the
+    release notes.
+      1. Manually add upgrade and deprecation notices based on the generated release notes
+      1. Double-check that the list of commits here matches your expectations
+         for the release. You might need to remove incorrect commits or copy/paste commits
+         from the release branch. Refer to previous releases to confirm the expected format.
 
-    6. Publish the GitHub release once all notes are correct and in order.
+    1. Un-check the "This is a pre-release" checkbox since you're making a legit for-reals release!
 
-10. Edit `README.md` on `master` branch, add entry to docs table with latest release links.
+    1. Publish the GitHub release once all notes are correct and in order.
 
-11. Push & make PR for updated `README.md`
+1. Edit `README.md` on `master` branch, add entry to docs table with latest release links.
 
-12. **Important: Stop pointing `kubectl` at dogfooding cluster.**
+1. Push & make PR for updated `README.md`
+
+1. **Important: Stop pointing `kubectl` at dogfooding cluster.**
 
     ```bash
     kubectl config use-context my-dev-cluster
     ```
 
-13. Test release that you just made.
+1. Test release that you just made.
 
     ```bash
     # Test latest
@@ -126,9 +140,9 @@ the pipelines repo, a terminal window and a text editor.
     kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.11.2/release.yaml
     ```
 
-14. Announce the release in Slack channels #general and #pipelines.
+1. Announce the release in Slack channels #general and #pipelines.
 
-15. Update [the catalog repo](https://github.com/tektoncd/catalog) test infrastructure
-to use the new release by updating the `RELEASE_YAML` link in [e2e-tests.sh](https://github.com/tektoncd/catalog/blob/v1beta1/test/e2e-tests.sh).
+1. Update [the catalog repo](https://github.com/tektoncd/catalog) test infrastructure
+to use the new release by updating the `RELEASE_YAML` link in [e2e-tests.sh](https://github.com/tektoncd/catalog/blob/master/test/e2e-tests.sh).
 
 Congratulations, you're done!


### PR DESCRIPTION
# Changes

Worked with @jerop to create the v0.19.0 release today and there were a
few parts of the cheat sheet that felt like they could use a bit more detail:

- You can configure kubectl to connect to multiple clusters if you want
- Some info on how to choose the commit to release
- The step that applies the PipelineResource was applying a file in the
  tekton dir that probably wasnt the one you meant to apply (the old
  instructions directed ppl to edit that file)
- ~Applying the env vars doesn't work with out `export`~ (thanks for explaining export vs. set @sbwsg !)
- Changed the numbering in markdown to all be `1.` so you can add more
  steps without having to update all the numbers
- Added some guidance on naming the release.
- Mentioned that you have to uncheck the pre-release box (which I didn't
  realize last time XD)
- Don't use patch versions in the example

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
