### PR TITLE
Copy serviceAccountName to affinity-assistant

### DIFF
--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -139,6 +139,11 @@ func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimNam
 		nodeSelector = pr.Spec.PodTemplate.NodeSelector
 	}
 
+	serviceAccount := "default"
+	if pr.Spec.ServiceAccountName != "" {
+		serviceAccount = pr.Spec.ServiceAccountName
+	}
+
 	containers := []corev1.Container{{
 		Name:  "affinity-assistant",
 		Image: affinityAssistantImage,
@@ -192,9 +197,10 @@ func affinityAssistantStatefulSet(name string, pr *v1beta1.PipelineRun, claimNam
 					Labels: getStatefulSetLabels(pr, name),
 				},
 				Spec: corev1.PodSpec{
-					Containers:   containers,
-					Tolerations:  tolerations,
-					NodeSelector: nodeSelector,
+					Containers:         containers,
+					Tolerations:        tolerations,
+					NodeSelector:       nodeSelector,
+					ServiceAccountName: serviceAccount,
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
 							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{repelOtherAffinityAssistantsPodAffinityTerm},

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -117,6 +117,24 @@ func TestThatCustomTolerationsAndNodeSelectorArePropagatedToAffinityAssistant(t 
 	}
 }
 
+func TestThatCustomServiceAccountIsPropagatedToAffinityAssistant(t *testing.T) {
+	prWithCustomPodTemplate := &v1beta1.PipelineRun{
+		TypeMeta: metav1.TypeMeta{Kind: "PipelineRun"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pipelinerun-with-custom-podtemplate",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			ServiceAccountName: "test-service-account",
+			PodTemplate:        &pod.Template{},
+		},
+	}
+
+	stsWithServiceAccount := affinityAssistantStatefulSet("test-assistant", prWithCustomPodTemplate, "mypvc", "nginx")
+	if stsWithServiceAccount.Spec.Template.Spec.ServiceAccountName != "test-service-account" {
+		t.Errorf("expected non-default ServiceAccountName in the StatefulSet")
+	}
+}
+
 func TestThatTheAffinityAssistantIsWithoutNodeSelectorAndTolerations(t *testing.T) {
 	prWithoutCustomPodTemplate := &v1beta1.PipelineRun{
 		TypeMeta: metav1.TypeMeta{Kind: "PipelineRun"},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Resolves #3748 

# Changes

When a serviceAccountName is specified on a PipelineRun, all Pods that
execute the constituent Tasks run with the specified ServiceAccount. If
an Affinity Assistant pod is launched, it should also run with the same
ServiceAccount. This ensures that cluster policies apply consistently to
Tekton-launched Pods, and it avoids use of the "default" ServiceAccount
that is discouraged by some Kubernetes security experts.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [-] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
bugfix: serviceAccountName from PipelineRun now applied to affinity-assistant pod
```