### PR TITLE
WhenExpressions in Finally Tasks

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -100,7 +100,47 @@ spec:
               image: ubuntu
               script: exit 1
     finally:
-      - name: do-something-finally
+      - name: finally-task-should-be-skipped-1 # when expression using execution status, evaluates to false
+        when:
+          - input: "$(tasks.echo-file-exists.status)"
+            operator: in
+            values: ["Failure"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: exit 1
+      - name: finally-task-should-be-skipped-2 # when expression using task result, evaluates to false
+        when:
+          - input: "$(tasks.check-file.results.exists)"
+            operator: in
+            values: ["missing"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: exit 1
+      - name: finally-task-should-be-skipped-3 # when expression using parameter, evaluates to false
+        when:
+          - input: "$(params.path)"
+            operator: notin
+            values: ["README.md"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: exit 1
+      - name: finally-task-should-be-executed # when expression using execution status, param and results
+        when:
+          - input: "$(tasks.echo-file-exists.status)"
+            operator: in
+            values: ["Succeeded"]
+          - input: "$(tasks.check-file.results.exists)"
+            operator: in
+            values: ["yes"]
+          - input: "$(params.path)"
+            operator: in
+            values: ["README.md"]
         taskSpec:
           steps:
             - name: echo

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -70,7 +70,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineResults(ps.Results))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
-	errs = errs.Also(validateWhenExpressions(ps.Tasks))
+	errs = errs.Also(validateWhenExpressions(ps.Tasks, ps.Finally))
 	return errs
 }
 
@@ -329,22 +329,32 @@ func validateExecutionStatusVariablesInFinally(tasks []PipelineTask, finally []P
 	ptNames := PipelineTaskList(tasks).Names()
 	for idx, t := range finally {
 		for _, param := range t.Params {
-			// retrieve a list of substitution expression from a param
-			if ps, ok := GetVarSubstitutionExpressionsForParam(param); ok {
-				// validate tasks.pipelineTask.status if this expression is not a result reference
-				if !LooksLikeContainsResultRefs(ps) {
-					for _, p := range ps {
-						// check if it contains context variable accessing execution status - $(tasks.taskname.status)
-						if containsExecutionStatusRef(p) {
-							// strip tasks. and .status from tasks.taskname.status to further verify task name
-							pt := strings.TrimSuffix(strings.TrimPrefix(p, "tasks."), ".status")
-							// report an error if the task name does not exist in the list of dag tasks
-							if !ptNames.Has(pt) {
-								errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("pipeline task %s is not defined in the pipeline", pt),
-									"value").ViaFieldKey("params", param.Name).ViaFieldIndex("finally", idx))
-							}
-						}
-					}
+			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
+				errs = errs.Also(validateExecutionStatusVariablesExpressions(expressions, ptNames, "value").ViaFieldKey(
+					"params", param.Name).ViaFieldIndex("finally", idx))
+			}
+		}
+		for i, we := range t.WhenExpressions {
+			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
+				errs = errs.Also(validateExecutionStatusVariablesExpressions(expressions, ptNames, "").ViaFieldIndex(
+					"when", i).ViaFieldIndex("finally", idx))
+			}
+		}
+	}
+	return errs
+}
+
+func validateExecutionStatusVariablesExpressions(expressions []string, ptNames sets.String, fieldPath string) (errs *apis.FieldError) {
+	// validate tasks.pipelineTask.status if this expression is not a result reference
+	if !LooksLikeContainsResultRefs(expressions) {
+		for _, expression := range expressions {
+			// check if it contains context variable accessing execution status - $(tasks.taskname.status)
+			if containsExecutionStatusRef(expression) {
+				// strip tasks. and .status from tasks.taskname.status to further verify task name
+				pt := strings.TrimSuffix(strings.TrimPrefix(expression, "tasks."), ".status")
+				// report an error if the task name does not exist in the list of dag tasks
+				if !ptNames.Has(pt) {
+					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("pipeline task %s is not defined in the pipeline", pt), fieldPath))
 				}
 			}
 		}
