### PR TITLE
Add test YAML helpers

### DIFF
--- a/test/status_test.go
+++ b/test/status_test.go
@@ -22,8 +22,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
 )
@@ -42,25 +40,24 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := &v1beta1.Task{
-		ObjectMeta: metav1.ObjectMeta{Name: "banana", Namespace: namespace},
-		Spec: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{{Container: corev1.Container{
-				Image:   "busybox",
-				Command: []string{"ls", "-la"},
-			}}},
-		},
-	}
+	task := mustParseTask(t, `
+metadata:
+  name: banana
+spec:
+  steps:
+  - name: foo
+    image: busybox
+    command: ['ls', '-la']`)
 	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "apple", Namespace: namespace},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef:            &v1beta1.TaskRef{Name: "banana"},
-			ServiceAccountName: "inexistent",
-		},
-	}
+	taskRun := mustParseTaskRun(t, `
+metadata:
+  name: apple
+spec:
+  taskRef:
+    name: banana
+  serviceAccountName: inexistent`)
 	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
@@ -70,25 +67,24 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	pipeline := &v1beta1.Pipeline{
-		ObjectMeta: metav1.ObjectMeta{Name: "tomatoes", Namespace: namespace},
-		Spec: v1beta1.PipelineSpec{
-			Tasks: []v1beta1.PipelineTask{{
-				Name:    "foo",
-				TaskRef: &v1beta1.TaskRef{Name: "banana"},
-			}},
-		},
-	}
-	pipelineRun := &v1beta1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "pear", Namespace: namespace},
-		Spec: v1beta1.PipelineRunSpec{
-			PipelineRef:        &v1beta1.PipelineRef{Name: "tomatoes"},
-			ServiceAccountName: "inexistent",
-		},
-	}
+	pipeline := mustParsePipeline(t, `
+metadata:
+  name: tomatoes
+spec:
+  tasks:
+  - name: foo
+    taskRef:
+      name: banana`)
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
 	}
+	pipelineRun := mustParsePipelineRun(t, `
+metadata:
+  name: pear
+spec:
+  pipelineRef:
+    name: tomatoes
+  serviceAccountName: inexistent`)
 	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
 	}

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func mustParseYAML(t *testing.T, yaml string, i runtime.Object) {
+	if _, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(yaml), nil, i); err != nil {
+		t.Fatalf("mustParseYAML (%s): %v", yaml, err)
+	}
+}
+
+func mustParseTaskRun(t *testing.T, yaml string) *v1beta1.TaskRun {
+	var tr v1beta1.TaskRun
+	yaml = `apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+` + yaml
+	mustParseYAML(t, yaml, &tr)
+	return &tr
+}
+
+func mustParseTask(t *testing.T, yaml string) *v1beta1.Task {
+	var task v1beta1.Task
+	yaml = `apiVersion: tekton.dev/v1beta1
+kind: Task
+` + yaml
+	mustParseYAML(t, yaml, &task)
+	return &task
+}
+
+func mustParsePipelineRun(t *testing.T, yaml string) *v1beta1.PipelineRun {
+	var pr v1beta1.PipelineRun
+	yaml = `apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+` + yaml
+	mustParseYAML(t, yaml, &pr)
+	return &pr
+}
+
+func mustParsePipeline(t *testing.T, yaml string) *v1beta1.Pipeline {
+	var pipeline v1beta1.Pipeline
+	yaml = `apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+` + yaml
+	mustParseYAML(t, yaml, &pipeline)
+	return &pipeline
+}


### PR DESCRIPTION
These helpers take a YAML string and return parsed, deserialized typed objects. They're intended to be easier to use than Go structs or test builders, focused on showing the YAML a user would write to specify our objects.

I proposed these a long time ago, but never merged them and I don't remember why. Talking to @bobcatfish today she mentioned she might like to use them, so I'm bringing them up again. Please let me know what you think! 🙏 

Some future improvements we might consider:
- exporting the helper methods so they can be used in code outside of `test/`, e.g., in unit tests
- basic templating using [`text/template`](https://pkg.go.dev/text/template), possibly taking an optional map of key/value replacements in the helper methods.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [y] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [y] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [y] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [y] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
