### PR TITLE
Implement TEP-0033: Add enable-api-fields feature-flag

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -87,3 +87,6 @@ data:
   # This is an experimental feature and thus should still be considered
   # an alpha feature.
   enable-custom-tasks: "false"
+  # Setting this flag will determine which gated features are enabled.
+  # Acceptable values are "stable" or "alpha".
+  enable-api-fields: "stable"

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -344,3 +344,125 @@ By default the roles are cluster-scoped for backwards-compatibility and ease-of-
 start running a multi-tenant service you are able to bind `tekton-pipelines-controller-tenant-access`
 using a `RoleBinding` instead of a `ClusterRoleBinding`, thereby limiting the access that the controller has to
 specific tenant namespaces.
+
+## Adding feature gated API fields
+
+We've introduced a feature-flag called `enable-api-fields` to the
+[config-feature-flags.yaml file](../../config/config-feature-flags.yaml) deployed
+as part of our releases.
+
+This field can be configured either to be `alpha` or `stable`. This
+field is documented as part of our [install docs](../install.md#customizing-the-pipelines-controller-behavior).
+
+For developers adding new features to Pipelines' CRDs we've got
+a couple of helpful tools to make gating those features simpler
+and to provide a consistent testing experience.
+
+### Guarding Features with Feature Gates
+
+Writing new features is made trickier when you need to support both
+the existing stable behaviour as well as your new alpha behaviour.
+
+In reconciler code you can guard your new features with an `if` statement
+such as the following:
+
+```go
+alphaAPIEnabled := config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha"
+if alphaAPIEnabled {
+  // new feature code goes here
+} else {
+  // existing stable code goes here
+}
+```
+
+Notice that you'll need a context object to be passed into your function
+for this to work. When writing new features keep in mind that you might
+need to include this in your new function signatures.
+
+### Guarding Validations with Feature Gates
+
+Just because your application code might be correctly observing
+the feature gate flag doesn't mean you're done yet! When a user submits
+a Tekton resource it's validated by Pipelines' webhook. Here too you'll need
+to ensure your new features aren't accidentally accepted when the feature gate
+suggests they shouldn't be. We've got a helper function,
+[`ValidateEnabledAPIFields`](../../pkg/apis/pipeline/v1beta1/version_validation.go),
+to make validating the current feature gate easier. Use it like this:
+
+```go
+requiredVersion := config.AlphaAPIFields
+// errs is an instance of *apis.FieldError, a common type in our validation code
+errs = errs.Also(ValidateEnabledAPIFields(ctx, "your feature name", requiredVersion))
+```
+
+If the user's cluster isn't configured with the required feature gate it'll
+return an error like this:
+
+```
+<your feature> requires "enable-api-fields" feature gate to be "alpha" but it is "stable"
+```
+
+### Unit Testing with Feature Gates
+
+Any new code you write that uses the `ctx` context variable is trivially
+unit tested with different feature gate settings. You should make sure
+to unit test your code both with and without a feature gate enabled to
+make sure it's properly guarded. See the following for an example of a
+unit test that sets the feature gate to test behaviour:
+
+```go
+featureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+        "enable-api-fields": "alpha",
+})
+if err != nil {
+	t.Fatalf("unexpected error initializing feature flags: %v", err)
+}
+cfg := &config.Config{
+        FeatureFlags: featureFlags,
+}
+ctx := config.ToContext(context.Background(), cfg)
+if err := ts.TestThing(ctx); err != nil {
+	t.Errorf("unexpected error with alpha feature gate enabled: %v", err)
+}
+```
+
+### Example YAMLs
+
+Writing new YAML examples that require a feature gate to be set is easy.
+New YAML example files typically go in a directory called something like
+`examples/v1beta1/taskruns` in the root of the repo. To create a YAML that
+should only be exercised when the `enable-api-fields` flag is `alpha` just
+put it in an `alpha` subdirectory so the structure looks like:
+
+```
+examples/v1beta1/taskruns/alpha/your-example.yaml
+```
+
+This should work for both taskruns and pipelineruns.
+
+**Note**: To execute alpha examples with the integration test runner you
+must manually set the `enable-api-fields` feature flag to `alpha` in your
+testing cluster before kicking off the tests.
+
+When you set this flag to `stable` in your cluster it will prevent
+`alpha` examples from being created by the test runner. When you set
+the flag to `alpha` all examples are run, since we want to exercise
+backwards-compatibility of the examples under alpha conditions.
+
+### Integration Tests
+
+For integration tests we provide the [`requireGate` function](../../test/gate.go) which
+should be passed to the `setup` function used by tests:
+
+```go
+c, namespace := setup(ctx, t, requireGate("enable-api-fields", "alpha"))
+```
+
+This will Skip your integration test if the feature gate is not set to `alpha`
+with a clear message explaining why it was skipped.
+
+**Note**: As with running example YAMLs you have to manually set the `enable-api-fields`
+flag to `alpha` in your test cluster to see your alpha integration tests
+run. When the flag in your cluster is `alpha` _all_ integration tests are executed,
+both `stable` and `alpha`. Setting the feature flag to `stable` will exclude `alpha`
+tests.

--- a/docs/install.md
+++ b/docs/install.md
@@ -7,6 +7,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 * [Installing Tekton Pipelines on OpenShift](#installing-tekton-pipelines-on-openshift)
 * [Configuring PipelineResource storage](#configuring-pipelineresource-storage)
 * [Customizing basic execution parameters](#customizing-basic-execution-parameters)
+  * [Customizing the Pipelines Controller behavior](#customizing-the-pipelines-controller-behavior)
 * [Configuring High Availability](#configuring-high-availability)
 * [Configuring Tekton pipeline controller performance](#configuring-tekton-pipeline-controller-performance)
 * [Creating a custom release of Tekton Pipelines](#creating-a-custom-release-of-tekton-pipelines)
@@ -356,6 +357,10 @@ The default is `false`. For more information, see the [associated issue](https:/
 - `enable-custom-tasks`: set this flag to `"true"` to enable the
 use of custom tasks in pipelines.
 
+- `enable-api-fields`: set this flag to "stable" to allow only the
+most stable features to be used. Set it to "alpha" to allow alpha
+features to be used.
+
 For example:
 
 ```yaml
@@ -366,6 +371,7 @@ metadata:
 data:
   disable-home-env-overwrite: "true" # Tekton will not override the $HOME variable for individual Steps.
   disable-working-directory-overwrite: "true" # Tekton will not override the working directory for individual Steps.
+  enable-api-fields: "alpha" # Allow alpha fields to be used in Tasks and Pipelines.
 ```
 
 ## Configuring High Availability

--- a/pkg/apis/config/testdata/feature-flags-invalid-boolean.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-boolean.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2021 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,11 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-home-env-overwrite: "true"
-  disable-working-directory-overwrite: "true"
-  disable-affinity-assistant: "true"
-  running-in-environment-with-injected-sidecars: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
+  "disable-creds-init": "im-really-not-a-valid-boolean"

--- a/pkg/apis/config/testdata/feature-flags-invalid-enable-api-fields.yaml
+++ b/pkg/apis/config/testdata/feature-flags-invalid-enable-api-fields.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Tekton Authors
+# Copyright 2021 The Tekton Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,11 +18,4 @@ metadata:
   name: feature-flags
   namespace: tekton-pipelines
 data:
-  disable-home-env-overwrite: "true"
-  disable-working-directory-overwrite: "true"
-  disable-affinity-assistant: "true"
-  running-in-environment-with-injected-sidecars: "false"
-  require-git-ssh-secret-known-hosts: "true"
-  enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
-  enable-api-fields: "alpha"
+  enable-api-fields: "im-not-a-valid-feature-gate"

--- a/pkg/apis/pipeline/v1beta1/version_validation.go
+++ b/pkg/apis/pipeline/v1beta1/version_validation.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"knative.dev/pkg/apis"
+)
+
+// ValidateEnabledAPIFields checks that the enable-api-fields feature gate is set
+// to the wantVersion value and, if not, returns an error stating which feature
+// is dependent on the version and what the current version actually is.
+func ValidateEnabledAPIFields(ctx context.Context, featureName, wantVersion string) *apis.FieldError {
+	currentVersion := config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields
+	if currentVersion != wantVersion {
+		var errs *apis.FieldError
+		message := fmt.Sprintf(`%s requires "enable-api-fields" feature gate to be %q but it is %q`, featureName, wantVersion, currentVersion)
+		return errs.Also(apis.ErrGeneric(message, "workspaces"))
+	}
+	var errs *apis.FieldError = nil
+	return errs
+}

--- a/pkg/apis/pipeline/v1beta1/version_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/version_validation_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+func TestValidateEnabledAPIFields(t *testing.T) {
+	version := "alpha"
+	flags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": version,
+	})
+	if err != nil {
+		t.Fatalf("error creating feature flags from map: %v", err)
+	}
+	cfg := &config.Config{
+		FeatureFlags: flags,
+	}
+	ctx := config.ToContext(context.Background(), cfg)
+	if err := ValidateEnabledAPIFields(ctx, "test feature", version); err != nil {
+		t.Errorf("unexpected error for compatible feature gates: %q", err)
+	}
+}
+
+func TestValidateEnabledAPIFieldsError(t *testing.T) {
+	flags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		"enable-api-fields": "stable",
+	})
+	if err != nil {
+		t.Fatalf("error creating feature flags from map: %v", err)
+	}
+	cfg := &config.Config{
+		FeatureFlags: flags,
+	}
+	ctx := config.ToContext(context.Background(), cfg)
+	err = ValidateEnabledAPIFields(ctx, "test feature", "alpha")
+
+	if err == nil {
+		t.Errorf("error expected for incompatible feature gates")
+	}
+}

--- a/test/gate.go
+++ b/test/gate.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/system"
+)
+
+// requireGate returns a setup func that will skip the current
+// test if the feature-flag with given name does not equal
+// given value. It will fatally fail the test if it cannot get
+// the feature-flag configmap.
+func requireGate(name, value string) func(context.Context, *testing.T, *clients, string) {
+	return func(ctx context.Context, t *testing.T, c *clients, namespace string) {
+		featureFlagsCM, err := c.KubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)
+		}
+		val, ok := featureFlagsCM.Data[name]
+		if !ok || val != value {
+			t.Skipf("Skipped because feature gate %q != %q", name, value)
+		}
+	}
+}

--- a/test/path_filtering.go
+++ b/test/path_filtering.go
@@ -1,0 +1,87 @@
+// +build examples
+
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+type pathFilter func(string) bool
+
+// getPathFilter returns a pathFilter that filters out examples
+// unsuitable for the current feature-gate. For example,
+// if the enable-api-fields feature flag is currently set
+// to "alpha" then all stable and alpha examples would be
+// allowed. When the flag is set to "stable", only stable
+// examples are allowed.
+func getPathFilter(t *testing.T) (pathFilter, error) {
+	enabledFeatureGate, err := getFeatureGate()
+	if err != nil {
+		return nil, fmt.Errorf("error reading enabled feature gate: %v", err)
+	}
+	var f pathFilter
+	switch enabledFeatureGate {
+	case "stable":
+		f = stablePathFilter
+	case "alpha":
+		f = alphaPathFilter
+	}
+	if f == nil {
+		return nil, fmt.Errorf("unable to create path filter from feature gate %q", enabledFeatureGate)
+	}
+	t.Logf("Allowing only %q examples", enabledFeatureGate)
+	return f, nil
+}
+
+// Memoize value of enable-api-fields flag so we don't
+// need to repeatedly query the feature flag configmap
+var enableAPIFields = ""
+
+func getFeatureGate() (string, error) {
+	if enableAPIFields == "" {
+		cmd := exec.Command("kubectl", "get", "configmap", "feature-flags", "-n", "tekton-pipelines", "-o", `jsonpath="{.data['enable-api-fields']}"`)
+		output, err := cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("error getting feature-flags configmap: %v", err)
+		}
+		output = bytes.TrimSpace(output)
+		output = bytes.Trim(output, "\"")
+		if len(output) == 0 {
+			output = []byte("stable")
+		}
+		enableAPIFields = string(output)
+	}
+	return enableAPIFields, nil
+}
+
+// stablePathFilter returns true for any example that should be allowed to run
+// when "enable-api-fields" is "stable".
+func stablePathFilter(p string) bool {
+	return !(strings.Contains(p, "/alpha/") || strings.Contains(p, "/beta/"))
+}
+
+// alphaPathFilter returns true for any example that should be allowed to run
+// when "enable-api-fields" is "alpha".
+func alphaPathFilter(p string) bool {
+	return strings.Contains(p, "/alpha/") || stablePathFilter(p)
+}

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -37,13 +37,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/system"
 	knativetest "knative.dev/pkg/test"
 )
 
