### PR TITLE
Change the implementation of the metrics podLatency with a map

### DIFF
--- a/pkg/reconciler/taskrun/metrics.go
+++ b/pkg/reconciler/taskrun/metrics.go
@@ -393,13 +393,3 @@ func sentCloudEvents(tr *v1beta1.TaskRun) int64 {
 	}
 	return sent
 }
-
-func getScheduledTime(pod *corev1.Pod) metav1.Time {
-	for _, c := range pod.Status.Conditions {
-		if c.Type == corev1.PodScheduled {
-			return c.LastTransitionTime
-		}
-	}
-
-	return metav1.Time{}
-}

--- a/pkg/reconciler/taskrun/metrics_test.go
+++ b/pkg/reconciler/taskrun/metrics_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package taskrun
 
 import (
-	"k8s.io/apimachinery/pkg/types"
 	"testing"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/metrics/metricstest"

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -447,6 +447,15 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 		}
 	}
 
+	runningTime := metav1.Time{Time: time.Now()}
+	go func(metrics *Recorder) {
+		if pod.Status.Phase == corev1.PodRunning {
+			err := metrics.MarkRunningTime(pod, runningTime)
+			if err != nil {
+				logger.Warnf("Failed to mark pod running time : %v", err)
+			}
+		}
+	}(c.metrics)
 	// Convert the Pod's status to the equivalent TaskRun Status.
 	tr.Status, err = podconvert.MakeTaskRunStatus(logger, *tr, pod)
 	if err != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixs #3608 .

Currently, podLatency reports the duration between pod creation time and pod scheduled
time, which means if the k8s cluster is not busy enough it would be 0 at most times.

In this PR, podLatency is changed to report the duration between pod creation time
and the time at which pod phase turns to `Running`. The startRunningTime is not stored
in the pod status so the time is collected in the reconciliation loop. Due to the latency
of reconciler, the minimum value of podLatency is 2s.

The unit of podLatency is changed to seconds from nanoseconds for better understanding.

Compared to another alternative PR https://github.com/tektoncd/pipeline/pull/3624. Instead
of adding a new taskrun status variable, this PR adds a map to metrics structure which
is used to save the startRunning time of every taskrun pods. The key of the map is
pod UID. This has some caveat that the delay of podLatency is longer than
https://github.com/tektoncd/pipeline/pull/3624.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Change podLatency to report the duration between between pod creation time and the time at which pod phase turns to `Running`
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:



For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
