### PR TITLE
Disable leader election for webhook

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -232,6 +232,7 @@ func main() {
 		log.Fatal(http.ListenAndServe(":"+port, mux))
 	}()
 
+	ctx = sharedmain.WithHADisabled(ctx)
 	sharedmain.WebhookMainWithConfig(ctx, serviceName,
 		sharedmain.ParseAndGetConfigOrDie(),
 		certificates.NewController,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
In `knative/pkg`, `controller` leverage `leader election` and `buckets` to support HA, but `webhook` has different approach, I mean `webhook` depends on `hpa` and `pdb`, so the `webhook` do not need any `leader election`, I mean do not need create `lease`,

Below is the case when I set `buckets: "3"` in [config-leader-election.yaml](https://github.com/tektoncd/pipeline/blob/main/config/config-leader-election.yaml), it's not make sense and useless.
```
tekton-pipelines-webhook.configmapwebhook.00-of-03                                                        tekton-pipelines-webhook-796fdf674c-nhwwb_f4c15288-0f1a-4eec-a0ca-f14b2a7dab4a      7m2s
tekton-pipelines-webhook.configmapwebhook.01-of-03                                                        tekton-pipelines-webhook-796fdf674c-nhwwb_f4c15288-0f1a-4eec-a0ca-f14b2a7dab4a      7m2s
tekton-pipelines-webhook.configmapwebhook.02-of-03                                                        tekton-pipelines-webhook-796fdf674c-nhwwb_f4c15288-0f1a-4eec-a0ca-f14b2a7dab4a      7m2s
tekton-pipelines-webhook.conversionwebhook.00-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_1c3bdb72-0398-4310-a3ed-c3c30acf1ceb      7m2s
tekton-pipelines-webhook.conversionwebhook.01-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_1c3bdb72-0398-4310-a3ed-c3c30acf1ceb      7m2s
tekton-pipelines-webhook.conversionwebhook.02-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_1c3bdb72-0398-4310-a3ed-c3c30acf1ceb      7m2s
tekton-pipelines-webhook.defaultingwebhook.00-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_6f471e5c-f136-46a2-82c2-bc04a7a3b0db      7m2s
tekton-pipelines-webhook.defaultingwebhook.01-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_6f471e5c-f136-46a2-82c2-bc04a7a3b0db      7m2s
tekton-pipelines-webhook.defaultingwebhook.02-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_6f471e5c-f136-46a2-82c2-bc04a7a3b0db      7m2s
tekton-pipelines-webhook.validationwebhook.00-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_d16d6390-b989-4d7f-b951-17ba1d974783      7m2s
tekton-pipelines-webhook.validationwebhook.01-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_d16d6390-b989-4d7f-b951-17ba1d974783      7m2s
tekton-pipelines-webhook.validationwebhook.02-of-03                                                       tekton-pipelines-webhook-796fdf674c-nhwwb_d16d6390-b989-4d7f-b951-17ba1d974783      7m2s
tekton-pipelines-webhook.webhookcertificates.00-of-03                                                     tekton-pipelines-webhook-796fdf674c-nhwwb_2272bb66-9d83-40b2-a874-011834ca781c      7m2s
tekton-pipelines-webhook.webhookcertificates.01-of-03                                                     tekton-pipelines-webhook-796fdf674c-nhwwb_2272bb66-9d83-40b2-a874-011834ca781c      7m2s
tekton-pipelines-webhook.webhookcertificates.02-of-03                                                     tekton-pipelines-webhook-796fdf674c-nhwwb_2272bb66-9d83-40b2-a874-011834ca781c      7m2s
```

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [ ] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [ ] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes
NONE
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
