### PR TITLE
Issue #3553 reduce unit test execution time

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -34,15 +34,16 @@ import (
 )
 
 var (
-	ep                  = flag.String("entrypoint", "", "Original specified entrypoint to execute")
-	waitFiles           = flag.String("wait_file", "", "Comma-separated list of paths to wait for")
-	waitFileContent     = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
-	postFile            = flag.String("post_file", "", "If specified, file to write upon completion")
-	terminationPath     = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
-	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
-	waitPollingInterval = time.Second
-	timeout             = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
+	ep              = flag.String("entrypoint", "", "Original specified entrypoint to execute")
+	waitFiles       = flag.String("wait_file", "", "Comma-separated list of paths to wait for")
+	waitFileContent = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
+	postFile        = flag.String("post_file", "", "If specified, file to write upon completion")
+	terminationPath = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
+	results         = flag.String("results", "", "If specified, list of file names that might contain task results")
+	timeout         = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
 )
+
+const defaultWaitPollingInterval = time.Second
 
 func cp(src, dst string) error {
 	s, err := os.Open(src)
@@ -102,7 +103,7 @@ func main() {
 		PostFile:        *postFile,
 		TerminationPath: *terminationPath,
 		Args:            flag.Args(),
-		Waiter:          &realWaiter{},
+		Waiter:          &realWaiter{waitPollingInterval: defaultWaitPollingInterval},
 		Runner:          &realRunner{},
 		PostWriter:      &realPostWriter{},
 		Results:         strings.Split(*results, ","),

--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -23,6 +23,8 @@ import (
 	"time"
 )
 
+const testWaitPollingInterval = 10 * time.Millisecond
+
 func TestRealWaiterWaitMissingFile(t *testing.T) {
 	// Create a temp file and then immediately delete it to get
 	// a legitimate tmp path and ensure the file doesnt exist
@@ -35,7 +37,7 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.Wait(tmp.Name(), false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), false)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -44,7 +46,7 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 	select {
 	case <-doneCh:
 		t.Errorf("did not expect Wait() to have detected a file at path %q", tmp.Name())
-	case <-time.After(2 * waitPollingInterval):
+	case <-time.After(2 * testWaitPollingInterval):
 		// Success
 	}
 }
@@ -58,7 +60,7 @@ func TestRealWaiterWaitWithFile(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.Wait(tmp.Name(), false)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), false)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -67,7 +69,7 @@ func TestRealWaiterWaitWithFile(t *testing.T) {
 	select {
 	case <-doneCh:
 		// Success
-	case <-time.After(2 * waitPollingInterval):
+	case <-time.After(2 * testWaitPollingInterval):
 		t.Errorf("expected Wait() to have detected the file's existence by now")
 	}
 }
@@ -81,7 +83,7 @@ func TestRealWaiterWaitMissingContent(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.Wait(tmp.Name(), true)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), true)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -90,7 +92,7 @@ func TestRealWaiterWaitMissingContent(t *testing.T) {
 	select {
 	case <-doneCh:
 		t.Errorf("no data was written to tmp file, did not expect Wait() to have detected a non-zero file size and returned")
-	case <-time.After(2 * waitPollingInterval):
+	case <-time.After(2 * testWaitPollingInterval):
 		// Success
 	}
 }
