### PR TITLE
Validate dependencies between resolved resources in a PipelineRun

### DIFF
--- a/examples/v1beta1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/using-optional-workspaces-in-when-expressions.yaml
@@ -44,6 +44,7 @@ spec:
       taskSpec:
         workspaces:
         - name: message-of-the-day
+          optional: true
         steps:
         - image: alpine
           script: |

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -200,37 +200,13 @@ func (pt PipelineTask) resourceDeps() []string {
 		for _, rd := range cond.Resources {
 			resourceDeps = append(resourceDeps, rd.From...)
 		}
-		for _, param := range cond.Params {
-			expressions, ok := GetVarSubstitutionExpressionsForParam(param)
-			if ok {
-				resultRefs := NewResultRefs(expressions)
-				for _, resultRef := range resultRefs {
-					resourceDeps = append(resourceDeps, resultRef.PipelineTask)
-				}
-			}
-		}
 	}
 
-	// Add any dependents from task results
-	for _, param := range pt.Params {
-		expressions, ok := GetVarSubstitutionExpressionsForParam(param)
-		if ok {
-			resultRefs := NewResultRefs(expressions)
-			for _, resultRef := range resultRefs {
-				resourceDeps = append(resourceDeps, resultRef.PipelineTask)
-			}
-		}
+	// Add any dependents from result references.
+	for _, ref := range PipelineTaskResultRefs(&pt) {
+		resourceDeps = append(resourceDeps, ref.PipelineTask)
 	}
-	// Add any dependents from when expressions
-	for _, whenExpression := range pt.WhenExpressions {
-		expressions, ok := whenExpression.GetVarSubstitutionExpressions()
-		if ok {
-			resultRefs := NewResultRefs(expressions)
-			for _, resultRef := range resultRefs {
-				resourceDeps = append(resourceDeps, resultRef.PipelineTask)
-			}
-		}
-	}
+
 	return resourceDeps
 }
 

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -129,3 +129,27 @@ func parseExpression(substitutionExpression string) (string, string, error) {
 	}
 	return subExpressions[1], subExpressions[3], nil
 }
