### PR TITLE
Make volume mount names RFC1123 DNS label strict

### DIFF
--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -35,6 +36,8 @@ const (
 	credsInitHomeMountPrefix = "tekton-creds-init-home"
 	sshKnownHosts            = "known_hosts"
 )
+
+var dnsLabel1123Forbidden = regexp.MustCompile("[^a-zA-Z0-9-]+")
 
 // credsInit reads secrets available to the given service account and
 // searches for annotations matching a specific format (documented in
@@ -88,7 +91,10 @@ func credsInit(ctx context.Context, serviceAccountName, namespace string, kubecl
 		}
 
 		if matched {
-			name := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("tekton-internal-secret-volume-%s", secret.Name))
+			// While secret names can use RFC1123 DNS subdomain name rules, the volume mount
+			// name required the stricter DNS label standard, for example no dots anymore.
+			sanitizedName := dnsLabel1123Forbidden.ReplaceAllString(secret.Name, "-")
+			name := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("tekton-internal-secret-volume-%s", sanitizedName))
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      name,
 				MountPath: credentials.VolumeName(secret.Name),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In our production environment, we ran into the issue that a Kubernetes secret name contained dots. Based on the [Object Names and IDs docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/), the object name has to follow RFC1123 DNS Subdomain rules, which allow dots. The volume mount names however only seem to support the RFC1123 DNS label standard, which forbids dots.

Added code to remove forbidden characters in name by replacing them with a dash. Introduced test sample with secret name containing dots. My rational was that the volume mount name is only used once as a reference in the same pod spec. In most cases the replacement with a dash should result in readable name. The random suffix should make name collisions impossible, where the replacement in different strings would otherwise lead to the same output.

/kind bug


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Fixed a bug where a secret name with dots (e.g. `gcr.io`) led to a TaskRun creation failure, because the secret name was used internally as part of a volume mount name. These volume mount name have the be RFC1123 DNS label conform and therefore disallow dots as part of the name.
```
