### PR TITLE
Improve documentation around variable behaviour and gotchas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ See the following topics to learn how to use Tekton Pipelines in your project:
 - [Using labels](labels.md)
 - [Viewing logs](logs.md)
 - [Pipelines metrics](metrics.md)
-- [Variable Substitutions](variables.md)
+- [Variable Substitutions](tasks.md#using-variable-substitution)
 - [Running a Custom Task (alpha)](runs.md)
 
 ## Contributing to Tekton Pipelines

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -19,6 +19,7 @@ weight: 3
     - [Guard `Task` execution using `When Expressions`](#guard-task-execution-using-whenexpressions)
     - [Guard `Task` execution using `Conditions`](#guard-task-execution-using-conditions)
     - [Configuring the failure timeout](#configuring-the-failure-timeout)
+  - [Using variable substitution](#using-variable-substitution)
   - [Using `Results`](#using-results)
     - [Passing one Task's `Results` into the `Parameters` of another](#passing-one-tasks-results-into-the-parameters-of-another)
     - [Emitting `Results` from a `Pipeline`](#emitting-results-from-a-pipeline)
@@ -513,6 +514,19 @@ spec:
         name: build-push
       timeout: "0h1m30s"
 ```
+
+## Using variable substitution
+
+Tekton provides variables to inject values into the contents of certain fields.
+The values you can inject come from a range of sources including other fields
+in the Pipeline, context-sensitive information that Tekton provides, and runtime
+information received from a PipelineRun.
+
+The mechanism of variable substitution is quite simple - string replacement is
+performed by the Tekton Controller when a PipelineRun is executed.
+
+See the [complete list of variable substitutions for Pipelines](./variables.md#variables-available-in-a-pipeline)
+and the [list of fields that accept substitutions](./variables.md#fields-that-accept-variable-substitutions).
 
 ## Using `Results`
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -7,6 +7,9 @@ weight: 15
 # Variable Substitutions Supported by `Tasks` and `Pipelines`
 
 This page documents the variable substitutions supported by `Tasks` and `Pipelines`.
+
+For instructions on using variable substitutions see the relevant section of [the Tasks doc](tasks.md#using-variable-substitution).
+
 **Note:** Tekton does not escape the contents of variables. Task authors are responsible for properly escaping a variable's value according to the shell, image or scripting language that the variable will be used in.
 
 ## Variables available in a `Pipeline`


### PR DESCRIPTION
# Changes

We used to link from the docs directory's README.md to our variables.md doc
but variables.md doesn't really explain the way variables work - it just
describes what values they can be used for and where they can be used in
our CRDs.

This commit changes the docs directory's README.md to point at the variable
documentation in our task doc, and adds a few lines there to talk a bit
more about how the substitution happens.

This commit also describes how to safely inject variables into `bash`
`script` blocks in Tasks without accidentally eval'ing the variable
contents.

Closes #3039

Closes #3458

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Add a doc describing how to safely use variables in script blocks of tasks without eval'ing their contents
```