### PR TITLE
Allow custom tasks to use workspaces, service accounts, pod templates

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -258,6 +258,9 @@ set for the target [`namespace`](https://kubernetes.io/docs/concepts/overview/wo
 
 For more information, see [`ServiceAccount`](auth.md).
 
+[`Custom tasks`](pipelines.md#using-custom-tasks) may or may not use a service account name.
+Consult the documentation of the custom task that you are using to determine whether it supports a service account name.
+
 ### Mapping `ServiceAccount` credentials to `Tasks`
 
 If you require more granularity in specifying execution credentials, use the `serviceAccountNames` field to
@@ -341,6 +344,9 @@ spec:
         claimName: my-volume-claim
 ```
 
+[`Custom tasks`](pipelines.md#using-custom-tasks) may or may not use a pod template.
+Consult the documentation of the custom task that you are using to determine whether it supports a pod template.
+
 ### Specifying taskRunSpecs
 
 Specifies a list of `PipelineTaskRunSpec` which contains `TaskServiceAccountName`, `TaskPodTemplate`
@@ -384,6 +390,9 @@ For more information, see the following topics:
 - For information on mapping `Workspaces` to `Volumes`, see [Specifying `Workspaces` in `PipelineRuns`](workspaces.md#specifying-workspaces-in-pipelineruns).
 - For a list of supported `Volume` types, see [Specifying `VolumeSources` in `Workspaces`](workspaces.md#specifying-volumesources-in-workspaces).
 - For an end-to-end example, see [`Workspaces` in a `PipelineRun`](../examples/v1beta1/pipelineruns/workspaces.yaml).
+
+[`Custom tasks`](pipelines.md#using-custom-tasks) may or may not use workspaces.
+Consult the documentation of the custom task that you are using to determine whether it supports workspaces.
 
 ### Specifying `LimitRange` values
 

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -954,13 +954,12 @@ If the `taskRef` specifies a name, the custom task controller should look up the
 If the `taskRef` does not specify a name, the custom task controller might support
 some default behavior for executing unnamed tasks.
 
-### Specifying `Parameters`
+### Specifying parameters
 
 If a custom task supports [`parameters`](tasks.md#parameters), you can use the
 `params` field to specify their values:
 
 ```yaml
-spec:
 spec:
   tasks:
     - name: run-custom-task
@@ -973,6 +972,24 @@ spec:
         value: bah
 ```
 
+### Specifying workspaces
+
+If the custom task supports it, you can provide [`Workspaces`](workspaces.md#using-workspaces-in-tasks) to share data with the custom task.
+
+```yaml
+spec:
+  tasks:
+    - name: run-custom-task
+      taskRef:
+        apiVersion: example.dev/v1alpha1
+        kind: Example
+        name: myexample
+      workspaces:
+      - name: my-workspace
+```
+
+Consult the documentation of the custom task that you are using to determine whether it supports workspaces and how to name them.
+
 ### Using `Results`
 
 If the custom task produces results, you can reference them in a Pipeline using the normal syntax,
@@ -980,14 +997,11 @@ If the custom task produces results, you can reference them in a Pipeline using 
 
 ### Limitations
 
-Pipelines do not directly support passing the following items to custom tasks:
+Pipelines do not support the following items with custom tasks:
 * Pipeline Resources
-* Workspaces
-* Service account name
-* Pod templates
-
-A pipeline task that references a custom task cannot reference `Conditions`.
-`Conditions` are deprecated.  Use [`WhenExpressions`](#guard-task-execution-using-whenexpressions) instead.
+* [`retries`](#using-the-retries-parameter)
+* [`timeout`](#configuring-the-failure-timeout)
+* Conditions (`Conditions` are deprecated.  Use [`WhenExpressions`](#guard-task-execution-using-whenexpressions) instead.)
 
 ## Code examples
 

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -10,7 +10,8 @@ weight: 2
 - [Overview](#overview)
 - [Configuring a `Run`](#configuring-a-run)
   - [Specifying the target Custom Task](#specifying-the-target-custom-task)
-  - [Specifying `Parameters`](#specifying-parameters)
+  - [Specifying Parameters](#specifying-parameters)
+  - [Specifying Workspaces, Service Account, and Pod Template](#specifying-workspaces-service-account-and-pod-template)
 - [Monitoring execution status](#monitoring-execution-status)
   - [Monitoring `Results`](#monitoring-results)
 - [Code examples](#code-examples)
@@ -51,6 +52,12 @@ A `Run` definition supports the following fields:
 - Optional:
   - [`params`](#specifying-parameters) - Specifies the desired execution
     parameters for the custom task.
+  - [`serviceAccountName`](#specifying-a-serviceaccount) - Specifies a `ServiceAccount`
+    object that provides custom credentials for executing the `Run`.
+  - [`workspaces`](#specifying-workspaces) - Specifies the physical volumes to use for the
+    [`Workspaces`](workspaces.md) required by a custom task.
+  - [`podTemplate`](#specifying-a-pod-template) - Specifies a [`Pod` template](podtemplates.md) to use
+    to configure pods created by the custom task.
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields
@@ -107,6 +114,57 @@ spec:
 If the custom task controller knows how to interpret the parameter value, it
 will do so. It might enforce that some parameter values must be specified, or
 reject unknown parameter values.
+
+### Specifying Workspaces, Service Account, and Pod Template
+
+A `Run` object can specify workspaces, a service account name, or a pod template.
+These are intended to be used with custom tasks that create Pods or other resources that embed a Pod specification.
+The custom task can use these specifications to construct the Pod specification.
+Not all custom tasks will support these values.
+Consult the documentation of the custom task that you are using to determine whether these values apply.
+
+#### Specifying workspaces
+
+If the custom task supports it, you can provide [`Workspaces`](workspaces.md) to share data with the custom task.
+
+```yaml
+spec:
+  workspaces:
+  - name: my-workspace
+    emptyDir: {}
+```
+
+Consult the documentation of the custom task that you are using to determine whether it supports workspaces and how to name them.
+
+#### Specifying a ServiceAccount
+
+If the custom task supports it, you can execute the `Run` with a specific set of credentials by
+specifying a `ServiceAccount` object name in the `serviceAccountName` field in your `Run`
+definition. If you do not explicitly specify this, the `Run` executes with the service account
+specified in the `configmap-defaults` `ConfigMap`. If this default is not specified, `Runs`
+will execute with the [`default` service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server)
+set for the target [`namespace`](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
+
+```yaml
+spec:
+  serviceAccountName: my-account
+```
+
+Consult the documentation of the custom task that you are using to determine whether it supports a service account name.
+
+#### Specifying a pod template
+
+If the custom task supports it, you can specify a [`Pod` template](podtemplates.md) configuration that the custom task will
+use to configure Pods (or other resources that embed a Pod specification) that it creates.
+
+```yaml
+spec:
+  podTemplate:
+    securityContext:
+      runAsUser: 1001
+```
+
+Consult the documentation of the custom task that you are using to determine whether it supports a pod template.
 
 ## Monitoring execution status
 

--- a/pkg/apis/pipeline/v1alpha1/run_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/run_defaults.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"knative.dev/pkg/apis"
 )
 
@@ -30,5 +31,13 @@ func (r *Run) SetDefaults(ctx context.Context) {
 }
 
 func (rs *RunSpec) SetDefaults(ctx context.Context) {
-	// No defaults to set.
+	cfg := config.FromContextOrDefaults(ctx)
+	defaultSA := cfg.Defaults.DefaultServiceAccount
+	if rs.ServiceAccountName == "" && defaultSA != "" {
+		rs.ServiceAccountName = defaultSA
+	}
+	defaultPodTemplate := cfg.Defaults.DefaultPodTemplate
+	if rs.PodTemplate == nil {
+		rs.PodTemplate = defaultPodTemplate
+	}
 }

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -48,10 +48,20 @@ type RunSpec struct {
 	// +optional
 	Status RunSpecStatus `json:"status,omitempty"`
 
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName"`
+
+	// PodTemplate holds pod specific configuration
+	// +optional
+	PodTemplate *PodTemplate `json:"podTemplate,omitempty"`
+
+	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
+	// +optional
+	Workspaces []v1beta1.WorkspaceBinding `json:"workspaces,omitempty"`
+
 	// TODO(https://github.com/tektoncd/community/pull/128)
 	// - timeout
 	// - inline task spec
-	// - workspaces ?
 }
 
 // RunSpecStatus defines the taskrun spec status the user can provide
@@ -76,6 +86,12 @@ func (rs RunSpec) GetParam(name string) *v1beta1.Param {
 const (
 	// RunReasonCancelled must be used in the Condition Reason to indicate that a Run was cancelled.
 	RunReasonCancelled = "RunCancelled"
+	// RunReasonWorkspaceNotSupported can be used in the Condition Reason to indicate that the
+	// Run contains a workspace which is not supported by this custom task.
+	RunReasonWorkspaceNotSupported = "RunWorkspaceNotSupported"
+	// RunReasonPodTemplateNotSupported can be used in the Condition Reason to indicate that the
+	// Run contains a pod template which is not supported by this custom task.
+	RunReasonPodTemplateNotSupported = "RunPodTemplateNotSupported"
 )
 
 // RunStatus defines the observed state of Run.

--- a/pkg/apis/pipeline/v1alpha1/run_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation.go
@@ -54,5 +54,9 @@ func (rs *RunSpec) Validate(ctx context.Context) *apis.FieldError {
 		return err
 	}
 
+	if err := validateWorkspaceBindings(ctx, rs.Workspaces); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -686,6 +686,18 @@ func (in *RunSpec) DeepCopyInto(out *RunSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PodTemplate != nil {
+		in, out := &in.PodTemplate, &out.PodTemplate
+		*out = new(pod.Template)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Workspaces != nil {
+		in, out := &in.Workspaces, &out.Workspaces
+		*out = make([]v1beta1.WorkspaceBinding, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -156,9 +156,6 @@ func validatePipelineTask(ctx context.Context, t PipelineTask, taskNames sets.St
 		if t.Resources != nil {
 			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support PipelineResources", "resources"))
 		}
-		if len(t.Workspaces) > 0 {
-			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support Workspaces", "workspaces"))
-		}
 		if t.Timeout != nil {
 			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support timeout", "timeout"))
 		}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -621,18 +621,6 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 		},
 		wc: enableFeature(t, "enable-custom-tasks"),
 	}, {
-		name: "pipelinetask custom task doesn't support workspaces",
-		tasks: []PipelineTask{{
-			Name:       "foo",
-			Workspaces: []WorkspacePipelineTaskBinding{{}},
-			TaskRef:    &TaskRef{APIVersion: "example.dev/v0", Kind: "Example"},
-		}},
-		expectedError: apis.FieldError{
-			Message: `invalid value: custom tasks do not support Workspaces`,
-			Paths:   []string{"tasks[0].workspaces"},
-		},
-		wc: enableFeature(t, "enable-custom-tasks"),
-	}, {
 		name: "pipelinetask custom task doesn't support timeout",
 		tasks: []PipelineTask{{
 			Name:    "foo",


### PR DESCRIPTION
Fixes #3593 
Fixes #3594 

Allow custom tasks to use workspaces, service accounts, and pod templates.
These features will be needed to build more complex custom tasks.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

* Add workspaces, service account name, and pod template to Run spec.
* Update pipelinerun controller to pass workspaces from pipeline task and service account name and pod template from PipelineRun to a Run

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Allow custom tasks to use workspaces, service accounts, and pod templates
```


