### PR TITLE
updating doc - pipelineResult referencing results of a finally task

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1069,16 +1069,8 @@ Final tasks can emit `Results` but results emitted from the final tasks can not 
       value: $(finally.check-count.results.comment-count-validate)
 ```
 
-In this example, `PipelineResults` is set to:
+In this example, `pipelineResults` in `status` will exclude the name-value pair for that result `comment-count-validate`.
 
-```
-"pipelineResults": [
-  {
-    "name": "comment-count-validate",
-    "value": "$(finally.check-count.results.comment-count-validate)"
-  }
-],
-```
 
 ## Using Custom Tasks
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Recently @sbwsg fixed the bug in which pipeline results emitted the result reference variable as is in case of a missing result (see PR https://github.com/tektoncd/pipeline/pull/3472). Updating the doc to reflect those changes when pipeline result has a result reference from finally tasks.

Thanks @sbwsg 🙏 

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