+
+// PipelineTaskResultRefs walks all the places a result reference can be used
+// in a PipelineTask and returns a list of any references that are found.
+func PipelineTaskResultRefs(pt *PipelineTask) []*ResultRef {
+	refs := []*ResultRef{}
+	for _, condition := range pt.Conditions {
+		for _, p := range condition.Params {
+			expressions, _ := GetVarSubstitutionExpressionsForParam(p)
+			refs = append(refs, NewResultRefs(expressions)...)
+		}
+	}
+
+	for _, p := range pt.Params {
+		expressions, _ := GetVarSubstitutionExpressionsForParam(p)
+		refs = append(refs, NewResultRefs(expressions)...)
+	}
+
+	for _, whenExpression := range pt.WhenExpressions {
+		expressions, _ := whenExpression.GetVarSubstitutionExpressions()
+		refs = append(refs, NewResultRefs(expressions)...)
+	}
+
+	return refs
+}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -102,6 +102,9 @@ const (
 	// ReasonInvalidTaskResultReference indicates a task result was declared
 	// but was not initialized by that task
 	ReasonInvalidTaskResultReference = "InvalidTaskResultReference"
+	// ReasonRequiredWorkspaceMarkedOptional indicates an optional workspace
+	// has been passed to a Task that is expecting a non-optional workspace
+	ReasonRequiredWorkspaceMarkedOptional = "RequiredWorkspaceMarkedOptional"
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.
@@ -489,6 +492,24 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	}
 
 	if pipelineRunFacts.State.IsBeforeFirstTaskRun() {
+		if err := resources.ValidatePipelineTaskResults(pipelineRunFacts.State); err != nil {
+			logger.Errorf("Failed to resolve task result reference for %q with error %v", pr.Name, err)
+			pr.Status.MarkFailed(ReasonInvalidTaskResultReference, err.Error())
+			return controller.NewPermanentError(err)
+		}
+
+		if err := resources.ValidatePipelineResults(pipelineSpec, pipelineRunFacts.State); err != nil {
+			logger.Errorf("Failed to resolve task result reference for %q with error %v", pr.Name, err)
+			pr.Status.MarkFailed(ReasonInvalidTaskResultReference, err.Error())
+			return controller.NewPermanentError(err)
+		}
+
+		if err := resources.ValidateOptionalWorkspaces(pipelineSpec.Workspaces, pipelineRunFacts.State); err != nil {
+			logger.Errorf("Optional workspace not supported by task: %v", err)
+			pr.Status.MarkFailed(ReasonRequiredWorkspaceMarkedOptional, err.Error())
+			return controller.NewPermanentError(err)
+		}
+
 		if pr.HasVolumeClaimTemplate() {
 			// create workspace PVC from template
 			if err = c.pvcHandler.CreatePersistentVolumeClaimsForWorkspaces(ctx, pr.Spec.Workspaces, pr.GetOwnerReference(), pr.Namespace); err != nil {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -5116,6 +5116,153 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 	}
 }
 
+func TestReconcile_DependencyValidationsImmediatelyFailPipelineRun(t *testing.T) {
+	names.TestingSeed()
+
+	ctx := context.Background()
+	cfg := config.NewStore(logtesting.TestLogger(t))
+	ctx = cfg.ToContext(ctx)
+
+	prs := []*v1beta1.PipelineRun{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipelinerun-param-invalid-result-variable",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			ServiceAccountName: "test-sa",
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "pt0",
+					TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{
+								Image: "foo:latest",
+							},
+						}},
+					}},
+				}, {
+					Name: "pt1",
+					Params: []v1beta1.Param{{
+						Name:  "p",
+						Value: *v1beta1.NewArrayOrString("$(tasks.pt0.results.r1)"),
+					}},
+					TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+						Params: []v1beta1.ParamSpec{{
+							Name: "p",
+						}},
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{
+								Image: "foo:latest",
+							},
+						}},
+					}},
+				}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipelinerun-pipeline-result-invalid-result-variable",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			ServiceAccountName: "test-sa",
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "pt0",
+					TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{
+								Image: "foo:latest",
+							},
+						}},
+					}},
+				}, {
+					Name: "pt1",
+					TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{
+								Image: "foo:latest",
+							},
+						}},
+					}},
+				}},
+				Results: []v1beta1.PipelineResult{{
+					Name:  "pr",
+					Value: "$(tasks.pt0.results.r)",
+				}},
+			},
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pipelinerun-with-optional-workspace-validation",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			ServiceAccountName: "test-sa",
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Workspaces: []v1beta1.PipelineWorkspaceDeclaration{{
+					Name:     "optional-workspace",
+					Optional: true,
+				}},
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "unit-test-1",
+					Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+						Name:      "ws",
+						Workspace: "optional-workspace",
+					}},
+					TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+						Workspaces: []v1beta1.WorkspaceDeclaration{{
+							Name:     "ws",
+							Optional: false,
+						}},
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{
+								Image: "foo:latest",
+							},
+						}},
+					}},
+				}},
+			},
+		},
+	}}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		ServiceAccounts: []*corev1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{Name: prs[0].Spec.ServiceAccountName, Namespace: "foo"},
+		}},
+	}
+
+	prt := NewPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	run1, _ := prt.reconcileRun("foo", "pipelinerun-param-invalid-result-variable", nil, true)
+	run2, _ := prt.reconcileRun("foo", "pipelinerun-pipeline-result-invalid-result-variable", nil, true)
+	run3, _ := prt.reconcileRun("foo", "pipelinerun-with-optional-workspace-validation", nil, true)
+
+	cond1 := run1.Status.GetCondition(apis.ConditionSucceeded)
+	cond2 := run2.Status.GetCondition(apis.ConditionSucceeded)
+	cond3 := run3.Status.GetCondition(apis.ConditionSucceeded)
+
+	for _, c := range []*apis.Condition{cond1, cond2, cond3} {
+		if c.Status != corev1.ConditionFalse {
+			t.Errorf("expected Succeeded/False condition but saw: %v", c)
+		}
+	}
+
+	if cond1.Reason != ReasonInvalidTaskResultReference {
+		t.Errorf("expected invalid task reference condition but saw: %v", cond1)
+	}
+
+	if cond2.Reason != ReasonInvalidTaskResultReference {
+		t.Errorf("expected invalid task reference condition but saw: %v", cond2)
+	}
+
+	if cond3.Reason != ReasonRequiredWorkspaceMarkedOptional {
+		t.Errorf("expected optional workspace not supported condition but saw: %v", cond3)
+	}
+}
+
 func getTaskRunWithTaskSpec(tr, pr, p, t string, labels, annotations map[string]string) *v1beta1.TaskRun {
 	return tb.TaskRun(tr,
 		tb.TaskRunNamespace("foo"),

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// ValidatePipelineTaskResults ensures that any result references used by pipeline tasks
+// resolve to valid results. This prevents a situation where a PipelineTask references
+// a result in another PipelineTask that doesn't exist or where the user has either misspelled
+// a result name or the referenced task just doesn't return a result with that name.
+func ValidatePipelineTaskResults(state PipelineRunState) error {
+	ptMap := state.ToMap()
+	for _, rprt := range state {
+		for _, ref := range v1beta1.PipelineTaskResultRefs(rprt.PipelineTask) {
+			if err := validateResultRef(ref, ptMap); err != nil {
+				return fmt.Errorf("invalid result reference in pipeline task %q: %s", rprt.PipelineTask.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// ValidatePipelineResults ensures that any result references used by PipelineResults
+// resolve to valid results. This prevents a situation where a PipelineResult references
+// a result in a PipelineTask that doesn't exist or where the user has either misspelled
+// a result name or the referenced task just doesn't return a result with that name.
+func ValidatePipelineResults(ps *v1beta1.PipelineSpec, state PipelineRunState) error {
+	ptMap := state.ToMap()
+	for _, result := range ps.Results {
+		expressions, _ := v1beta1.GetVarSubstitutionExpressionsForPipelineResult(result)
+		refs := v1beta1.NewResultRefs(expressions)
+		for _, ref := range refs {
+			if err := validateResultRef(ref, ptMap); err != nil {
+				return fmt.Errorf("invalid pipeline result %q: %s", result.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+// validateResultRef takes a ResultRef and searches for the result using the given
+// map of PipelineTask name to ResolvedPipelineRunTask. If the ResultRef does not point
+// to a pipeline task or named result then an error is returned.
+func validateResultRef(ref *v1beta1.ResultRef, ptMap map[string]*ResolvedPipelineRunTask) error {
+	if _, ok := ptMap[ref.PipelineTask]; !ok {
+		return fmt.Errorf("referenced pipeline task %q does not exist", ref.PipelineTask)
+	}
+	taskProvidesResult := false
+	if ptMap[ref.PipelineTask].CustomTask {
+		// We're not able to validate results pointing to custom tasks because
+		// there's no facility to check what the result names will be before the
+		// custom task executes.
+		return nil
+	}
+	if ptMap[ref.PipelineTask].ResolvedTaskResources == nil || ptMap[ref.PipelineTask].ResolvedTaskResources.TaskSpec == nil {
+		return fmt.Errorf("unable to validate result referencing pipeline task %q: task spec not found", ref.PipelineTask)
+	}
+	for _, taskResult := range ptMap[ref.PipelineTask].ResolvedTaskResources.TaskSpec.Results {
+		if taskResult.Name == ref.Result {
+			taskProvidesResult = true
+			break
+		}
+	}
+	if !taskProvidesResult {
+		return fmt.Errorf("%q is not a named result returned by pipeline task %q", ref.Result, ref.PipelineTask)
+	}
+	return nil
+}
+
+// validateOptionalWorkspaces validates that any workspaces in the Pipeline that are
+// marked as optional are also marked optional in the Tasks that receive them. This
+// prevents a situation where a Task requires a workspace but a Pipeline does not offer
+// the same guarantee the workspace will be provided at runtime.
+func ValidateOptionalWorkspaces(pipelineWorkspaces []v1beta1.PipelineWorkspaceDeclaration, state PipelineRunState) error {
+	optionalWorkspaces := sets.NewString()
+	for _, ws := range pipelineWorkspaces {
+		if ws.Optional {
+			optionalWorkspaces.Insert(ws.Name)
+		}
+	}
+
+	for _, rprt := range state {
+		for _, pws := range rprt.PipelineTask.Workspaces {
+			if optionalWorkspaces.Has(pws.Workspace) {
+				for _, tws := range rprt.ResolvedTaskResources.TaskSpec.Workspaces {
+					if tws.Name == pws.Name {
+						if !tws.Optional {
+							return fmt.Errorf("pipeline workspace %q is marked optional but pipeline task %q requires it be provided", pws.Workspace, rprt.PipelineTask.Name)
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// TestValidatePipelineTaskResults_ValidStates tests that a pipeline task with
+// valid content and result variables does not trigger validation errors.
+func TestValidatePipelineTaskResults_ValidStates(t *testing.T) {
+	for _, tc := range []struct {
+		desc  string
+		state PipelineRunState
+	}{{
+		desc: "no variables used",
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+				Params: []v1beta1.Param{{
+					Name:  "p1",
+					Value: *v1beta1.NewArrayOrString("foo"),
+				}},
+			},
+		}},
+	}, {
+		desc: "correct use of task and result names",
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+			},
+			ResolvedTaskResources: &resources.ResolvedTaskResources{
+				TaskName: "t",
+				TaskSpec: &v1beta1.TaskSpec{
+					Results: []v1beta1.TaskResult{{
+						Name: "result",
+					}},
+				},
+			},
+		}, {
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt2",
+				Conditions: []v1beta1.PipelineTaskCondition{{
+					Params: []v1beta1.Param{{
+						Name:  "p",
+						Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.result)"),
+					}},
+				}},
+			},
+		}},
+	}, {
+		desc: "custom task results are not validated",
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+			},
+			CustomTask: true,
+			RunName:    "foo-run",
+		}, {
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt2",
+				Conditions: []v1beta1.PipelineTaskCondition{{
+					Params: []v1beta1.Param{{
+						Name:  "p",
+						Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.a-dynamic-custom-task-result)"),
+					}},
+				}},
+			},
+		}},
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			if err := ValidatePipelineTaskResults(tc.state); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidatePipelineTaskResults_IncorrectTaskName tests that a result variable with
+// a misnamed PipelineTask is correctly caught by the validatePipelineTaskResults func.
+func TestValidatePipelineTaskResults_IncorrectTaskName(t *testing.T) {
+	missingPipelineTaskVariable := "$(tasks.pt2.results.result1)"
+	for _, tc := range []struct {
+		desc  string
+		state PipelineRunState
+	}{{
+		desc: "invalid result reference in param",
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+				Params: []v1beta1.Param{{
+					Name:  "p1",
+					Value: *v1beta1.NewArrayOrString(missingPipelineTaskVariable),
+				}},
+			},
+		}},
+	}, {
+		desc: "invalid result reference in condition",
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+				Conditions: []v1beta1.PipelineTaskCondition{{
+					Params: []v1beta1.Param{{
+						Name:  "p1",
+						Value: *v1beta1.NewArrayOrString(missingPipelineTaskVariable),
+					}},
+				}},
+			},
+		}},
+	}, {
+		desc: "invalid result reference in when expression",
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values: []string{
+						missingPipelineTaskVariable,
+					},
+				}},
+			},
+		}},
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := ValidatePipelineTaskResults(tc.state)
+			if err == nil || !strings.Contains(err.Error(), `referenced pipeline task "pt2" does not exist`) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidatePipelineTaskResults_IncorrectResultName tests that a result variable with
+// a misnamed Result is correctly caught by the validatePipelineTaskResults func.
+func TestValidatePipelineTaskResults_IncorrectResultName(t *testing.T) {
+	pt1 := &ResolvedPipelineRunTask{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "pt1",
+		},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskName: "t",
+			TaskSpec: &v1beta1.TaskSpec{
+				Results: []v1beta1.TaskResult{{
+					Name: "not-the-result-youre-looking-for",
+				}},
+			},
+		},
+	}
+	for _, tc := range []struct {
+		desc  string
+		state PipelineRunState
+	}{{
+		desc: "invalid result reference in param",
+		state: PipelineRunState{pt1, {
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt2",
+				Params: []v1beta1.Param{{
+					Name:  "p1",
+					Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.result1)"),
+				}},
+			},
+		}},
+	}, {
+		desc: "invalid result reference in condition",
+		state: PipelineRunState{pt1, {
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt2",
+				Conditions: []v1beta1.PipelineTaskCondition{{
+					Params: []v1beta1.Param{{
+						Name:  "p1",
+						Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.result1)"),
+					}},
+				}},
+			},
+		}},
+	}, {
+		desc: "invalid result reference in when expression",
+		state: PipelineRunState{pt1, {
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt2",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values: []string{
+						"$(tasks.pt1.results.result1)",
+					},
+				}},
+			},
+		}},
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := ValidatePipelineTaskResults(tc.state)
+			if err == nil || !strings.Contains(err.Error(), `"result1" is not a named result returned by pipeline task "pt1"`) {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidatePipelineTaskResults_MissingTaskSpec tests that a malformed PipelineTask
+// with a name but no spec results in a validation error being returned.
+func TestValidatePipelineTaskResults_MissingTaskSpec(t *testing.T) {
+	pt1 := &ResolvedPipelineRunTask{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "pt1",
+		},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskName: "t",
+			TaskSpec: nil,
+		},
+	}
+	state := PipelineRunState{pt1, {
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "pt2",
+			Params: []v1beta1.Param{{
+				Name:  "p1",
+				Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.result1)"),
+			}},
+		},
+	}}
+	err := ValidatePipelineTaskResults(state)
+	if err == nil || !strings.Contains(err.Error(), `task spec not found`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidatePipelineResults_ValidStates tests that a pipeline results with
+// valid content and result variables do not trigger a validation error.
+func TestValidatePipelineResults_ValidStates(t *testing.T) {
+	for _, tc := range []struct {
+		desc  string
+		spec  *v1beta1.PipelineSpec
+		state PipelineRunState
+	}{{
+		desc: "no result variables",
+		spec: &v1beta1.PipelineSpec{
+			Results: []v1beta1.PipelineResult{{
+				Name:  "foo-result",
+				Value: "just a text pipeline result",
+			}},
+		},
+		state: nil,
+	}, {
+		desc: "correct use of task and result names",
+		spec: &v1beta1.PipelineSpec{
+			Results: []v1beta1.PipelineResult{{
+				Name:  "foo-result",
+				Value: "test $(tasks.pt1.results.result1) 123",
+			}},
+		},
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+			},
+			ResolvedTaskResources: &resources.ResolvedTaskResources{
+				TaskName: "t",
+				TaskSpec: &v1beta1.TaskSpec{
+					Results: []v1beta1.TaskResult{{
+						Name: "result1",
+					}},
+				},
+			},
+		}},
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			if err := ValidatePipelineResults(tc.spec, tc.state); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidatePipelineResults tests that a result variable used in a PipelineResult
+// with a misnamed PipelineTask is correctly caught by the validatePipelineResults func.
+func TestValidatePipelineResults_IncorrectTaskName(t *testing.T) {
+	spec := &v1beta1.PipelineSpec{
+		Results: []v1beta1.PipelineResult{{
+			Name:  "foo-result",
+			Value: "$(tasks.pt1.results.result1)",
+		}},
+	}
+	state := PipelineRunState{}
+	err := ValidatePipelineResults(spec, state)
+	if err == nil || !strings.Contains(err.Error(), `referenced pipeline task "pt1" does not exist`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidatePipelineResults tests that a result variable used in a PipelineResult
+// with a misnamed Result is correctly caught by the validatePipelineResults func.
+func TestValidatePipelineResults_IncorrectResultName(t *testing.T) {
+	spec := &v1beta1.PipelineSpec{
+		Results: []v1beta1.PipelineResult{{
+			Name:  "foo-result",
+			Value: "$(tasks.pt1.results.result1)",
+		}},
+	}
+	state := PipelineRunState{{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "pt1",
+		},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskName: "t",
+			TaskSpec: &v1beta1.TaskSpec{
+				Results: []v1beta1.TaskResult{{
+					Name: "not-the-result-youre-looking-for",
+				}},
+			},
+		},
+	}}
+	err := ValidatePipelineResults(spec, state)
+	if err == nil || !strings.Contains(err.Error(), `"result1" is not a named result returned by pipeline task "pt1"`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestValidateOptionalWorkspaces_ValidStates tests that a pipeline sending
+// correctly configured optional workspaces does not trigger validation errors.
+func TestValidateOptionalWorkspaces_ValidStates(t *testing.T) {
+	for _, tc := range []struct {
+		desc       string
+		workspaces []v1beta1.PipelineWorkspaceDeclaration
+		state      PipelineRunState
+	}{{
+		desc:       "no workspaces declared",
+		workspaces: nil,
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name:       "pt1",
+				Workspaces: nil,
+			},
+			ResolvedTaskResources: &resources.ResolvedTaskResources{
+				TaskSpec: &v1beta1.TaskSpec{
+					Workspaces: nil,
+				},
+			},
+		}},
+	}, {
+		desc:       "pipeline can omit workspace if task workspace is optional",
+		workspaces: nil,
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name:       "pt1",
+				Workspaces: []v1beta1.WorkspacePipelineTaskBinding{},
+			},
+			ResolvedTaskResources: &resources.ResolvedTaskResources{
+				TaskSpec: &v1beta1.TaskSpec{
+					Workspaces: []v1beta1.WorkspaceDeclaration{{
+						Name:     "foo",
+						Optional: true,
+					}},
+				},
+			},
+		}},
+	}, {
+		desc: "optional pipeline workspace matches optional task workspace",
+		workspaces: []v1beta1.PipelineWorkspaceDeclaration{{
+			Name:     "ws1",
+			Optional: true,
+		}},
+		state: PipelineRunState{{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name: "pt1",
+				Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+					Name:      "foo",
+					Workspace: "ws1",
+				}},
+			},
+			ResolvedTaskResources: &resources.ResolvedTaskResources{
+				TaskSpec: &v1beta1.TaskSpec{
+					Workspaces: []v1beta1.WorkspaceDeclaration{{
+						Name:     "foo",
+						Optional: true,
+					}},
+				},
+			},
+		}},
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			if err := ValidateOptionalWorkspaces(tc.workspaces, tc.state); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateOptionalWorkspaces tests that an error is generated if an optional pipeline
+// workspace is bound to a non-optional task workspace.
+func TestValidateOptionalWorkspaces_NonOptionalTaskWorkspace(t *testing.T) {
+	workspaces := []v1beta1.PipelineWorkspaceDeclaration{{
+		Name:     "ws1",
+		Optional: true,
+	}}
+	state := PipelineRunState{{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "pt1",
+			Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+				Name:      "foo",
+				Workspace: "ws1",
+			}},
+		},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &v1beta1.TaskSpec{
+				Workspaces: []v1beta1.WorkspaceDeclaration{{
+					Name:     "foo",
+					Optional: false,
+				}},
+			},
+		},
+	}}
+	err := ValidateOptionalWorkspaces(workspaces, state)
+	if err == nil || !strings.Contains(err.Error(), `pipeline workspace "ws1" is marked optional but pipeline task "pt1" requires it be provided`) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -50,6 +50,9 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	}
 
 	task := getFailTask(t, namespace)
