### PR TITLE
Add doc links for 0.23.0 to README and update release-cheat-sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ a cluster with **Kubernetes version 1.17 or later***.
 | Version | Docs | Examples |
 | ------- | ---- | -------- |
 | [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
+| [v0.23.0](https://github.com/tektoncd/pipeline/releases/tag/v0.23.0) | [Docs @ v0.23.0](https://github.com/tektoncd/pipeline/tree/v0.23.0/docs#tekton-pipelines) | [Examples @ v0.23.0](https://github.com/tektoncd/pipeline/tree/v0.23.0/examples#examples) |
 | [v0.22.0](https://github.com/tektoncd/pipeline/releases/tag/v0.22.0) | [Docs @ v0.22.0](https://github.com/tektoncd/pipeline/tree/v0.22.0/docs#tekton-pipelines) | [Examples @ v0.22.0](https://github.com/tektoncd/pipeline/tree/v0.22.0/examples#examples) |
 | [v0.21.0](https://github.com/tektoncd/pipeline/releases/tag/v0.21.0) | [Docs @ v0.21.0](https://github.com/tektoncd/pipeline/tree/v0.21.0/docs#tekton-pipelines) | [Examples @ v0.21.0](https://github.com/tektoncd/pipeline/tree/v0.21.0/examples#examples) |
 | [v0.20.1](https://github.com/tektoncd/pipeline/releases/tag/v0.20.1) | [Docs @ v0.20.1](https://github.com/tektoncd/pipeline/tree/v0.20.1/docs#tekton-pipelines) | [Examples @ v0.20.1](https://github.com/tektoncd/pipeline/tree/v0.20.1/examples#examples) |

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -58,27 +58,33 @@ the pipelines repo, a terminal window and a text editor.
 
 1. Once the pipeline is complete, check its results:
 
-   ```bash
-   tkn --context dogfooding pr describe <pipeline-run-name>
+    ```bash
+    tkn --context dogfooding pr describe <pipeline-run-name>
 
-   (...)
-   📝 Results
+    (...)
+    📝 Results
 
-   NAME                    VALUE
-   ∙ commit-sha            ff6d7abebde12460aecd061ab0f6fd21053ba8a7
-   ∙ release-file           https://storage.googleapis.com/tekton-releases-nightly/pipeline/previous/v20210223-xyzxyz/release.yaml
-   ∙ release-file-no-tag    https://storage.googleapis.com/tekton-releases-nightly/pipeline/previous/v20210223-xyzxyz/release.notag.yaml
+    NAME                    VALUE
+    ∙ commit-sha            ff6d7abebde12460aecd061ab0f6fd21053ba8a7
+    ∙ release-file           https://storage.googleapis.com/tekton-releases-nightly/pipeline/previous/v20210223-xyzxyz/release.yaml
+    ∙ release-file-no-tag    https://storage.googleapis.com/tekton-releases-nightly/pipeline/previous/v20210223-xyzxyz/release.notag.yaml
 
-   (...)
-   ```
+    (...)
+    ```
 
-   The `commit-sha` should match `$TEKTON_RELEASE_GIT_SHA`.
-   The two URLs can be opened in the browser or via `curl` to download the release manifests.
+    The `commit-sha` should match `$TEKTON_RELEASE_GIT_SHA`.
+    The two URLs can be opened in the browser or via `curl` to download the release manifests.
 
-    1. The YAMLs are now released! Anyone installing Tekton Pipelines will now get the new version. Time to create a new GitHub release announcement:
+1. The YAMLs are now released! Anyone installing Tekton Pipelines will get the new version. Time to create a new GitHub release announcement:
 
-    1. Choose a name for the new release! The usual pattern is "< cat breed > < famous robot >" e.g. "Ragdoll Norby".
-       (Check the previous releases to avoid repetition: https://github.com/tektoncd/pipeline/releases.)
+    1. Choose a name for the new release! The usual pattern is "< cat breed > < famous robot >" e.g. "Ragdoll Norby". Browse [the releases page](https://github.com/tektoncd/pipeline/releases) or run this command to check which names have already been used:
+
+    ```bash
+    curl \
+      -H "Accept: application/vnd.github.v3+json" \
+      https://api.github.com/repos/tektoncd/pipeline/releases\?per_page=100 \
+      | jq ".[].name"
+    ```
 
     1. Create additional environment variables
 
@@ -148,7 +154,7 @@ the pipelines repo, a terminal window and a text editor.
     kubectl --context my-dev-cluster apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.11.2/release.yaml
     ```
 
-1. Announce the release in Slack channels #general and #pipelines.
+1. Announce the release in Slack channels #general, #announcements and #pipelines.
 
 1. Update [the catalog repo](https://github.com/tektoncd/catalog) test infrastructure
 to use the new release by updating the `RELEASE_YAML` link in [e2e-tests.sh](https://github.com/tektoncd/catalog/blob/master/test/e2e-tests.sh).


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


0.23.0 has just been released so this commit adds an entry to our README.md
for this release's docs and examples.

During the release process I documented a `curl`+`jq` command that the
release captain can use to get a complete list of all release names
used so far by Pipelines. This helps when checking for name collisions
while picking the next "&lt;cat breed> &lt;famous robot>" pair.

Also indents a section in the cheat sheet that was using 3 spaces to match
the 4-space indent used elsewhere in the same doc.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```