### PR TITLE
Fix a broken link to the service account docs

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -294,10 +294,11 @@ You may also specify a fixed digest instead of a tag.
  ```
 
 Any of the above options will fetch the image using the `ImagePullSecrets` attached to the
-`ServiceAccount` specified in the `PipelineRun`. See the [Service Account](
-pipelineruns.md#service-accounts) section for details on how to configure a `ServiceAccount`
-on a `PipelineRun`. The `PipelineRun` will then run that `Task` without registering it in
-the cluster allowing multiple versions of the same named `Task` to be run at once.
+`ServiceAccount` specified in the `PipelineRun`.
+See the [Service Account](pipelineruns.md#specifying-custom-serviceaccount-credentials) section
+for details on how to configure a `ServiceAccount` on a `PipelineRun`. The `PipelineRun` will then
+run that `Task` without registering it in the cluster allowing multiple versions of the same named
+`Task` to be run at once.
 
 `Tekton Bundles` may be constructed with any toolsets that produce valid OCI image artifacts
 so long as the artifact adheres to the [contract](tekton-bundle-contracts.md).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The fragment in the link was broken, and the link was split
over two lines. Fixes https://github.com/tektoncd/website/issues/229

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```