@@ -104,7 +106,7 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 	rw := realWaiter{}
 	doneCh := make(chan struct{})
 	go func() {
-		err := rw.Wait(tmp.Name(), true)
+		err := rw.setWaitPollingInterval(testWaitPollingInterval).Wait(tmp.Name(), true)
 		if err != nil {
 			t.Errorf("error waiting on tmp file %q", tmp.Name())
 		}
@@ -116,7 +118,7 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 	select {
 	case <-doneCh:
 		// Success
-	case <-time.After(2 * waitPollingInterval):
+	case <-time.After(2 * testWaitPollingInterval):
 		t.Errorf("expected Wait() to have detected a non-zero file size by now")
 	}
 }

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -427,7 +427,7 @@ func setupFakeContext(t *testing.T, behaviour FakeClientBehaviour, withClient bo
 }
 
 func eventFromChannel(c chan string, testName string, wantEvent string) error {
-	timer := time.NewTimer(1 * time.Second)
+	timer := time.NewTimer(10 * time.Millisecond)
 	select {
 	case event := <-c:
 		if wantEvent == "" {

--- a/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -71,13 +71,13 @@ func (t TektonEventType) String() string {
 type CEClient cloudevents.Client
 
 // TektonCloudEventData type is used to marshal and unmarshal the payload of
-// a Tekton cloud event. It can include a PipelineRun or a PipelineRun
+// a Tekton cloud event. It can include a TaskRun or a PipelineRun
 type TektonCloudEventData struct {
 	TaskRun     *v1beta1.TaskRun     `json:"taskRun,omitempty"`
 	PipelineRun *v1beta1.PipelineRun `json:"pipelineRun,omitempty"`
 }
 
-// NewTektonCloudEventData returns a new instance of NewTektonCloudEventData
+// NewTektonCloudEventData returns a new instance of TektonCloudEventData
 func NewTektonCloudEventData(runObject objectWithCondition) TektonCloudEventData {
 	tektonCloudEventData := TektonCloudEventData{}
 	switch v := runObject.(type) {
@@ -121,7 +121,7 @@ func EventForTaskRun(taskRun *v1beta1.TaskRun) (*cloudevents.Event, error) {
 	return EventForObjectWithCondition(taskRun)
 }
 
-// EventForPipelineRun will create a new event based on a TaskRun,
+// EventForPipelineRun will create a new event based on a PipelineRun,
 // or return an error if not possible.
 func EventForPipelineRun(pipelineRun *v1beta1.PipelineRun) (*cloudevents.Event, error) {
 	// Check if the TaskRun is defined

--- a/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -84,7 +84,7 @@ func getPipelineRunByCondition(status corev1.ConditionStatus, reason string) *v1
 }
 
 func TestEventForTaskRun(t *testing.T) {
-	for _, c := range []struct {
+	taskRunTests := []struct {
 		desc          string
 		taskRun       *v1beta1.TaskRun
 		wantEventType TektonEventType
@@ -108,7 +108,9 @@ func TestEventForTaskRun(t *testing.T) {
 		desc:          "send a cloud event with successful status taskrun",
 		taskRun:       getTaskRunByCondition(corev1.ConditionTrue, "yay"),
 		wantEventType: TaskRunSuccessfulEventV1,
-	}} {
+	}}
+
+	for _, c := range taskRunTests {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
 
@@ -141,7 +143,7 @@ func TestEventForTaskRun(t *testing.T) {
 }
 
 func TestEventForPipelineRun(t *testing.T) {
-	for _, c := range []struct {
+	pipelineRunTests := []struct {
 		desc          string
 		pipelineRun   *v1beta1.PipelineRun
 		wantEventType TektonEventType
@@ -165,7 +167,9 @@ func TestEventForPipelineRun(t *testing.T) {
 		desc:          "send a cloud event with unknown status pipelinerun",
 		pipelineRun:   getPipelineRunByCondition(corev1.ConditionFalse, "meh"),
 		wantEventType: PipelineRunFailedEventV1,
-	}} {
+	}}
+
+	for _, c := range pipelineRunTests {
 		t.Run(c.desc, func(t *testing.T) {
 			names.TestingSeed()
 

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -246,7 +246,7 @@ func TestEmit(t *testing.T) {
 }
 
 func eventFromChannel(c chan string, testName string, wantEvent string) error {
-	timer := time.NewTimer(1 * time.Second)
+	timer := time.NewTimer(10 * time.Millisecond)
 	select {
 	case event := <-c:
 		if wantEvent == "" {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -44,8 +44,6 @@ import (
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -186,7 +184,7 @@ func eventFromChannel(c chan string, testName string, wantEvents []string) error
 	// We only hit the timeout in case of failure of the test, so the actual value
 	// of the timeout is not so relevant, it's only used when tests are going to fail.
 	// on the channel forever if fewer than expected events are received
-	timer := time.NewTimer(1 * time.Second)
+	timer := time.NewTimer(10 * time.Millisecond)
 	foundEvents := []string{}
 	for ii := 0; ii < len(wantEvents)+1; ii++ {
 		// We loop over all the events that we expect. Once they are all received
@@ -3936,8 +3934,7 @@ func TestUpdatePipelineRunStatusFromTaskRuns(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.prName, func(t *testing.T) {
-			observer, _ := observer.New(zap.InfoLevel)
-			logger := zap.New(observer).Sugar()
+			logger := logtesting.TestLogger(t)
 
 			pr := &v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Name: tc.prName, UID: prUID},

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -331,7 +331,7 @@ func eventFromChannel(c chan string, testName string, wantEvents []string) error
 	// We only hit the timeout in case of failure of the test, so the actual value
 	// of the timeout is not so relevant, it's only used when tests are going to fail.
 	// on the channel forever if fewer than expected events are received
-	timer := time.NewTimer(1 * time.Second)
+	timer := time.NewTimer(10 * time.Millisecond)
 	foundEvents := []string{}
 	for ii := 0; ii < len(wantEvents)+1; ii++ {
 		// We loop over all the events that we expect. Once they are all received
@@ -365,7 +365,7 @@ func eventFromChannel(c chan string, testName string, wantEvents []string) error
 // expects to receive. The events can be received in any order. Any extra or too few
 // events are both considered errors.
 func eventFromChannelUnordered(c chan string, wantEvents []string) error {
-	timer := time.NewTimer(1 * time.Second)
+	timer := time.NewTimer(10 * time.Millisecond)
 	expected := append([]string{}, wantEvents...)
 	// loop len(expected) + 1 times to catch extra erroneous events received that the test is not expecting
 	maxEvents := len(expected) + 1
@@ -3245,7 +3245,7 @@ func TestFailTaskRun(t *testing.T) {
 				pvcHandler:       volumeclaim.NewPVCHandler(testAssets.Clients.Kube, testAssets.Logger),
 			}
 
-			err := c.failTaskRun(context.Background(), tc.taskRun, tc.reason, tc.message)
+			err := c.failTaskRun(testAssets.Ctx, tc.taskRun, tc.reason, tc.message)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -3265,7 +3265,7 @@ func TestFailTaskRun(t *testing.T) {
 
 func Test_storeTaskSpec(t *testing.T) {
 
-	ctx := context.Background()
+	ctx, _ := ttesting.SetupFakeContext(t)
 	tr := tb.TaskRun("foo", tb.TaskRunSpec(tb.TaskRunTaskRef("foo-task")))
 
 	ts := tb.Task("some-task", tb.TaskSpec(tb.TaskDescription("foo-task"))).Spec

--- a/pkg/reconciler/testing/logger.go
+++ b/pkg/reconciler/testing/logger.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	rtesting "knative.dev/pkg/reconciler/testing"
@@ -25,9 +26,6 @@ func WithLogger(ctx context.Context, t *testing.T) context.Context {
 }
 
 func TestLogger(t *testing.T) *zap.SugaredLogger {
-	logger, err := zap.NewDevelopment(zap.AddCaller())
-	if err != nil {
-		t.Fatalf("failed to create logger: %s", err)
-	}
+	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
 	return logger.Sugar().Named(t.Name())
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Issue #3553
# Changes

## cmd/entrypoint
Refactor realWaiter to add a field

The waitPollingInterval field is used by the Wait function

Define a setWaitPollingInterval function in order to

permit setting pollingInterval before calling Wait()

It is used in the test functions to set a small interval(10ms)

## pkg/reconciler/events/cloudevent
Reduce test time from 3.147s to hundreds of ms
    
Refactor cloudevent_test.go for readability

## pkg/reconciler/events

Refactor event_test.go to reduce time to 10ms prior to check events
 
## pkg/reconciler/pipelinerun  
    
Refactor pipelinerun_test.go
      set test logger where missing
      reduce timeout to 10ms prior to check events

## pkg/reconciler/pipelinerun

 Refactor taskrun_test.go
      set test logger where missing
      reduce timeout to 10ms prior to check events
    
Correct comments typos

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
