### PR TITLE
Remove error when converting Finally field to alpha1

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -100,10 +100,9 @@ func (sink *PipelineSpec) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 			}
 		}
 	}
-	// finally clause was introduced in v1beta1 and not available in v1alpha1
-	if len(source.Finally) > 0 {
-		return ConvertErrorf(FinallyFieldName, ConversionErrorFieldNotAvailableMsg)
-	}
+	// source.Finally is dropped on the floor because otherwise kube api spams pipelines
+	// webhook repeatedly. See https://github.com/tektoncd/pipeline/issues/3206 for more
+	// info.
 	return nil
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3206

/hold

I'm posting this PR because I don't know what the right thing to do here is.  Looking for feedback from anyone who knows the conversion webhook stuff better than me.

Prior to this commit pipelines returned an error when converting from
a v1beta1 pipeline to a v1alpha1 pipeline if that pipeline had a Finally
section in it. As a result of this error the kubeapi would repeatedly
request v1alpha1 pipelines every second, filling up our webhook logs
with these errors.

[This is the place that kubernetes is repeatedly hitting us with conversion attempts.](https://github.com/kubernetes/apiserver/blob/ab31715e135fe7a7fbcd6f2d91ee25c2c7e6eaf9/pkg/storage/cacher/cacher.go#L383-L387)

This commit removes the error when downgrading a beta1 resource to alpha1.
I actually have no idea if this is the correct thing to do and I can't find
any docs explaining the dos and donts of conversion. This stops the spam
though.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

# Release Notes

```release-note
Fix issue where webhook logs would rapidly fill up with conversion errors when a pipeline with Finally was applied to the cluster.
```
