### PR TITLE
Add ability to run e2e tests on top of nightly release

### DIFF
--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -122,8 +123,10 @@ func TestTaskRunFailure(t *testing.T) {
 	}
 
 	releaseAnnotation, ok := taskrun.Annotations[pod.ReleaseAnnotation]
-	if !ok || releaseAnnotation != "devel" {
-		t.Fatalf("expected Taskrun to be annotated with %s=devel, got %s=%s", pod.ReleaseAnnotation, pod.ReleaseAnnotation, releaseAnnotation)
+	// Nightly release tag looks like v20210323-0593c7bef3
+	nightlyReleaseRegexp := regexp.MustCompile("^v[0-9]{8}-[0-9a-z]{10}$")
+	if !ok || !(releaseAnnotation == "devel" || nightlyReleaseRegexp.MatchString(releaseAnnotation)) {
+		t.Fatalf("expected Taskrun to be annotated with %s=devel or with nightly release tag, got %s=%s", pod.ReleaseAnnotation, pod.ReleaseAnnotation, releaseAnnotation)
 	}
 }
 


### PR DESCRIPTION
# Changes

Extend release tag annotation check in the TestTaskRunFailure test to cover also nightly release builds.
This patch is required to be able to run nightly tests on top of nightly builds.

/kind misc

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```

