### PR TITLE
Change to use new base images for git and pullrequest images

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,8 +1,7 @@
 defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
   # git-init uses a base image that supports running either as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/build-base:latest
+  github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/git-init-build-base:latest
 
-  # PullRequest resource needs root because in output mode it needs to access pr.json
-  # which might have been copied or written with any level of permissions.
-  github.com/tektoncd/pipeline/cmd/pullrequest-init: gcr.io/distroless/static:latest
+  # PullRequest resource uses a distroless base image that supports running either as root or as user nonroot with UID 65532.
+  github.com/tektoncd/pipeline/cmd/pullrequest-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/pullrequest-init-build-base:latest

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,7 +1,0 @@
-FROM alpine:3.11
-
-RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
-
-RUN apk add --update git git-lfs openssh-client \
-    && apk update \
-    && apk upgrade

--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -58,14 +58,6 @@ spec:
       #check the state
       docker buildx inspect --bootstrap --builder builder-buildx1
 
-      #build multi-arch original build-base image
-      docker buildx build \
-        --platform $(params.platforms) \
-        --tag $(params.imageRegistry)/$(params.imageRegistryPath)/$(params.package)/build-base \
-        --push \
-        --no-cache \
-        $(workspaces.source.path)/images
-
       #build multi-arch git-init build-base image
       docker buildx build \
         --platform $(params.platforms) \

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -64,11 +64,11 @@ spec:
       # This matches the value configured in .ko.yaml
       defaultBaseImage: gcr.io/distroless/static:nonroot
       baseImageOverrides:
-        $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/build-base:latest
+        $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/git-init-build-base:latest
 
         # These match values configured in .ko.yaml
         $(params.package)/cmd/entrypoint: gcr.io/distroless/base:debug-nonroot
-        $(params.package)/cmd/pullrequest-init: gcr.io/distroless/static:latest
+        $(params.package)/cmd/pullrequest-init: ${CONTAINER_REGISTRY}/$(params.package)/pullrequest-init-build-base:latest
       EOF
 
       cat ${PROJECT_ROOT}/.ko.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

This PR is a follow-up PR after https://github.com/tektoncd/pipeline/pull/3810

We already swtiched the `git-init` and pullrequest-init` Dockerfile into the different folder and add these two image build process in the build/publish process.

In this PR, we can officially switch to use these two build-base image in the `.ko.yaml` and remove the old Dockerfile or build-base image.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ n ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ n ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ n ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ y ] Release notes block has been filled in or deleted (only if no user facing changes)

For pull requests with a release note:

```release-note
Add nonroot user in the PullRequest init base image
```
