### PR TITLE
Revert "Revert "Add a "dropNetworking" function and unit tests to the…

### DIFF
--- a/cmd/entrypoint/namespaces.go
+++ b/cmd/entrypoint/namespaces.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package main
+
+import "os/exec"
+
+// The implementation of this currently only works on Linux.
+// This is a placeholder for compilation/testing.
+func dropNetworking(cmd *exec.Cmd) {
+	panic("only implemented on linux")
+}

--- a/cmd/entrypoint/namespaces_linux.go
+++ b/cmd/entrypoint/namespaces_linux.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"math"
+	"os/exec"
+	"syscall"
+)
+
+// We need the max value of an unsigned 32 bit integer (4294967295), but we also need this number
+// to fit into an "int". One some systems this is 32 bits, so the max uint32 can't fit into here.
+// maxIntForArch is the higher of those two values.
+func maxIntForArch() int {
+	// We have to do over two lines as a variable. The go compiler optimizes
+	// away types for constants, so int(uint32(math.MaxUint32)) is the same as int(math.MaxUint32),
+	// which overflows.
+	maxUint := uint32(math.MaxUint32)
+	if int(maxUint) > math.MaxInt32 {
+		return int(maxUint)
+	}
+	return math.MaxInt32
+}
+
+// dropNetworking modifies the supplied exec.Cmd to execute in a net set of namespaces that do not
+// have network access
+func dropNetworking(cmd *exec.Cmd) {
+	// These flags control the behavior of the new process.
+	// Documentation for these is available here: https://man7.org/linux/man-pages/man2/clone.2.html
+	// We mostly want to just create a new network namespace, unattached to any networking devices.
+	// The other flags are necessary for that to work.
+
+	if cmd.SysProcAttr == nil {
+		// We build this up piecemeal in case it was already set, to avoid overwriting anything.
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Cloneflags = syscall.CLONE_NEWNS |
+		syscall.CLONE_NEWPID | // NEWPID creates a new process namespace
+		syscall.CLONE_NEWNET | // NEWNET creates a new network namespace (this is the one we really care about)
+		syscall.CLONE_NEWUSER // NEWUSER creates a new user namespace
+
+	// We need to map the existing user IDs into the new namespace.
+	// Just map everything.
+	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			// Map all users
+			Size: maxIntForArch(),
+		},
+	}
+
+	// This is needed to allow programs to call setgroups when in a new Gid namespace.
+	// Things like apt-get install require this to work.
+	cmd.SysProcAttr.GidMappingsEnableSetgroups = true
+	// We need to map the existing group IDs into the new namespace.
+	// Just map everything.
+	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
+		{
+			ContainerID: 0,
+			HostID:      0,
+
+			//  Map all groups
+			Size: maxIntForArch(),
+		},
+	}
+}

--- a/cmd/entrypoint/namespaces_test.go
+++ b/cmd/entrypoint/namespaces_test.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// This isn't a great unit test, but it's the best I can think of.
+// It attempts to verify there is no network access by making a network
+// request. If the test were to run in an offline environment, or an already
+// sandboxed environment, the test could pass even if the dropNetworking
+// function did nothing.
+func TestDropNetworking(t *testing.T) {
+	cmd := exec.Command("curl", "google.com")
+	dropNetworking(cmd)
+	b, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Errorf("Expected an error making a network connection. Got %s", string(b))
+	}
+
+	// Other things (env, etc.) should all be the same
+	cmds := []string{"env", "whoami", "pwd", "uname"}
+	for _, cmd := range cmds {
+		withNetworking := exec.Command(cmd)
+		withoutNetworking := exec.Command(cmd)
+		dropNetworking(withoutNetworking)
+
+		b1, err1 := withNetworking.CombinedOutput()
+		b2, err2 := withoutNetworking.CombinedOutput()
+		if err1 != err2 {
+			t.Errorf("Expected no errors, got %v %v", err1, err2)
+		}
+		if diff := cmp.Diff(string(b1), string(b2)); diff != "" {
+			t.Error(diff)
+		}
+	}
+}


### PR DESCRIPTION
… runner package.""

# Changes

This fixes the size calculation to also work on 32-bit systems. This can be quickly
checked with "GOOS=linux GOARCH=arm go build ./..."

The two commits can be seen separately here: https://github.com/tektoncd/pipeline/compare/master...dlorenc:rollbacknet

This reverts commit dccd0ed2920ff2c8df90f4afaba7b814464e288f.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```