@@ -429,9 +439,6 @@ func validateFinalTasks(tasks []PipelineTask, finalTasks []PipelineTask) *apis.F
 		if len(f.Conditions) != 0 {
 			return apis.ErrInvalidValue(fmt.Sprintf("no conditions allowed under spec.finally, final task %s has conditions specified", f.Name), "").ViaFieldIndex("finally", idx)
 		}
-		if len(f.WhenExpressions) != 0 {
-			return apis.ErrInvalidValue(fmt.Sprintf("no when expressions allowed under spec.finally, final task %s has when expressions specified", f.Name), "").ViaFieldIndex("finally", idx)
-		}
 	}
 
 	ts := PipelineTaskList(tasks).Names()
@@ -487,10 +494,13 @@ func validateTasksInputFrom(tasks []PipelineTask) (errs *apis.FieldError) {
 	return errs
 }
 
-func validateWhenExpressions(tasks []PipelineTask) (errs *apis.FieldError) {
+func validateWhenExpressions(tasks []PipelineTask, finalTasks []PipelineTask) (errs *apis.FieldError) {
 	for i, t := range tasks {
 		errs = errs.Also(validateOneOfWhenExpressionsOrConditions(t).ViaFieldIndex("tasks", i))
 		errs = errs.Also(t.WhenExpressions.validate().ViaFieldIndex("tasks", i))
+	}
+	for i, t := range finalTasks {
+		errs = errs.Also(t.WhenExpressions.validate().ViaFieldIndex("finally", i))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -277,6 +277,55 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 			Paths:   []string{"tasks[0].when[0]"},
 		},
 	}, {
+		name: "invalid pipeline with final task having when expression with invalid operator (not In/NotIn)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "bar-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "bar-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.Exists,
+					Values:   []string{"foo"},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: operator "exists" is not recognized. valid operators: in,notin`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with dag task and final task having when expression with invalid operator (not In/NotIn)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "bar-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.Exists,
+					Values:   []string{"foo"},
+				}},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "bar-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.Exists,
+					Values:   []string{"foo"},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: operator "exists" is not recognized. valid operators: in,notin`,
+			Paths:   []string{"tasks[0].when[0]", "finally[0].when[0]"},
+		},
+	}, {
 		name: "invalid pipeline with one pipeline task having when expression with invalid values (empty)",
 		ps: &PipelineSpec{
 			Description: "this is an invalid pipeline with invalid pipeline task",
@@ -293,6 +342,55 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `invalid value: expecting non-empty values field`,
 			Paths:   []string{"tasks[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with final task having when expression with invalid values (empty)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expecting non-empty values field`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with dag task and final task having when expression with invalid values (empty)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{},
+				}},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expecting non-empty values field`,
+			Paths:   []string{"tasks[0].when[0]", "finally[0].when[0]"},
 		},
 	}, {
 		name: "invalid pipeline with one pipeline task having when expression with invalid operator (missing)",
@@ -312,6 +410,52 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 			Paths:   []string{"tasks[0].when[0]"},
 		},
 	}, {
+		name: "invalid pipeline with final task having when expression with invalid operator (missing)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:  "foo",
+					Values: []string{"foo"},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: operator "" is not recognized. valid operators: in,notin`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with dag task and final task having when expression with invalid operator (missing)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:  "foo",
+					Values: []string{"foo"},
+				}},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:  "foo",
+					Values: []string{"foo"},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: operator "" is not recognized. valid operators: in,notin`,
+			Paths:   []string{"tasks[0].when[0]", "finally[0].when[0]"},
+		},
+	}, {
 		name: "invalid pipeline with one pipeline task having when expression with invalid values (missing)",
 		ps: &PipelineSpec{
 			Description: "this is an invalid pipeline with invalid pipeline task",
@@ -327,6 +471,52 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `invalid value: expecting non-empty values field`,
 			Paths:   []string{"tasks[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with final task having when expression with invalid values (missing)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expecting non-empty values field`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with dag task and final task having when expression with invalid values (missing)",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+				}},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expecting non-empty values field`,
