### PR TITLE
Remove creds-init image from release/nightly pipelines

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -29,8 +29,6 @@ spec:
       type: image
     - name: builtKubeconfigWriterImage
       type: image
-    - name: builtCredsInitImage
-      type: image
     - name: builtGitInitImage
       type: image
     - name: builtControllerImage
@@ -167,7 +165,6 @@ spec:
         $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtEntrypointImage.url):$(params.versionTag)
         $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtNopImage.url):$(params.versionTag)
         $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtKubeconfigWriterImage.url):$(params.versionTag)
-        $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtCredsInitImage.url):$(params.versionTag)
         $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtGitInitImage.url):$(params.versionTag)
         $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtControllerImage.url):$(params.versionTag)
         $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtWebhookImage.url):$(params.versionTag)

--- a/tekton/release-pipeline-nightly.yaml
+++ b/tekton/release-pipeline-nightly.yaml
@@ -24,8 +24,6 @@ spec:
     type: image
   - name: builtKubeconfigWriterImage
     type: image
-  - name: builtCredsInitImage
-    type: image
   - name: builtGitInitImage
     type: image
   - name: builtControllerImage
@@ -103,8 +101,6 @@ spec:
             resource: builtNopImage
           - name: builtKubeconfigWriterImage
             resource: builtKubeconfigWriterImage
-          - name: builtCredsInitImage
-            resource: builtCredsInitImage
           - name: builtGitInitImage
             resource: builtGitInitImage
           - name: builtControllerImage

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -28,8 +28,6 @@ spec:
     type: image
   - name: builtKubeconfigWriterImage
     type: image
-  - name: builtCredsInitImage
-    type: image
   - name: builtGitInitImage
     type: image
   - name: builtControllerImage
@@ -129,8 +127,6 @@ spec:
             resource: builtNopImage
           - name: builtKubeconfigWriterImage
             resource: builtKubeconfigWriterImage
-          - name: builtCredsInitImage
-            resource: builtCredsInitImage
           - name: builtGitInitImage
             resource: builtGitInitImage
           - name: builtControllerImage


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The creds-init image is no more, so we can remove it from the images
that are built during the release (nightly or official).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @sbwsg @afrittoli 

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
