### PR TITLE
an aggregate status of tasks in finally

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -24,7 +24,7 @@ For instructions on using variable substitutions see the relevant section of [th
 | `context.pipelineRun.uid` | The uid of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipeline.name` | The name of this `Pipeline` . |
 | `tasks.<pipelineTaskName>.status` | The execution status of the specified `pipelineTask`, only available in `finally` tasks. |
-
+| `tasks.status` | An aggregate status of all `tasks`, only available in `finally` tasks. |
 
 ## Variables available in a `Task`
 

--- a/examples/v1beta1/pipelineruns/pipelinerun-task-execution-status.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-task-execution-status.yaml
@@ -42,3 +42,17 @@ spec:
               if [[ $(params.task1Status) != "Succeeded" ||  $(params.task2Status) != "None" ]]; then
                 exit 1;
               fi
+    - name: task4 # this task verifies the aggregate status of all tasks, it fails if verification fails
+      params:
+        - name: aggregateStatus
+          value: "$(tasks.status)"
+      taskSpec:
+        params:
+          - name: aggregateStatus
+        steps:
+          - image: alpine
+            name: verify-aggregate-tasks-status
+            script: |
+              if [[ $(params.aggregateStatus) != "Completed" ]]; then
+                exit 1;
+              fi

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -130,9 +130,22 @@ spec:
             - name: echo
               image: ubuntu
               script: exit 1
-      - name: finally-task-should-be-executed # when expression using execution status, param and results
+      - name: finally-task-should-be-skipped-4 # when expression using tasks execution status, evaluates to false
+        when:
+          - input: "$(tasks.status)"
+            operator: in
+            values: ["Failure"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: exit 1
+      - name: finally-task-should-be-executed # when expression using execution status, tasks execution status, param, and results
         when:
           - input: "$(tasks.echo-file-exists.status)"
+            operator: in
+            values: ["Succeeded"]
+          - input: "$(tasks.status)"
             operator: in
             values: ["Succeeded"]
           - input: "$(tasks.check-file.results.exists)"

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -31,6 +31,11 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+const (
+	// PipelineTasksAggregateStatus is a param representing aggregate status of all dag pipelineTasks
+	PipelineTasksAggregateStatus = "tasks.status"
+)
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:noStatus

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -87,7 +87,7 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 	}
 }
 
-//ApplyPipelineTaskContext replaces context variables referring to execution status with the specified status
+// ApplyPipelineTaskContext replaces context variables referring to execution status with the specified status
 func ApplyPipelineTaskContext(state PipelineRunState, replacements map[string]string) {
 	for _, resolvedPipelineRunTask := range state {
 		if resolvedPipelineRunTask.PipelineTask != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implementing [TEP-0049](https://github.com/tektoncd/community/blob/main/teps/0049-aggregate-status-of-dag-tasks.md), it is now possible to access an aggregate execution status of all the tasks using `$(tasks.status)`. This context variable is only available in a finally task.

/kind feature

Partially Closes #1020
Closes #3806 
Implements [TEP #0049](https://github.com/tektoncd/community/blob/main/teps/0049-aggregate-status-of-dag-tasks.md)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes


```release-note
Introducing a variable $(tasks.status) to access aggregate execution status of tasks in finally.
```
