### PR TITLE
Resolving integration test failures by bumping plumbing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0 // indirect
-	github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5
+	github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9
 	go.opencensus.io v0.22.5
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect

--- a/go.sum
+++ b/go.sum
@@ -740,6 +740,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5 h1:Y2Gd3X79zqvCd6AdiWyi/pnSewSkLxKygpvXNFXwscg=
 github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
+github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9 h1:ZLPo8/vilaxvpdvvdd9ZgIhhQJPkHyS5GeKK8UH4/Yo=
+github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9/go.mod h1:WTWwsg91xgm+jPOKoyKVK/yRYxnVDlUYeDlypB1lDdQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/vendor/github.com/tektoncd/plumbing/.gitignore
+++ b/vendor/github.com/tektoncd/plumbing/.gitignore
@@ -1,0 +1,5 @@
+# IDEs
+.idea/
+
+# Coverage
+.coverage

--- a/vendor/github.com/tektoncd/plumbing/CONTRIBUTING.md
+++ b/vendor/github.com/tektoncd/plumbing/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for your interest in contributing!
 **All contributors must comply with
 [the code of conduct](./code-of-conduct.md).**
 
-* To become an [OWNER](OWNER), see the requirements at [tektoncd/community](https://github.com/tektoncd/community/blob/master/process.md#requirements)
+* To become an [OWNER](OWNER), see the requirements at [tektoncd/community](https://github.com/tektoncd/community/blob/main/process.md#requirements)
 * This repo holds configuration for infrastructure that is used by projects in
   https://github.com/tektoncd.
 * [The README](README.md) describes components of this infrastructure and how to interact
@@ -14,11 +14,11 @@ Thank you for your interest in contributing!
 In [the community repo](https://github.com/tektoncd/community) you'll
 find info on:
 
-* [Contacting other contributors](https://github.com/tektoncd/community/blob/master/contact.md)
-* [Development standards](https://github.com/tektoncd/community/blob/master/standards.md) around
-  [principles](https://github.com/tektoncd/community/blob/master/standards.md#principles),
-  [commit messages](https://github.com/tektoncd/community/blob/master/standards.md#commit-messages)
-  and [code](https://github.com/tektoncd/community/blob/master/standards.md#coding-standards)
-* [Processes](https://github.com/tektoncd/community/blob/master/process.md) like
-  [reviews](https://github.com/tektoncd/community/blob/master/process.md#reviews)
-  and [becoming an OWNER](https://github.com/tektoncd/community/blob/master/process.md#owners)
+* [Contacting other contributors](https://github.com/tektoncd/community/blob/main/contact.md)
+* [Development standards](https://github.com/tektoncd/community/blob/main/standards.md) around
+  [principles](https://github.com/tektoncd/community/blob/main/standards.md#principles),
+  [commit messages](https://github.com/tektoncd/community/blob/main/standards.md#commit-messages)
+  and [code](https://github.com/tektoncd/community/blob/main/standards.md#coding-standards)
+* [Processes](https://github.com/tektoncd/community/blob/main/process.md) like
+  [reviews](https://github.com/tektoncd/community/blob/main/process.md#reviews)
+  and [becoming an OWNER](https://github.com/tektoncd/community/blob/main/process.md#owners)

--- a/vendor/github.com/tektoncd/plumbing/README.md
+++ b/vendor/github.com/tektoncd/plumbing/README.md
@@ -22,8 +22,8 @@ More details on the infrastructure are available in the [documentation](docs/REA
 
 ## Support
 
-If you need support, reach out [in the tektoncd slack](https://github.com/tektoncd/community/blob/master/contact.md#slack)
+If you need support, reach out [in the tektoncd slack](https://github.com/tektoncd/community/blob/main/contact.md#slack)
 via the `#plumbing` channel.
 
-[Members of the Tekton governing board](https://github.com/tektoncd/community/blob/master/governance.md)
-[have access to the underlying resources](https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access).
+[Members of the Tekton governing board](https://github.com/tektoncd/community/blob/main/governance.md)
+[have access to the underlying resources](https://github.com/tektoncd/community/blob/main/governance.md#permissions-and-access).

--- a/vendor/github.com/tektoncd/plumbing/adjustpermissions.py
+++ b/vendor/github.com/tektoncd/plumbing/adjustpermissions.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python3
 
 """
-addpermissions.py gives users access to the Tekton GCP projects
+adjustpermissions.py gives users access to the Tekton GCP projects
 
 In order to interact with GCP resources
-(https://github.com/tektoncd/plumbing/blob/master/README.md#gcp-projects)
+(https://github.com/tektoncd/plumbing/blob/main/README.md#gcp-projects)
 folks sometimes need to be able to do actions like push images and view
 a project in the web console.
 
 This script will add the permissions allowed to folks on the governing board
-(https://github.com/tektoncd/community/blob/master/governance.md#permissions-and-access)
-to all GCP projects.
-
+(https://github.com/tektoncd/community/blob/main/governance.md#permissions-and-access)
+to all GCP projects. It can also be used to remove permissions if needed.
 
 This script requires the `gcloud` command line tool and the python
 `PyYaml` library.
 
 Example usage:
-  python3 addpermissions.py --users "foo@something.com,bar@something.com"
+  python3 adjustpermissions.py --users "foo@something.com,bar@something.com"
+Or to remove access for foo@something.com and bar@something.com:
+  python3 adjustpermissions.py --users "foo@something.com,bar@something.com --remove"
 """
 import argparse
 import shlex
@@ -40,7 +41,7 @@ KNOWN_PROJECTS = (
   "tekton-releases",
   "tekton-nightly",
 )
-BOSKOS_CONFIG_URL = "https://raw.githubusercontent.com/tektoncd/plumbing/master/boskos/boskos-config.yaml"
+BOSKOS_CONFIG_URL = "https://raw.githubusercontent.com/tektoncd/plumbing/main/boskos/boskos-config.yaml"
 
 
 def gcloud_required() -> None:
@@ -49,12 +50,13 @@ def gcloud_required() -> None:
     sys.exit(1)
 
 
-def add_to_all_projects(users: List[str], projects: List[str]) -> None:
+def update_all_projects(users: List[str], projects: List[str], remove: bool) -> None:
+  command = "remove-iam-policy-binding" if remove else "add-iam-policy-binding"
   for user in users:
     for project in projects:
       for role in ROLES:
         subprocess.check_call(shlex.split(
-            "gcloud projects add-iam-policy-binding {} --member user:{} --role {}".format(project, user, role)
+            "gcloud projects {} {} --member user:{} --role {}".format(command, project, user, role)
         ))
 
 
@@ -71,11 +73,10 @@ if __name__ == '__main__':
       description="Give a user access to all plumbing resources")
   arg_parser.add_argument("--users", type=str, required=True,
                           help="The names of the users' accounts, usually their email address, comma separated")
+  arg_parser.add_argument("--remove", action="store_true",
+                          help="Use this flag to remove user access instead of adding it")
   args = arg_parser.parse_args()
 
   gcloud_required()
-
   boskos_projects = parse_boskos_projects()
-
-  add_to_all_projects([u.strip() for u in args.users.split(",")], list(KNOWN_PROJECTS) + boskos_projects)
-
+  update_all_projects([u.strip() for u in args.users.split(",")], list(KNOWN_PROJECTS) + boskos_projects, args.remove)

--- a/vendor/github.com/tektoncd/plumbing/scripts/README.md
+++ b/vendor/github.com/tektoncd/plumbing/scripts/README.md
@@ -59,21 +59,30 @@ This is a helper script to run the presubmit tests. To use it:
    integration tests (either your custom one or the default action) and will cause
    the test to fail if they don't return success.
 
+1. [optional] Define the function `conformance_tests()`. If you don't define
+   this function, the default action for running the conformance tests is to run
+   `go test -race -v ./test -tags=conformance` in the repo.
+
+1. [optional] Define the functions `pre_conformance_tests()` and/or
+   `post_conformance_tests()`. These functions will be called before or after the
+   conformance tests (either your custom one or the default action) and will cause
+   the test to fail if they don't return success.
+
 1. Call the `main()` function passing `$@` (without quotes).
 
 Running the script without parameters, or with the `--all-tests` flag causes
 all tests to be executed, in the right order (i.e., build, then unit, then
-integration tests).
+integration, then conformance tests).
 
-Use the flags `--build-tests`, `--unit-tests` and `--integration-tests` to run
-a specific set of tests. The flag `--emit-metrics` is used to emit metrics when
+Use the flags `--build-tests`, `--unit-tests`, `--integration-tests` and `--conformance-tests`
+to run a specific set of tests. The flag `--emit-metrics` is used to emit metrics when
 running the tests, and is automatically handled by the default action for
 integration tests (see above).
 
 The script will automatically skip all presubmit tests for PRs where all changed
 files are exempt of tests (e.g., a PR changing only the `OWNERS` file).
 
-Also, for PRs touching only markdown files, the unit and integration tests are
+Also, for PRs touching only markdown files, the unit, integration and conformance tests are
 skipped.
 
 ### Sample presubmit test script
@@ -226,7 +235,7 @@ Prerequisites:
 
 Usage:
 
-`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file]`
+`deploy-release.sh -p project -v version [-b bucket] [-e extra-path] [-f file] [-g post-file]`
 
 Where:
 
@@ -239,5 +248,7 @@ Where:
 - `extra-path` is the root path within the bucket where release are stored, empty by default
 
 - `file` is the name of the release file, `release.yaml` by default
+
+- `post-file` is the name of the 2nd release file, none by default, `interceptors.yaml` by default for triggers
 
 To summarize, the deployment job will look for the release file into `<bucket>/<extra-path>/<project>/previous/<version>/<file>`

--- a/vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/e2e-tests.sh
@@ -314,7 +314,7 @@ function setup_test_cluster() {
 # Gets the exit of the test script.
 # For more details, see set_test_return_code().
 function get_test_return_code() {
-  echo $(cat ${TEST_RESULT_FILE})
+  echo $(cat "${TEST_RESULT_FILE}")
 }
 
 # Set the return code that the test script will return.

--- a/vendor/github.com/tektoncd/plumbing/scripts/library.sh
+++ b/vendor/github.com/tektoncd/plumbing/scripts/library.sh
@@ -19,7 +19,7 @@
 # called from command line.
 
 # Default GKE version to be used with Tekton Serving
-readonly SERVING_GKE_VERSION=gke-latest
+readonly SERVING_GKE_VERSION=gke-channel-regular
 readonly SERVING_GKE_IMAGE=cos
 
 # Conveniently set GOPATH if unset
@@ -295,7 +295,7 @@ function report_go_test() {
   # Install go-junit-report if necessary.
   run_go_tool github.com/jstemmer/go-junit-report go-junit-report --help > /dev/null 2>&1
   local xml=$(mktemp ${ARTIFACTS}/junit_XXXXXXXX.xml)
-  cat ${report} \
+  cat "${report}" \
       | go-junit-report \
       | sed -e "s#\"github.com/tektoncd/${REPO_NAME}/#\"#g" \
       > ${xml}
@@ -325,7 +325,7 @@ function run_go_tool() {
   ${tool} "$@"
 }
 
-# Run dep-collector to update licenses.
+# Update licenses.
 # Parameters: $1 - output file, relative to repo root dir.
 #             $2...$n - directories and files to inspect.
 function update_licenses() {
@@ -339,7 +339,7 @@ function update_licenses() {
    chmod +w $(find ${dst} -type d)
 }
 
-# Run dep-collector to check for forbidden liceses.
+# Check for forbidden liceses.
 # Parameters: $1...$n - directories and files to inspect.
 function check_licenses() {
   go-licenses check ./...

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -298,7 +298,7 @@ github.com/shurcooL/graphql/internal/jsonutil
 github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
-# github.com/tektoncd/plumbing v0.0.0-20201021153918-6b7e894737b5
+# github.com/tektoncd/plumbing v0.0.0-20210420200944-17170d5e7bc9
 github.com/tektoncd/plumbing
 github.com/tektoncd/plumbing/scripts
 # github.com/vdemeester/k8s-pkg-credentialprovider v1.19.7


### PR DESCRIPTION
# Changes

This change pushes the plumbing version to the latest which will set the GKE version to 1.18
based off the regular release channel. This preserves the basic authentication features for the
integration test suite




/kind failing-test


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
