### PR TITLE
WIP Add breakpoint to TaskRun Spec

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -34,13 +34,14 @@ import (
 )
 
 var (
-	ep              = flag.String("entrypoint", "", "Original specified entrypoint to execute")
-	waitFiles       = flag.String("wait_file", "", "Comma-separated list of paths to wait for")
-	waitFileContent = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
-	postFile        = flag.String("post_file", "", "If specified, file to write upon completion")
-	terminationPath = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
-	results         = flag.String("results", "", "If specified, list of file names that might contain task results")
-	timeout         = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
+	ep                  = flag.String("entrypoint", "", "Original specified entrypoint to execute")
+	waitFiles           = flag.String("wait_file", "", "Comma-separated list of paths to wait for")
+	waitFileContent     = flag.Bool("wait_file_content", false, "If specified, expect wait_file to have content")
+	postFile            = flag.String("post_file", "", "If specified, file to write upon completion")
+	terminationPath     = flag.String("termination_path", "/tekton/termination", "If specified, file to write upon termination")
+	results             = flag.String("results", "", "If specified, list of file names that might contain task results")
+	timeout             = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
+	breakpointOnFailure = flag.Bool("breakpoint_on_failure", false, "If specified, expect steps to not skip on failure")
 )
 
 const defaultWaitPollingInterval = time.Second
