### PR TITLE
tekton controller logger key

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	// ControllerLogKey is the name of the logger for the controller cmd
-	ControllerLogKey = "tekton"
+	ControllerLogKey = "tekton-pipelines-controller"
 )
 
 var (


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tekton controller logs have the logger key set to "tekton" which is hard for the metrics collections. Changing it to "tekton-pipelines-controller", making it more consistent with webhook which is set to "tekton-pipelines-webhook" in PR #3741.

Before:

```
{"level":"info","ts":"2021-02-04T21:45:55.162Z","logger":"tekton","caller":"leaderelection/context.go:147","msg":"\"tekton-pipelines-controller-754b4dd74f-54hb8_8503783c-6ee2-4a01-b1cd-4d13208c8990\" has started leading \"tekton-pipelines-controller.github.com.tektoncd.pipeline.pkg.reconciler.pipelinerun.reconciler.00-of-01\"","commit":"62d8621"}
```

After:

```
{"level":"info","ts":"2021-02-04T21:45:55.162Z","logger":"tekton-pipelines-controller","caller":"leaderelection/context.go:147","msg":"\"tekton-pipelines-controller-754b4dd74f-54hb8_8503783c-6ee2-4a01-b1cd-4d13208c8990\" has started leading \"tekton-pipelines-controller.github.com.tektoncd.pipeline.pkg.reconciler.pipelinerun.reconciler.00-of-01\"","commit":"62d8621"}
```

Closes #2987 

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
The controller logger key is now set to "tekton-pipelines-controller" instead of "tekton" which is consistent with the webhook service name "tekton-pipelines-webhook".
```
