### PR TITLE
Remove YAML merge and variable from config YAML

### DIFF
--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -25,8 +25,7 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - &version
-    name: v1alpha1
+  - name: v1alpha1
     served: true
     storage: false
     schema:
@@ -44,9 +43,24 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - <<: *version
-    name: v1beta1
+  - name: v1beta1
+    served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: ClusterTask
     plural: clustertasks

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -25,8 +25,7 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - &version
-    name: v1alpha1
+  - name: v1alpha1
     served: true
     storage: false
     # Opt into the status subresource so metadata.generation
@@ -44,9 +43,24 @@ spec:
         # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
         # See issue: https://github.com/knative/serving/issues/912
         x-kubernetes-preserve-unknown-fields: true
-  - <<: *version
-    name: v1beta1
+  - name: v1beta1
+    served: true
     storage: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Pipeline
     plural: pipelines

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -25,8 +25,7 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - &version
-    name: v1alpha1
+  - name: v1alpha1
     served: true
     storage: false
     schema:
@@ -57,9 +56,37 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - <<: *version
-    name: v1beta1
+  - name: v1beta1
+    served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      jsonPath: .status.completionTime
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: PipelineRun
     plural: pipelineruns

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -25,8 +25,7 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - &version
-    name: v1alpha1
+  - name: v1alpha1
     served: true
     storage: false
     schema:
@@ -44,9 +43,24 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - <<: *version
-    name: v1beta1
+  - name: v1beta1
+    served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: Task
     plural: tasks

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -25,8 +25,7 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - &version
-    name: v1alpha1
+  - name: v1alpha1
     served: true
     storage: false
     schema:
@@ -57,9 +56,37 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - <<: *version
-    name: v1beta1
+  - name: v1beta1
+    served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      jsonPath: .status.completionTime
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: TaskRun
     plural: taskruns


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/3794

This enables kustomize and ytt users to more easily consume and modify the YAML.

/kind feature

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [n] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [y] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [y] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
Make release.yaml more easily consumed by tools like kustomize and ytt
```