### PR TITLE
Adding power (ppc64le) architecture image mappings

### DIFF
--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -62,7 +62,8 @@ func getTestArch() string {
 
 // initImageNames returns the map with arch dependent image names for e2e tests
 func initImageNames() map[int]string {
-	if getTestArch() == "s390x" {
+	switch getTestArch() {
+	case "s390x":
 		return map[int]string{
 			busyboxImage:   "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977",
 			registryImage:  "ibmcom/registry:2.6.2.5",
@@ -71,14 +72,24 @@ func initImageNames() map[int]string {
 			kanikoImage:    "gcr.io/kaniko-project/executor:s390x-9ed158c1f63a059cde4fd5f8b95af51d452d9aa7",
 			dockerizeImage: "ibmcom/dockerize-s390x",
 		}
-	}
-	return map[int]string{
-		busyboxImage:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
-		registryImage:  "registry",
-		kubectlImage:   "lachlanevenson/k8s-kubectl",
-		helmImage:      "alpine/helm:3.1.2",
-		kanikoImage:    "gcr.io/kaniko-project/executor:v1.3.0",
-		dockerizeImage: "jwilder/dockerize",
+	case "ppc64le":
+		return map[int]string{
+			busyboxImage:   "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977",
+			registryImage:  "ppc64le/registry:2",
+			kubectlImage:   "ibmcom/kubectl:v1.13.9",
+			helmImage:      "ibmcom/helm-ppc64le:latest",
+			kanikoImage:    "ibmcom/kaniko-project-executor-ppc64le:v0.17.1",
+			dockerizeImage: "ibmcom/dockerize-ppc64le",
+		}
+	default:
+		return map[int]string{
+			busyboxImage:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
+			registryImage:  "registry",
+			kubectlImage:   "lachlanevenson/k8s-kubectl",
+			helmImage:      "alpine/helm:3.1.2",
+			kanikoImage:    "gcr.io/kaniko-project/executor:v1.3.0",
+			dockerizeImage: "jwilder/dockerize",
+		}
 	}
 }
 
@@ -98,7 +109,9 @@ func getImagesMappingRE() map[*regexp.Regexp][]byte {
 // imageNamesMapping provides mapping between image name in the examples yaml files and desired image name for specific arch.
 // by default empty map is returned.
 func imageNamesMapping() map[string]string {
-	if getTestArch() == "s390x" {
+
+	switch getTestArch() {
+	case "s390x":
 		return map[string]string{
 			"registry":                              getTestImage(registryImage),
 			"node":                                  "node:alpine3.11",
@@ -110,6 +123,19 @@ func imageNamesMapping() map[string]string {
 			"stedolan/jq":                           "ibmcom/jq-s390x:latest",
 			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
 		}
+	case "ppc64le":
+		return map[string]string{
+			"registry":                              getTestImage(registryImage),
+			"node":                                  "node:alpine3.11",
+			"lachlanevenson/k8s-kubectl":            getTestImage(kubectlImage),
+			"gcr.io/cloud-builders/git":             "alpine/git:latest",
+			"docker:dind":                           "ibmcom/docker-ppc64le:19.03-dind",
+			"docker":                                "docker:18.06.3",
+			"mikefarah/yq:3":                        "danielxlee/yq:2.4.0",
+			"stedolan/jq":                           "ibmcom/jq-ppc64le:latest",
+			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
+		}
+
 	}
 
 	return make(map[string]string)
@@ -117,7 +143,21 @@ func imageNamesMapping() map[string]string {
 
 // initExcludedTests provides list of excluded tests for e2e and exanples tests
 func initExcludedTests() sets.String {
-	if getTestArch() == "s390x" {
+
+	switch getTestArch() {
+	case "s390x":
+		return sets.NewString(
+			//examples
+			"TestExamples/v1alpha1/taskruns/build-gcs-targz",
+			"TestExamples/v1beta1/taskruns/build-gcs-targz",
+			"TestExamples/v1beta1/taskruns/build-gcs-zip",
+			"TestExamples/v1alpha1/taskruns/build-gcs-zip",
+			"TestExamples/v1alpha1/taskruns/gcs-resource",
+			"TestExamples/v1beta1/taskruns/gcs-resource",
+			"TestExamples/v1beta1/pipelineruns/pipelinerun",
+			"TestYamls/yamls/v1beta1/pipelineruns/pipelinerun.yaml",
+		)
+	case "ppc64le":
 		return sets.NewString(
 			//examples
 			"TestExamples/v1alpha1/taskruns/build-gcs-targz",
@@ -130,6 +170,7 @@ func initExcludedTests() sets.String {
 			"TestYamls/yamls/v1beta1/pipelineruns/pipelinerun.yaml",
 		)
 	}
+
 	return sets.NewString()
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Adds ppc64le architecture image mappings
- Excludes some of the test cases for ppc64le

/kind misc
# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

## Release Notes
```release-note
NONE
```