### PR TITLE
Update docs to use Kubernetes 1.17 as the minimum version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -153,7 +153,7 @@ _Adding the `upstream` remote sets you up nicely for regularly
 
 The recommended configuration is:
 
--   Kubernetes version 1.16 or later
+-   Kubernetes version 1.17 or later
 -   4 vCPU nodes (`n1-standard-4`)
 -   Node autoscaling, up to 3 nodes
 -   API scopes for cloud-platform
@@ -174,7 +174,7 @@ The recommended configuration is:
     variable (e.g. `PROJECT_ID`).
 
 1.  Create a GKE cluster (with `--cluster-version=latest` but you can use any
-    version 1.16 or later):
+    version 1.17 or later):
 
     ```bash
     export PROJECT_ID=my-gcp-project
@@ -192,7 +192,7 @@ The recommended configuration is:
      --machine-type=n1-standard-4 \
      --image-type=cos \
      --num-nodes=1 \
-     --cluster-version=1.16
+     --cluster-version=1.17
     ```
 
     Note that

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Tekton Pipelines are **Typed**:
 - Jump in with [the tutorial!](docs/tutorial.md)
 - Take a look at our [roadmap](roadmap.md)
 
-*Note that starting from the 0.11 release of Tekton, you need to have
-a cluster with **Kubernetes version 1.16 or later***.
+*Note that starting from the 0.20 release of Tekton, you need to have
+a cluster with **Kubernetes version 1.17 or later***.
 
 ### Read the docs
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -42,7 +42,7 @@ This document makes reference in a few places to different profiles for Tekton i
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.16 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
+There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.17 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
 
 ## Modifying This Specification
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 
 ## Before you begin
 
-1. You must have a Kubernetes cluster running version 1.16 or later.
+1. You must have a Kubernetes cluster running version 1.17 or later.
 
    If you don't already have a cluster, you can create one for testing with `kind`.
    [Install `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and create a cluster by running [`kind create cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). This

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -6,7 +6,7 @@ weight: 12
 -->
 # Pod templates
 
-A Pod template defines a portion of a [`PodSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#pod-v1-core)
+A Pod template defines a portion of a [`PodSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#pod-v1-core)
 configuration that Tekton can use as "boilerplate" for a Pod that runs your `Tasks` and `Pipelines`.
 
 You can specify a Pod template for `TaskRuns` and `PipelineRuns`. In the template, you can specify custom values for fields governing


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As of v0.20, Tekton Pipelines requires Kubernetes 1.17
(https://github.com/tektoncd/pipeline/releases/tag/v0.20.0), but the
docs were not updated. This updates all references of Kubernetes 1.16 to
1.17 as necessary.

/kind documentation

Fixes #3803



# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n/a] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).
#3700

## Additional Notes

Once this is submitted, we probably want to cherrypick this commit onto the release branches so that the tekton.dev docs are updated as well.