### PR TITLE
Add SYSTEM_NAMESPACE introduction in test README

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -115,6 +115,8 @@ Environment variables used by end to end tests:
 - `KO_DOCKER_REPO` - Set this to an image registry your tests can push images to
 - `GCP_SERVICE_ACCOUNT_KEY_PATH` - Tests that need to interact with GCS buckets
   will use the json credentials at this path to authenticate with GCS.
+- `SYSTEM_NAMESPACE` - Set this to your Tekton deployment namespace like `tekton-pipelines`.
+  Without this setting, the E2E test will use `knative-testing` as default namespace.
 
 - In Kaniko e2e test, setting `GCP_SERVICE_ACCOUNT_KEY_PATH` as the path of the
   GCP service account JSON key which has permissions to push to the registry
@@ -146,6 +148,8 @@ gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$EMAI
 gcloud iam service-accounts keys create config.json --iam-account $EMAIL
 
 export GCP_SERVICE_ACCOUNT_KEY_PATH="$PWD/config.json"
+
+export SYSTEM_NAMESPACE=tekton-pipelines
 ```
 
 ### Running


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Recently, there is a new change in the Knative test framework:
By default, the `SYSTEM_NAMESPACE` will be set as `knative-testing`:
https://github.com/knative/pkg/blob/67d950c438f17c46108761215c0c8394484edea5/system/testing/names.go#L29

So Tekton introduced this change, to set `SYSTEM_NAMESPACE=tekton-pipelines` during `install_pipeline_crd`:
https://github.com/tektoncd/pipeline/blob/master/test/e2e-common.sh#L30

But for our scenario, **we deploy Tekton by ourselves** and just need to run the E2E test by using `go test` directly:
https://github.com/tektoncd/pipeline/tree/master/test#end-to-end-tests

But if I don't run `e2e-tests.sh` I will miss this setting `SYSTEM_NAMESPACE=tekton-pipelines` which makes failure in some of E2E tests, like:
`Failed to get ConfigMap feature-flags: configmaps "feature-flags" not found`, because we don't have `knative-testing` namespace, so of course no configmaps "feature-flags" in there:
https://github.com/tektoncd/pipeline/blob/master/test/tektonbundles_test.go#L524


So I add this `SYSTEM_NAMESPACE` in the test README to help the person who wants to run the E2E by using `go test` directly.

/kind documentation


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
