### PR TITLE
Add linux/arm to build-base target platform.

### DIFF
--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -48,14 +48,14 @@ spec:
         docker context create context1
 
         #create builder
-        docker buildx create context1 --name builder-buildx1 --driver docker-container --platform linux/amd64,linux/s390x,linux/ppc64le,linux/arm64 --use
+        docker buildx create context1 --name builder-buildx1 --driver docker-container --platform linux/amd64,linux/s390x,linux/ppc64le,linux/arm64,linux/arm --use
 
         #check the state
         docker buildx inspect --bootstrap --builder builder-buildx1
 
         #build multi-arch image
         docker buildx build \
-        --platform linux/amd64,linux/s390x,linux/ppc64le,linux/arm64 \
+        --platform linux/amd64,linux/s390x,linux/ppc64le,linux/arm64,linux/arm \
         --tag $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtBaseImage.url) \
         --push \
         /workspace/go/src/github.com/tektoncd/pipeline/images


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`gcr.io/distroless/static:nonroot` does support this platform. We need
to build our base image for it too, otherwise the `arm` version of
pipeline is broken as it cannot run `creds-init` and `git-init` images.

Fixes #3647

Long term, we might need to specify by hand the platform we support when we release as we may run into this next time distroless supports a new platform.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @bobcatfish @barthy1 

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Build `git-init` and `creds-init` image for linux/arm too
```
