### PR TITLE
Remove mention of absolute vs relative path from workspaces doc

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -110,10 +110,6 @@ Note the following:
   **at most** one _writeable_ `Workspace`.
 - A `readOnly` `Workspace` will have its volume mounted as read-only. Attempting to write
   to a `readOnly` `Workspace` will result in errors and failed `TaskRuns`.
-- `mountPath` can be either absolute or relative. Absolute paths start with `/` and relative paths
-  start with the name of a directory. For example, a `mountPath` of `"/foobar"` is  absolute and exposes
-  the `Workspace` at `/foobar` inside the `Task's` `Steps`, but a `mountPath` of `"foobar"` is relative and
-  exposes the `Workspace` at `/workspace/foobar`.
 
 Below is an example `Task` definition that includes a `Workspace` called `messages` to which the `Task` writes a message:
 


### PR DESCRIPTION
# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3851

Similarly to commit d80cbc our workspace docs stated that if you provide
a relative path to the workspace's `mountPath` then it would be appended
to `/workspace`.

This was never the case and so this commit removes mention of it.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/kind documentation

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Removed incorrect doc that stated workspaces with relative mountPath would be mounted relative to /workspace
```