### PR TITLE
param validation - execution status variable

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -854,9 +854,6 @@ This kind of variable can have any one of the values from the following table:
 
 For an end-to-end example, see [`status` in a `PipelineRun`](../examples/v1beta1/pipelineruns/pipelinerun-task-execution-status.yaml).
 
-**Note:** `$(tasks.<pipelineTask>.status)` is instantiated and available at runtime and must be used as a param value
-as is without concatenating it with any other param or string, for example, this kind of usage is not validated/supported
-`task status is $(tasks.<pipelineTask>.status)`.
 
 ### Known Limitations
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -272,6 +272,15 @@ func (l PipelineTaskList) Items() []dag.Task {
 	return tasks
 }
 
+// Names returns a set of pipeline task names from the given list of pipeline tasks
+func (l PipelineTaskList) Names() sets.String {
+	names := sets.String{}
+	for _, pt := range l {
+		names.Insert(pt.Name)
+	}
+	return names
+}
+
 // PipelineTaskParam is used to provide arbitrary string parameters to a Task.
 type PipelineTaskParam struct {
 	Name  string `json:"name"`

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/test/diff"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestPipelineTaskList_Names(t *testing.T) {
+	tasks := []PipelineTask{
+		{Name: "task-1"},
+		{Name: "task-2"},
+	}
+	expectedTaskNames := sets.String{}
+	expectedTaskNames.Insert("task-1")
+	expectedTaskNames.Insert("task-2")
+	actualTaskNames := PipelineTaskList(tasks).Names()
+	if d := cmp.Diff(expectedTaskNames, actualTaskNames); d != "" {
+		t.Fatalf("Failed to get list of pipeline task names, diff: %s", diff.PrintWantGot(d))
+	}
+}

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -60,22 +60,6 @@ func ValidateVariableP(value, prefix string, vars sets.String) *apis.FieldError 
 	return nil
 }
 
-func ValidateVariablePS(value, prefix string, suffix string, vars sets.String) *apis.FieldError {
-	if vs, present := extractVariablesFromString(value, prefix); present {
-		for _, v := range vs {
-			v = strings.TrimSuffix(v, suffix)
-			if !vars.Has(v) {
-				return &apis.FieldError{
-					Message: fmt.Sprintf("non-existent variable in %q", value),
-					// Empty path is required to make the `ViaField`, … work
-					Paths: []string{""},
-				}
-			}
-		}
-	}
-	return nil
-}
-
 // Verifies that variables matching the relevant string expressions do not reference any of the names present in vars.
 func ValidateVariableProhibited(name, value, prefix, locationName, path string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -116,39 +116,6 @@ func TestValidateVariables(t *testing.T) {
 	}
 }
 
-func TestValidateVariablePS(t *testing.T) {
-	type args struct {
-		paramValue string
-		vars       sets.String
-	}
-	for _, tc := range []struct {
-		name          string
-		paramValue    string
-		vars          sets.String
-		expectedError *apis.FieldError
-	}{{
-		name:          "valid pipeline task in variable",
-		paramValue:    "--flag=$(tasks.task1.status)",
-		vars:          sets.NewString("task1"),
-		expectedError: nil,
-	}, {
-		name:       "undefined pipeline task",
-		paramValue: "--flag=$(tasks.task1.status)",
-		vars:       sets.NewString("foo"),
-		expectedError: &apis.FieldError{
-			Message: `non-existent variable in "--flag=$(tasks.task1.status)"`,
-			Paths:   []string{""},
-		},
-	}} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := substitution.ValidateVariablePS(tc.paramValue, "tasks", "status", tc.vars)
-			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
-				t.Errorf("ValidateVariablePS() error did not match expected error for %s: %s", tc.name, diff.PrintWantGot(d))
-			}
-		})
-	}
-}
-
 func TestApplyReplacements(t *testing.T) {
 	type args struct {
 		input        string


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adding param validation while accessing execution status along with any other param or extra string. Updated pipelines documenting the limitation.

Also, avoiding task results validation as it follows very similar pattern with `$(tasks.taskname.results.status)` where
"status" being the result of some task.

Closes #3681 
Closes #3692 

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