@@ -51,7 +49,7 @@ import (
 // images.
 func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	ctx := context.Background()
-	c, namespace := setup(ctx, t, withRegistry, skipIfTektonOCIBundleDisabled)
+	c, namespace := setup(ctx, t, withRegistry, requireGate("enable-tekton-oci-bundles", "true"))
 
 	t.Parallel()
 
@@ -191,7 +189,7 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 // TestTektonBundlesUsingRegularImage is an integration test which passes a non-Tekton bundle as a task reference.
 func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	ctx := context.Background()
-	c, namespace := setup(ctx, t, withRegistry, skipIfTektonOCIBundleDisabled)
+	c, namespace := setup(ctx, t, withRegistry, requireGate("enable-tekton-oci-bundles", "true"))
 
 	t.Parallel()
 
@@ -276,7 +274,7 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 // task reference.
 func TestTektonBundlesUsingImproperFormat(t *testing.T) {
 	ctx := context.Background()
-	c, namespace := setup(ctx, t, withRegistry, skipIfTektonOCIBundleDisabled)
+	c, namespace := setup(ctx, t, withRegistry, requireGate("enable-tekton-oci-bundles", "true"))
 
 	t.Parallel()
 
@@ -515,16 +513,5 @@ func publishImg(ctx context.Context, t *testing.T, c *clients, namespace string,
 		} else {
 			t.Fatalf("Failed to create image. Pod logs are: \n%s", string(logs))
 		}
-	}
-}
-
-func skipIfTektonOCIBundleDisabled(ctx context.Context, t *testing.T, c *clients, namespace string) {
-	featureFlagsCM, err := c.KubeClient.CoreV1().ConfigMaps(system.Namespace()).Get(ctx, config.GetFeatureFlagsConfigName(), metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Failed to get ConfigMap `%s`: %s", config.GetFeatureFlagsConfigName(), err)
-	}
-	enableTetkonOCIBundle, ok := featureFlagsCM.Data["enable-tekton-oci-bundles"]
-	if !ok || enableTetkonOCIBundle != "true" {
-		t.Skip("Skip because enable-tekton-oci-bundles != true")
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implements TEP-0033:
https://github.com/tektoncd/community/blob/main/teps/0033-tekton-feature-gates.md

This commit introduces a new feature flag, "enable-api-fields", that
can be set to "alpha" or "stable". The default is "stable".

This commit provides:

- dev documentation describing how to check the feature gate and use the provided tools during testing
- a helper for performing feature gate validation in our validating webhook
- a test helper, `requireGate` that allows an integration test to be easily skipped if "enable-api-fields" is not "alpha".
- a way to run YAML examples specific to each feature-gate:

New examples can be added under a directory called "alpha". When
the "enable-api-fields" flag is set to "alpha" the test runner will
_only_ run those tests in "alpha" directories. Similarly if the flag is
"stable" then the examples under "alpha" will be prevented from running.
See the Step and Sidecar Workspaces branch for examples that use this
new mechanism:

- https://github.com/sbwsg/pipeline/commit/ba4ca8d18e5a0c6a3ffc3e71424b95385314a5cf#diff-b33f1e031894c58e1c3f02fd3291bc14bdae76333d9c19a3b672b88736821a6b
- https://github.com/sbwsg/pipeline/commit/ba4ca8d18e5a0c6a3ffc3e71424b95385314a5cf#diff-71bc2dcaacd303b560c738c3f1fb2e4eb35ebe628e8cf53038f7b85c63ccfb5d
- https://github.com/sbwsg/pipeline/commit/ba4ca8d18e5a0c6a3ffc3e71424b95385314a5cf#diff-568a92e9e9f73030ce0dfbb15adf76f4e65e7e28aef0474421ba5b415911f9c7

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
A new feature-flag, "enable-api-fields" has been added. Valid values are "alpha" and "stable". It defaults to "stable".

Setting the "enable-api-fields" flag tells Tekton what level of API stability you require in the cluster. As new features are added to Pipelines we'll first place those features under the "alpha" flag. When the feature is ready we'll promote it to "stable". This process is described in TEP-0033[1].

Opting in to "alpha" gives you early exposure to exciting new features as they're added to Pipelines but those features are still undergoing development and could be subject to backwards-incompatible changes.

[1] https://github.com/tektoncd/community/blob/main/teps/0033-tekton-feature-gates.md
```