### PR TITLE
Fix TestPipelineLevelFinally_OneDAGTaskFailed test to avoid false negative error

### DIFF
--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -17,6 +17,7 @@ package test
 
 import (
 	"context"
+	"sort"
 	"strings"
 	"testing"
 
@@ -284,7 +285,11 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 		Name: "finaltaskconsumingdagtask4",
 	}}
 
-	if d := cmp.Diff(pr.Status.SkippedTasks, expectedSkippedTasks); d != "" {
+	actualSkippedTasks := pr.Status.SkippedTasks
+	// Sort tasks based on their names to get similar order as in expected list
+	sort.Slice(actualSkippedTasks, func(i int, j int) bool { return actualSkippedTasks[i].Name < actualSkippedTasks[j].Name })
+
+	if d := cmp.Diff(actualSkippedTasks, expectedSkippedTasks); d != "" {
 		t.Fatalf("Expected four skipped tasks, dag task with condition failure dagtask3, dag task with when expression,"+
 			"two final tasks with missing result reference finaltaskconsumingdagtask1 and finaltaskconsumingdagtask4 in SkippedTasks."+
 			" Diff: %s", diff.PrintWantGot(d))


### PR DESCRIPTION
# Changes

For TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure test list of skipped tasks is checked. In case if order of actual skipped tasks is different than expected, test may fail despite equality between actual and expected skipped tasks.
```
    pipelinefinally_test.go:288: Expected four skipped tasks, dag task with condition failure dagtask3, dag task with when expression,two final tasks with missing result reference finaltaskconsumingdagtask1 and finaltaskconsumingdagtask4 in SkippedTasks. Diff: (-want, +got):   []v1beta1.SkippedTask{
          	{Name: "dagtask3"},
          	{Name: "dagtask4", WhenExpressions: {{Input: "foo", Operator: "notin", Values: {"foo"}}}},
          	{
        - 		Name:            "finaltaskconsumingdagtask4",
        + 		Name:            "finaltaskconsumingdagtask1",
          		WhenExpressions: nil,
          	},
          	{
        - 		Name:            "finaltaskconsumingdagtask1",
        + 		Name:            "finaltaskconsumingdagtask4",
          		WhenExpressions: nil,
          	},
          }
...
--- FAIL: TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure (29.51s)
```

Sort of actual skipped tasks based on their names will fix this problem.

/kind failing-test

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

