### PR TITLE
Cleanup s390x exclude test list with build-gcs tests

### DIFF
--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -148,10 +148,6 @@ func initExcludedTests() sets.String {
 	case "s390x":
 		return sets.NewString(
 			//examples
-			"TestExamples/v1alpha1/taskruns/build-gcs-targz",
-			"TestExamples/v1beta1/taskruns/build-gcs-targz",
-			"TestExamples/v1beta1/taskruns/build-gcs-zip",
-			"TestExamples/v1alpha1/taskruns/build-gcs-zip",
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/pipelineruns/pipelinerun",


### PR DESCRIPTION
# Changes

As per https://github.com/tektoncd/pipeline/pull/3771 build-gcs support(and tests) was removed. The build-gcs tests were in exclude list for s390x. 
Now the list can be reduced.

/kind cleanup


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
