### PR TITLE
Last minute fixups from review feedback on "enable-api-fields" PR

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -118,7 +118,7 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 }
 
 // setEnabledAPIFields sets the "enable-api-fields" flag based on the content of a given map.
-// If the feature gate is invalid or missing then the flag is set to its default.
+// If the feature gate is invalid or missing then an error is returned.
 func setEnabledAPIFields(cfgMap map[string]string, defaultValue string, feature *string) error {
 	value := defaultValue
 	if cfg, ok := cfgMap[enableAPIFields]; ok {

--- a/test/path_filtering_test.go
+++ b/test/path_filtering_test.go
@@ -1,0 +1,104 @@
+// +build examples
+
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStablePathFilter(t *testing.T) {
+	for _, tc := range []struct {
+		path    string
+		allowed bool
+	}{{
+		path:    "/test.yaml",
+		allowed: true,
+	}, {
+		path:    "/alpha/test.yaml",
+		allowed: false,
+	}, {
+		path:    "/beta/test.yaml",
+		allowed: false,
+	}, {
+		path:    "/foo/test.yaml",
+		allowed: true,
+	}, {
+		path:    "/v1alpha1/taskruns/test.yaml",
+		allowed: true,
+	}, {
+		path:    "/v1alpha1/taskruns/alpha/test.yaml",
+		allowed: false,
+	}, {
+		path:    "/v1beta1/taskruns/test.yaml",
+		allowed: true,
+	}, {
+		path:    "/v1beta1/taskruns/alpha/test.yaml",
+		allowed: false,
+	}, {
+		path:    "/v1beta1/taskruns/alpha/test.yaml",
+		allowed: false,
+	}, {
+		path:    "/v1alpha1/pipelineruns/beta/test.yaml",
+		allowed: false,
+	}, {
+		path:    "/v1alpha1/pipelineruns/beta/test.yaml",
+		allowed: false,
+	}} {
+		name := strings.Replace(tc.path, "/", " ", -1)
+		t.Run(name, func(t *testing.T) {
+			if got := stablePathFilter(tc.path); got != tc.allowed {
+				t.Errorf("path %q: want %t got %t", tc.path, tc.allowed, got)
+			}
+		})
+	}
+}
+
+func TestAlphaPathFilter(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+	}{{
+		path: "/test.yaml",
+	}, {
+		path: "/alpha/test.yaml",
+	}, {
+		path: "/foo/test.yaml",
+	}, {
+		path: "/v1alpha1/taskruns/test.yaml",
+	}, {
+		path: "/v1alpha1/taskruns/alpha/test.yaml",
+	}, {
+		path: "/v1beta1/taskruns/test.yaml",
+	}, {
+		path: "/v1beta1/taskruns/alpha/test.yaml",
+	}, {
+		path: "/v1beta1/taskruns/alpha/test.yaml",
+	}, {
+		path: "/v1alpha1/pipelineruns/beta/test.yaml",
+	}, {
+		path: "/v1alpha1/pipelineruns/beta/test.yaml",
+	}} {
+		name := strings.Replace(tc.path, "/", " ", -1)
+		t.Run(name, func(t *testing.T) {
+			if got := alphaPathFilter(tc.path); got != true {
+				t.Errorf("path %q: want %t got %t", tc.path, true, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In https://github.com/tektoncd/pipeline/pull/3881 we added the new
"enable-api-fields" feature gate and some related helpers.

There were a couple of comments I missed before the PR got merged
so adding them here instead.

This commit adds tests for the bits of "test/path_filtering.go" that
can be checked without a cluster running Tekton Pipelines.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```