### PR TITLE
Add Dockerfile for pullrequest nonroot build base image

### DIFF
--- a/images/git-init/Dockerfile
+++ b/images/git-init/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.11
+
+RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
+
+RUN apk add --update git git-lfs openssh-client \
+    && apk update \
+    && apk upgrade

--- a/images/pullrequest-init/Dockerfile
+++ b/images/pullrequest-init/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.11 as source
+RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
+
+FROM gcr.io/distroless/static:latest
+COPY --from=source /etc/passwd /etc/passwd
+COPY --from=source /etc/group /etc/group

--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -58,12 +58,26 @@ spec:
       #check the state
       docker buildx inspect --bootstrap --builder builder-buildx1
 
-      #build multi-arch image
+      #build multi-arch original build-base image
       docker buildx build \
         --platform $(params.platforms) \
         --tag $(params.imageRegistry)/$(params.imageRegistryPath)/$(params.package)/build-base \
         --push \
         $(workspaces.source.path)/images
+
+      #build multi-arch git-init build-base image
+      docker buildx build \
+        --platform $(params.platforms) \
+        --tag $(params.imageRegistry)/$(params.imageRegistryPath)/$(params.package)/git-init-build-base \
+        --push \
+        $(workspaces.source.path)/images/git-init
+
+      #build multi-arch pullrequest-init build-base image
+      docker buildx build \
+        --platform $(params.platforms) \
+        --tag $(params.imageRegistry)/$(params.imageRegistryPath)/$(params.package)/pullrequest-init-build-base \
+        --push \
+        $(workspaces.source.path)/images/pullrequest-init
 
     volumeMounts:
     - mountPath: /certs/client


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

As discussed in the issue: https://github.com/tektoncd/pipeline/issues/3746

It was planed to support to run pullrequset init image by both root and non-root USER. And in the end, we have an agreement to provide a new Dockerfile on `distroless` and adding a nonroot 65532 USER.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ n ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ n ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ y ] Release notes block has been filled in or deleted (only if no user facing changes)

/kind misc

# Release Notes
For pull requests with a release note:

```release-note
Add Dockerfile for pullrequset nonroot build base image
```
