### PR TITLE
Update auth.md

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -162,6 +162,8 @@ before executing any `Steps` in the `Run`, Tekton creates a `~/.gitconfig` file 
 specified in the `Secret`. When the `Steps` execute, Tekton uses those credentials to retrieve
 `PipelineResources` specified in the `Run`.
 
+Note: Github deprecated basic authentication with username and password. You can still use basic authentication, but you wil need to use a personal access token instead of the cleartext password in the following example. You can find out how to create such a token on the [Github documentation site](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+
 1. In `secret.yaml`, define a `Secret` that specifies the username and password that you want Tekton
    to use to access the target Git repository:
 


### PR DESCRIPTION
Added a note about Github authentication with basic-auth. Users need to use a personal access token instead of the cleartext password.

# Changes

Added a side note about using personal access token instead of password as documented here: https://docs.github.com/en/rest/overview/other-authentication-methods#basic-authentication

/kind documentation


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

```release-note
NONE
```