### PR TITLE
Updates the Tekton Bundle spec and resolver to be more explicit.

### DIFF
--- a/docs/tekton-bundle-contracts.md
+++ b/docs/tekton-bundle-contracts.md
@@ -22,7 +22,7 @@ Each layer of the image must map 1:1 with a single Tekton resource (eg Task).
 Each layer must contain all of the following annotations:
 
 - `dev.tekton.image.name` => `ObjectMeta.Name` of the resource
-- `dev.tekton.image.kind` => `TypeMeta.Kind` of the resource, all lowercased (eg, `task`)
+- `dev.tekton.image.kind` => `TypeMeta.Kind` of the resource, all lower-cased and singular (eg, `task`)
 - `dev.tekton.image.apiVersion` => `TypeMeta.APIVersion` of the resource (eg 
 "tekton.dev/v1alpha1")  
 
@@ -38,7 +38,7 @@ Furthermore, each layer must contain a YAML or JSON representation of the underl
 missing any identifying fields (missing an `apiVersion` for instance) then it will be considered invalid.
 
 Any tool creating a Tekton bundle must enforce this format and ensure that the annotations and contents all match and
-confirm to this spec. Additionally, the Tekton controller will reject non-conforming Tekton Bundles.
+conform to this spec. Additionally, the Tekton controller will reject non-conforming Tekton Bundles.
 
 ## Examples
 

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -59,7 +59,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 
 			// Because the resolver will only return references with the same kind (eg ClusterTask), this will ensure we
 			// don't accidentally return a Task with the same name but different kind.
-			obj, err := resolver.Get(strings.ToLower(string(kind)), name)
+			obj, err := resolver.Get(strings.TrimSuffix(strings.ToLower(string(kind)), "s"), name)
 			if err != nil {
 				return nil, err
 			}

--- a/test/remote.go
+++ b/test/remote.go
@@ -33,10 +33,30 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// ObjectAnnotationMapper is a func alias that maps a runtime Object to the Tekton Bundle annotations map.
+type ObjectAnnotationMapper func(object runtime.Object) map[string]string
+
+var (
+	// DefaultObjectAnnotationMapper does the "right" thing by conforming to the Tekton Bundle spec.
+	DefaultObjectAnnotationMapper = func(obj runtime.Object) map[string]string {
+		return map[string]string{
+			tkremote.TitleAnnotation:      getObjectName(obj),
+			tkremote.KindAnnotation:       strings.TrimSuffix(strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), "s"),
+			tkremote.APIVersionAnnotation: obj.GetObjectKind().GroupVersionKind().Version,
+		}
+	}
+)
+
 // CreateImage will push a new OCI image artifact with the provided raw data object as a layer and return the full image
 // reference with a digest to fetch the image. Key must be specified as [lowercase kind]/[object name]. The image ref
 // with a digest is returned.
 func CreateImage(ref string, objs ...runtime.Object) (string, error) {
+	return CreateImageWithAnnotations(ref, DefaultObjectAnnotationMapper, objs...)
+}
+
+// CreateImageWithAnnotations is the base form of #CreateImage which accepts an ObjectAnnotationMapper to map an object
+// to the annotations for it.
+func CreateImageWithAnnotations(ref string, mapper ObjectAnnotationMapper, objs ...runtime.Object) (string, error) {
 	imgRef, err := name.ParseReference(ref)
 	if err != nil {
 		return "", fmt.Errorf("undexpected error producing image reference %w", err)
@@ -73,13 +93,10 @@ func CreateImage(ref string, objs ...runtime.Object) (string, error) {
 			return "", fmt.Errorf("unexpected error adding layer to image %w", err)
 		}
 
+		annotations := mapper(obj)
 		img, err = mutate.Append(img, mutate.Addendum{
-			Layer: layer,
-			Annotations: map[string]string{
-				tkremote.TitleAnnotation:      getObjectName(obj),
-				tkremote.KindAnnotation:       strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind),
-				tkremote.APIVersionAnnotation: strings.ToLower(obj.GetObjectKind().GroupVersionKind().Version),
-			},
+			Layer:       layer,
+			Annotations: annotations,
 		})
 		if err != nil {
 			return "", fmt.Errorf("could not add layer to image %w", err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The current spec is ambiguous with regards to the form of the `kind` annotation. In the code, we implicitely enforce that the kind must be singular, and lowercased. The spec half-way asks for this and the resolver doesn't enforce this. Therefore, this change:

- adds validation to the oci resolver to enforce the annotation rules
- adds corresponding tests to ensure the enforcement is invoked
- modifies the bundle contract to explicitely state the pluralization requirement
- modifies a test utility for invoking this case

The tkn cli has been updated as well to conform to this explicit spec.
/kind documentation
/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
