### PR TITLE
Document deprecation of the build-gcs PipelineResource type

### DIFF
--- a/docs/resources.md
+++ b/docs/resources.md
@@ -933,7 +933,11 @@ service account.
 
 --------------------------------------------------------------------------------
 
-#### BuildGCS Storage Resource
+#### `Deprecated: `BuildGCS Storage Resource
+
+**NB:** This Resource type is _deprecated_, and will be removed in a future
+release. To fetch objects from Google Cloud Storage, prefer the [GCS storage
+resource](#gcs-storage-resource) instead.
 
 The `build-gcs` storage resource points to a
 [Google Cloud Storage](https://cloud.google.com/storage/) blob like

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -95,6 +95,9 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 
 #### Variables for the  `BuildGCS` type
 
+**NB:** This Resource type is **Deprecated**. See [BuildGCS Storage
+Resource](./resources.md#buildgcs-storage-resource) for more information.
+
 | Variable | Description |
 | -------- | ----------- |
 | `name` | The name of the resource. |

--- a/examples/v1alpha1/taskruns/build-gcs-targz.yaml
+++ b/examples/v1alpha1/taskruns/build-gcs-targz.yaml
@@ -21,5 +21,7 @@ spec:
             value: gs://build-crd-tests/archive.tar.gz
           - name: artifactType
             value: TarGzArchive
+          # NB: The build-gcs PipelineResource type is deprecated, and will be
+          # removed in a future release.
           - name: type
             value: build-gcs

--- a/examples/v1alpha1/taskruns/build-gcs-zip.yaml
+++ b/examples/v1alpha1/taskruns/build-gcs-zip.yaml
@@ -21,5 +21,7 @@ spec:
             value: gs://build-crd-tests/archive.zip
           - name: artifactType
             value: ZipArchive
+          # NB: The build-gcs PipelineResource type is deprecated, and will be
+          # removed in a future release.
           - name: type
             value: build-gcs

--- a/examples/v1beta1/taskruns/build-gcs-targz.yaml
+++ b/examples/v1beta1/taskruns/build-gcs-targz.yaml
@@ -21,5 +21,7 @@ spec:
             value: gs://build-crd-tests/archive.tar.gz
           - name: artifactType
             value: TarGzArchive
+          # NB: The build-gcs PipelineResource type is deprecated, and will be
+          # removed in a future release.
           - name: type
             value: build-gcs

--- a/examples/v1beta1/taskruns/build-gcs-zip.yaml
+++ b/examples/v1beta1/taskruns/build-gcs-zip.yaml
@@ -21,5 +21,7 @@ spec:
             value: gs://build-crd-tests/archive.zip
           - name: artifactType
             value: ZipArchive
+          # NB: The build-gcs PipelineResource type is deprecated, and will be
+          # removed in a future release.
           - name: type
             value: build-gcs

--- a/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
+++ b/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
@@ -56,6 +56,7 @@ const (
 
 	// PipelineResourceTypeBuildGCS is the subtype for the BuildGCSResources, which is simialr to the GCSResource but
 	// with additional functionality that was added to be compatible with knative build.
+	// Deprecated: This PipelineResource type is deprecated and support will be removed in a future release.
 	PipelineResourceTypeBuildGCS PipelineResourceType = "build-gcs"
 )
 


### PR DESCRIPTION
# Changes

This adds deprecation notices to documentation and code comments noting that `build-gcs` is being deprecated and support will be removed in a future release.

See [TEP-0037](https://github.com/tektoncd/community/blob/master/teps/0037-remove-gcs-fetcher.md)

/kind cleanup 

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [y] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
Deprecate the build-gcs sub-type of the storage PipelineResource
```