### PR TITLE
Remove random suffixes on creds-init volumes

### DIFF
--- a/pkg/pod/creds_init.go
+++ b/pkg/pod/creds_init.go
@@ -122,13 +122,14 @@ func credsInit(ctx context.Context, serviceAccountName, namespace string, kubecl
 }
 
 // getCredsInitVolume returns a Volume and VolumeMount for /tekton/creds. Each call
-// will return a new volume and volume mount with randomized name.
-func getCredsInitVolume(ctx context.Context) (*corev1.Volume, *corev1.VolumeMount) {
+// will return a new volume and volume mount. Takes an integer index to append to
+// the name of the volume.
+func getCredsInitVolume(ctx context.Context, idx int) (*corev1.Volume, *corev1.VolumeMount) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if cfg != nil && cfg.FeatureFlags != nil && cfg.FeatureFlags.DisableCredsInit {
 		return nil, nil
 	}
-	name := names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(credsInitHomeMountPrefix)
+	name := fmt.Sprintf("%s-%d", credsInitHomeMountPrefix, idx)
 	v := corev1.Volume{
 		Name: name,
 		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -174,7 +174,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 		// guarantee what UID container runs with. If legacy credential helper (creds-init)
 		// is disabled via feature flag then these can be nil since we don't want to mount
 		// the automatic credential volume.
-		v, vm := getCredsInitVolume(ctx)
+		v, vm := getCredsInitVolume(ctx, i)
 		if v != nil && vm != nil {
 			volumes = append(volumes, *v)
 			s.VolumeMounts = append(s.VolumeMounts, *vm)

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -117,7 +117,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -125,7 +125,7 @@ func TestPodBuild(t *testing.T) {
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -162,7 +162,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -170,7 +170,7 @@ func TestPodBuild(t *testing.T) {
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -215,7 +215,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-mz4c7",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, append(append([]corev1.VolumeMount{}, implicitVolumeMounts...), corev1.VolumeMount{
 					Name:      "tekton-internal-secret-volume-multi-creds-9l9zj",
@@ -226,7 +226,7 @@ func TestPodBuild(t *testing.T) {
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, secretsVolume, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-mz4c7",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -280,14 +280,14 @@ func TestPodBuild(t *testing.T) {
 				VolumeMounts: append([]corev1.VolumeMount{
 					toolsMount,
 					downwardMount,
-					{Name: "tekton-creds-init-home-9l9zj", MountPath: "/tekton/creds"},
+					{Name: "tekton-creds-init-home-0", MountPath: "/tekton/creds"},
 				}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
 				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 			SecurityContext: &corev1.PodSecurityContext{
@@ -335,7 +335,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -343,7 +343,7 @@ func TestPodBuild(t *testing.T) {
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -377,7 +377,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -385,7 +385,7 @@ func TestPodBuild(t *testing.T) {
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -430,7 +430,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             filepath.Join(pipeline.WorkspaceDir, "test"),
@@ -438,7 +438,7 @@ func TestPodBuild(t *testing.T) {
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -479,7 +479,7 @@ func TestPodBuild(t *testing.T) {
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -493,7 +493,7 @@ func TestPodBuild(t *testing.T) {
 				},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -550,7 +550,7 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-mssqb",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -566,7 +566,7 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 			}},
 			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-mssqb",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -610,7 +610,7 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -624,7 +624,7 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				},
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -672,7 +672,7 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir: pipeline.WorkspaceDir,
@@ -701,7 +701,7 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, {
-					Name:      "tekton-creds-init-home-mz4c7",
+					Name:      "tekton-creds-init-home-1",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir: pipeline.WorkspaceDir,
@@ -715,10 +715,10 @@ sidecar-script-heredoc-randomly-generated-mz4c7
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}, corev1.Volume{
-				Name:         "tekton-creds-init-home-mz4c7",
+				Name:         "tekton-creds-init-home-1",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -799,7 +799,7 @@ script-heredoc-randomly-generated-78c5n
 				},
 				Env: append(implicitEnvVars, corev1.EnvVar{Name: "FOO", Value: "bar"}),
 				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-6nl7g",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -824,7 +824,7 @@ script-heredoc-randomly-generated-78c5n
 				},
 				Env: append(implicitEnvVars, corev1.EnvVar{Name: "FOO", Value: "bar"}),
 				VolumeMounts: append([]corev1.VolumeMount{{Name: "i-have-a-volume-mount"}, scriptsVolumeMount, toolsMount, {
-					Name:      "tekton-creds-init-home-j2tds",
+					Name:      "tekton-creds-init-home-1",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -850,7 +850,7 @@ script-heredoc-randomly-generated-78c5n
 				},
 				Env: append(implicitEnvVars, corev1.EnvVar{Name: "FOO", Value: "bar"}),
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, {
-					Name:      "tekton-creds-init-home-vr6ds",
+					Name:      "tekton-creds-init-home-2",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -858,13 +858,13 @@ script-heredoc-randomly-generated-78c5n
 				TerminationMessagePath: "/tekton/termination",
 			}},
 			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-6nl7g",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}, corev1.Volume{
-				Name:         "tekton-creds-init-home-j2tds",
+				Name:         "tekton-creds-init-home-1",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}, corev1.Volume{
-				Name:         "tekton-creds-init-home-vr6ds",
+				Name:         "tekton-creds-init-home-2",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 		},
@@ -891,7 +891,7 @@ script-heredoc-randomly-generated-78c5n
 			InitContainers: []corev1.Container{placeToolsInit},
 			SchedulerName:  "there-scheduler",
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 			Containers: []corev1.Container{{
@@ -912,7 +912,7 @@ script-heredoc-randomly-generated-78c5n
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -942,7 +942,7 @@ script-heredoc-randomly-generated-78c5n
 			RestartPolicy:  corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{placeToolsInit},
 			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-9l9zj",
+				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 			Containers: []corev1.Container{{
@@ -963,7 +963,7 @@ script-heredoc-randomly-generated-78c5n
 				},
 				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-9l9zj",
+					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             pipeline.WorkspaceDir,
@@ -995,7 +995,7 @@ script-heredoc-randomly-generated-78c5n
 				RestartPolicy:  corev1.RestartPolicyNever,
 				InitContainers: []corev1.Container{placeToolsInit},
 				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				Containers: []corev1.Container{{
@@ -1016,7 +1016,7 @@ script-heredoc-randomly-generated-78c5n
 					},
 					Env: implicitEnvVars,
 					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-						Name:      "tekton-creds-init-home-9l9zj",
+						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
 					WorkingDir:             pipeline.WorkspaceDir,
@@ -1047,7 +1047,7 @@ script-heredoc-randomly-generated-78c5n
 				InitContainers: []corev1.Container{placeToolsInit},
 				HostNetwork:    true,
 				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				Containers: []corev1.Container{{
@@ -1068,7 +1068,7 @@ script-heredoc-randomly-generated-78c5n
 					},
 					Env: implicitEnvVars,
 					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-						Name:      "tekton-creds-init-home-9l9zj",
+						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
 					WorkingDir:             pipeline.WorkspaceDir,
@@ -1113,7 +1113,7 @@ script-heredoc-randomly-generated-78c5n
 				InitContainers: []corev1.Container{placeToolsInit},
 				HostNetwork:    false,
 				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				Containers: []corev1.Container{{
@@ -1134,7 +1134,7 @@ script-heredoc-randomly-generated-78c5n
 					},
 					Env: implicitEnvVars,
 					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-						Name:      "tekton-creds-init-home-9l9zj",
+						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
 					WorkingDir:             pipeline.WorkspaceDir,
@@ -1176,7 +1176,7 @@ script-heredoc-randomly-generated-78c5n
 					},
 					Env: implicitEnvVars,
 					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
-						Name:      "tekton-creds-init-home-9l9zj",
+						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
 					WorkingDir:             pipeline.WorkspaceDir,
@@ -1184,7 +1184,7 @@ script-heredoc-randomly-generated-78c5n
 					TerminationMessagePath: "/tekton/termination",
 				}},
 				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 			},

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -443,7 +443,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(defaultSAName),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -465,7 +465,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -487,7 +487,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName("test-sa"),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -509,7 +509,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -619,7 +619,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -641,7 +641,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 					tb.EnvVar("foo", "bar"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -664,7 +664,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -685,7 +685,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1009,7 +1009,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1031,7 +1031,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1057,7 +1057,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName("test-sa"),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1079,7 +1079,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1106,23 +1106,23 @@ func TestReconcile(t *testing.T) {
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(
 					workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-						Name:         "tekton-creds-init-home-78c5n",
+						Name:         "tekton-creds-init-home-0",
 						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 					},
 					corev1.Volume{
-						Name:         "tekton-creds-init-home-6nl7g",
+						Name:         "tekton-creds-init-home-1",
 						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 					},
 					corev1.Volume{
-						Name:         "tekton-creds-init-home-j2tds",
+						Name:         "tekton-creds-init-home-2",
 						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 					},
 					corev1.Volume{
-						Name:         "tekton-creds-init-home-vr6ds",
+						Name:         "tekton-creds-init-home-3",
 						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 					},
 					corev1.Volume{
-						Name:         "tekton-creds-init-home-l22wn",
+						Name:         "tekton-creds-init-home-4",
 						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 					},
 					corev1.Volume{
@@ -1156,7 +1156,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-78c5n", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1172,7 +1172,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("TEKTON_RESOURCE_NAME", "workspace"),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-					tb.VolumeMount("tekton-creds-init-home-6nl7g", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-1", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1187,7 +1187,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-					tb.VolumeMount("tekton-creds-init-home-j2tds", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-2", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1200,7 +1200,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-					tb.VolumeMount("tekton-creds-init-home-vr6ds", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-3", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1214,7 +1214,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-					tb.VolumeMount("tekton-creds-init-home-l22wn", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-4", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1239,10 +1239,10 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-mz4c7",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}, corev1.Volume{
-					Name:         "tekton-creds-init-home-mssqb",
+					Name:         "tekton-creds-init-home-1",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1273,7 +1273,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-mz4c7", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1286,7 +1286,7 @@ func TestReconcile(t *testing.T) {
 						"/tekton/termination", "-entrypoint", "/mycmd", "--", "--my-arg=foo"),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-					tb.VolumeMount("tekton-creds-init-home-mssqb", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-1", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1312,7 +1312,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1334,7 +1334,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1359,10 +1359,10 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-mz4c7",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}, corev1.Volume{
-					Name:         "tekton-creds-init-home-mssqb",
+					Name:         "tekton-creds-init-home-1",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1394,7 +1394,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-mz4c7", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1407,7 +1407,7 @@ func TestReconcile(t *testing.T) {
 					tb.WorkingDir(workspaceDir),
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
-					tb.VolumeMount("tekton-creds-init-home-mssqb", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-1", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1433,7 +1433,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1454,7 +1454,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1479,7 +1479,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1501,7 +1501,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),
@@ -1527,7 +1527,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodSpec(
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, toolsVolume, downwardVolume, corev1.Volume{
-					Name:         "tekton-creds-init-home-9l9zj",
+					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				tb.PodRestartPolicy(corev1.RestartPolicyNever),
@@ -1549,7 +1549,7 @@ func TestReconcile(t *testing.T) {
 					tb.EnvVar("HOME", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-tools", "/tekton/tools"),
 					tb.VolumeMount("tekton-internal-downward", "/tekton/downward"),
-					tb.VolumeMount("tekton-creds-init-home-9l9zj", "/tekton/creds"),
+					tb.VolumeMount("tekton-creds-init-home-0", "/tekton/creds"),
 					tb.VolumeMount("tekton-internal-workspace", workspaceDir),
 					tb.VolumeMount("tekton-internal-home", "/tekton/home"),
 					tb.VolumeMount("tekton-internal-results", "/tekton/results"),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Removed the random suffixes that used to appear on creds-init volumes. These
didn't serve any purpose that couldn't be equally well-served with an
incrementing integer.

The benefit of doing it this way is that our unit tests become less brittle -
those random suffixes were a source of considerable churn whenever other
volumes were added or removed to test data because the random pool of suffixes
was shared with those other volumes.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```