### PR TITLE
validate the context variable in when expressions

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -215,6 +215,18 @@ func validateExecutionStatusVariablesInTasks(tasks []PipelineTask) (errs *apis.F
 				}
 			}
 		}
+		for i, we := range t.WhenExpressions {
+			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
+				if !LooksLikeContainsResultRefs(expressions) {
+					for _, e := range expressions {
+						if containsExecutionStatusRef(e) {
+							errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("when expressions in pipeline tasks can not refer to execution status of any other pipeline task"),
+								"").ViaFieldIndex("when", i).ViaFieldIndex("tasks", idx))
+						}
+					}
+				}
+			}
+		}
 	}
 	return errs
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Context variable to access execution status can only be used in `finally`. Adding validation to restrict `when` expressions to use such context in `dag` tasks similar to the restriction in place for `params`.

Without this validation, `when` expressions in `dag` tasks are allowed to specify `$(tasks.<pipelineTask>.status)`.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
Do not allow `when` expressions in `dag` to specify the context variable accessing the execution status of any other task - `$(tasks.<pipelineTask>.status)`
```