@@ -62,6 +63,15 @@ func cp(src, dst string) error {
 
 	_, err = io.Copy(d, s)
 	return err
+}
+
+func checkForBreakpointOnFailure(e entrypoint.Entrypointer, breakpointExitPostFile string) {
+	if e.BreakpointOnFailure {
+		if waitErr := e.Waiter.Wait(breakpointExitPostFile, false); waitErr != nil {
+			log.Println("error occurred while waiting for " + breakpointExitPostFile)
+		}
+		os.Exit(0)
+	}
 }
 
 func main() {
@@ -97,17 +107,18 @@ func main() {
 	}
 
 	e := entrypoint.Entrypointer{
-		Entrypoint:      *ep,
-		WaitFiles:       strings.Split(*waitFiles, ","),
-		WaitFileContent: *waitFileContent,
-		PostFile:        *postFile,
-		TerminationPath: *terminationPath,
-		Args:            flag.Args(),
-		Waiter:          &realWaiter{waitPollingInterval: defaultWaitPollingInterval},
-		Runner:          &realRunner{},
-		PostWriter:      &realPostWriter{},
-		Results:         strings.Split(*results, ","),
-		Timeout:         timeout,
+		Entrypoint:          *ep,
+		WaitFiles:           strings.Split(*waitFiles, ","),
+		WaitFileContent:     *waitFileContent,
+		PostFile:            *postFile,
+		TerminationPath:     *terminationPath,
+		Args:                flag.Args(),
+		Waiter:              &realWaiter{waitPollingInterval: defaultWaitPollingInterval},
+		Runner:              &realRunner{},
+		PostWriter:          &realPostWriter{},
+		Results:             strings.Split(*results, ","),
+		Timeout:             timeout,
+		BreakpointOnFailure: *breakpointOnFailure,
 	}
 
 	// Copy any creds injected by the controller into the $HOME directory of the current
@@ -117,6 +128,7 @@ func main() {
 	}
 
 	if err := e.Go(); err != nil {
+		breakpointExitPostFile := e.PostFile + ".breakpointexit"
 		switch t := err.(type) {
 		case skipError:
 			log.Print("Skipping step because a previous step failed")
@@ -132,11 +144,14 @@ func main() {
 			// in both cases has an ExitStatus() method with the
 			// same signature.
 			if status, ok := t.Sys().(syscall.WaitStatus); ok {
+				checkForBreakpointOnFailure(e, breakpointExitPostFile)
 				os.Exit(status.ExitStatus())
 			}
 			log.Fatalf("Error executing command (ExitError): %v", err)
 		default:
+			checkForBreakpointOnFailure(e, breakpointExitPostFile)
 			log.Fatalf("Error executing command: %v", err)
 		}
 	}
 }
+

--- a/cmd/entrypoint/waiter.go
+++ b/cmd/entrypoint/waiter.go
@@ -42,6 +42,10 @@ func (rw *realWaiter) Wait(file string, expectContent bool) error {
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("waiting for %q: %w", file, err)
 		}
+		// Don't skip step if breakpointOnFailure enabled (to halt execution of the TaskRun)
+		//if _, err := os.Stat(file + ".err"); err == nil && !breakpointOnFailure{
+		//	return skipError("error file present, bail and skip the step")
+		//}
 		if _, err := os.Stat(file + ".err"); err == nil {
 			return skipError("error file present, bail and skip the step")
 		}

--- a/examples/v1beta1/taskruns/task-result-with-breakpoint.yaml
+++ b/examples/v1beta1/taskruns/task-result-with-breakpoint.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: print-date-
+spec:
+  breakpoint:
+    onFailure: true 
+  taskSpec:
+    description: |
+      A simple task that prints the date.
+    results:
+      - name: current-date-unix-timestamp
+        description: The current date in unix timestamp format
+      - name: current-date-human-readable
+        description: The current date in human readable format
+    steps:
+      - name: print-date-unix-timestamp
+        image: bash:latest
+        script: |
+          #!/usr/bin/env bash
+          date +%s | tee /tekton/results/current-date-unix-timestamp
+          exit 1 
+      - name: print-date-human-readable
+        image: bash:latest
+        script: |
+          #!/usr/bin/env bash
+          date | tee /tekton/results/current-date-human-readable
+      - name: print-date-unix-timestamp2
+        image: bash:latest
+        script: |
+          #!/usr/bin/env bash
+          date +%s | tee /tekton/results/current-date-unix-timestamp2
+      - name: print-date-human-readable2
+        image: bash:latest
+        script: |
+          #!/usr/bin/env bash
+          date | tee /tekton/results/current-date-human-readable2
+          exit 1
+

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -43,6 +43,8 @@ var (
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {
 	// +optional
+	Breakpoint *TaskRunBreakpoint `json:"breakpoint,omitempty"`
+	// +optional
 	Params []Param `json:"params,omitempty"`
 	// +optional
 	Resources *TaskRunResources `json:"resources,omitempty"`
@@ -76,6 +78,12 @@ const (
 	// if not already cancelled or terminated
 	TaskRunSpecStatusCancelled = "TaskRunCancelled"
 )
+
+// TaskRunBreakpoint defines the breakpoint config for a particular TaskRun
+type TaskRunBreakpoint struct {
+	// +optional
+	OnFailure bool `json:"onFailure"`
+}
 
 // TaskRunInputs holds the input values that this task was invoked with.
 type TaskRunInputs struct {

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -29,8 +29,12 @@ import (
 
 const (
 	scriptsVolumeName     = "tekton-internal-scripts"
+	debugScriptsVolumeName     = "tekton-internal-debug-scripts"
+	debugInfoVolumeName = "tekton-internal-debug-info"
 	scriptsDir            = "/tekton/scripts"
+	debugScriptsDir            = "/tekton/debug/scripts"
 	defaultScriptPreamble = "#!/bin/sh\nset -xe\n"
+	debugInfoDir = "/tekton/debug/info"
 )
 
 var (
@@ -44,6 +48,18 @@ var (
 		Name:      scriptsVolumeName,
 		MountPath: scriptsDir,
 	}
+	debugScriptsVolume = corev1.Volume{
+		Name:         debugScriptsVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
+	debugScriptsVolumeMount = corev1.VolumeMount{
+		Name:      debugScriptsVolumeName,
+		MountPath: debugScriptsDir,
+	}
+	debugInfoVolume = corev1.Volume{
+		Name:         debugInfoVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	}
 )
 
 // convertScripts converts any steps and sidecars that specify a Script field into a normal Container.
@@ -51,8 +67,11 @@ var (
 // It does this by prepending a container that writes specified Script bodies
 // to executable files in a shared volumeMount, then produces Containers that
 // simply run those executable files.
-func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.Sidecar) (*corev1.Container, []corev1.Container, []corev1.Container) {
+func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.Sidecar, breakpointConfig *v1beta1.TaskRunBreakpoint) (*corev1.Container, []corev1.Container, []corev1.Container) {
 	placeScripts := false
+	// Place scripts is an init container used for creating scripts in the
+	// /tekton/scripts directory which would be later used by the step containers
+	// as a Command
 	placeScriptsInit := corev1.Container{
 		Name:         "place-scripts",
 		Image:        shellImage,
@@ -61,8 +80,9 @@ func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 	}
 
-	convertedStepContainers := convertListOfSteps(steps, &placeScriptsInit, &placeScripts, "script")
+	var convertedStepContainers []corev1.Container
 
+	breakpointEnabled := false
 	sideCarSteps := []v1beta1.Step{}
 	for _, step := range sidecars {
 		sidecarStep := v1beta1.Step{
@@ -72,7 +92,16 @@ func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.
 		}
 		sideCarSteps = append(sideCarSteps, sidecarStep)
 	}
-	sidecarContainers := convertListOfSteps(sideCarSteps, &placeScriptsInit, &placeScripts, "sidecar-script")
+
+	// Disable breakpoint in sidecar step to container conversion to not rewrite the scripts
+	sidecarContainers := convertListOfSteps(sideCarSteps, &placeScriptsInit, &placeScripts, &breakpointEnabled,  "sidecar-script")
+
+	if breakpointConfig != nil && breakpointConfig.OnFailure {
+		breakpointEnabled = true
+		placeScriptsInit.VolumeMounts = append(placeScriptsInit.VolumeMounts, debugScriptsVolumeMount)
+	}
+
+	convertedStepContainers = convertListOfSteps(steps, &placeScriptsInit, &placeScripts, &breakpointEnabled,"script")
 
 	if placeScripts {
 		return &placeScriptsInit, convertedStepContainers, sidecarContainers
@@ -84,7 +113,7 @@ func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.
 //
 // It iterates through the list of steps (or sidecars), generates the script file name and heredoc termination string,
 // adds an entry to the init container args, sets up the step container to run the script, and sets the volume mounts.
-func convertListOfSteps(steps []v1beta1.Step, initContainer *corev1.Container, placeScripts *bool, namePrefix string) []corev1.Container {
+func convertListOfSteps(steps []v1beta1.Step, initContainer *corev1.Container, placeScripts, breakpointEnabled *bool, namePrefix string) []corev1.Container {
 	containers := []corev1.Container{}
 	for i, s := range steps {
 		if s.Script == "" {
@@ -125,14 +154,127 @@ cat > ${tmpfile} << '%s'
 %s
 `, tmpFile, heredoc, script, heredoc)
 
+		debugInfoVolumeMount := corev1.VolumeMount{
+			Name: debugInfoVolumeName,
+			MountPath: filepath.Join(debugInfoDir,fmt.Sprintf("%d",i)),
+		}
+
 		// Set the command to execute the correct script in the mounted
 		// volume.
 		// A previous merge with stepTemplate may have populated
 		// Command and Args, even though this is not normally valid, so
 		// we'll clear out the Args and overwrite Command.
 		steps[i].Command = []string{tmpFile}
-		steps[i].VolumeMounts = append(steps[i].VolumeMounts, scriptsVolumeMount)
+		steps[i].VolumeMounts = append(steps[i].VolumeMounts, scriptsVolumeMount, debugScriptsVolumeMount, debugInfoVolumeMount)
 		containers = append(containers, steps[i].Container)
 	}
+
+	// Setup the breakpoint container and place scripts for if breakpoint is enabled
+	if *breakpointEnabled {
+		// Debug script names
+		debugBreakpointExitScriptName := "breakpoint-exit"
+		debugContinueScriptName := "continue"
+		debugContinueFailScriptName := "continue-fail"
+		// Initial profile path which would be later changed by the debug-run command
+		profilePath := filepath.Join("etc","profile")
+		aliasheredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", "debug-alias"))
+		aliases := ``
+
+		// debugBreakpointExitScript is used by the step-breakpoint container as an entrypoint
+		debugBreakpointExitScript := defaultScriptPreamble+fmt.Sprintf(`
+numberOfSteps=%d
+debugInfo=%s
+tektonTools=%s
+
+postFile="$(ls ${debugInfo} | grep -E '[0-9]+' | tail -1)"
+stepNumber="$(echo ${postFile} | sed 's/[^0-9]*//g')"
+
+if [ $stepNumber -lt $numberOfSteps ]; then
+	echo "debug" > ${tektonTools}/${stepNumber}.breakpointexit
+	echo "Clearing breapoint for step $stepNumber..."
+else
+	echo "Last breakpoint (no. $stepNumber) has already been executed, exiting !"
+	exit 0
+fi`, len(steps), debugInfoDir, mountPoint)
+
+		// debugContinueScript can be used by the user to mark the failing step as a success
+		debugContinueScript := defaultScriptPreamble+fmt.Sprintf(`
+numberOfSteps=%d
+debugInfo=%s
+tektonTools=%s
+
+postFile="$(ls ${debugInfo} | grep -E '[0-9]+' | tail -1)"
+stepNumber="$(echo ${postFile} | sed 's/[^0-9]*//g')"
+
+if [ $stepNumber -lt $numberOfSteps ]; then
+	echo "debug" > ${tektonTools}/${stepNumber} # Mark step as success
+	echo "Executing step $stepNumber..."
+else
+	echo "Last step (no. $stepNumber) has already been executed, breakpoint exiting !"
+	exit 0
+fi`, len(steps), debugInfoDir, mountPoint)
+
+		// debugContinueScript can be used by the user to mark the failing step as a success
+		debugContinueFailScript := defaultScriptPreamble+fmt.Sprintf(`
+numberOfSteps=%d
+debugInfo=%s
+tektonTools=%s
+
+postFile="$(ls ${debugInfo} | grep -E '[0-9]+' | tail -1)"
+stepNumber="$(echo ${postFile} | sed 's/[^0-9]*//g')"
+
+if [ $stepNumber -lt $numberOfSteps ]; then
+	echo "debug" > ${tektonTools}/${stepNumber}.err # Mark step as success
+	echo "Executing step $stepNumber..."
+else
+	echo "Last step (no. $stepNumber) has already been executed, breakpoint exiting !"
+	exit 0
+fi`, len(steps), debugInfoDir, mountPoint)
+
+		// Script names and their content
+		debugScripts := map[string]string{
+			debugBreakpointExitScriptName: debugBreakpointExitScript,
+			debugContinueScriptName:       debugContinueScript,
+			debugContinueFailScriptName:   debugContinueFailScript,
+		}
+
+		// Script names and their file paths which would be added ahead
+		debugScriptsPaths := map[string]string{
+			debugBreakpointExitScriptName: filepath.Join(debugScriptsDir, fmt.Sprintf("%s-%s", "debug", debugBreakpointExitScriptName)),
+			debugContinueScriptName:       filepath.Join(debugScriptsDir, fmt.Sprintf("%s-%s", "debug", debugContinueScriptName)),
+		}
+
+		// Add /etc/profile
+
+		// Make a list of aliases for the scripts which would be added to /.profile
+		for debugScriptName, debugScriptPath := range debugScriptsPaths {
+			aliases += fmt.Sprintf(`
+alias debug-%s=%s`, debugScriptName, debugScriptPath)
+		}
+
+		// Add routine in the initContainer to create /etc/profile
+		initContainer.Args[1] += fmt.Sprintf(`tmpfile="%s"
+touch ${tmpfile} && chmod +x ${tmpfile}
+cat > ${tmpfile} << '%s'
+%s
+%s
+`, profilePath, aliasheredoc, aliases, aliasheredoc)
+
+		// Add debug/breakpoint related scripts to /tekton/debug/scripts
+		// Iterate through the debugScripts and add routine for each of them in the initContainer for their creation
+		for debugScriptName, debugScript := range debugScripts {
+			tmpFile := filepath.Join(debugScriptsDir, fmt.Sprintf("%s-%s", "debug", debugScriptName))
+			heredoc := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-heredoc-randomly-generated", "debug", debugScriptName))
+
+			initContainer.Args[1] += fmt.Sprintf(`tmpfile="%s"
+touch ${tmpfile} && chmod +x ${tmpfile}
+cat > ${tmpfile} << '%s'
+%s
+%s
+`, tmpFile, heredoc, debugScript, heredoc)
+		}
+
+	}
+
 	return containers
 }


### PR DESCRIPTION
# Changes

Add step-breakpoint container monitoring failure situations

When this API detail is provided in the TaskRun payload,
step-breakpoint container is added to the TaskRun Pod which
can be used upon the failure of a step.

Add -breakpoint_on_failure to entrypointer

-breakpoint_on_failure disables exit of container upon failure

Complete breakpoint execution if no failure

If the TaskRun does not fail, free the step-breakpoint container

Add continue script for breakpoint container

debug-continue script is added to /tekton/debug which the users can
use to mark the step as a success

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
