### PR TITLE
Add documenation about setting resource limits on a Task step

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -198,6 +198,11 @@ spec:
 
 **Note:** You can use the `paths` field to [override the paths to a `Resource`](resources.md#overriding-where-resources-are-copied-from).
 
+### Specifying `Resource` limits
+
+Each Step in a Task can specify its resource requirements. See
+[Defining `Steps`](tasks.md#defining-steps)
+
 ### Specifying a `Pod` template
 
 You can specify a [`Pod` template](podtemplates.md) configuration that will serve as the configuration starting

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -156,12 +156,30 @@ The following requirements apply to each container image referenced in a `steps`
 
 - The container image must abide by the [container contract](./container-contract.md).
 - Each container image runs to completion or until the first failure occurs.
-- The CPU, memory, and ephemeral storage resource requests will be set to zero, or, if
-  specified, the minimums set through `LimitRanges` in that `Namespace`,
-  if the container image does not have the largest resource request out of all
-  container images in the `Task.` This ensures that the Pod that executes the `Task`
-  only requests enough resources to run a single container image in the `Task` rather
-  than hoard resources for all container images in the `Task` at once.
+- The CPU, memory, and ephemeral storage resource requests will be set
+  to zero (also known as
+  [BestEffort](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-besteffort)),
+  or, if specified, the minimums set through `LimitRanges` in that
+  `Namespace`, if the container image does not have the largest
+  resource request out of all container images in the `Task.` This
+  ensures that the Pod that executes the `Task` only requests enough
+  resources to run a single container image in the `Task` rather than
+  hoard resources for all container images in the `Task` at once.
+
+Below is an example of setting the resource requests and limits for a step:
+
+```yaml
+spec:
+  steps:
+  - name: step-with-limts
+    resources:
+      requests:
+        memory: 1Gi
+        cpu: 500m
+      limits:
+         memory: 2Gi
+        cpu: 800m
+```
 
 #### Reserved directories
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For our use case we needed a way to limit the number of steps that run simultaneously on a worker node. I tried using limit ranges but when used with sidecars it doubles the resource usage. Thanks to #3756 I learned about this method and decided a doc update could save others the trouble.

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

```release-note
NONE
```