+			Paths:   []string{"tasks[0].when[0]", "finally[0].when[0]"},
 		},
 	}, {
 		name: "invalid pipeline with one pipeline task having when expression with misconfigured result reference",
@@ -350,6 +540,61 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 			Paths:   []string{"tasks[1].when[0]"},
 		},
 	}, {
+		name: "invalid pipeline with final task having when expression with misconfigured result reference",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "$(tasks.a-task.resultTypo.bResult)",
+					Operator: selection.In,
+					Values:   []string{"bar"},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expected all of the expressions [tasks.a-task.resultTypo.bResult] to be result expressions but only [] were`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with dag task and final task having when expression with misconfigured result reference",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "$(tasks.a-task.resultTypo.bResult)",
+					Operator: selection.In,
+					Values:   []string{"bar"},
+				}},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-task-finally",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "$(tasks.a-task.resultTypo.bResult)",
+					Operator: selection.In,
+					Values:   []string{"bar"},
+				}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expected all of the expressions [tasks.a-task.resultTypo.bResult] to be result expressions but only [] were`,
+			Paths:   []string{"tasks[1].when[0]", "finally[0].when[0]"},
+		},
+	}, {
 		name: "invalid pipeline with one pipeline task having blank when expression",
 		ps: &PipelineSpec{
 			Description: "this is an invalid pipeline with invalid pipeline task",
@@ -365,6 +610,49 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
 			Paths:   []string{"tasks[1].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with final task having blank when expression",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:            "invalid-pipeline-task-finally",
+				TaskRef:         &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `missing field(s)`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid pipeline with dag task and final task having blank when expression",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "valid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}, {
+				Name:            "invalid-pipeline-task",
+				TaskRef:         &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{}},
+			}},
+			Finally: []PipelineTask{{
+				Name:            "invalid-pipeline-task-finally",
+				TaskRef:         &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{}},
+			}},
+		},
+		expectedError: apis.FieldError{
+			Message: `missing field(s)`,
+			Paths:   []string{"tasks[1].when[0]", "finally[0].when[0]"},
 		},
 	}, {
 		name: "invalid pipeline with pipeline task having reference to resources which does not exist",
@@ -2047,21 +2335,6 @@ func TestValidateFinalTasks_Failure(t *testing.T) {
 			Message: `invalid value: invalid task result reference, final task param param1 has task result reference from a task which is not defined in the pipeline`,
 			Paths:   []string{"finally[0].params"},
 		},
-	}, {
-		name: "invalid pipeline with final task specifying when expressions",
-		finalTasks: []PipelineTask{{
-			Name:    "final-task",
-			TaskRef: &TaskRef{Name: "final-task"},
-			WhenExpressions: []WhenExpression{{
-				Input:    "foo",
-				Operator: selection.In,
-				Values:   []string{"foo", "bar"},
-			}},
-		}},
-		expectedError: apis.FieldError{
-			Message: `invalid value: no when expressions allowed under spec.finally, final task final-task has when expressions specified`,
-			Paths:   []string{"finally[0]"},
-		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2293,6 +2566,42 @@ func TestPipelineTasksExecutionStatus(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `invalid value: pipeline task notask is not defined in the pipeline`,
 			Paths:   []string{"finally[0].params[notask-status].value"},
+		},
+	}, {
+		name: "invalid string variable in finally accessing missing pipelineTask status in when expression",
+		finalTasks: []PipelineTask{{
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.notask.status)",
+				Operator: selection.In,
+				Values:   []string{"Success"},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `invalid value: pipeline task notask is not defined in the pipeline`,
+			Paths:   []string{"finally[0].when[0]"},
+		},
+	}, {
+		name: "invalid string variable in finally accessing missing pipelineTask status in params and when expression",
+		finalTasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "notask-status", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(tasks.notask.status)"},
+			}},
+		}, {
+			Name:    "foo",
+			TaskRef: &TaskRef{Name: "foo-task"},
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.notask.status)",
+				Operator: selection.In,
+				Values:   []string{"Success"},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `invalid value: pipeline task notask is not defined in the pipeline`,
+			Paths:   []string{"finally[0].params[notask-status].value", "finally[1].when[0]"},
 		},
 	}, {
 		name: "invalid variable concatenated with extra string in finally accessing missing pipelineTask status",

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -630,7 +630,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 	}
 
 	for _, rprt := range nextRprts {
-		if rprt == nil || rprt.Skip(pipelineRunFacts) {
+		if rprt == nil || rprt.Skip(pipelineRunFacts) || rprt.IsFinallySkipped(pipelineRunFacts) {
 			continue
 		}
 		if rprt.ResolvedConditionChecks == nil || rprt.ResolvedConditionChecks.IsSuccess() {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -93,6 +93,7 @@ func ApplyPipelineTaskContext(state PipelineRunState, replacements map[string]st
 		if resolvedPipelineRunTask.PipelineTask != nil {
 			pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
 			pipelineTask.Params = replaceParamValues(pipelineTask.Params, replacements, nil)
+			pipelineTask.WhenExpressions = pipelineTask.WhenExpressions.ReplaceWhenExpressionsVariables(replacements)
 			resolvedPipelineRunTask.PipelineTask = pipelineTask
 		}
 	}
@@ -129,6 +130,7 @@ func ApplyReplacements(p *v1beta1.PipelineSpec, replacements map[string]string, 
 
 	for i := range p.Finally {
 		p.Finally[i].Params = replaceParamValues(p.Finally[i].Params, replacements, arrayReplacements)
+		p.Finally[i].WhenExpressions = p.Finally[i].WhenExpressions.ReplaceWhenExpressionsVariables(replacements)
 	}
 
 	return p

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -197,6 +197,11 @@ func TestApplyParameters(t *testing.T) {
 					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param)")},
 				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "$(params.first-param)",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param)"},
+				}},
 			}},
 		},
 		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value")}},
