### PR TITLE
Ignore generated openapi code when running golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,7 @@ run:
   - e2e
   skip-files:
   - .*/zz_generated.deepcopy.go
+  - pkg/apis/pipeline/v1beta1/openapi_generated.go
   skip-dirs:
   - vendor
   - pkg/client


### PR DESCRIPTION
# Changes

Currently a dev using `make golangci-lint` will get a bunch of errors in openapi_generated.go.
This file isn't something we're supposed to make updates in, it's generated, so I don't think
reporting those errors makes a lot of sense.

This commit skips the openapi_generated.go file when running `make golangci-lint`.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```