### PR TITLE
Add variables context.pipelineTask.retries and context.task.retry-count

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -20,6 +20,7 @@ weight: 3
     - [Guard `Task` execution using `Conditions`](#guard-task-execution-using-conditions)
     - [Configuring the failure timeout](#configuring-the-failure-timeout)
   - [Using variable substitution](#using-variable-substitution)
+    - [Using the `retries` and `retry-count` variable substitutions](#using-the-retries-and-retry-count-variable-substitutions)
   - [Using `Results`](#using-results)
     - [Passing one Task's `Results` into the `Parameters` or `WhenExpressions` of another](#passing-one-tasks-results-into-the-parameters-or-whenexpressions-of-another)
     - [Emitting `Results` from a `Pipeline`](#emitting-results-from-a-pipeline)
@@ -549,6 +550,35 @@ performed by the Tekton Controller when a PipelineRun is executed.
 
 See the [complete list of variable substitutions for Pipelines](./variables.md#variables-available-in-a-pipeline)
 and the [list of fields that accept substitutions](./variables.md#fields-that-accept-variable-substitutions).
+
+### Using the `retries` and `retry-count` variable substitutions
+
+Tekton supports variable substitution for the [`retries`](#using-the-retries-parameter)
+parameter of `PipelineTask`. Variables like `context.pipelineTask.retries` and
+`context.task.retry-count` can be added to the parameters of a `PipelineTask`.
+`context.pipelineTask.retries` will be replaced by `retries` of the `PipelineTask`, while
+`context.task.retry-count` will be replaced by current retry number of the `PipelineTask`.
+
+```yaml
+params:
+- name: pipelineTask-retries
+  value: "$(context.pipelineTask.retries)"
+taskSpec:
+  params:
+  - name: pipelineTask-retries
+  steps:
+  - image: ubuntu
+    name: print-if-retries-exhausted
+    script: |
+      if [ "$(context.task.retry-count)" == "$(params.pipelineTask-retries)" ]
+      then
+        echo "This is the last retry."
+      fi
+      exit 1
+```
+
+**Note:** Every `PipelineTask` can only access its own `retries` and `retry-count`. These
+values aren't accessible for other `PipelineTask`s.
 
 ## Using `Results`
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -25,6 +25,7 @@ For instructions on using variable substitutions see the relevant section of [th
 | `context.pipeline.name` | The name of this `Pipeline` . |
 | `tasks.<pipelineTaskName>.status` | The execution status of the specified `pipelineTask`, only available in `finally` tasks. The execution status can be set to any one of the values (`Succeeded`, `Failed`, or `None`) described [here](pipelines.md#using-execution-status-of-pipelinetask)|
 | `tasks.status` | An aggregate status of all the `pipelineTasks` under the `tasks` section (excluding the `finally` section). This variable is only available in the `finally` tasks and can have any one of the values (`Succeeded`, `Failed`, `Completed`, or `None`) described [here](pipelines.md#using-aggregate-execution-status-of-all-tasks).  |
+| `context.pipelineTask.retries` | The retries of this `PipelineTask`. |
 
 ## Variables available in a `Task`
 
@@ -43,6 +44,7 @@ For instructions on using variable substitutions see the relevant section of [th
 | `context.taskRun.namespace` | The namespace of the `TaskRun` that this `Task` is running in. |
 | `context.taskRun.uid` | The uid of the `TaskRun` that this `Task` is running in. |
 | `context.task.name` | The name of this `Task`. |
+| `context.task.retry-count` | The current retry number of this `Task`. |
 
 ### `PipelineResource` variables available in a `Task`
 

--- a/examples/v1beta1/pipelineruns/using-retries-and-retry-count-variables.yaml
+++ b/examples/v1beta1/pipelineruns/using-retries-and-retry-count-variables.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: retry-example-
+spec:
+  serviceAccountName: 'default'
+  pipelineSpec:
+    tasks:
+    - name: retry-me
+      retries: 5
+      params:
+      - name: pipelineTask-retries
+        value: "$(context.pipelineTask.retries)"
+      - name: pipelineTask-retry-count
+        value: "$(context.task.retry-count)"
+      taskSpec:
+        params:
+        - name: pipelineTask-retries
+        - name: pipelineTask-retry-count
+        steps:
+        - image: alpine:3.12.0
+          script: |
+            #!/usr/bin/env sh
+            if [ "$(params.pipelineTask-retry-count)" == "$(params.pipelineTask-retries)" ]; then
+              echo "This is the last retry."
+              exit 0;
+            fi
+            echo "The PipelineTask has retried $(context.task.retry-count) times."
+            exit 1
+    - name: hello-world
+      runAfter:
+      - retry-me
+      taskSpec:
+        steps:
+        - image: busybox
+          script: |
+            echo "hello world"

--- a/examples/v1beta1/pipelineruns/using_context_variables.yaml
+++ b/examples/v1beta1/pipelineruns/using_context_variables.yaml
@@ -7,6 +7,7 @@ spec:
   pipelineSpec:
     tasks:
     - name: task1
+      retries: 7
       params:
       - name: pipeline-uid
         value: "$(context.pipelineRun.uid)"
@@ -14,11 +15,14 @@ spec:
         value: "$(context.pipeline.name)"
       - name: pipelineRun-name
         value: "$(context.pipelineRun.name)"
+      - name: pipelineTask-retries
+        value: "$(context.pipelineTask.retries)"
       taskSpec:
         params:
         - name: pipeline-uid
         - name: pipeline-name
         - name: pipelineRun-name
+        - name: pipelineTask-retries
         steps:
         - image: ubuntu
           name: print-uid
@@ -32,3 +36,8 @@ spec:
             echo "TaskRun name: $(context.taskRun.name)"
             echo "Pipeline name from params: $(params.pipeline-name)"
             echo "PipelineRun name from params: $(params.pipelineRun-name)"
+        - image: ubuntu
+          name: print-retries
+          script: |
+            echo "PipelineTask retries from params: $(params.pipelineTask-retries)"
+            echo "PipelineTask current retry count: $(context.task.retry-count)"

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -276,6 +276,7 @@ func validateTaskContextVariables(steps []Step) *apis.FieldError {
 	)
 	taskContextNames := sets.NewString().Insert(
 		"name",
+		"retry-count",
 	)
 	errs := validateVariables(steps, "context\\.taskRun", taskRunContextNames)
 	return errs.Also(validateVariables(steps, "context\\.task", taskContextNames))

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -282,6 +282,19 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "valid task retry count context",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Image: "my-image",
+					Args:  []string{"arg"},
+				},
+				Script: `
+				#!/usr/bin/env  bash
+				retry count "$(context.task.retry-count)"`,
+			}},
+		},
+	}, {
 		name: "valid taskrun name context",
 		fields: fields{
 			Steps: []v1beta1.Step{{

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -614,7 +614,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 	fnextRprts := pipelineRunFacts.GetFinalTasks()
 	if len(fnextRprts) != 0 {
 		// apply the runtime context just before creating taskRuns for final tasks in queue
-		resources.ApplyPipelineTaskContext(fnextRprts, pipelineRunFacts.GetPipelineTaskStatus())
+		resources.ApplyPipelineTaskStateContext(fnextRprts, pipelineRunFacts.GetPipelineTaskStatus())
 
 		// Before creating TaskRun for scheduled final task, check if it's consuming a task result
 		// Resolve and apply task result wherever applicable, report warning in case resolution fails
@@ -707,6 +707,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 		return c.PipelineClientSet.TektonV1beta1().TaskRuns(pr.Namespace).UpdateStatus(ctx, tr, metav1.UpdateOptions{})
 	}
 
+	rprt.PipelineTask = resources.ApplyPipelineTaskContexts(rprt.PipelineTask)
 	taskRunSpec := pr.GetTaskRunSpec(rprt.PipelineTask.Name)
 	tr = &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -107,6 +108,7 @@ func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1bet
 		"context.task.name":         rtr.TaskName,
 		"context.taskRun.namespace": tr.Namespace,
 		"context.taskRun.uid":       string(tr.ObjectMeta.UID),
+		"context.task.retry-count":  strconv.Itoa(len(tr.Status.RetriesStatus)),
 	}
 	return ApplyReplacements(spec, replacements, map[string][]string{})
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`context.pipelineTask.retries` exposes the total retries of a pipelineTask.

`context.task.retry-count` exposes the current number of retry. The reason why the
variable isn't named `context.pipelineTask.retry-count` is that every task has a retry
count, only pipelineTask has retries.

Rename function `ApplyPipelineTaskContext` to `ApplyPipelineTaskStateContext` in
"pipelinerun/apply.go" to distinguish from `ApplyPipelineTaskContexts`.

related issue: https://github.com/tektoncd/pipeline/issues/2725
TEP: https://github.com/tektoncd/community/blob/main/teps/0039-add-variable-retries-and-retrycount.md

/kind feature



# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Add variables context.pipelineTask.retries and context.task.retry-count
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
