### PR TITLE
Serialize and deserialize Finally in PipelineRuns too

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -39,21 +40,11 @@ func (source *Pipeline) ConvertTo(ctx context.Context, obj apis.Convertible) err
 		if err := source.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
 			return err
 		}
-		if source.Annotations != nil {
-			if _, ok := source.Annotations[finallyAnnotationKey]; ok {
-				finally := []v1beta1.PipelineTask{}
-				if err := json.Unmarshal([]byte(source.Annotations[finallyAnnotationKey]), &finally); err != nil {
-					return fmt.Errorf("error converting finally annotation into beta field: %w", err)
-				}
-				if err := v1beta1.ValidatePipelineTasks(ctx, sink.Spec.Tasks, finally); err != nil {
-					return fmt.Errorf("error converting finally annotation into beta field: %w", err)
-				}
-				delete(sink.ObjectMeta.Annotations, finallyAnnotationKey)
-				if len(sink.ObjectMeta.Annotations) == 0 {
-					sink.ObjectMeta.Annotations = nil
-				}
-				sink.Spec.Finally = finally
-			}
+		if err := deserializeFinally(&sink.ObjectMeta, &sink.Spec); err != nil {
+			return err
+		}
+		if err := v1beta1.ValidatePipelineTasks(ctx, sink.Spec.Tasks, sink.Spec.Finally); err != nil {
+			return fmt.Errorf("error converting finally annotation into beta field: %w", err)
 		}
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
@@ -102,15 +93,8 @@ func (sink *Pipeline) ConvertFrom(ctx context.Context, obj apis.Convertible) err
 	switch source := obj.(type) {
 	case *v1beta1.Pipeline:
 		sink.ObjectMeta = source.ObjectMeta
-		if len(source.Spec.Finally) != 0 {
-			b, err := json.Marshal(source.Spec.Finally)
-			if err != nil {
-				return err
-			}
-			if sink.ObjectMeta.Annotations == nil {
-				sink.ObjectMeta.Annotations = make(map[string]string)
-			}
-			sink.ObjectMeta.Annotations[finallyAnnotationKey] = string(b)
+		if err := serializeFinally(&sink.ObjectMeta, source.Spec.Finally); err != nil {
+			return err
 		}
 		return sink.Spec.ConvertFrom(ctx, source.Spec)
 	default:
@@ -150,5 +134,42 @@ func (sink *PipelineTask) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
 	sink.Timeout = source.Timeout
+	return nil
+}
+
+// serializeFinally serializes a list of Finally Tasks to the annotations
+// of an object's metadata section. This can then be used to re-instantiate
+// the Finally Tasks when converting back up to v1beta1 and beyond.
+func serializeFinally(meta *metav1.ObjectMeta, finally []v1beta1.PipelineTask) error {
+	if len(finally) != 0 {
+		b, err := json.Marshal(finally)
+		if err != nil {
+			return err
+		}
+		if meta.Annotations == nil {
+			meta.Annotations = make(map[string]string)
+		}
+		meta.Annotations[finallyAnnotationKey] = string(b)
+	}
+	return nil
+}
+
+// deserializeFinally populates a PipelineSpec's Finally list
+// from an annotation found on resources that have been previously
+// converted down from v1beta1 to v1alpha1.
+func deserializeFinally(meta *metav1.ObjectMeta, spec *v1beta1.PipelineSpec) error {
+	if meta.Annotations != nil {
+		if str, ok := meta.Annotations[finallyAnnotationKey]; ok {
+			finally := []v1beta1.PipelineTask{}
+			if err := json.Unmarshal([]byte(str), &finally); err != nil {
+				return fmt.Errorf("error converting finally annotation into beta field: %w", err)
+			}
+			delete(meta.Annotations, finallyAnnotationKey)
+			if len(meta.Annotations) == 0 {
+				meta.Annotations = nil
+			}
+			spec.Finally = finally
+		}
+	}
 	return nil
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In commit 3ea5981 we added a way for Pipeline.Spec.Finally to be serialized into
alpha Pipelines when downgrading from v1beta1. This was done to fix an
error occurring during conversion and to avoid potential data loss.

This commit adds a similar feature to PipelineRuns. Specifically, if a
PipelineRun nests a PipelineSpec with Finally then that too needs to be
serialized and stored on the alpha version to be deserialized later.

/kind bug

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix issue where PipelineRun with finally in nested pipeline spec would lose those finally tasks when converted down to v1alpha1 and back up to v1beta1 again.
```
