### PR TITLE
release: publish only on a given list of platforms 💻

### DIFF
--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -7,6 +7,9 @@ spec:
   - name: imageRegistry
   - name: pathToProject
     description: The path to the folder in the go/src dir that contains the project, which is used by `ko` to name the resulting images
+  - name: platforms
+    description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   resources:
     inputs:
     - name: source
@@ -48,14 +51,14 @@ spec:
         docker context create context1
 
         #create builder
-        docker buildx create context1 --name builder-buildx1 --driver docker-container --platform linux/amd64,linux/s390x,linux/ppc64le,linux/arm64 --use
+        docker buildx create context1 --name builder-buildx1 --driver docker-container --platform $(params.platforms) --use
 
         #check the state
         docker buildx inspect --bootstrap --builder builder-buildx1
 
         #build multi-arch image
         docker buildx build \
-        --platform linux/amd64,linux/s390x,linux/ppc64le,linux/arm64 \
+        --platform $(params.platforms) \
         --tag $(params.imageRegistry)/$(params.pathToProject)/$(resources.outputs.builtBaseImage.url) \
         --push \
         /workspace/go/src/github.com/tektoncd/pipeline/images

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -13,6 +13,9 @@ spec:
   - name: releaseAsLatest
     description: Whether to tag and publish this release as Pipelines' latest
     default: "true"
+  - name: platforms
+    description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   resources:
     inputs:
     - name: source
@@ -128,11 +131,11 @@ spec:
       OUTPUT_BUCKET_RELEASE_DIR="/workspace/output/bucket/previous/$(params.versionTag)"
 
       # Publish images and create release.yaml
-      ko resolve --platform=all --preserve-import-paths -t $(params.versionTag) -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
+      ko resolve --platform=$(params.platforms) --preserve-import-paths -t $(params.versionTag) -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.yaml
       # Publish images and create release.notags.yaml
       # This is useful if your container runtime doesn't support the `image-reference:tag@digest` notation
       # This is currently the case for `cri-o` (and most likely others)
-      ko resolve --platform=all --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml
+      ko resolve --platform=$(params.platforms) --preserve-import-paths -f /workspace/go/src/github.com/tektoncd/pipeline/config/ > $OUTPUT_BUCKET_RELEASE_DIR/release.notags.yaml
     volumeMounts:
       - name: gcp-secret
         mountPath: /secret

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -15,6 +15,9 @@ spec:
   - name: releaseAsLatest
     description: Whether to tag and publish this release as Pipelines' latest
     default: "true"
+  - name: platforms
+    description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
+    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
   resources:
   - name: source-repo
     type: git
@@ -92,6 +95,8 @@ spec:
           value: $(params.package)
         - name: imageRegistry
           value: $(params.imageRegistry)
+        - name: platforms
+          value: $(params.platforms)
       resources:
         inputs:
           - name: source
@@ -112,6 +117,8 @@ spec:
           value: $(params.imageRegistry)
         - name: releaseAsLatest
           value: $(params.releaseAsLatest)
+        - name: platforms
+          value: $(params.platforms)
       resources:
         inputs:
           - name: source


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This update the publish task to build and publish images for a given
set of platforms instead of all supported by base images. This allows
to be a bit more explicit on which architecture we build on (not
necessarly supporting them yet).

One of the reason for this is to not build an incomplete set of images
for a given platform/architecture if a base image doesn't support
it (e.g. linux/arm).

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @afrittoli @bobcatfish @barthy1

This replaces #3664 and relates to #3647, without fixing it as we won't publish anything for `linux/arm` anymore.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Publish images for a finite list of architecture instead of all the one supported by base images. The current list is : linux/amd64 (supported) and linux/arm64, linux/s390x, linux/ppc64le.
```
