### PR TITLE
Allow pipeline results to use custom task results

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -542,7 +542,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks()
 
 	if after.Status == corev1.ConditionTrue {
-		pr.Status.PipelineResults = resources.ApplyTaskResultsToPipelineResults(pipelineSpec.Results, pr.Status.TaskRuns)
+		pr.Status.PipelineResults = resources.ApplyTaskResultsToPipelineResults(pipelineSpec.Results, pr.Status.TaskRuns, pr.Status.Runs)
 	}
 
 	logger.Infof("PipelineRun %s status is being set to %s", pr.Name, after)

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -186,23 +186,18 @@ func TestCustomTask(t *testing.T) {
 	}
 
 	// Validate that the pipeline's result reference to the custom task's result was resolved.
-	// This validation has been commented out because of a race condition.
-	// The pipelinerun reconciler updates the pipelinerun results AFTER the pipelinerun is marked DONE.
-	// So when the test case sees the pipelinerun is done, the results may or may not have been
-	// updated yet.  The FUBAR logic in the pipelinerun reconciler needs to be fixed to not mark
-	// the PR done before all the status updates are made.
 
-	// expectedPipelineResults := []v1beta1.PipelineRunResult{{
-	//	Name:  "prResult",
-	//	Value: "aResultValue",
-	// }}
+	expectedPipelineResults := []v1beta1.PipelineRunResult{{
+		Name:  "prResult",
+		Value: "aResultValue",
+	}}
 
-	// if len(pr.Status.PipelineResults) == 0 {
-	//	t.Fatalf("Expected PipelineResults but there are none")
-	// }
-	// if d := cmp.Diff(expectedPipelineResults, pr.Status.PipelineResults); d != "" {
-	// 	t.Fatalf("Unexpected PipelineResults: %s", diff.PrintWantGot(d))
-	// }
+	if len(pr.Status.PipelineResults) == 0 {
+		t.Fatalf("Expected PipelineResults but there are none")
+	}
+	if d := cmp.Diff(expectedPipelineResults, pr.Status.PipelineResults); d != "" {
+		t.Fatalf("Unexpected PipelineResults: %s", diff.PrintWantGot(d))
+	}
 }
 
 func skipIfCustomTasksDisabled(ctx context.Context, t *testing.T, c *clients, namespace string) {


### PR DESCRIPTION
Fixes #3595

This PR enables pipeline results to refer to pipeline tasks that run custom tasks and produce results.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Adds support to resolve pipeline result references to pipeline tasks that run custom tasks and produce results.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Pipeline results now can refer to pipeline tasks that run custom tasks and produce results.
```