+	task.Spec.Results = append(task.Spec.Results, v1beta1.TaskResult{
+		Name: "result",
+	})
 	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag Task: %s", err)
 	}
@@ -60,6 +63,9 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	}
 
 	successTask := getSuccessTask(t, namespace)
+	successTask.Spec.Results = append(successTask.Spec.Results, v1beta1.TaskResult{
+		Name: "result",
+	})
 	if _, err := c.TaskClient.Create(ctx, successTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create final Task: %s", err)
 	}
@@ -70,6 +76,9 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	}
 
 	taskProducingResult := getSuccessTaskProducingResults(t, namespace)
+	taskProducingResult.Spec.Results = append(taskProducingResult.Spec.Results, v1beta1.TaskResult{
+		Name: "result",
+	})
 	if _, err := c.TaskClient.Create(ctx, taskProducingResult, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task producing task results: %s", err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3499

When a PipelineRun is started there are several error conditions that can be
hit due to invalid Pipeline configuration. These errors have previously
only surfaced halfway through execution of the PipelineRun because validating
them requires a number of different resources to be resolved.

This commit performs validation on resolved dependencies of a PipelineRun before
it is allowed to start:
- All result variables used in the Pipeline are checked to be pointing at valid
Tasks and TaskResults. This requires looking at resolved TaskSpecs.
-  Workspaces marked optional by the Pipeline are confirmed to also be Optional
in the Tasks they're passed to. This also requires looking at resolved TaskSpecs.

This validation required searching for result variables in a PipelineTask in a very
similar way we do in several other places in our codebase. I've refactored all of these
to use a common func called `PipelineTaskResultRefs()`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Added extra validations before PipelineRun can start: all result variables in the Pipeline must be valid and optional workspaces from a pipeline can only be passed to tasks expecting optional workspaces.
```