### PR TITLE
Correct url in migration doc and modify to main branch in doc urls

### DIFF
--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -79,7 +79,7 @@ _More on the reasoning and what's left to do in
 [Why aren't PipelineResources in Beta?](resources.md#why-arent-pipelineresources-in-beta)._
 
 To ease migration away from `PipelineResources`
-[some types have an equivalent `Task` in the Catalog](#pipelineresource-equivalent-catalog-tasks).
+[some types have an equivalent `Task` in the Catalog](#replacing-pipelineresources-with-tasks).
 To use these replacement `Tasks` you will need to combine them with your existing `Tasks` via a `Pipeline`.
 
 For example, if you were using this `Task` which was fetching from `git` and building with
@@ -170,26 +170,26 @@ spec:
   # able to fully deliver with the Image PipelineResource!
 ```
 
-_Note that [the `image` `PipelineResource` is gone in this example](#image-resource) (replaced with
-a [`result`](docs/tasks.md#resultes)), and also that now the `Task` doesn't need to know anything
+_Note that [the `image` `PipelineResource` is gone in this example](#replacing-an-image-resource) (replaced with
+a [`result`](tasks.md#emitting-results)), and also that now the `Task` doesn't need to know anything
 about where the files come from that it builds from._
 
 ### Replacing a `git` resource
 
-You can replace a `git` resource with the [`git-clone` Catalog `Task`](https://github.com/tektoncd/catalog/tree/master/task/git-clone).
+You can replace a `git` resource with the [`git-clone` Catalog `Task`](https://github.com/tektoncd/catalog/tree/main/task/git-clone).
 
 ### Replacing a `pullrequest` resource
 
-You can replace a `pullrequest` resource with the [`pullrequest` Catalog `Task`](https://github.com/tektoncd/catalog/tree/master/task/pull-request).
+You can replace a `pullrequest` resource with the [`pullrequest` Catalog `Task`](https://github.com/tektoncd/catalog/tree/main/task/pull-request).
 
 ### Replacing a `gcs` resource
 
-You can replace a `gcs` resource with the [`gcs` Catalog `Task`](https://github.com/tektoncd/catalog/tree/master/task/gcs-generic).
+You can replace a `gcs` resource with the [`gcs` Catalog `Task`](https://github.com/tektoncd/catalog/tree/main/task/gcs-generic).
 
 ### Replacing an `image` resource
 
 Since the `image` resource is simply a way to share the digest of a built image with subsequent
-`Tasks` in your `Pipeline`, you can use [`Task` results](tasks.md#storing-execution-results) to
+`Tasks` in your `Pipeline`, you can use [`Task` results](tasks.md#emitting-results) to
 achieve equivalent functionality.
 
 For examples of replacing an `image` resource, see the following Catalog `Tasks`:
@@ -201,7 +201,7 @@ For examples of replacing an `image` resource, see the following Catalog `Tasks`
 
 ### Replacing a `cluster` resource
 
-You can replace a `cluster` resource with the [`kubeconfig-creator` Catalog `Task`](https://github.com/tektoncd/catalog/tree/master/task/kubeconfig-creator).
+You can replace a `cluster` resource with the [`kubeconfig-creator` Catalog `Task`](https://github.com/tektoncd/catalog/tree/main/task/kubeconfig-creator).
 
 ## Changes to PipelineResources
 
@@ -267,7 +267,7 @@ spec:
         type: git
         params:
           - name: revision
-            value: master
+            value: main
           - name: url
             value: https://github.com/tektoncd/pipeline
     outputs:

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -909,8 +909,8 @@ Status`](#using-execution-status-of-pipelinetask) of `Tasks`.
 
 #### `WhenExpressions` using `Parameters` in `Finally Tasks`
 
-`WhenExpressions` in `Finally Tasks` can utilize `Parameters` as demonstrated using [`golang-build`](https://github.com/tektoncd/catalog/tree/master/task/golang-build/0.1)
-and [`send-to-channel-slack`](https://github.com/tektoncd/catalog/tree/master/task/send-to-channel-slack/0.1) Catalog
+`WhenExpressions` in `Finally Tasks` can utilize `Parameters` as demonstrated using [`golang-build`](https://github.com/tektoncd/catalog/tree/main/task/golang-build/0.1)
+and [`send-to-channel-slack`](https://github.com/tektoncd/catalog/tree/main/task/send-to-channel-slack/0.1) Catalog
 `Tasks`:
 
 ```yaml
@@ -948,8 +948,8 @@ spec:
 
 #### `WhenExpressions` using `Results` in `Finally Tasks`
 
-`WhenExpressions` in `Finally Tasks` can utilize `Results`, as demonstrated using [`git-clone`](https://github.com/tektoncd/catalog/tree/master/task/git-clone/0.2)
-and [`github-add-comment`](https://github.com/tektoncd/catalog/tree/master/task/github-add-comment/0.2) Catalog `Tasks`:
+`WhenExpressions` in `Finally Tasks` can utilize `Results`, as demonstrated using [`git-clone`](https://github.com/tektoncd/catalog/tree/main/task/git-clone/0.2)
+and [`github-add-comment`](https://github.com/tektoncd/catalog/tree/main/task/github-add-comment/0.2) Catalog `Tasks`:
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -985,8 +985,8 @@ If the `WhenExpressions` in a `Finally Task` use `Results` from a skipped or fai
 #### `WhenExpressions` using `Execution Status` of `PipelineTask` in `Finally Tasks`
 
 `WhenExpressions` in `Finally Tasks` can utilize [`Execution Status` of `PipelineTasks`](#using-execution-status-of-pipelinetask), 
-as as demonstrated using [`golang-build`](https://github.com/tektoncd/catalog/tree/master/task/golang-build/0.1) and
-[`send-to-channel-slack`](https://github.com/tektoncd/catalog/tree/master/task/send-to-channel-slack/0.1) Catalog `Tasks`:
+as as demonstrated using [`golang-build`](https://github.com/tektoncd/catalog/tree/main/task/golang-build/0.1) and
+[`send-to-channel-slack`](https://github.com/tektoncd/catalog/tree/main/task/send-to-channel-slack/0.1) Catalog `Tasks`:
 
 ```yaml
 apiVersion: tekton.dev/v1beta1

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -429,9 +429,9 @@ and the [`Workspaces` in a `TaskRun`](../examples/v1beta1/taskruns/workspace.yam
 
 A Task is able to emit string results that can be viewed by users and passed to other Tasks in a Pipeline. These
 results have a wide variety of potential uses. To highlight just a few examples from the Tekton Catalog: the
-[`git-clone` Task](https://github.com/tektoncd/catalog/blob/master/task/git-clone/0.1/git-clone.yaml) emits a
-cloned commit SHA as a result, the [`generate-build-id` Task](https://github.com/tektoncd/catalog/blob/master/task/generate-build-id/0.1/generate-build-id.yaml)
-emits a randomized ID as a result, and the [`kaniko` Task](https://github.com/tektoncd/catalog/tree/master/task/kaniko/0.1)
+[`git-clone` Task](https://github.com/tektoncd/catalog/blob/main/task/git-clone/0.1/git-clone.yaml) emits a
+cloned commit SHA as a result, the [`generate-build-id` Task](https://github.com/tektoncd/catalog/blob/main/task/generate-build-id/0.1/generate-build-id.yaml)
+emits a randomized ID as a result, and the [`kaniko` Task](https://github.com/tektoncd/catalog/tree/main/task/kaniko/0.1)
 emits a container image digest as a result. In each case these results convey information for users to see when
 looking at their TaskRuns and can also be used in a Pipeline to pass data along from one Task to the next.
 

--- a/docs/tekton-controller-performance-configuration.md
+++ b/docs/tekton-controller-performance-configuration.md
@@ -22,7 +22,7 @@ This document will show us how to configure [tekton-pipeline-controller](./../co
 #### Configure Thread, QPS and Burst
 
 ---
-Default, the value of ThreadsPerController, QPS and Burst is [2](https://github.com/knative/pkg/blob/master/controller/controller.go#L58), [5.0](https://github.com/tektoncd/pipeline/blob/main/vendor/k8s.io/client-go/rest/config.go#L44) and [10](https://github.com/tektoncd/pipeline/blob/main/vendor/k8s.io/client-go/rest/config.go#L45) accordingly.
+Default, the value of ThreadsPerController, QPS and Burst is [2](https://github.com/knative/pkg/blob/main/controller/controller.go#L58), [5.0](https://github.com/tektoncd/pipeline/blob/main/vendor/k8s.io/client-go/rest/config.go#L44) and [10](https://github.com/tektoncd/pipeline/blob/main/vendor/k8s.io/client-go/rest/config.go#L45) accordingly.
 
 Sometimes, above default values can't meet performance requirements, then you need to overwrite these values. You can modify them in the [tekton controller deployment](./../config/controller.yaml). You can specify these customized values in the `tekton-pipelines-controller` container via `threads-per-controller`, `kube-api-qps` and `kube-api-burst` flags accordingly. For example:
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

1. When I reviewing the migration doc: https://github.com/tektoncd/pipeline/blob/main/docs/migrating-v1alpha1-to-v1beta1.md
I found some of the links are wrong, like:
- #pipelineresource-equivalent-catalog-tasks (Correct is: https://github.com/tektoncd/pipeline/blob/main/docs/migrating-v1alpha1-to-v1beta1.md#replacing-pipelineresources-with-tasks)
- #image-resource (Correct is: https://github.com/tektoncd/pipeline/blob/main/docs/migrating-v1alpha1-to-v1beta1.md#replacing-an-image-resource)
- docs/tasks.md#resultes (Correct is: https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#emitting-results)

Correct them to the right link

2. Then I also found some of the Tekton links are still using `master`, so modify them togheter.

/kind docs


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Correct the links in migration doc and modify url to use main branch
```

