### PR TITLE
Disable Webhook PDB by default, document enabling it

### DIFF
--- a/config/webhook-hpa.yaml
+++ b/config/webhook-hpa.yaml
@@ -39,31 +39,3 @@ spec:
       resource:
         name: cpu
         targetAverageUtilization: 100
----
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: tekton-pipelines-webhook
-  namespace: tekton-pipelines
-  labels:
-    app.kubernetes.io/name: webhook
-    app.kubernetes.io/component: webhook
-    app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "devel"
-    app.kubernetes.io/part-of: tekton-pipelines
-    # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "devel"
-    # labels below are related to istio and should not be used for resource lookup
-    version: "devel"
-spec:
-  # Ensure at least one replica is available.
-  # If a node is running the only replica of this pod, K8s will spin up another
-  # replica on another node if it needs to, before killing the original replica
-  # so its node can drain.
-  minAvailable: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: webhook
-      app.kubernetes.io/component: webhook
-      app.kubernetes.io/instance: default
-      app.kubernetes.io/part-of: tekton-pipelines


### PR DESCRIPTION
Fixes #3654 

# Changes

This change disables PodDisruptionBudget for the webhook deployment, and documents how to re-enable it in docs/enabling-ha. It also makes some edits to enabling-ha.md to streamline and recommend best practices.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [y] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Disable PodDisruptionBudget for the webhook deployment by default
```

cc @vdemeester @nikhil-thomas @bobcatfish 