@@ -210,6 +215,11 @@ func TestApplyParameters(t *testing.T) {
 					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("second-value")},
 				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "default-value",
+					Operator: selection.In,
+					Values:   []string{"second-value"},
+				}},
 			}},
 		},
 	}, {
@@ -230,6 +240,11 @@ func TestApplyParameters(t *testing.T) {
 					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param)")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param)")},
 				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "$(params.first-param)",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param)"},
+				}},
 			}},
 		},
 		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value")}},
@@ -249,6 +264,11 @@ func TestApplyParameters(t *testing.T) {
 					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("default-value")},
 					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("second-value")},
 				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "default-value",
+					Operator: selection.In,
+					Values:   []string{"second-value"},
+				}},
 			}},
 		},
 	}} {
@@ -1062,6 +1082,11 @@ func TestApplyTaskRunContext(t *testing.T) {
 				Name:  "task3",
 				Value: *v1beta1.NewArrayOrString("$(tasks.task3.status)"),
 			}},
+			WhenExpressions: v1beta1.WhenExpressions{{
+				Input:    "$(tasks.task1.status)",
+				Operator: selection.In,
+				Values:   []string{"$(tasks.task3.status)"},
+			}},
 		},
 	}}
 	expectedState := PipelineRunState{{
@@ -1074,6 +1099,11 @@ func TestApplyTaskRunContext(t *testing.T) {
 			}, {
 				Name:  "task3",
 				Value: *v1beta1.NewArrayOrString("none"),
+			}},
+			WhenExpressions: v1beta1.WhenExpressions{{
+				Input:    "succeeded",
+				Operator: selection.In,
+				Values:   []string{"none"},
 			}},
 		},
 	}}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -145,6 +145,9 @@ func (t ResolvedPipelineRunTask) IsConditionStatusFalse() bool {
 }
 
 func (t *ResolvedPipelineRunTask) checkParentsDone(facts *PipelineRunFacts) bool {
+	if facts.isFinalTask(t.PipelineTask.Name) {
+		return true
+	}
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]
 	for _, p := range node.Prev {
@@ -223,6 +226,9 @@ func (t *ResolvedPipelineRunTask) IsFinallySkipped(facts *PipelineRunFacts) bool
 	}
 	if facts.checkDAGTasksDone() && facts.isFinalTask(t.PipelineTask.Name) {
 		if _, err := ResolveResultRef(facts.State, t); err != nil {
+			return true
+		}
+		if t.whenExpressionsSkip(facts) {
 			return true
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2244,11 +2244,55 @@ func TestResolvedPipelineRunTask_IsFinallySkipped(t *testing.T) {
 				Value: *v1beta1.NewArrayOrString("$(tasks.dag-task.results.missingResult)"),
 			}},
 		},
