### PR TITLE
promoting webhook service name in the logger

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -232,10 +232,7 @@ func main() {
 		log.Fatal(http.ListenAndServe(":"+port, mux))
 	}()
 
-	// NOTE(afrittoli) - we should have the name "webhook-pipeline"
-	// configurable. Once the change is done on knative/pkg side
-	// knative/eventing#4530 we can inherit it from it
-	sharedmain.WebhookMainWithConfig(ctx, "webhook-pipeline",
+	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		sharedmain.ParseAndGetConfigOrDie(),
 		certificates.NewController,
 		newDefaultingAdmissionController,


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I came across this `NOTE` while troubleshooting https://github.com/tektoncd/pipeline/issues/3206.

The `NOTE` has reference to issue in knative eventing which is fixed now: https://github.com/knative/eventing/issues/4530

We already have a configuration in [webhook.yaml](https://github.com/tektoncd/pipeline/blob/master/config/webhook.yaml#L97) to configure service name and defaulting to `tekton-pipelines-webhook` if not specified.

Instead of hardcoding "webhook-pipeline", reading it from the env if specified to be consistent.

Please note that the webhook logs will now have the consistent service name in the logs, i.e. `"logger":"tekton-pipelines-webhook.*"` or the name specified in `WEBHOOK_SERVICE_NAME` env. variable instead of `"logger":"webhook-pipeline.*"`

e.g.

Before:

```
{"level":"info","ts":"2021-02-02T01:23:41.115Z","logger":"webhook-pipeline.ValidationWebhook","caller":"controller/controller.go:530","msg":"Reconcile succeeded","commit":"9751b95","knative.dev/traceid":"ddfcbe3c-5efb-42fe-a171-bac521072674","knative.dev/key":"validation.webhook.pipeline.tekton.dev","duration":0.0131361}

```

After:
```
{"level":"info","ts":"2021-02-02T01:23:41.115Z","logger":"tekton-pipelines-webhook.ValidationWebhook","caller":"controller/controller.go:530","msg":"Reconcile succeeded","commit":"9751b95","knative.dev/traceid":"ddfcbe3c-5efb-42fe-a171-bac521072674","knative.dev/key":"validation.webhook.pipeline.tekton.dev","duration":0.0131361}
```

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
Promoting webhook service name in the logger instead of always defaulting to "webhook-pipeline". The service name is read from the env. variable `WEBHOOK_SERVICE_NAME` if specified else defaults to "tekton-pipelines-webhook"
```

