### PR TITLE
Fix duplicate Pods when TaskRun or Pod labels are changed

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -40,7 +40,8 @@ const (
 	// ResultsDir is the folder used by default to create the results file
 	ResultsDir = "/tekton/results"
 
-	taskRunLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
+	// TaskRunLabelKey is the name of the label added to the Pod to identify the TaskRun
+	TaskRunLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
 )
 
 // These are effectively const, but Go doesn't have such an annotation.
@@ -314,7 +315,7 @@ func MakeLabels(s *v1beta1.TaskRun) map[string]string {
 
 	// NB: Set this *after* passing through TaskRun Labels. If the TaskRun
 	// specifies this label, it should be overridden by this value.
-	labels[taskRunLabelKey] = s.Name
+	labels[TaskRunLabelKey] = s.Name
 	return labels
 }
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1260,7 +1260,7 @@ script-heredoc-randomly-generated-78c5n
 func TestMakeLabels(t *testing.T) {
 	taskRunName := "task-run-name"
 	want := map[string]string{
-		taskRunLabelKey: taskRunName,
+		TaskRunLabelKey: taskRunName,
 		"foo":           "bar",
 		"hello":         "world",
 	}


### PR DESCRIPTION
Fixes #3656 

The TaskRun reconciler may be given a TaskRun that does not have a previous status update containing the name of the pod it created.  The TaskRun reconciler deals with this by listing pods associated with the TaskRun.  It uses the TaskRun's labels, which were propagated to the pod, to find the pod.  If the user changes the TaskRun's labels, the Task's labels which are propagated to the TaskRun, or the pod's labels, while the TaskRun is running, it may cause the code to not find the existing pod and as a result it may create a duplicate.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Change the TaskRun reconciler to only use the Tekton-controlled label `tekton.dev/taskRun` when calling LIST to find the pod.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fix duplicate Pods when TaskRun or Pod labels are changed
```
