### PR TITLE
Set minAvailable:1 to unblock node upgrades

### DIFF
--- a/config/webhook-hpa.yaml
+++ b/config/webhook-hpa.yaml
@@ -56,7 +56,11 @@ metadata:
     # labels below are related to istio and should not be used for resource lookup
     version: "devel"
 spec:
-  minAvailable: 80%
+  # Ensure at least one replica is available.
+  # If a node is running the only replica of this pod, K8s will spin up another
+  # replica on another node if it needs to, before killing the original replica
+  # so its node can drain.
+  minAvailable: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook


### PR DESCRIPTION
Fixes #3654 

cc @nikhil-thomas 

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Modify webhook PodDisruptionBudget minAvailable to 1, so node upgrades aren't blocked
```