### PR TITLE
Fix the cr URL for crane

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -185,11 +185,11 @@ spec:
 
       # Auth with account credentials for all regions.
       HOSTNAME=gcr.io
-      cat /secret/release.json | crane auth login -u _json_key --password-stdin https://${HOSTNAME}
+      cat /secret/release.json | crane auth login -u _json_key --password-stdin ${HOSTNAME}
       for REGION in ${REGIONS}
       do
         HOSTNAME=${REGION}.gcr.io
-        cat /secret/release.json | crane auth login -u _json_key --password-stdin https://${HOSTNAME}
+        cat /secret/release.json | crane auth login -u _json_key --password-stdin ${HOSTNAME}
       done
 
       # Tag the images and put them in all the regions


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We use crane in the release pipeline to copy the images to various
registries. The URL of the container registry shall not include the
protocol part (https://).

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```