### PR TITLE
Fix issue with "$$" in Script blocks

### DIFF
--- a/examples/v1alpha1/taskruns/step-script.yaml
+++ b/examples/v1alpha1/taskruns/step-script.yaml
@@ -87,3 +87,22 @@ spec:
         [[ $# == 2 ]]
         [[ $1 == "hello" ]]
         [[ $2 == "world" ]]
+
+    # Test that multiple dollar signs next to each other are not replaced by Kubernetes
+    - name: dollar-signs-allowed
+      image: python
+      script: |
+        #!/usr/bin/env python3
+        if '$' != '\u0024':
+          print('single dollar signs ($) are not passed through as expected :(')
+          exit(1)
+        if '$$' != '\u0024\u0024':
+          print('double dollar signs ($$) are not passed through as expected :(')
+          exit(2)
+        if '$$$' != '\u0024\u0024\u0024':
+          print('three dollar signs ($$$) are not passed through as expected :(')
+          exit(3)
+        if '$$$$' != '\u0024\u0024\u0024\u0024':
+          print('four dollar signs ($$$$) are not passed through as expected :(')
+          exit(3)
+        print('dollar signs appear to be handled correctly! :)')

--- a/examples/v1beta1/taskruns/step-script.yaml
+++ b/examples/v1beta1/taskruns/step-script.yaml
@@ -86,3 +86,22 @@ spec:
         [[ $# == 2 ]]
         [[ $1 == "hello" ]]
         [[ $2 == "world" ]]
+
+    # Test that multiple dollar signs next to each other are not replaced by Kubernetes
+    - name: dollar-signs-allowed
+      image: python
+      script: |
+        #!/usr/bin/env python3
+        if '$' != '\u0024':
+          print('single dollar signs ($) are not passed through as expected :(')
+          exit(1)
+        if '$$' != '\u0024\u0024':
+          print('double dollar signs ($$) are not passed through as expected :(')
+          exit(2)
+        if '$$$' != '\u0024\u0024\u0024':
+          print('three dollar signs ($$$) are not passed through as expected :(')
+          exit(3)
+        if '$$$$' != '\u0024\u0024\u0024\u0024':
+          print('four dollar signs ($$$$) are not passed through as expected :(')
+          exit(3)
+        print('dollar signs appear to be handled correctly! :)')

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -107,6 +107,12 @@ func convertListOfSteps(steps []v1beta1.Step, initContainer *corev1.Container, p
 		// non-nil init container.
 		*placeScripts = true
 
+		// Kubernetes replaces instances of "$$" with "$". So we double-up
+		// on these instances in our args and Kubernetes reduces them back down
+		// to the expected number of dollar signs. This is a workaround for
+		// https://github.com/kubernetes/kubernetes/issues/101137
+		script = strings.Replace(script, "$$", "$$$$", -1)
+
 		// Append to the place-scripts script to place the
 		// script file in a known location in the scripts volume.
 		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", namePrefix, i)))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix issue with "$$" in Script blocks

Prior to this commit Steps with Scripts that include twodollar signs resulted in only one dollar sign ending upin the final executed script. This is because the scriptis passed into an init container via its "args" field andKubernetes replaces instances of the literal string"$$" with "$". This is a documented behaviour of the"args" field (sort of) but it doesn't make sense to havethose replacements happen for our "script" blocks. "$$"in bash scripts is the current process id so replacing thischaracter sequence can be problematic.

This commit replaces instances of two dollar signs in a scriptwith four dollar signs. Kubernetes then converts these backto two dollar signs. This replacement behaviour only existsfor dollar symbols so hard-coding this replacement feels likean acceptable workaround that will have the least impacton backwards compatibility.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix a bug where the literal characters "$$" in a Step's script block would be replaced with a single "$".
```

/kind bug