### PR TITLE
Short term fix for Cloud Event Source

### DIFF
--- a/pkg/reconciler/events/cloudevent/cloudevent.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent.go
@@ -95,7 +95,18 @@ func EventForObjectWithCondition(runObject objectWithCondition) (*cloudevents.Ev
 	event := cloudevents.NewEvent()
 	event.SetID(uuid.New().String())
 	event.SetSubject(runObject.GetObjectMeta().GetName())
-	event.SetSource(runObject.GetObjectMeta().GetSelfLink()) // TODO: SelfLink is deprecated https://github.com/tektoncd/pipeline/issues/2676
+	// TODO: SelfLink is deprecated https://github.com/tektoncd/pipeline/issues/2676
+	source := runObject.GetObjectMeta().GetSelfLink()
+	if source == "" {
+		gvk := runObject.GetObjectKind().GroupVersionKind()
+		source = fmt.Sprintf("/apis/%s/%s/namespaces/%s/%s/%s",
+			gvk.Group,
+			gvk.Version,
+			runObject.GetObjectMeta().GetNamespace(),
+			gvk.Kind,
+			runObject.GetObjectMeta().GetName())
+	}
+	event.SetSource(source)
 	eventType, err := getEventType(runObject)
 	if err != nil {
 		return nil, err

--- a/pkg/reconciler/events/cloudevent/cloudevent_test.go
+++ b/pkg/reconciler/events/cloudevent/cloudevent_test.go
@@ -108,6 +108,15 @@ func TestEventForTaskRun(t *testing.T) {
 		desc:          "send a cloud event with successful status taskrun",
 		taskRun:       getTaskRunByCondition(corev1.ConditionTrue, "yay"),
 		wantEventType: TaskRunSuccessfulEventV1,
+	}, {
+		desc: "send a cloud event with successful status taskrun, empty selflink",
+		taskRun: func() *v1beta1.TaskRun {
+			tr := getTaskRunByCondition(corev1.ConditionTrue, "yay")
+			// v1.20 does not set selfLink in controller
+			tr.ObjectMeta.SelfLink = ""
+			return tr
+		}(),
+		wantEventType: TaskRunSuccessfulEventV1,
 	}}
 
 	for _, c := range taskRunTests {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Closes #2676 

SelfLink is deprecated and is causing an error on Kubernetes v1.20
clusters as outlined in the issue. This is a short term fix that
would set the source field to a value that should match the current
source URI without the value of the auto-populated selfLink field.

Another field could be used for the source field without issue, but
could cause concerns about backwards compatibility.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Resolves #2676 by providing Cloud Event source value when selfLink unset
```