+	}, {
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "final-task-3",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+			WhenExpressions: v1beta1.WhenExpressions{{
+				Input:    "foo",
+				Operator: selection.NotIn,
+				Values:   []string{"bar"},
+			}},
+		},
+	}, {
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "final-task-4",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+			WhenExpressions: v1beta1.WhenExpressions{{
+				Input:    "foo",
+				Operator: selection.In,
+				Values:   []string{"bar"},
+			}},
+		},
+	}, {
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "final-task-5",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+			WhenExpressions: v1beta1.WhenExpressions{{
+				Input:    "$(tasks.dag-task.results.commit)",
+				Operator: selection.In,
+				Values:   []string{"SHA2"},
+			}},
+		},
+	}, {
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "final-task-6",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+			WhenExpressions: v1beta1.WhenExpressions{{
+				Input:    "$(tasks.dag-task.results.missing)",
+				Operator: selection.In,
+				Values:   []string{"none"},
+			}},
+		},
 	}}
 
 	expected := map[string]bool{
 		"final-task-1": false,
 		"final-task-2": true,
+		"final-task-3": false,
+		"final-task-4": true,
+		"final-task-5": false,
+		"final-task-6": true,
 	}
 
 	tasks := v1beta1.PipelineTaskList([]v1beta1.PipelineTask{*state[0].PipelineTask})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -380,6 +380,11 @@ func (facts *PipelineRunFacts) GetSkippedTasks() []v1beta1.SkippedTask {
 			skippedTask := v1beta1.SkippedTask{
 				Name: rprt.PipelineTask.Name,
 			}
+			// include the when expressions only when the finally task was skipped because
+			// its when expressions evaluated to false (not because results variables were missing)
+			if !rprt.PipelineTask.WhenExpressions.HaveVariables() {
+				skippedTask.WhenExpressions = rprt.PipelineTask.WhenExpressions
+			}
 			skipped = append(skipped, skippedTask)
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

Users can guard execution of `Tasks` using `WhenExpressions`, but that
is currently not supported in `Finally Tasks`.

This change adds support for `WhenExpressions` in `Finally Tasks` not
only to provide efficient guarded execution but also to improve the
reusability of `Tasks` in `Finally`. The proposal is described further in
the [WhenExpressions in Finally Tasks TEP](https://github.com/tektoncd/community/blob/master/teps/0045-whenexpressions-in-finally-tasks.md).

Given we've recently added support for `Results` and `Status` in
`Finally Tasks`, this is an opportune time to enable `WhenExpressions`
in `Finally Tasks`.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
WhenExpressions are supported in Finally Tasks not only to provide efficient guarded execution but also to improve the
reusability of `Tasks` in `Finally`
```