### PR TITLE
Add comment to PipelineRunSpecStatusPending

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -197,6 +197,8 @@ const (
 	// if not already cancelled or terminated
 	PipelineRunSpecStatusCancelled = "PipelineRunCancelled"
 
+	// PipelineRunSpecStatusPending indicates that the user wants to postpone starting a PipelineRun
+	// until some condition is met
 	PipelineRunSpecStatusPending = "PipelineRunPending"
 )
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Following up on my issue comment here: https://github.com/tektoncd/pipeline/pull/3522#discussion_r564726338

Prior to this commit we didn't have a comment attached to the PipelinerunSpecStatusPending
status string.

This commit adds a comment to the status string.


# Submitter Checklist

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```