### PR TITLE
refactor pipelineTask validation

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -17,7 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +170,80 @@ type PipelineTask struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
+// validateRefOrSpec validates at least one of taskRef or taskSpec is specified
+func (pt PipelineTask) validateRefOrSpec() (errs *apis.FieldError) {
+	// can't have both taskRef and taskSpec at the same time
+	if pt.TaskRef != nil && pt.TaskSpec != nil {
+		errs = errs.Also(apis.ErrMultipleOneOf("taskRef", "taskSpec"))
+	}
+	// Check that one of TaskRef and TaskSpec is present
+	if pt.TaskRef == nil && pt.TaskSpec == nil {
+		errs = errs.Also(apis.ErrMissingOneOf("taskRef", "taskSpec"))
+	}
+	return errs
+}
+
+// validateCustomTask validates custom task specifications - checking kind and fail if not yet supported features specified
+func (pt PipelineTask) validateCustomTask() (errs *apis.FieldError) {
+	if pt.TaskRef.Kind == "" {
+		errs = errs.Also(apis.ErrInvalidValue("custom task ref must specify kind", "taskRef.kind"))
+	}
+	// Conditions are deprecated so the effort to support them with custom tasks is not justified.
+	// When expressions should be used instead.
+	if len(pt.Conditions) > 0 {
+		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support conditions - use when expressions instead", "conditions"))
+	}
+	// TODO(#3133): Support these features if possible.
+	if pt.Retries > 0 {
+		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support retries", "retries"))
+	}
+	if pt.Resources != nil {
+		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support PipelineResources", "resources"))
+	}
+	if pt.Timeout != nil {
+		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support timeout", "timeout"))
+	}
+	return errs
+}
+
+// validateBundle validates bundle specifications - checking name and bundle
+func (pt PipelineTask) validateBundle() (errs *apis.FieldError) {
+	// bundle requires a TaskRef to be specified
+	if (pt.TaskRef != nil && pt.TaskRef.Bundle != "") && pt.TaskRef.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("taskRef.name"))
+	}
+	// If a bundle url is specified, ensure it is parsable
+	if pt.TaskRef != nil && pt.TaskRef.Bundle != "" {
+		if _, err := name.ParseReference(pt.TaskRef.Bundle); err != nil {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("invalid bundle reference (%s)", err.Error()), "taskRef.bundle"))
+		}
+	}
+	return errs
+}
+
+// validateTask validates a pipeline task or a final task for taskRef and taskSpec
+func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError) {
+	// Validate TaskSpec if it's present
+	if pt.TaskSpec != nil {
+		errs = errs.Also(pt.TaskSpec.Validate(ctx).ViaField("taskSpec"))
+	}
+	if pt.TaskRef != nil {
+		if pt.TaskRef.Name != "" {
+			// TaskRef name must be a valid k8s name
+			if errSlice := validation.IsQualifiedName(pt.TaskRef.Name); len(errSlice) != 0 {
+				errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), "name"))
+			}
+		} else {
+			errs = errs.Also(apis.ErrInvalidValue("taskRef must specify name", "taskRef.name"))
+		}
+		// fail if bundle is present when EnableTektonOCIBundles feature flag is off (as it won't be allowed nor used)
+		if pt.TaskRef.Bundle != "" {
+			errs = errs.Also(apis.ErrDisallowedFields("taskref.bundle"))
+		}
+	}
+	return errs
+}
+
 func (pt *PipelineTask) TaskSpecMetadata() PipelineTaskMetadata {
 	return pt.TaskSpec.Metadata
 }
@@ -183,6 +262,25 @@ func (pt PipelineTask) ValidateName() *apis.FieldError {
 		}
 	}
 	return nil
+}
+
+// Validate classifies whether a task is a custom task, bundle, or a regular task(dag/final)
+// calls the validation routine based on the type of the task
+func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
+	errs = errs.Also(pt.validateRefOrSpec())
+	cfg := config.FromContextOrDefaults(ctx)
+	// If EnableCustomTasks feature flag is on, validate custom task specifications
+	// pipeline task having taskRef with APIVersion is classified as custom task
+	switch {
+	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
+		errs = errs.Also(pt.validateCustomTask())
+		// If EnableTektonOCIBundles feature flag is on, validate bundle specifications
+	case cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef != nil && pt.TaskRef.Bundle != "":
+		errs = errs.Also(pt.validateBundle())
+	default:
+		errs = errs.Also(pt.validateTask(ctx))
+	}
+	return
 }
 
 func (pt PipelineTask) Deps() []string {
@@ -264,6 +362,22 @@ func (l PipelineTaskList) Names() sets.String {
 		names.Insert(pt.Name)
 	}
 	return names
+}
+
+// Validate a list of pipeline tasks including custom task and bundles
+func (l PipelineTaskList) Validate(ctx context.Context, taskNames sets.String, path string) (errs *apis.FieldError) {
+	for i, t := range l {
+		// validate pipeline task name
+		errs = errs.Also(t.ValidateName().ViaFieldIndex(path, i))
+		// names cannot be duplicated - checking that pipelineTask names are unique
+		if _, ok := taskNames[t.Name]; ok {
+			errs = errs.Also(apis.ErrMultipleOneOf("name").ViaFieldIndex(path, i))
+		}
+		taskNames.Insert(t.Name)
+		// validate custom task, bundle, dag, or final task
+		errs = errs.Also(t.Validate(ctx).ViaFieldIndex(path, i))
+	}
+	return errs
 }
 
 // PipelineTaskParam is used to provide arbitrary string parameters to a Task.

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -21,15 +21,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
 
