### PR TITLE
Fix nightly builds (again)

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -83,8 +83,32 @@ spec:
     - "-p"
     - "/workspace/output/bucket/previous/$(params.versionTag)/"
 
+  - name: container-registy-auth
+    image: gcr.io/go-containerregistry/crane:debug
+    env:
+      - name: CONTAINER_REGISTY_CREDENTIALS
+        value: "/secret/release.json"
+      - name: REGIONS
+        value: "us eu asia"
+    script: |
+      #!/busybox/sh
+      set -ex
+
+      # Login to gcr.io
+      DOCKER_CONFIG=$(cat ${CONTAINER_REGISTY_CREDENTIALS} | \
+        crane auth login -u _json_key --password-stdin gcr.io 2>&1 | \
+        sed 's,^.*logged in via \(.*\)$,\1,g')
+
+      # Auth with account credentials for all regions.
+      for region in ${REGIONS}
+      do
+        HOSTNAME=${region}.gcr.io
+        cat ${CONTAINER_REGISTY_CREDENTIALS} | crane auth login -u _json_key --password-stdin ${HOSTNAME}
+      done
+      cp ${DOCKER_CONFIG} /workspace/docker-config.json
+
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko-gcloud:latest
+    image: gcr.io/tekton-releases/dogfooding/ko:latest
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)
@@ -94,17 +118,14 @@ spec:
       value: "off"
     - name: GOFLAGS
       value: "-mod=vendor"
-    - name: GOOGLE_APPLICATION_CREDENTIALS
-      value: "/secret/release.json"
     script: |
-      #!/usr/bin/env bash
+      #!/usr/bin/env sh
       set -ex
 
-      # Activate service account
-      gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
-
       # Setup docker-auth
-      gcloud auth configure-docker
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
 
       # Change to directory with our .ko.yaml
       cd /workspace/go/src/github.com/tektoncd/pipeline
@@ -181,16 +202,12 @@ spec:
       #!/busybox/sh
       set -ex
 
-      REGIONS="us eu asia"
+      # Setup docker-auth
+      DOCKER_CONFIG=~/.docker
+      mkdir -p ${DOCKER_CONFIG}
+      cp /workspace/docker-config.json ${DOCKER_CONFIG}/
 
-      # Auth with account credentials for all regions.
-      HOSTNAME=gcr.io
-      cat /secret/release.json | crane auth login -u _json_key --password-stdin ${HOSTNAME}
-      for REGION in ${REGIONS}
-      do
-        HOSTNAME=${REGION}.gcr.io
-        cat /secret/release.json | crane auth login -u _json_key --password-stdin ${HOSTNAME}
-      done
+      REGIONS="us eu asia"
 
       # Tag the images and put them in all the regions
       for IMAGE in $(cat /workspace/built_images)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Stop using google cred helper for good. The authentication step
with the gcloud client in the "run-ko" step creates a docker file
that affects the behaviour of crane in the "tag-images" step.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug 

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```