### PR TITLE
Skip the dropNetworking test if it doesn't have the correct privileges.

### DIFF
--- a/cmd/entrypoint/namespaces_test.go
+++ b/cmd/entrypoint/namespaces_test.go
@@ -15,6 +15,18 @@ import (
 // sandboxed environment, the test could pass even if the dropNetworking
 // function did nothing.
 func TestDropNetworking(t *testing.T) {
+	// First make sure we can run the dropNetworking command.
+	// Some older kernels require special configurations to run this.
+	// I haven't been able to come up with an exhaustive list of what is needed,
+	// but it includes things like CAP_SYS_ADMIN, kernel.unprivileged_userns_clone=1
+	// and maybe others.
+	// For the sake of this test just check it first.
+	testCmd := exec.Command("true")
+	dropNetworking(testCmd)
+	if _, err := testCmd.CombinedOutput(); err != nil {
+		t.Skipf("skipping test as required namespace features are not available: %v", err)
+	}
+
 	cmd := exec.Command("curl", "google.com")
 	dropNetworking(cmd)
 	b, err := cmd.CombinedOutput()


### PR DESCRIPTION
# Changes

I decided to check for the required privileges directly, but just running it
on something that should always work and looking for an error. I considered
directly testing the capabilities required, but that couples the test to the
implementation and is probably not going to be perfect anyway.

/kind failing-test

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [X] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [X] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