@@ -74,101 +71,13 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs
 }
 
-// validatePipelineTasks ensures that pipeline tasks has unique label, pipeline tasks has specified one of
+// ValidatePipelineTasks ensures that pipeline tasks has unique label, pipeline tasks has specified one of
 // taskRef or taskSpec, and in case of a pipeline task with taskRef, it has a reference to a valid task (task name)
 func ValidatePipelineTasks(ctx context.Context, tasks []PipelineTask, finalTasks []PipelineTask) *apis.FieldError {
-	// Names cannot be duplicated
 	taskNames := sets.NewString()
 	var errs *apis.FieldError
-	for i, t := range tasks {
-		errs = errs.Also(validatePipelineTask(ctx, t, taskNames).ViaFieldIndex("tasks", i))
-	}
-	for i, t := range finalTasks {
-		errs = errs.Also(validatePipelineTask(ctx, t, taskNames).ViaFieldIndex("finally", i))
-	}
-	return errs
-}
-
-func validatePipelineTask(ctx context.Context, t PipelineTask, taskNames sets.String) *apis.FieldError {
-	cfg := config.FromContextOrDefaults(ctx)
-	errs := t.ValidateName()
-
-	hasTaskRef := t.TaskRef != nil
-	hasTaskSpec := t.TaskSpec != nil
-	isCustomTask := cfg.FeatureFlags.EnableCustomTasks && hasTaskRef && t.TaskRef.APIVersion != ""
-
-	// can't have both taskRef and taskSpec at the same time
-	if hasTaskRef && hasTaskSpec {
-		errs = errs.Also(apis.ErrMultipleOneOf("taskRef", "taskSpec"))
-	}
-	// Check that one of TaskRef and TaskSpec is present
-	if !hasTaskRef && !hasTaskSpec {
-		errs = errs.Also(apis.ErrMissingOneOf("taskRef", "taskSpec"))
-	}
-	// Validate TaskSpec if it's present
-	if hasTaskSpec {
-		errs = errs.Also(t.TaskSpec.Validate(ctx).ViaField("taskSpec"))
-	}
-
-	// Check that PipelineTask names are unique.
-	if _, ok := taskNames[t.Name]; ok {
-		errs = errs.Also(apis.ErrMultipleOneOf("name"))
-	}
-	taskNames[t.Name] = struct{}{}
-
-	if hasTaskRef {
-		if t.TaskRef.Name != "" {
-			// TaskRef name must be a valid k8s name
-			if errSlice := validation.IsQualifiedName(t.TaskRef.Name); len(errSlice) != 0 {
-				errs = errs.Also(apis.ErrInvalidValue(strings.Join(errSlice, ","), "name"))
-			}
-		} else {
-			// Custom Task refs are allowed to have no name.
-			if !isCustomTask {
-				errs = errs.Also(apis.ErrInvalidValue("taskRef must specify name", "taskRef.name"))
-			}
-		}
-	}
-
-	if isCustomTask {
-		if t.TaskRef.Kind == "" {
-			errs = errs.Also(apis.ErrInvalidValue("custom task ref must specify kind", "taskRef.kind"))
-		}
-		// Conditions are deprecated so the effort to support them with custom tasks is not justified.
-		// When expressions should be used instead.
-		if len(t.Conditions) > 0 {
-			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support conditions - use when expressions instead", "conditions"))
-		}
-		// TODO(#3133): Support these features if possible.
-		if t.Retries > 0 {
-			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support retries", "retries"))
-		}
-		if t.Resources != nil {
-			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support PipelineResources", "resources"))
-		}
-		if t.Timeout != nil {
-			errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support timeout", "timeout"))
-		}
-	}
-
-	// If EnableTektonOCIBundles feature flag is on validate it.
-	// Otherwise, fail if it is present (as it won't be allowed nor used)
-	if cfg.FeatureFlags.EnableTektonOCIBundles {
-		// Check that if a bundle is specified, that a TaskRef is specified as well.
-		if (t.TaskRef != nil && t.TaskRef.Bundle != "") && t.TaskRef.Name == "" {
-			errs = errs.Also(apis.ErrMissingField("taskref.name"))
-		}
-
-		// If a bundle url is specified, ensure it is parseable.
-		if t.TaskRef != nil && t.TaskRef.Bundle != "" {
-			if _, err := name.ParseReference(t.TaskRef.Bundle); err != nil {
-				errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("invalid bundle reference (%s)", err.Error()), "taskref.bundle"))
-			}
-		}
-	} else if t.TaskRef != nil && t.TaskRef.Bundle != "" {
-		errs = errs.Also(apis.ErrDisallowedFields("taskref.bundle"))
-	}
-
+	errs = errs.Also(PipelineTaskList(tasks).Validate(ctx, taskNames, "tasks"))
+	errs = errs.Also(PipelineTaskList(finalTasks).Validate(ctx, taskNames, "finally"))
 	return errs
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Introducing `pipelineTask` and `pipelineTaskList` validation receiver functions to simplify the way tasks are validated for `taskRef` and `taskSpec`.

This is a pure refactoring, no functional changes expected.

/kind cleanup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
