### PR TITLE
Serialize entire v1beta1 PipelineSpec when converting to v1alpha

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -27,8 +27,12 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-const FinallyFieldName = "finally"
+// This annotation was used to serialize and deserialize Finally tasks in the
+// 0.22 Pipelines release. Keep it around to continue supporting any documents
+// converted during that time.
 const finallyAnnotationKey = "tekton.dev/v1beta1Finally"
+
+const V1Beta1PipelineSpecSerializedAnnotationKey = "tekton.dev/v1beta1PipelineSpec"
 
 var _ apis.Convertible = (*Pipeline)(nil)
 
@@ -37,14 +41,24 @@ func (source *Pipeline) ConvertTo(ctx context.Context, obj apis.Convertible) err
 	switch sink := obj.(type) {
 	case *v1beta1.Pipeline:
 		sink.ObjectMeta = source.ObjectMeta
-		if err := source.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
+		if hasV1Beta1PipelineSpecAnnotation(sink.ObjectMeta.Annotations) {
+			if err := deserializeIntoV1Beta1PipelineSpec(&sink.ObjectMeta, &sink.Spec); err != nil {
+				return fmt.Errorf("error deserializing v1beta1 annotation into spec: %w", err)
+			}
+		} else if err := source.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
 			return err
 		}
 		if err := deserializeFinally(&sink.ObjectMeta, &sink.Spec); err != nil {
-			return err
-		}
-		if err := v1beta1.ValidatePipelineTasks(ctx, sink.Spec.Tasks, sink.Spec.Finally); err != nil {
 			return fmt.Errorf("error converting finally annotation into beta field: %w", err)
+		}
+
+		// The defaults and validation criteria might have changed since this
+		// resource was serialized. This would likely be the result of a bug
+		// in Pipelines so this is intended to help prevent or surface those
+		// potential bugs.
+		sink.SetDefaults(ctx)
+		if err := sink.Validate(ctx); err != nil {
+			return fmt.Errorf("invalid v1beta1 pipeline after conversion: %w", err)
 		}
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
@@ -57,6 +71,7 @@ func (source *PipelineSpec) ConvertTo(ctx context.Context, sink *v1beta1.Pipelin
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
 	sink.Description = source.Description
+	sink.Results = source.Results
 	if len(source.Tasks) > 0 {
 		sink.Tasks = make([]v1beta1.PipelineTask, len(source.Tasks))
 		for i := range source.Tasks {
@@ -93,7 +108,7 @@ func (sink *Pipeline) ConvertFrom(ctx context.Context, obj apis.Convertible) err
 	switch source := obj.(type) {
 	case *v1beta1.Pipeline:
 		sink.ObjectMeta = source.ObjectMeta
-		if err := serializeFinally(&sink.ObjectMeta, source.Spec.Finally); err != nil {
+		if err := serializeV1Beta1PipelineSpec(&sink.ObjectMeta, &source.Spec); err != nil {
 			return err
 		}
 		return sink.Spec.ConvertFrom(ctx, source.Spec)
@@ -107,6 +122,7 @@ func (sink *PipelineSpec) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 	sink.Params = source.Params
 	sink.Workspaces = source.Workspaces
 	sink.Description = source.Description
+	sink.Results = source.Results
 	if len(source.Tasks) > 0 {
 		sink.Tasks = make([]PipelineTask, len(source.Tasks))
 		for i := range source.Tasks {
@@ -137,26 +153,12 @@ func (sink *PipelineTask) ConvertFrom(ctx context.Context, source v1beta1.Pipeli
 	return nil
 }
 
-// serializeFinally serializes a list of Finally Tasks to the annotations
-// of an object's metadata section. This can then be used to re-instantiate
-// the Finally Tasks when converting back up to v1beta1 and beyond.
-func serializeFinally(meta *metav1.ObjectMeta, finally []v1beta1.PipelineTask) error {
-	if len(finally) != 0 {
-		b, err := json.Marshal(finally)
-		if err != nil {
-			return err
-		}
-		if meta.Annotations == nil {
-			meta.Annotations = make(map[string]string)
-		}
-		meta.Annotations[finallyAnnotationKey] = string(b)
-	}
-	return nil
-}
-
 // deserializeFinally populates a PipelineSpec's Finally list
-// from an annotation found on resources that have been previously
-// converted down from v1beta1 to v1alpha1.
+// from an annotation found on resources that were converted
+// from v1beta1 to v1alpha1. This annotation was only used
+// for a short time (the 0.22 release) but is kept here to
+// continue supporting any documents converted to v1alpha1 during
+// that period.
 func deserializeFinally(meta *metav1.ObjectMeta, spec *v1beta1.PipelineSpec) error {
 	if meta.Annotations != nil {
 		if str, ok := meta.Annotations[finallyAnnotationKey]; ok {
@@ -164,11 +166,56 @@ func deserializeFinally(meta *metav1.ObjectMeta, spec *v1beta1.PipelineSpec) err
 			if err := json.Unmarshal([]byte(str), &finally); err != nil {
 				return fmt.Errorf("error converting finally annotation into beta field: %w", err)
 			}
-			delete(meta.Annotations, finallyAnnotationKey)
+			if len(meta.Annotations) == 1 {
+				meta.Annotations = nil
+			} else {
+				delete(meta.Annotations, finallyAnnotationKey)
+			}
+			spec.Finally = finally
+		}
+	}
+	return nil
+}
+
+// hasV1Beta1PipelineSpecAnnotation returns true if the provided annotations
+// map contains the key expected for serialized v1beta1 PipelineSpecs.
+func hasV1Beta1PipelineSpecAnnotation(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+	_, has := annotations[V1Beta1PipelineSpecSerializedAnnotationKey]
+	return has
+}
+
+// serializeV1Beta1PipelineSpec serializes a v1beta1.PipelineSpec to an
+// annotation in the provided meta. This will be used when applying the
+// v1alpha1 resource back to the cluster in order to rehydrate a v1beta1 doc
+// exactly as it appeared before being converted.
+func serializeV1Beta1PipelineSpec(meta *metav1.ObjectMeta, spec *v1beta1.PipelineSpec) error {
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("error serializing v1beta1 document into annotation: %w", err)
+	}
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	meta.Annotations[V1Beta1PipelineSpecSerializedAnnotationKey] = string(b)
+	return nil
+}
+
+// deserializeIntoV1Beta1PipelineSpec populates a PipelineSpec
+// from a JSON annotation found on resources that have been previously
+// converted from v1beta1 to v1alpha1.
+func deserializeIntoV1Beta1PipelineSpec(meta *metav1.ObjectMeta, spec *v1beta1.PipelineSpec) error {
+	if meta.Annotations != nil {
+		if str, ok := meta.Annotations[V1Beta1PipelineSpecSerializedAnnotationKey]; ok {
+			if err := json.Unmarshal([]byte(str), spec); err != nil {
+				return fmt.Errorf("error deserializing v1beta1 document from annotation: %w", err)
+			}
+			delete(meta.Annotations, V1Beta1PipelineSpecSerializedAnnotationKey)
 			if len(meta.Annotations) == 0 {
 				meta.Annotations = nil
 			}
-			spec.Finally = finally
 		}
 	}
 	return nil

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion_test.go
@@ -27,8 +27,31 @@ import (
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"knative.dev/pkg/apis"
 )
+
+var ignoreAnnotations = cmp.FilterPath(func(p cmp.Path) bool {
+	if len(p) < 2 {
+		return false
+	}
+	structField, ok := p.Index(-2).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	if structField.Name() != "ObjectMeta" {
+		return false
+	}
+
+	structField, ok = p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	if structField.Name() != "Annotations" {
+		return false
+	}
+	return true
+}, cmp.Ignore())
 
 func TestPipelineConversionBadType(t *testing.T) {
 	good, bad := &Pipeline{}, &Task{}
@@ -81,8 +104,7 @@ func TestPipelineConversion_Success(t *testing.T) {
 					Conditions: []PipelineTaskCondition{{
 						ConditionRef: "condition1",
 					}},
-					Retries:  10,
-					RunAfter: []string{"task1"},
+					Retries: 10,
 					Resources: &PipelineTaskResources{
 						Inputs: []v1beta1.PipelineTaskInputResource{{
 							Name:     "input1",
@@ -128,9 +150,8 @@ func TestPipelineConversion_Success(t *testing.T) {
 				if err := got.ConvertFrom(context.Background(), ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
-				// compare origin input and roundtrip Pipeline i.e. v1alpha1 pipeline converted to v1beta1 and then converted back to v1alpha1
-				// this check is making sure that we do not end up with different object than what we started with
-				if d := cmp.Diff(test.in, got); d != "" {
+
+				if d := cmp.Diff(test.in, got, ignoreAnnotations); d != "" {
 					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
 				}
 			})
@@ -219,18 +240,16 @@ func TestPipelineConversionFromWithFinally(t *testing.T) {
 			source.(*v1beta1.Pipeline).Spec.Finally = []v1beta1.PipelineTask{{Name: "finaltask", TaskRef: &TaskRef{Name: "task"}}}
 			got := &Pipeline{}
 			if err := got.ConvertFrom(context.Background(), source); err != nil {
-				cce, ok := err.(*CannotConvertError)
-				// conversion error contains the field name which resulted in the failure and should be equal to "Finally" here
-				if ok && cce.Field == FinallyFieldName {
-					return
-				}
-				t.Errorf("ConvertFrom() should have failed")
+				t.Errorf("ConvertFrom() unexpected error: %v", err)
 			}
 		})
 	}
 }
 
-func TestPipelineConversionFromBetaToAlphaWithFinally(t *testing.T) {
+// TestV1Beta1PipelineConversionRoundTrip checks that a populated v1beta1 pipeline
+// correctly round-trips through v1alpha1 conversion and back again without losing
+// any v1beta1-specific fields.
+func TestV1Beta1PipelineConversionRoundTrip(t *testing.T) {
 	p := &v1beta1.Pipeline{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "foo",
@@ -238,21 +257,108 @@ func TestPipelineConversionFromBetaToAlphaWithFinally(t *testing.T) {
 			Generation: 1,
 		},
 		Spec: v1beta1.PipelineSpec{
-			Tasks:   []v1beta1.PipelineTask{{Name: "mytask", TaskRef: &TaskRef{Name: "task"}}},
-			Finally: []v1beta1.PipelineTask{{Name: "myfinallytask", TaskRef: &TaskRef{Name: "task"}}},
+			Tasks: []v1beta1.PipelineTask{
+				{Name: "mytask", TaskRef: &TaskRef{Kind: "Task", Name: "task"}},
+				{
+					Name:    "task-with-when",
+					TaskRef: &TaskRef{Kind: "Task", Name: "task"},
+					WhenExpressions: v1beta1.WhenExpressions{{
+						Input:    "test",
+						Operator: selection.NotIn,
+						Values:   []string{"foo", "bar"},
+					}},
+				},
+			},
+			Finally: []v1beta1.PipelineTask{{Name: "myfinallytask", TaskRef: &TaskRef{Kind: "Task", Name: "task"}}},
 		},
 	}
-	t.Run("finally stored by v1alpha1 and rehydrated for v1beta1", func(t *testing.T) {
-		downgrade := &Pipeline{}
-		if err := downgrade.ConvertFrom(context.Background(), p); err != nil {
-			t.Errorf("error converting from v1beta1 with finally field to v1alpha1 with finally annotation: %v", err)
-		}
-		upgrade := &v1beta1.Pipeline{}
-		if err := downgrade.ConvertTo(context.Background(), upgrade); err != nil {
-			t.Errorf("error converting from v1alpha1 with finally annotation to v1beta1 with finally field: %v", err)
-		}
-		if d := cmp.Diff(p, upgrade); d != "" {
-			t.Errorf("unexpected difference between v1beta1 with finally field and round-tripped v1beta1 with finally field: %s", diff.PrintWantGot(d))
-		}
-	})
+	downgrade := &Pipeline{}
+	if err := downgrade.ConvertFrom(context.Background(), p); err != nil {
+		t.Errorf("error converting from v1beta1 to v1alpha1: %v", err)
+	}
+	upgrade := &v1beta1.Pipeline{}
+	if err := downgrade.ConvertTo(context.Background(), upgrade); err != nil {
+		t.Errorf("error converting from v1alpha1 to v1beta1: %v", err)
+	}
+	if d := cmp.Diff(p, upgrade); d != "" {
+		t.Errorf("unexpected difference between original and round-tripped v1beta1 document: %s", diff.PrintWantGot(d))
+	}
+}
+
+// TestConvertToDeserializationErrors confirms that errors are returned
+// for invalid serialized data.
+func TestConvertToDeserializationErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source Pipeline
+	}{
+		{
+			name: "invalid v1beta1 spec annotation",
+			source: Pipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						V1Beta1PipelineSpecSerializedAnnotationKey: "invalid json",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid finally annotation",
+			source: Pipeline{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						finallyAnnotationKey: "invalid json",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &v1beta1.Pipeline{}
+			err := tc.source.ConvertTo(context.Background(), sink)
+			t.Logf("received error %q", err)
+			if err == nil {
+				t.Errorf("expected error but received none")
+			}
+		})
+	}
+}
+
+// TestAlphaPipelineConversionWithFinallyAnnotation tests that a v1alpha1
+// pipeline with a specific annotation correctly gets turned into a v1beta1
+// pipeline with Finally section. The annotation was given to pipelines with
+// Finally when converted from v1beta1 to v1alpha1 in the 0.22 Pipelines
+// release.
+func TestAlphaPipelineConversionWithFinallyAnnotation(t *testing.T) {
+	p := &Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "foo",
+			Namespace:  "bar",
+			Generation: 1,
+			Annotations: map[string]string{
+				finallyAnnotationKey: `[{"name": "myfinallytask", "taskRef": {"name": "task"}}]`,
+			},
+		},
+		Spec: PipelineSpec{
+			Tasks: []PipelineTask{{Name: "task1", TaskRef: &TaskRef{Name: "task1"}}},
+		},
+	}
+	expected := &v1beta1.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "foo",
+			Namespace:  "bar",
+			Generation: 1,
+		},
+		Spec: v1beta1.PipelineSpec{
+			Tasks:   []v1beta1.PipelineTask{{Name: "task1", TaskRef: &TaskRef{Name: "task1", Kind: "Task"}}},
+			Finally: []v1beta1.PipelineTask{{Name: "myfinallytask", TaskRef: &TaskRef{Kind: "Task", Name: "task"}}},
+		},
+	}
+	upgrade := &v1beta1.Pipeline{}
+	if err := p.ConvertTo(context.Background(), upgrade); err != nil {
+		t.Errorf("error converting from v1alpha1 to v1beta1: %v", err)
+	}
+	if d := cmp.Diff(expected, upgrade); d != "" {
+		t.Errorf("unexpected difference: %s", diff.PrintWantGot(d))
+	}
 }

--- a/test/clients.go
+++ b/test/clients.go
@@ -54,6 +54,7 @@ type clients struct {
 	KubeClient *knativetest.KubeClient
 
 	PipelineClient         v1beta1.PipelineInterface
+	PipelineClientV1Alpha1 v1alpha1.PipelineInterface
 	ClusterTaskClient      v1beta1.ClusterTaskInterface
 	TaskClient             v1beta1.TaskInterface
 	TaskRunClient          v1beta1.TaskRunInterface
@@ -90,6 +91,7 @@ func newClients(t *testing.T, configPath, clusterName, namespace string) *client
 		t.Fatalf("failed to create pipeline clientset from config file at %s: %s", configPath, err)
 	}
 	c.PipelineClient = cs.TektonV1beta1().Pipelines(namespace)
+	c.PipelineClientV1Alpha1 = cs.TektonV1alpha1().Pipelines(namespace)
 	c.ClusterTaskClient = cs.TektonV1beta1().ClusterTasks()
 	c.TaskClient = cs.TektonV1beta1().Tasks(namespace)
 	c.TaskRunClient = cs.TektonV1beta1().TaskRuns(namespace)

--- a/test/pipeline_beta_alpha_roundtrip_test.go
+++ b/test/pipeline_beta_alpha_roundtrip_test.go
@@ -1,0 +1,115 @@
+// +build e2e
+
+/*
+Copyright 2021 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
+	knativetest "knative.dev/pkg/test"
+)
+
+func TestPipelineBetaAlphaRoundtrip(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c, namespace := setup(ctx, t)
+	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+	defer tearDown(ctx, t, c, namespace)
+
+	pipelineName := "pipeline1"
+	pipeline := &v1beta1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "tekton.dev/v1beta1",
+			Kind:       "pipeline",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pipelineName,
+		},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name: "test1",
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test1-task",
+				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "foo",
+					Operator: selection.NotIn,
+					Values:   []string{"bar", "baz"},
+				}},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Name: "test2",
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test2-task",
+				},
+			}},
+			Results: []v1beta1.PipelineResult{{
+				Name:        "result1",
+				Description: "A test result from this pipeline.",
+				Value:       "$(tasks.test1.results.r)",
+			}},
+		},
+	}
+
+	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create Pipeline: %v", err)
+	}
+
+	pV1beta1, err := c.PipelineClient.Get(ctx, pipelineName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting initial v1beta1 pipeline: %v", err)
+	}
+
+	pV1alpha1, err := c.PipelineClientV1Alpha1.Get(ctx, pipelineName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting initial v1alpha1 pipeline: %v", err)
+	}
+
+	if _, ok := pV1alpha1.Annotations[v1alpha1.V1Beta1PipelineSpecSerializedAnnotationKey]; !ok {
+		t.Fatal("the serialized v1beta1 object is not present in the v1alpha1 object's annotations")
+	}
+
+	// this value will be overwritten when the v1alpha1 resource is converted up to v1beta1
+	// because the v1beta1 annotation will overwrite whatever changes we make to the v1alpha1
+	// spec here.
+	updatedResultValue := "this message should not be present in the pipeline results"
+	pV1alpha1.Spec.Results[0].Value = updatedResultValue
+
+	if _, err := c.PipelineClientV1Alpha1.Update(ctx, pV1alpha1, v1.UpdateOptions{}); err != nil {
+		t.Fatalf("error applying modified v1alpha1 pipeline: %v", err)
+	}
+
+	pV1beta1After, err := c.PipelineClient.Get(ctx, pipelineName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting updated v1beta1 pipeline: %v", err)
+	}
+
+	// ignore the "meta" section of the pipelines when diffing them
+	// because it contains fields like "generation" which are expected to
+	// change every update.
+	if d := cmp.Diff(pV1beta1, pV1beta1After, cmpopts.IgnoreFields(v1beta1.Pipeline{}, "ObjectMeta")); d != "" {
+		t.Fatalf("unexpected difference detected after round trip: %s", diff.PrintWantGot(d))
+	}
+}


### PR DESCRIPTION
# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3815

I've added everyone that I've spoken to about this as reviewers on the PR. Sorry
for the spam but I want to widely publicise it before moving ahead.

Prior to this commit our conversion of pipelines from v1beta1 to v1alpha1
did not account for fields that were solely present in the v1beta1
pipeline spec. This meant, for example, that `WhenExpressions` in `PipelineTasks`
were quietly dropped when moving from v1beta1 to v1alpha1. If a user
subsequently re-applied that v1alpha1 resource to the cluster then
the resource would be upgraded back to v1beta1 for storage without
those when expressions.

Why would this down-conversion happen? Users with older clients that
don't know about v1beta1 yet will still be requesting resources using the v1alpha1
`apiVersion`.

Over time this problem would only be exacerbated - any new features added to the
v1beta1 spec would be lost on conversion unless we ensured that all new fields were
_also_ added to the v1alpha1 spec (or accounted for in the conversion webhook).

So, to account for all the fields that might be in v1beta1 but not in v1alpha1 this commit
serializes the entire v1beta1 pipeline spec into an annotation
on `Pipelines` and `PipelineRuns` (when the nested `pipelineSpec` field is present). This will
protect the entire set of beta-only fields from being lost in translation through this conversion
process.  This annotation only exists in the YAML that is returned to the user. This annotation never
gets stored in etcd (unless I'm missing something!)

Unfortunately this approach does also have drawbacks: if a user makes changes
to the v1alpha1 YAML and then re-applies it then those changes
will be lost, overwritten by the contents of the annotation. I'm not sure if
there's a great way to determine, for all fields, how to successfully "merge"
the beta annotation with the contents of the modified v1alpha1 spec when
up-converting.  There's no clear signal, as far as I can tell, that any given field has or
has not been modified (beyond performing a `cmp.Diff`? Would that be an acceptable option?)

/hold

# Submitter Checklist

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Users requesting the v1alpha1 version of Pipelines or PipelineRuns with nested PipelineSpec will now find an entire copy of the v1beta1 PipelineSpec stored as an annotation in the returned data. This is to work around a bug where fields that are beta-specific could be lost if the v1alpha1 document is re-applied to the cluster. No further action is required but you may notice larger-than-expected documents (approx. 2x larger) being returned if your clients are still requesting v1alpha1 Pipelines or PipelineRuns.

It's strongly recommended to upgrade your clients to newer versions that support v1beta1 Tasks and Pipelines.
```