### PR TITLE
Add Jerop as an owner 🎉

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,7 @@ aliases:
   - sbwsg
   - vdemeester
   - pritidesai
+  - jerop
 
   apis-approvers:
   - afrittoli
@@ -18,6 +19,7 @@ aliases:
   - sbwsg
   - vdemeester
   - pritidesai
+  - jerop
 
   productivity-approvers:
   - afrittoli


### PR DESCRIPTION
# Changes

@jerop has been reviewed 32 PRs in pipelines
(https://github.com/tektoncd/pipeline/pulls?q=is%3Apr+reviewed-by%3Ajerop+-author%3Ajerop)
and has authored 27 PRs against this repo (https://github.com/tektoncd/pipeline/pulls/jerop)
including when expressions https://github.com/tektoncd/pipeline/pull/3135,
in addition to making significant improvements to our processes
(e.g. defining design principles https://github.com/tektoncd/community/pull/171
and recently proposing topical areas of ownership)

Thanks for all your hard work @jerop!!

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
