### PR TITLE
Add nonroot user to pipeline's build-base image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.11
-  
+
+RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
+
 RUN apk add --update git git-lfs openssh-client \
     && apk update \
     && apk upgrade


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3712

Prior to this commit the git-init image only provided a root
user, meaning git clones had to be performed as root.

After this commit the git-init image provides a nonroot user
with UID and GID of 65532 and a home directory of /home/nonroot.
Utilizing this UID results in creds-init credentials being placed
in /home/nonroot/.ssh when disable-home-env-overwrite is "true",
and results in the cloned files being owned by UID 65532.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Added non-root user 65532 to pipelines' build-base image. Git-init can now be used to clone repositories as a non-root user.
```