### PR TITLE
Fix stuck PipelineRun caused by optional workspace

### DIFF
--- a/examples/v1beta1/pipelineruns/optional-workspaces.yaml
+++ b/examples/v1beta1/pipelineruns/optional-workspaces.yaml
@@ -80,6 +80,8 @@ spec:
     - name: run-js
       runAfter: [print-bound-state]
       workspaces:
+      - name: prelaunch
+        workspace: prelaunch
       - name: launch
         workspace: launch
       taskRef:

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -752,7 +752,18 @@ func getTaskrunWorkspaces(pr *v1beta1.PipelineRun, rprt *resources.ResolvedPipel
 			}
 			workspaces = append(workspaces, taskWorkspaceByWorkspaceVolumeSource(b, taskWorkspaceName, pipelineTaskSubPath, pr.GetOwnerReference()))
 		} else {
-			return nil, "", fmt.Errorf("expected workspace %q to be provided by pipelinerun for pipeline task %q", pipelineWorkspaceName, rprt.PipelineTask.Name)
+			workspaceIsOptional := false
+			if rprt.ResolvedTaskResources != nil && rprt.ResolvedTaskResources.TaskSpec != nil {
+				for _, taskWorkspaceDeclaration := range rprt.ResolvedTaskResources.TaskSpec.Workspaces {
+					if taskWorkspaceDeclaration.Name == taskWorkspaceName && taskWorkspaceDeclaration.Optional {
+						workspaceIsOptional = true
+						break
+					}
+				}
+			}
+			if !workspaceIsOptional {
+				return nil, "", fmt.Errorf("expected workspace %q to be provided by pipelinerun for pipeline task %q", pipelineWorkspaceName, rprt.PipelineTask.Name)
+			}
 		}
 	}
 	return workspaces, pipelinePVCWorkspaceName, nil


### PR DESCRIPTION
# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

When a Pipeline accepts an optional workspace and gives it to a PipelineTask
the PipelineRun reconciler stalls if the workspace isn't provided. This happens
because the reconciler didn't know that a missing workspace binding is a valid
state for an optional workspace.  When it creates a TaskRun it considers the
missing workspace an error.

This commit fixes the problem by ensuring that the PipelineRun reconciler doesn't
fail to create a taskrun if an optional workspace is not provided.

Fixes #3703 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixed bug where PipelineRun that didn't provide an optional workspace to the Pipeline would stall until timing out.
```