### PR TITLE
Add a "set -e" to the dind-sidecar test script.

### DIFF
--- a/examples/v1alpha1/taskruns/dind-sidecar.yaml
+++ b/examples/v1alpha1/taskruns/dind-sidecar.yaml
@@ -19,6 +19,7 @@ spec:
         value: /certs/client
       script: |
           #!/usr/bin/env sh
+          set -e
           # Run a Docker container.
           docker run busybox echo hello
 
@@ -28,7 +29,7 @@ spec:
           RUN apt-get update
           ENTRYPOINT ["echo", "hello"]
           EOF
-          docker build -t hello . && docker run hello
+          docker build -t hello .
           docker images
 
           # ...then run it!

--- a/examples/v1beta1/taskruns/dind-sidecar.yaml
+++ b/examples/v1beta1/taskruns/dind-sidecar.yaml
@@ -19,6 +19,7 @@ spec:
         value: /certs/client
       script: |
           #!/usr/bin/env sh
+          set -e
           # Run a Docker container.
           docker run busybox echo hello
 
@@ -28,7 +29,7 @@ spec:
           RUN apt-get update
           ENTRYPOINT ["echo", "hello"]
           EOF
-          docker build -t hello . && docker run hello
+          docker build -t hello .
           docker images
 
           # ...then run it!


### PR DESCRIPTION
# Changes

I was bitten by this test not having one, when the "docker build"
failed but we continued on executing anyway. I did a cursory look
at the other tests, and they either already have this or are so
short/simple that it doesn't matter.

Ref https://github.com/tektoncd/pipeline/pull/3628

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
