### PR TITLE
Correct workspace doc on behaviour of mountPath

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -100,10 +100,9 @@ To configure one or more `Workspaces` in a `Task`, add a `workspaces` list with 
 - `description` - An informative string describing the purpose of the `Workspace`
 - `readOnly` - A boolean declaring whether the `Task` will write to the `Workspace`. Defaults to `false`.
 - `optional` - A boolean indicating whether a TaskRun can omit the `Workspace`. Defaults to `false`.
-- `mountPath` - A path to a location on disk where the workspace will be available to `Steps`. Relative
-  paths will be prepended with `/workspace`. If a `mountPath` is not provided the workspace
-  will be placed by default at `/workspace/<name>` where `<name>` is the workspace's
-  unique name.
+- `mountPath` - A path to a location on disk where the workspace will be available to `Steps`. If a
+  `mountPath` is not provided the workspace will be placed by default at `/workspace/<name>` where `<name>`
+  is the workspace's unique name.
 
 Note the following:
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #3716 

# Changes

Prior to this commit we documented that if a workspace's mountPath was
relative then Pipelines would prepend "/workspace/" to it. This behaviour
has never actually worked that way. Pipelines passes the literal mountPath
value directly to the volumeMount's mountPath, without any other
processing. It's then up to the platform to decide what to do with it.

This commit fixes the workspaces doc to remove the incorrect description.



# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixed doc issue: relative workspace mountPaths are not prepended with "/workspace/" and never have been.
```