### PR TITLE
Remove cluster-wide namespace list/watch permissions

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -22,11 +22,8 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
   - apiGroups: [""]
-    # Namespace access is required because the controller timeout handling logic
-    # iterates over all namespaces and times out any PipelineRuns that have expired.
-    # Pod access is required because the taskrun controller wants to be updated when
-    # a Pod underlying a TaskRun changes state.
-    resources: ["namespaces", "pods"]
+    # Controller needs to watch Pods created by TaskRuns to see them progress.
+    resources: ["pods"]
     verbs: ["list", "watch"]
     # Controller needs cluster access to all of the CRDs that it is responsible for
     # managing.


### PR DESCRIPTION
This permission was previously needed to support how we enforced
timeouts, by listing all TaskRuns/PipelineRuns across all namespaces and
determining whether they were past their timeout. Since
https://github.com/tektoncd/pipeline/pull/3500/ this check was changed
to not require listing all namespaces, so I believe the permission is no
longer necessary.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [y] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [y] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [y] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
The controller SA no longer requests cluster-wide permission to list and watch namespaces.
```