### PR TITLE
Run conformance tests regularly 🏃‍♀️

### DIFF
--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -1,7 +1,7 @@
 // +build conformance
 
 /*
-Copyright 2020 The Tekton Authors
+Copyright 2021 The Tekton Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import (
 
 type conditionFn func(name string) ConditionAccessorFn
 
-func TestTaskRun(t *testing.T) {
+func TestTaskRunConformance(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -29,9 +29,9 @@ install_pipeline_crd
 
 failed=0
 
-# Run the integration tests
+# Run the integration tests (including the conformance tests)
 header "Running Go e2e tests"
-go_test_e2e -timeout=20m ./test/... || failed=1
+go_test_e2e tags=e2e,conformance -timeout=20m ./test/... || failed=1
 
 # Run these _after_ the integration tests b/c they don't quite work all the way
 # and they cause a lot of noise in the logs, making it harder to debug integration


### PR DESCRIPTION
# Changes

In https://github.com/tektoncd/pipeline/pull/3400 we added an initial
conformance test, and added a build tag `conformance` to make it so that
folks could run just conformance tests if they wanted to. From what I
can see it doesn't look like we use this tag at all in our automation,
so I want to add it to the tags we use to run our end to end test to
make sure this continues working over time.

In the long run I think we might want to explore a couple other
alternatives for implementing conformance tests, e.g. including making
use of our example tests (though those dont express the desired end
state), maybe a tool like [kuttl](https://github.com/kudobuilder/kuttl#kuttl)
which @chhsia0 has mentioned in preivous working groups, or like the
approach that knative seems to be taking via
https://github.com/knative-sandbox/reconciler-test

But in the short run let's at least make sure this test keeps working :D

Also renamed the test to make it a bit more clear what this test is for
in case it fails.

/kind clenaup

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [tests](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if functionality changed/added)
- [x] Includes [docs](https://github.com/tektoncd/community/blob/master/standards.md#principles) (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
- [x] Release notes block has been filled in or deleted (only if no user facing changes)

_See [the contribution guide](https://github.com/tektoncd/pipeline/blob/master/CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a new binary/image to the `cmd` dir](../cmd), please update
  [the release Task](../tekton/publish.yaml) to build and release this image.

## Reviewer Notes

If [API changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md) are included, [additive changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#additive-changes) must be approved by at least two [OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS) and [backwards incompatible changes](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-incompatible-changes) must be approved by [more than 50% of the OWNERS](https://github.com/tektoncd/pipeline/blob/master/OWNERS), and they must first be added [in a backwards compatible way](https://github.com/tektoncd/pipeline/blob/master/api_compatibility_policy.md#backwards-compatible-changes-first).

# Release Notes

```release-note
NONE
```
