### PR TITLE
Allow dot character in resource names

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -17,7 +17,7 @@ roleRef:
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: unit-tests
+  name: "unit.tests"
 spec:
   workspaces:
   - name: source
@@ -222,7 +222,7 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: demo-pipeline
+  name: "demo.pipeline"
 spec:
   params:
   - name: image-registry
@@ -244,7 +244,7 @@ spec:
   - name: skaffold-unit-tests
     runAfter: [fetch-from-git]
     taskRef:
-      name: unit-tests
+      name: "unit.tests"
     workspaces:
     - name: source
       workspace: git-source
@@ -313,7 +313,7 @@ metadata:
   name: demo-pipeline-run-1
 spec:
   pipelineRef:
-    name: demo-pipeline
+    name: "demo.pipeline"
   serviceAccountName: 'default'
   workspaces:
   - name: git-source

--- a/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation_test.go
@@ -56,10 +56,10 @@ func TestCondition_Invalid(t *testing.T) {
 	}{{
 		name: "invalid meta",
 		cond: &v1alpha1.Condition{
-			ObjectMeta: metav1.ObjectMeta{Name: "invalid.,name"},
+			ObjectMeta: metav1.ObjectMeta{Name: "invalid,name"},
 		},
 		expectedError: apis.FieldError{
-			Message: "Invalid resource name: special character . must not be present",
+			Message: `invalid resource name "invalid,name": must be a valid DNS label`,
 			Paths:   []string{"metadata.name"},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation_test.go
@@ -45,9 +45,9 @@ func TestPipeline_Validate(t *testing.T) {
 		},
 		failureExpected: false,
 	}, {
-		name: "period in name",
+		name: "comma in name",
 		p: &v1alpha1.Pipeline{
-			ObjectMeta: metav1.ObjectMeta{Name: "pipe.line"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pipe,line"},
 			Spec: v1alpha1.PipelineSpec{
 				Tasks: []v1alpha1.PipelineTask{{
 					Name:    "foo",

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation_test.go
@@ -48,18 +48,18 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 			name: "invalid pipelinerun metadata",
 			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinerun.name",
+					Name: "pipelinerun,name",
 				},
 			},
 			want: &apis.FieldError{
-				Message: "Invalid resource name: special character . must not be present",
+				Message: `invalid resource name "pipelinerun,name": must be a valid DNS label`,
 				Paths:   []string{"metadata.name"},
 			},
 		}, {
 			name: "no pipeline reference",
 			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
+					Name: "pipelinelinename",
 				},
 				Spec: v1alpha1.PipelineRunSpec{
 					ServiceAccountName: "foo",
@@ -70,7 +70,7 @@ func TestPipelineRun_Invalidate(t *testing.T) {
 			name: "negative pipeline timeout",
 			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
+					Name: "pipelinelinename",
 				},
 				Spec: v1alpha1.PipelineRunSpec{
 					PipelineRef: &v1alpha1.PipelineRef{
@@ -102,7 +102,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 			name: "normal case",
 			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
+					Name: "pipelinelinename",
 				},
 				Spec: v1alpha1.PipelineRunSpec{
 					PipelineRef: &v1alpha1.PipelineRef{
@@ -114,7 +114,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 			name: "no timeout",
 			pr: v1alpha1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
+					Name: "pipelinelinename",
 				},
 				Spec: v1alpha1.PipelineRunSpec{
 					PipelineRef: &v1alpha1.PipelineRef{

--- a/pkg/apis/pipeline/v1alpha1/run_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation_test.go
@@ -36,20 +36,18 @@ func TestRun_Invalid(t *testing.T) {
 		want *apis.FieldError
 	}{{
 		name: "missing spec",
-		run:  &v1alpha1.Run{},
-		want: apis.ErrMissingField("spec"),
-	}, {
-		name: "invalid metadata",
 		run: &v1alpha1.Run{
-			ObjectMeta: metav1.ObjectMeta{Name: "run.name"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 		},
-		want: &apis.FieldError{
-			Message: "Invalid resource name: special character . must not be present",
-			Paths:   []string{"metadata.name"},
-		},
+		want: apis.ErrMissingField("spec"),
 	}, {
 		name: "missing ref",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: nil,
 			},
@@ -58,6 +56,9 @@ func TestRun_Invalid(t *testing.T) {
 	}, {
 		name: "missing apiVersion",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "",
@@ -68,6 +69,9 @@ func TestRun_Invalid(t *testing.T) {
 	}, {
 		name: "missing kind",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -79,6 +83,9 @@ func TestRun_Invalid(t *testing.T) {
 	}, {
 		name: "non-unique params",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -111,6 +118,9 @@ func TestRun_Valid(t *testing.T) {
 	}{{
 		name: "no params",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -122,6 +132,9 @@ func TestRun_Valid(t *testing.T) {
 	}, {
 		name: "unnamed",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -132,6 +145,9 @@ func TestRun_Valid(t *testing.T) {
 	}, {
 		name: "unique params",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -149,6 +165,9 @@ func TestRun_Valid(t *testing.T) {
 	}, {
 		name: "valid workspace",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -177,6 +196,9 @@ func TestRun_Workspaces_Invalid(t *testing.T) {
 	}{{
 		name: "make sure WorkspaceBinding validation invoked",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",
@@ -194,6 +216,9 @@ func TestRun_Workspaces_Invalid(t *testing.T) {
 	}, {
 		name: "bind same workspace twice",
 		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
 			Spec: v1alpha1.RunSpec{
 				Ref: &v1alpha1.TaskRef{
 					APIVersion: "blah",

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation_test.go
@@ -42,9 +42,9 @@ func TestTaskRun_Invalid(t *testing.T) {
 		want: apis.ErrMissingField("spec"),
 	}, {
 		name: "invalid taskrun metadata",
-		task: tb.TaskRun("task.name"),
+		task: tb.TaskRun("task,name"),
 		want: &apis.FieldError{
-			Message: "Invalid resource name: special character . must not be present",
+			Message: `invalid resource name "task,name": must be a valid DNS label`,
 			Paths:   []string{"metadata.name"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -48,6 +48,7 @@ func TestPipeline_Validate_Success(t *testing.T) {
 	}, {
 		name: "pipelinetask custom task references",
 		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
 			Spec: PipelineSpec{
 				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: ""}}},
 			},
@@ -134,15 +135,15 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 		expectedError apis.FieldError
 		wc            func(context.Context) context.Context
 	}{{
-		name: "period in name",
+		name: "comma in name",
 		p: &Pipeline{
-			ObjectMeta: metav1.ObjectMeta{Name: "pipe.line"},
+			ObjectMeta: metav1.ObjectMeta{Name: "pipe,line"},
 			Spec: PipelineSpec{
 				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{Name: "foo-task"}}},
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `Invalid resource name: special character . must not be present`,
+			Message: `invalid resource name "pipe,line": must be a valid DNS label`,
 			Paths:   []string{"metadata.name"},
 		},
 	}, {
@@ -154,7 +155,7 @@ func TestPipeline_Validate_Failure(t *testing.T) {
 			},
 		},
 		expectedError: apis.FieldError{
-			Message: `Invalid resource name: length must be no more than 63 characters`,
+			Message: "Invalid resource name: length must be no more than 63 characters",
 			Paths:   []string{"metadata.name"},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -37,107 +37,106 @@ func TestPipelineRun_Invalid(t *testing.T) {
 		pr   v1beta1.PipelineRun
 		want *apis.FieldError
 		wc   func(context.Context) context.Context
-	}{
-		{
-			name: "invalid pipelinerun metadata",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinerun.name",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						Name: "prname",
-					},
-				},
+	}{{
+		name: "no pipeline reference",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
 			},
-			want: &apis.FieldError{
-				Message: "Invalid resource name: special character . must not be present",
-				Paths:   []string{"metadata.name"},
+			Spec: v1beta1.PipelineRunSpec{
+				ServiceAccountName: "foo",
 			},
-		}, {
-			name: "no pipeline reference",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					ServiceAccountName: "foo",
-				},
-			},
-			want: apis.ErrMissingField("spec.pipelineref.name, spec.pipelinespec"),
-		}, {
-			name: "negative pipeline timeout",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						Name: "prname",
-					},
-					Timeout: &metav1.Duration{Duration: -48 * time.Hour},
-				},
-			},
-			want: apis.ErrInvalidValue("-48h0m0s should be >= 0", "spec.timeout"),
-		}, {
-			name: "wrong pipelinerun cancel",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						Name: "prname",
-					},
-					Status: "PipelineRunCancell",
-				},
-			},
-			want: apis.ErrInvalidValue("PipelineRunCancell should be PipelineRunCancelled or PipelineRunPending", "spec.status"),
-		}, {
-			name: "use of bundle without the feature flag set",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						Name:   "my-pipeline",
-						Bundle: "docker.io/foo",
-					},
-				},
-			},
-			want: apis.ErrDisallowedFields("spec.pipelineref.bundle"),
-		}, {
-			name: "bundle missing name",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						Bundle: "docker.io/foo",
-					},
-					PipelineSpec: &v1beta1.PipelineSpec{Description: "foo"},
-				},
-			},
-			want: apis.ErrMissingField("spec.pipelineref.name"),
-			wc:   enableTektonOCIBundles(t),
-		}, {
-			name: "invalid bundle reference",
-			pr: v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pipelinelineName",
-				},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineRef: &v1beta1.PipelineRef{
-						Name:   "my-pipeline",
-						Bundle: "not a valid reference",
-					},
-				},
-			},
-			want: apis.ErrInvalidValue("invalid bundle reference (could not parse reference: not a valid reference)", "spec.pipelineref.bundle"),
-			wc:   enableTektonOCIBundles(t),
 		},
+		want: apis.ErrMissingField("spec.pipelineref.name, spec.pipelinespec"),
+	}, {
+		name: "invalid pipelinerun metadata",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinerun,name",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "prname",
+				},
+			},
+		},
+		want: &apis.FieldError{
+			Message: `invalid resource name "pipelinerun,name": must be a valid DNS label`,
+			Paths:   []string{"metadata.name"},
+		},
+	}, {
+		name: "negative pipeline timeout",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "prname",
+				},
+				Timeout: &metav1.Duration{Duration: -48 * time.Hour},
+			},
+		},
+		want: apis.ErrInvalidValue("-48h0m0s should be >= 0", "spec.timeout"),
+	}, {
+		name: "wrong pipelinerun cancel",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "prname",
+				},
+				Status: "PipelineRunCancell",
+			},
+		},
+		want: apis.ErrInvalidValue("PipelineRunCancell should be PipelineRunCancelled or PipelineRunPending", "spec.status"),
+	}, {
+		name: "use of bundle without the feature flag set",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name:   "my-pipeline",
+					Bundle: "docker.io/foo",
+				},
+			},
+		},
+		want: apis.ErrDisallowedFields("spec.pipelineref.bundle"),
+	}, {
+		name: "bundle missing name",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Bundle: "docker.io/foo",
+				},
+				PipelineSpec: &v1beta1.PipelineSpec{Description: "foo"},
+			},
+		},
+		want: apis.ErrMissingField("spec.pipelineref.name"),
+		wc:   enableTektonOCIBundles(t),
+	}, {
+		name: "invalid bundle reference",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name:   "my-pipeline",
+					Bundle: "not a valid reference",
+				},
+			},
+		},
+		want: apis.ErrInvalidValue("invalid bundle reference (could not parse reference: not a valid reference)", "spec.pipelineref.bundle"),
+		wc:   enableTektonOCIBundles(t),
+	},
 		{
 			name: "pipelinerun pending while running",
 			pr: v1beta1.PipelineRun{
@@ -185,7 +184,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 		name: "normal case",
 		pr: v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelineName",
+				Name: "pipelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
@@ -197,7 +196,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 		name: "no timeout",
 		pr: v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelineName",
+				Name: "pipelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineRef: &v1beta1.PipelineRef{
@@ -210,7 +209,7 @@ func TestPipelineRun_Validate(t *testing.T) {
 		name: "array param with pipelinespec and taskspec",
 		pr: v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelineName",
+				Name: "pipelinelinename",
 			},
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineSpec: &v1beta1.PipelineSpec{

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -38,21 +38,8 @@ func TestTaskRun_Invalidate(t *testing.T) {
 	}{{
 		name: "invalid taskspec",
 		task: &v1beta1.TaskRun{},
-		want: apis.ErrMissingField("spec.taskref.name", "spec.taskspec"),
-	}, {
-		name: "invalid taskrun metadata",
-		task: &v1beta1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "task.name",
-			},
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "task"},
-			},
-		},
-		want: &apis.FieldError{
-			Message: "Invalid resource name: special character . must not be present",
-			Paths:   []string{"metadata.name"},
-		},
+		want: apis.ErrMissingField("spec.taskref.name", "spec.taskspec").Also(
+			apis.ErrGeneric(`invalid resource name "": must be a valid DNS label`, "metadata.name")),
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -35,6 +36,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		{
 			name: "cluster with invalid url",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeCluster,
 					Params: []v1alpha1.ResourceParam{{
@@ -59,6 +63,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		{
 			name: "cluster with missing auth",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeCluster,
 					Params: []v1alpha1.ResourceParam{{
@@ -72,6 +79,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "cluster with missing cadata",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeCluster,
 					Params: []v1alpha1.ResourceParam{{
@@ -89,6 +99,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "storage with no type",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeStorage,
 					Params: []v1alpha1.ResourceParam{{
@@ -100,6 +113,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "storage with unimplemented type",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeStorage,
 					Params: []v1alpha1.ResourceParam{{
@@ -111,6 +127,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "storage with gcs type with no location param",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeStorage,
 					Params: []v1alpha1.ResourceParam{{
@@ -122,6 +141,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "storage with gcs type with empty location param",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeStorage,
 					Params: []v1alpha1.ResourceParam{{
@@ -135,6 +157,9 @@ func TestResourceValidation_Invalid(t *testing.T) {
 		}, {
 			name: "invalid resource type",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: "not-supported",
 				},
@@ -142,11 +167,19 @@ func TestResourceValidation_Invalid(t *testing.T) {
 			want: apis.ErrInvalidValue("spec.type", "not-supported"),
 		}, {
 			name: "missing spec",
-			res:  &v1alpha1.PipelineResource{},
+			res: &v1alpha1.PipelineResource{
+
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
+			},
 			want: apis.ErrMissingField("spec.type"),
 		}, {
 			name: "pull request with invalid field name in secrets",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypePullRequest,
 					SecretParams: []v1alpha1.SecretParam{{
@@ -175,6 +208,9 @@ func TestClusterResourceValidation_Valid(t *testing.T) {
 		{
 			name: "success validate",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeCluster,
 					Params: []v1alpha1.ResourceParam{{
@@ -198,6 +234,9 @@ func TestClusterResourceValidation_Valid(t *testing.T) {
 		{
 			name: "specify insecure without cadata",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypeCluster,
 					Params: []v1alpha1.ResourceParam{{
@@ -217,6 +256,9 @@ func TestClusterResourceValidation_Valid(t *testing.T) {
 		{
 			name: "specify pullrequest with no secrets",
 			res: &v1alpha1.PipelineResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "temp",
+				},
 				Spec: v1alpha1.PipelineResourceSpec{
 					Type: v1alpha1.PipelineResourceTypePullRequest,
 				},

--- a/pkg/apis/validate/metadata.go
+++ b/pkg/apis/validate/metadata.go
@@ -17,20 +17,21 @@ limitations under the License.
 package validate
 
 import (
-	"strings"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
 )
 
-const MaxLength = 63
+const MaxLength = validation.DNS1123LabelMaxLength
 
 func ObjectMetadata(meta metav1.Object) *apis.FieldError {
 	name := meta.GetName()
 
-	if strings.Contains(name, ".") {
+	if err := validation.IsDNS1123Subdomain(name); len(err) > 0 {
 		return &apis.FieldError{
-			Message: "Invalid resource name: special character . must not be present",
+			Message: fmt.Sprintf("invalid resource name %q: must be a valid DNS label", name),
 			Paths:   []string{"name"},
 		}
 	}

--- a/pkg/apis/validate/metadata_test.go
+++ b/pkg/apis/validate/metadata_test.go
@@ -28,7 +28,7 @@ func TestMetadataInvalidLongName(t *testing.T) {
 
 	invalidMetas := []*metav1.ObjectMeta{
 		{Name: strings.Repeat("s", validate.MaxLength+1)},
-		{Name: "bad.name"},
+		{Name: "bad,name"},
 	}
 	for _, invalidMeta := range invalidMetas {
 		if err := validate.ObjectMetadata(invalidMeta); err == nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Fixes #3891 to allow dot (`.`) characters in resource names.

The basic approach here was to update `pkg/apis/validate/metadata.go` so that it checks if Tekton resource names meet the criteria of [DNS Subdomain names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names) (`.` is a valid character in a DNS subdomain). It does this by using the `IsDNS1123Subdomain()` function from `k8s.io/apimachinery/pkg/util/validation`. 

There had previously been a 63 character limit on resource names that, to my understanding, was put in place due to the fact that Tekton pod names are composed based on `pipelineRun + pipeline + pipelineTask`. For reference, a DNS subdomain can be up to 253 characters in length.

Some updates were made to the tests as well:
* tests that checked for failure if a `.` was found in the resource name were updated to instead check for a comma
* several tests used camelCase in the `metadata.name` field -- capital letters are not valid for `metadata.name`, and the new validation method will throw errors on any resource name in camelCase. I've updated the tests to use all lowercase letters for resource names. As this PR has been steadily increasing in size, I'll add new tests for camelCase in a separate PR
* `examples/v1beta1/pipelineruns/pipelinerun.yaml` was updated to include resource names with a `.` in it, in order to catch any future issues that may arise with resource names containing a `.`

/kind feature
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Allow resource names to contain the dot character (".") 
Resource names now validated using the common `validation.IsDNS1123Subdomain()` function
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
