### PR TITLE
PVC: Use Owner UIDs instead of Owner names.

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2982,12 +2982,15 @@ func TestReconcileWorkspaceWithVolumeClaimTemplate(t *testing.T) {
 		if w.PersistentVolumeClaim != nil {
 			t.Fatalf("expected workspace from volumeClaimTemplate to be translated to PVC")
 		}
-	}
-
-	expectedPVCName := fmt.Sprintf("%s-%s", claimName, "a521418087")
-	_, err = clients.Kube.CoreV1().PersistentVolumeClaims(taskRun.Namespace).Get(testAssets.Ctx, expectedPVCName, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("expected PVC %s to exist but instead got error when getting it: %v", expectedPVCName, err)
+		expectedPVCName := volumeclaim.GetPersistentVolumeClaimName(&corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: w.VolumeClaimTemplate.Name,
+			},
+		}, w, ttt.GetOwnerReference())
+		_, err = clients.Kube.CoreV1().PersistentVolumeClaims(taskRun.Namespace).Get(testAssets.Ctx, expectedPVCName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected PVC %s to exist but instead got error when getting it: %v", expectedPVCName, err)
+		}
 	}
 }
 

--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -91,13 +91,14 @@ func getPersistentVolumeClaims(workspaceBindings []v1beta1.WorkspaceBinding, own
 
 // GetPersistentVolumeClaimName gets the name of PersistentVolumeClaim for a Workspace and PipelineRun or TaskRun. claim
 // must be a PersistentVolumeClaim from a volumeClaimTemplate. The returned name must be consistent given the same
-// workspaceBinding name and ownerReference name - because it is first used for creating a PVC and later,
+// workspaceBinding name and ownerReference UID - because it is first used for creating a PVC and later,
 // possibly several TaskRuns to lookup the PVC to mount.
+// We use ownerReference UID over ownerReference name to distinguish runs with the same name.
 func GetPersistentVolumeClaimName(claim *corev1.PersistentVolumeClaim, wb v1beta1.WorkspaceBinding, owner metav1.OwnerReference) string {
 	if claim.Name == "" {
-		return fmt.Sprintf("%s-%s", "pvc", getPersistentVolumeClaimIdentity(wb.Name, owner.Name))
+		return fmt.Sprintf("%s-%s", "pvc", getPersistentVolumeClaimIdentity(wb.Name, string(owner.UID)))
 	}
-	return fmt.Sprintf("%s-%s", claim.Name, getPersistentVolumeClaimIdentity(wb.Name, owner.Name))
+	return fmt.Sprintf("%s-%s", claim.Name, getPersistentVolumeClaimIdentity(wb.Name, string(owner.UID)))
 }
 
 func getPersistentVolumeClaimIdentity(workspaceName, ownerName string) string {

--- a/pkg/reconciler/volumeclaim/pvchandler_test.go
+++ b/pkg/reconciler/volumeclaim/pvchandler_test.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -69,7 +70,7 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ownerRef := metav1.OwnerReference{Name: ownerName}
+	ownerRef := metav1.OwnerReference{UID: types.UID(ownerName)}
 	namespace := "ns"
 	fakekubeclient := fakek8s.NewSimpleClientset()
 	pvcHandler := defaultPVCHandler{fakekubeclient, zap.NewExample().Sugar()}
@@ -110,7 +111,7 @@ func TestCreatePersistentVolumeClaimsForWorkspaces(t *testing.T) {
 		t.Fatalf("unexpected number of ownerreferences on created PVC; expected: %d got %d", expectedNumberOfOwnerRefs, len(pvc.OwnerReferences))
 	}
 
-	if pvc.OwnerReferences[0].Name != ownerName {
+	if string(pvc.OwnerReferences[0].UID) != ownerName {
 		t.Fatalf("unexptected name in ownerreference on created PVC; expected: %s got %s", ownerName, pvc.OwnerReferences[0].Name)
 	}
 }
@@ -134,7 +135,7 @@ func TestCreatePersistentVolumeClaimsForWorkspacesWithoutMetadata(t *testing.T) 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ownerRef := metav1.OwnerReference{Name: ownerName}
+	ownerRef := metav1.OwnerReference{UID: types.UID(ownerName)}
 	namespace := "ns"
 	fakekubeclient := fakek8s.NewSimpleClientset()
 	pvcHandler := defaultPVCHandler{fakekubeclient, zap.NewExample().Sugar()}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We've noticed that using Owner names can lead to race conditions in
deleting a volumeClaimTemplate PVC in where a PipelineRun is quickly deleted
then recreated (see https://github.com/tektoncd/pipeline/issues/3855).

Using the UID allows us to uniquely identify independent runs with the
same name, avoiding this issue while keeping the same semantic.

Fixes #3855 

/kind bug

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [n/a] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [n/a] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
