### PR TITLE
Format code blocks with prettier

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -198,7 +198,7 @@ Note: Github deprecated basic authentication with username and password. You can
 
    - Associate the `ServiceAccount` with your `TaskRun`:
 
-    ```yaml
+     ```yaml
      apiVersion: tekton.dev/v1beta1
      kind: TaskRun
      metadata:
@@ -463,7 +463,7 @@ Kubernetes `Secrets`.
      spec:
        serviceAccountName: build-bot
        steps:
-       ...
+       # ...
      ```
 
    - Associate the `ServiceAccount` with your `PipelineRun`:

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -260,16 +260,16 @@ you end up with this task run status:
 ```yaml
 apiVersion: tekton.dev/v1alpha1
 kind: TaskRun
-...
+# ...
 status:
-...
+# ...
   taskResults:
-  - name: current-date-human-readable
-    value: |
-      Wed Jan 22 19:47:26 UTC 2020
-  - name: current-date-unix-timestamp
-    value: |
-      1579722445
+    - name: current-date-human-readable
+      value: |
+        Wed Jan 22 19:47:26 UTC 2020
+    - name: current-date-unix-timestamp
+      value: |
+        1579722445
 ```
 
 Instead of hardcoding the path to the result file, the user can also use a variable. So `/tekton/results/current-date-unix-timestamp` can be replaced with: `$(results.current-date-unix-timestamp.path)`. This is more flexible if the path to result files ever changes.
@@ -294,7 +294,7 @@ apiVersion: tekton.dev/v1alpha1
 kind: Pipeline
 metadata:
   name: sum-and-multiply-pipeline
-    #...
+  #...
   tasks:
     - name: sum-inputs
     #...

--- a/docs/enabling-ha.md
+++ b/docs/enabling-ha.md
@@ -50,12 +50,12 @@ If HA is not required, you can disable it by scaling the deployment back to one 
 spec:
   serviceAccountName: tekton-pipelines-controller
   containers:
-  - name: tekton-pipelines-controller
-    ...
-    args: [
-      # Other flags defined here...
-      "-disable-ha=true"
-    ]
+    - name: tekton-pipelines-controller
+      # ...
+      args: [
+          # Other flags defined here...
+          "-disable-ha=true",
+        ]
 ```
 
 **Note:** If you set `-disable-ha=false` and run multiple replicas of the Controller, each replica will process work items separately, which will lead to unwanted behavior when creating resources (e.g., `TaskRuns`, etc.).
@@ -83,7 +83,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: tekton-pipelines-webhook
-...
+# ...
 spec:
   minReplicas: 1
 ```
@@ -103,7 +103,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    ...
+    # ...
 spec:
   minAvailable: 1
   selector:

--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -37,16 +37,16 @@ For example, consider the following `v1alpha1` parameters:
 spec:
   inputs:
     params:
-    - name: ADDR
-      description: Address to curl.
-      type: string
+      - name: ADDR
+        description: Address to curl.
+        type: string
 
 # TaskRun.yaml (v1alpha1)
 spec:
   inputs:
     params:
-    - name: ADDR
-      value: https://example.com/foo.json
+      - name: ADDR
+        value: https://example.com/foo.json
 ```
 
 The above parameters are now represented as follows in `v1beta1`:
@@ -55,15 +55,15 @@ The above parameters are now represented as follows in `v1beta1`:
 # Task.yaml (v1beta1)
 spec:
   params:
-  - name: ADDR
-    description: Address to curl.
-    type: string
+    - name: ADDR
+      description: Address to curl.
+      type: string
 
 # TaskRun.yaml (v1beta1)
 spec:
   params:
-  - name: ADDR
-    value: https://example.com/foo.json
+    - name: ADDR
+      value: https://example.com/foo.json
 ```
 
 ## Replacing `PipelineResources` with Tasks
@@ -93,32 +93,32 @@ metadata:
 spec:
   inputs:
     resources:
-    - name: workspace
-      type: git
+      - name: workspace
+        type: git
     params:
-    - name: pathToDockerFile
-      description: The path to the dockerfile to build
-      default: /workspace/workspace/Dockerfile
-    - name: pathToContext
-      description: The build context used by Kaniko
-      default: /workspace/workspace
+      - name: pathToDockerFile
+        description: The path to the dockerfile to build
+        default: /workspace/workspace/Dockerfile
+      - name: pathToContext
+        description: The build context used by Kaniko
+        default: /workspace/workspace
   outputs:
     resources:
-    - name: builtImage
-      type: image
+      - name: builtImage
+        type: image
   steps:
-  - name: build-and-push
-    image: gcr.io/kaniko-project/executor:v0.17.1
-    env:
-    - name: "DOCKER_CONFIG"
-      value: "/tekton/home/.docker/"
-    args:
-    - --dockerfile=$(inputs.params.pathToDockerFile)
-    - --destination=$(outputs.resources.builtImage.url)
-    - --context=$(inputs.params.pathToContext)
-    - --oci-layout-path=$(inputs.resources.builtImage.path)
-    securityContext:
-      runAsUser: 0
+    - name: build-and-push
+      image: gcr.io/kaniko-project/executor:v0.17.1
+      env:
+        - name: "DOCKER_CONFIG"
+          value: "/tekton/home/.docker/"
+      args:
+        - --dockerfile=$(inputs.params.pathToDockerFile)
+        - --destination=$(outputs.resources.builtImage.url)
+        - --context=$(inputs.params.pathToContext)
+        - --oci-layout-path=$(inputs.resources.builtImage.path)
+      securityContext:
+        runAsUser: 0
 ```
 
 To do the same thing with the `git` catalog `Task` and the kaniko `Task` you will need to combine them in a
@@ -133,38 +133,38 @@ metadata:
   name: kaniko-pipeline
 spec:
   params:
-  - name: git-url
-  - name: git-revision
-  - name: image-name
-  - name: path-to-image-context
-  - name: path-to-dockerfile
+    - name: git-url
+    - name: git-revision
+    - name: image-name
+    - name: path-to-image-context
+    - name: path-to-dockerfile
   workspaces:
-  - name: git-source
+    - name: git-source
   tasks:
-  - name: fetch-from-git
-    taskRef:
-      name: git-clone
-    params:
-    - name: url
-      value: $(params.git-url)
-    - name: revision
-      value: $(params.git-revision)
-    workspaces:
-    - name: output
-      workspace: git-source
-  - name: build-image
-    taskRef:
-      name: kaniko
-    params:
-    - name: IMAGE
-      value: $(params.image-name)
-    - name: CONTEXT
-      value: $(params.path-to-image-context)
-    - name: DOCKERFILE
-      value: $(params.path-to-dockerfile)
-    workspaces:
-    - name: source
-      workspace: git-source
+    - name: fetch-from-git
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.git-revision)
+      workspaces:
+        - name: output
+          workspace: git-source
+    - name: build-image
+      taskRef:
+        name: kaniko
+      params:
+        - name: IMAGE
+          value: $(params.image-name)
+        - name: CONTEXT
+          value: $(params.path-to-image-context)
+        - name: DOCKERFILE
+          value: $(params.path-to-dockerfile)
+      workspaces:
+        - name: source
+          workspace: git-source
   # If you want you can add a Task that uses the IMAGE_DIGEST from the kaniko task
   # via $(tasks.build-image.results.IMAGE_DIGEST) - this was a feature we hadn't been
   # able to fully deliver with the Image PipelineResource!
@@ -216,33 +216,33 @@ For example, consider the following `v1alpha1` definition:
 spec:
   inputs:
     resources:
-    - name: skaffold
-      type: git
+      - name: skaffold
+        type: git
   outputs:
     resources:
-    - name: baked-image
-      type: image
+      - name: baked-image
+        type: image
 
 # TaskRun.yaml (v1alpha1)
 spec:
   inputs:
     resources:
-    - name: skaffold
-      resourceSpec:
-        type: git
-        params:
-          - name: revision
-            value: v0.32.0
-          - name: url
-            value: https://github.com/GoogleContainerTools/skaffold
+      - name: skaffold
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: v0.32.0
+            - name: url
+              value: https://github.com/GoogleContainerTools/skaffold
   outputs:
     resources:
-    - name: baked-image
-      resourceSpec:
-      - type: image
-        params:
-        - name: url
-          value: gcr.io/foo/bar
+      - name: baked-image
+        resourceSpec:
+          - type: image
+            params:
+              - name: url
+                value: gcr.io/foo/bar
 ```
 
 The above definition becomes the following in `v1beta1`:
@@ -252,29 +252,29 @@ The above definition becomes the following in `v1beta1`:
 spec:
   resources:
     inputs:
-    - name: src-repo
-      type: git
+      - name: src-repo
+        type: git
     outputs:
-    - name: baked-image
-      type: image
+      - name: baked-image
+        type: image
 
 # TaskRun.yaml (v1beta1)
 spec:
   resources:
     inputs:
-    - name: src-repo
-      resourceSpec:
-        type: git
-        params:
-          - name: revision
-            value: main
-          - name: url
-            value: https://github.com/tektoncd/pipeline
+      - name: src-repo
+        resourceSpec:
+          type: git
+          params:
+            - name: revision
+              value: main
+            - name: url
+              value: https://github.com/tektoncd/pipeline
     outputs:
-    - name: baked-image
-      resourceSpec:
-      - type: image
-        params:
-        - name: url
-          value: gcr.io/foo/bar
+      - name: baked-image
+        resourceSpec:
+          - type: image
+            params:
+              - name: url
+                value: gcr.io/foo/bar
 ```

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -81,7 +81,6 @@ To specify the target `Pipeline` by reference, use the `pipelineRef` field:
 spec:
   pipelineRef:
     name: mypipeline
-
 ```
 To embed a `Pipeline` definition in the `PipelineRun`, use the `pipelineSpec` field:
 
@@ -89,9 +88,9 @@ To embed a `Pipeline` definition in the `PipelineRun`, use the `pipelineSpec` fi
 spec:
   pipelineSpec:
     tasks:
-    - name: task1
-      taskRef:
-        name: mytask
+      - name: task1
+        taskRef:
+          name: mytask
 ```
 
 The `Pipeline` in the [`pipelineSpec` example](../examples/v1beta1/pipelineruns/pipelinerun-with-pipelinespec.yaml)
@@ -111,10 +110,9 @@ You can also embed a `Task` definition the embedded `Pipeline` definition:
 spec:
   pipelineSpec:
     tasks:
-    - name: task1
-      taskSpec:
-        steps:
-          ...
+      - name: task1
+        taskSpec:
+          steps: ...
 ```
 
 In the [`taskSpec` in `pipelineSpec` example](../examples/v1beta1/pipelineruns/pipelinerun-with-pipelinespec-and-taskspec.yaml)
@@ -128,18 +126,18 @@ and cleaning up completed pod with certain labels, etc) even being part of one s
 spec:
   pipelineSpec:
     tasks:
-    - name: task1
-      taskSpec:
-        metadata:
-          labels:
-            pipeline-sdk-type: kfp
-       ...
-    - name: task2
-      taskSpec:
-        metadata:
-          labels:
-            pipeline-sdk-type: tfx
-       ...
+      - name: task1
+        taskSpec:
+          metadata:
+            labels:
+              pipeline-sdk-type: kfp
+        # ...
+      - name: task2
+        taskSpec:
+          metadata:
+            labels:
+              pipeline-sdk-type: tfx
+        # ...
 ```
 
 #### Tekton Bundles
@@ -238,10 +236,10 @@ For example:
 ```yaml
 spec:
   params:
-  - name: pl-param-x
-    value: "100"
-  - name: pl-param-y
-    value: "500"
+    - name: pl-param-x
+      value: "100"
+    - name: pl-param-y
+      value: "500"
 ```
 You can pass in extra `Parameters` if needed depending on your use cases. An example use
 case is when your CI system autogenerates `PipelineRuns` and it has `Parameters` it wants to
@@ -340,9 +338,9 @@ spec:
       runAsNonRoot: true
       runAsUser: 1001
     volumes:
-    - name: my-cache
-      persistentVolumeClaim:
-        claimName: my-volume-claim
+      - name: my-cache
+        persistentVolumeClaim:
+          claimName: my-volume-claim
 ```
 
 [`Custom tasks`](pipelines.md#using-custom-tasks) may or may not use a pod template.
@@ -358,7 +356,7 @@ for example:
 
 ```yaml
 spec:
-   podTemplate:
+  podTemplate:
     securityContext:
       runAsUser: 1000
       runAsGroup: 2000
@@ -381,10 +379,10 @@ can map a `PersistentVolumeClaim` volume to a `Workspace` as follows:
 
 ```yaml
 workspaces:
-- name: myworkspace # must match workspace name in Task
-  persistentVolumeClaim:
-    claimName: mypvc # this PVC must already exist
-  subPath: my-subdir
+  - name: myworkspace # must match workspace name in Task
+    persistentVolumeClaim:
+      claimName: mypvc # this PVC must already exist
+    subPath: my-subdir
 ```
 
 For more information, see the following topics:
@@ -435,11 +433,11 @@ The following example shows an extract from the `status` field of a `PipelineRun
 ```yaml
 completionTime: "2020-05-04T02:19:14Z"
 conditions:
-- lastTransitionTime: "2020-05-04T02:19:14Z"
-  message: 'Tasks Completed: 4, Skipped: 0'
-  reason: Succeeded
-  status: "True"
-  type: Succeeded
+  - lastTransitionTime: "2020-05-04T02:19:14Z"
+    message: "Tasks Completed: 4, Skipped: 0"
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
 startTime: "2020-05-04T02:00:11Z"
 taskRuns:
   triggers-release-nightly-frwmw-build-ng2qk:
@@ -447,28 +445,28 @@ taskRuns:
     status:
       completionTime: "2020-05-04T02:10:49Z"
       conditions:
-      - lastTransitionTime: "2020-05-04T02:10:49Z"
-        message: All Steps have completed executing
-        reason: Succeeded
-        status: "True"
-        type: Succeeded
+        - lastTransitionTime: "2020-05-04T02:10:49Z"
+          message: All Steps have completed executing
+          reason: Succeeded
+          status: "True"
+          type: Succeeded
       podName: triggers-release-nightly-frwmw-build-ng2qk-pod-8vj99
       resourcesResult:
-      - key: commit
-        resourceRef:
-          name: git-source-triggers-frwmw
-        value: 9ab5a1234166a89db352afa28f499d596ebb48db
+        - key: commit
+          resourceRef:
+            name: git-source-triggers-frwmw
+          value: 9ab5a1234166a89db352afa28f499d596ebb48db
       startTime: "2020-05-04T02:05:07Z"
       steps:
-      - container: step-build
-        imageID: docker-pullable://golang@sha256:a90f2671330831830e229c3554ce118009681ef88af659cd98bfafd13d5594f9
-        name: build
-        terminated:
-          containerID: docker://6b6471f501f59dbb7849f5cdde200f4eeb64302b862a27af68821a7fb2c25860
-          exitCode: 0
-          finishedAt: "2020-05-04T02:10:45Z"
-          reason: Completed
-          startedAt: "2020-05-04T02:06:24Z"
+        - container: step-build
+          imageID: docker-pullable://golang@sha256:a90f2671330831830e229c3554ce118009681ef88af659cd98bfafd13d5594f9
+          name: build
+          terminated:
+            containerID: docker://6b6471f501f59dbb7849f5cdde200f4eeb64302b862a27af68821a7fb2c25860
+            exitCode: 0
+            finishedAt: "2020-05-04T02:10:45Z"
+            reason: Completed
+            startedAt: "2020-05-04T02:06:24Z"
   ```
 
 The following tables shows how to read the overall status of a `PipelineRun`.

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -276,10 +276,10 @@ repeatable reference to a `Task`.
  ```yaml
  spec:
    tasks:
-   - name: hello-world
-     taskRef:
-       name: echo-task
-       bundle: docker.com/myrepo/mycatalog:v1.0.1
+     - name: hello-world
+       taskRef:
+         name: echo-task
+         bundle: docker.com/myrepo/mycatalog:v1.0.1
  ```
 
 You may also specify a fixed digest instead of a tag.
@@ -287,10 +287,10 @@ You may also specify a fixed digest instead of a tag.
  ```yaml
  spec:
    tasks:
-   - name: hello-world
-     taskRef:
-       name: echo-task
-       bundle: docker.io/myrepo/mycatalog@sha256:abc123
+     - name: hello-world
+       taskRef:
+         name: echo-task
+         bundle: docker.io/myrepo/mycatalog@sha256:abc123
  ```
 
 Any of the above options will fetch the image using the `ImagePullSecrets` attached to the
@@ -425,7 +425,7 @@ tasks:
         operator: in
         values: ["yes"]
     taskRef:
-        name: echo-file-exists
+      name: echo-file-exists
 ---
 tasks:
   - name: run-lint
@@ -590,9 +590,9 @@ In the snippet below, a `WhenExpression` is provided its value from the `exists`
 
 ```yaml
 when:
-- input: "$(tasks.check-file.results.exists)"
-  operator: in
-  values: ["yes"]
+  - input: "$(tasks.check-file.results.exists)"
+    operator: in
+    values: ["yes"]
 ```
 
 For an end-to-end example, see [`Task` `Results` in a `PipelineRun`](../examples/v1beta1/pipelineruns/task_results_example.yaml).
@@ -616,10 +616,10 @@ In the example below, the `Pipeline` specifies a `results` entry with the name `
 references the `outputValue` `Result` emitted by the `calculate-sum` `Task`.
 
 ```yaml
-  results:
-    - name: sum
-      description: the sum of all three operands
-      value: $(tasks.calculate-sum.results.outputValue)
+results:
+  - name: sum
+    description: the sum of all three operands
+    value: $(tasks.calculate-sum.results.outputValue)
 ```
 
 For an end-to-end example, see [`Results` in a `PipelineRun`](../examples/v1beta1/pipelineruns/pipelinerun-results.yaml).
@@ -872,22 +872,22 @@ what kind of events are triggered based on the `Pipelinerun` status.
 Finally Task can utilize execution status of any of the `pipelineTasks` under `tasks` section using param:
 
 ```yaml
-    finally:
-    - name: finaltask
+finally:
+  - name: finaltask
+    params:
+      - name: task1Status
+        value: "$(tasks.task1.status)"
+    taskSpec:
       params:
         - name: task1Status
-          value: "$(tasks.task1.status)"
-      taskSpec:
-        params:
-          - name: task1Status
-        steps:
-          - image: ubuntu
-            name: print-task-status
-            script: |
-              if [ $(params.task1Status) == "Failed" ]
-              then
-                echo "Task1 has failed, continue processing the failure"
-              fi
+      steps:
+        - image: ubuntu
+          name: print-task-status
+          script: |
+            if [ $(params.task1Status) == "Failed" ]
+            then
+              echo "Task1 has failed, continue processing the failure"
+            fi
 ```
 
 This kind of variable can have any one of the values from the following table:
@@ -921,9 +921,9 @@ metadata:
 spec:
   pipelineSpec:
     params:
-    - name: enable-notifications
-      type: string
-      description: a boolean indicating whether the notifications should be sent
+      - name: enable-notifications
+        type: string
+        description: a boolean indicating whether the notifications should be sent
     tasks:
       - name: golang-build
         taskRef:
@@ -1065,9 +1065,9 @@ Final tasks can emit `Results` but results emitted from the final tasks can not 
 (tracked in issue [#2710](https://github.com/tektoncd/pipeline/issues/2710)).
 
 ```yaml
-  results:
-    - name: comment-count-validate
-      value: $(finally.check-count.results.comment-count-validate)
+results:
+  - name: comment-count-validate
+    value: $(finally.check-count.results.comment-count-validate)
 ```
 
 In this example, `pipelineResults` in `status` will exclude the name-value pair for that result `comment-count-validate`.
@@ -1138,8 +1138,8 @@ spec:
         kind: Example
         name: myexample
       params:
-      - name: foo
-        value: bah
+        - name: foo
+          value: bah
 ```
 
 ### Specifying workspaces
@@ -1155,7 +1155,7 @@ spec:
         kind: Example
         name: myexample
       workspaces:
-      - name: my-workspace
+        - name: my-workspace
 ```
 
 Consult the documentation of the custom task that you are using to determine whether it supports workspaces and how to name them.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -239,10 +239,10 @@ For an example of what this output looks like:
 
 ```yaml
 resourcesResult:
-- key: digest
-  value: sha256:a08412a4164b85ae521b0c00cf328e3aab30ba94a526821367534b81e51cb1cb
-  resourceRef:
-    name: skaffold-image-leeroy-web
+  - key: digest
+    value: sha256:a08412a4164b85ae521b0c00cf328e3aab30ba94a526821367534b81e51cb1cb
+    resourceRef:
+      name: skaffold-image-leeroy-web
 ```
 
 ### Description
@@ -283,7 +283,7 @@ spec:
       optional: true
   tasks:
     - name: check-workspace
-...
+# ...
 ```
 
 You can refer to different examples demonstrating usage of optional resources in
@@ -381,10 +381,10 @@ When used as an input, the Git resource includes the exact commit fetched in the
 
 ```yaml
 resourceResults:
-- key: commit
-  value: 6ed7aad5e8a36052ee5f6079fc91368e362121f7
-  resourceRef:
-    name: skaffold-git
+  - key: commit
+    value: 6ed7aad5e8a36052ee5f6079fc91368e362121f7
+    resourceRef:
+      name: skaffold-git
 ```
 
 #### Using a fork
@@ -662,13 +662,13 @@ for example:
 
 ```yaml
 status:
-    ...
+    # ...
     resourcesResult:
-    - key: "digest"
-      value: "sha256:eed29cd0b6feeb1a92bc3c4f977fd203c63b376a638731c88cacefe3adb1c660"
-      resourceRef:
-        name: skaffold-image-leeroy-web
-    ...
+      - key: "digest"
+        value: "sha256:eed29cd0b6feeb1a92bc3c4f977fd203c63b376a638731c88cacefe3adb1c660"
+        resourceRef:
+          name: skaffold-image-leeroy-web
+    # ...
 ```
 
 If the `index.json` file is not produced, the image digest will not be included
@@ -958,8 +958,8 @@ metadata:
 spec:
   type: cloudEvent
   params:
-  - name: targetURI
-    value: http://sink:8080
+    - name: targetURI
+      value: http://sink:8080
 ```
 
 The content of an event is for example:

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -107,8 +107,8 @@ If a custom task supports [`parameters`](tasks.md#parameters), you can use the
 ```yaml
 spec:
   params:
-  - name: my-param
-    value: chicken
+    - name: my-param
+      value: chicken
 ```
 
 If the custom task controller knows how to interpret the parameter value, it
@@ -130,8 +130,8 @@ If the custom task supports it, you can provide [`Workspaces`](workspaces.md) to
 ```yaml
 spec:
   workspaces:
-  - name: my-workspace
-    emptyDir: {}
+    - name: my-workspace
+      emptyDir: {}
 ```
 
 Consult the documentation of the custom task that you are using to determine whether it supports workspaces and how to name them.
@@ -178,11 +178,11 @@ successfully:
 ```yaml
 completionTime: "2019-08-12T18:22:57Z"
 conditions:
-- lastTransitionTime: "2019-08-12T18:22:57Z"
-  message: Execution was successful
-  reason: Succeeded
-  status: "True"
-  type: Succeeded
+  - lastTransitionTime: "2019-08-12T18:22:57Z"
+    message: Execution was successful
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
 startTime: "2019-08-12T18:22:51Z"
 ```
 
@@ -278,8 +278,8 @@ spec:
     kind: Example
     name: my-example-task
   params:
-  - name: my-first-param
-    value: i'm number one
-  - name: my-second-param
-    value: close second
+    - name: my-first-param
+      value: i'm number one
+    - name: my-second-param
+      value: close second
 ```

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -243,9 +243,9 @@ spec:
       runAsNonRoot: true
       runAsUser: 1001
     volumes:
-    - name: my-cache
-      persistentVolumeClaim:
-        claimName: my-volume-claim
+      - name: my-cache
+        persistentVolumeClaim:
+          claimName: my-volume-claim
 ```
 
 ### Specifying `Workspaces`
@@ -256,10 +256,10 @@ can map a `PersistentVolumeClaim` volume to a `Workspace` as follows:
 
 ```yaml
 workspaces:
-- name: myworkspace # must match workspace name in the Task
-  persistentVolumeClaim:
-    claimName: mypvc # this PVC must already exist
-  subPath: my-subdir
+  - name: myworkspace # must match workspace name in the Task
+    persistentVolumeClaim:
+      claimName: mypvc # this PVC must already exist
+    subPath: my-subdir
 ```
 
 For more information, see the following topics:
@@ -352,23 +352,23 @@ The following example shows the `status` field of a `TaskRun` that has executed 
 ```yaml
 completionTime: "2019-08-12T18:22:57Z"
 conditions:
-- lastTransitionTime: "2019-08-12T18:22:57Z"
-  message: All Steps have completed executing
-  reason: Succeeded
-  status: "True"
-  type: Succeeded
+  - lastTransitionTime: "2019-08-12T18:22:57Z"
+    message: All Steps have completed executing
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
 podName: status-taskrun-pod-6488ef
 startTime: "2019-08-12T18:22:51Z"
 steps:
-- container: step-hello
-  imageID: docker-pullable://busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649
-  name: hello
-  terminated:
-    containerID: docker://d5a54f5bbb8e7a6fd3bc7761b78410403244cf4c9c5822087fb0209bf59e3621
-    exitCode: 0
-    finishedAt: "2019-08-12T18:22:56Z"
-    reason: Completed
-    startedAt: "2019-08-12T18:22:54Z"
+  - container: step-hello
+    imageID: docker-pullable://busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649
+    name: hello
+    terminated:
+      containerID: docker://d5a54f5bbb8e7a6fd3bc7761b78410403244cf4c9c5822087fb0209bf59e3621
+      exitCode: 0
+      finishedAt: "2019-08-12T18:22:56Z"
+      reason: Completed
+      startedAt: "2019-08-12T18:22:54Z"
   ```
 
 The following tables shows how to read the overall status of a `TaskRun`:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -171,14 +171,14 @@ Below is an example of setting the resource requests and limits for a step:
 ```yaml
 spec:
   steps:
-  - name: step-with-limts
-    resources:
-      requests:
-        memory: 1Gi
-        cpu: 500m
-      limits:
-         memory: 2Gi
-        cpu: 800m
+    - name: step-with-limts
+      resources:
+        requests:
+          memory: 1Gi
+          cpu: 500m
+        limits:
+          memory: 2Gi
+          cpu: 800m
 ```
 
 #### Reserved directories
@@ -216,50 +216,50 @@ The example below executes a Bash script:
 
 ```yaml
 steps:
-- image: ubuntu  # contains bash
-  script: |
-    #!/usr/bin/env bash
-    echo "Hello from Bash!"
+  - image: ubuntu # contains bash
+    script: |
+      #!/usr/bin/env bash
+      echo "Hello from Bash!"
 ```
 
 The example below executes a Python script:
 
 ```yaml
 steps:
-- image: python  # contains python
-  script: |
-    #!/usr/bin/env python3
-    print("Hello from Python!")
+  - image: python # contains python
+    script: |
+      #!/usr/bin/env python3
+      print("Hello from Python!")
 ```
 
 The example below executes a Node script:
 
 ```yaml
 steps:
-- image: node  # contains node
-  script: |
-    #!/usr/bin/env node
-    console.log("Hello from Node!")
+  - image: node # contains node
+    script: |
+      #!/usr/bin/env node
+      console.log("Hello from Node!")
 ```
 
 You can execute scripts directly in the workspace:
 
 ```yaml
 steps:
-- image: ubuntu
-  script: |
-    #!/usr/bin/env bash
-    /workspace/my-script.sh  # provided by an input resource
+  - image: ubuntu
+    script: |
+      #!/usr/bin/env bash
+      /workspace/my-script.sh  # provided by an input resource
 ```
 
 You can also execute scripts within the container image:
 
 ```yaml
 steps:
-- image: my-image  # contains /bin/my-binary
-  script: |
-    #!/usr/bin/env bash
-    /bin/my-binary
+  - image: my-image # contains /bin/my-binary
+    script: |
+      #!/usr/bin/env bash
+      /bin/my-binary
 ```
 #### Specifying a timeout
 
@@ -276,7 +276,7 @@ The example `Step` below is supposed to sleep for 60 seconds but will be cancele
 steps:
   - name: sleep-then-timeout
     image: ubuntu
-    script: | 
+    script: |
       #!/usr/bin/env bash
       echo "I am supposed to sleep for 60 seconds!"
       sleep 60
@@ -359,8 +359,7 @@ resources:
 steps:
   - image: objectuser/run-java-jar #https://hub.docker.com/r/objectuser/run-java-jar/
     command: [jar]
-    args:
-      ["-cvf", "-o", "/workspace/output/storage-gcs/", "projectname.war", "*"]
+    args: ["-cvf", "-o", "/workspace/output/storage-gcs/", "projectname.war", "*"]
     env:
       - name: "FOO"
         value: "world"
@@ -387,18 +386,18 @@ resources:
   outputs:
     name: tar-artifact
 steps:
- - name: untar
+  - name: untar
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['-c', 'mkdir -p /workspace/tar-scratch-space/ && tar -xvf /workspace/customworkspace/rules_docker-master.tar -C /workspace/tar-scratch-space/']
- - name: edit-tar
+    args: ["-c", "mkdir -p /workspace/tar-scratch-space/ && tar -xvf /workspace/customworkspace/rules_docker-master.tar -C /workspace/tar-scratch-space/"]
+  - name: edit-tar
     image: ubuntu
     command: ["/bin/bash"]
-    args: ['-c', 'echo crazy > /workspace/tar-scratch-space/rules_docker-master/crazy.txt']
- - name: tar-it-up
-   image: ubuntu
-   command: ["/bin/bash"]
-   args: ['-c', 'cd /workspace/tar-scratch-space/ && tar -cvf /workspace/customworkspace/rules_docker-master.tar rules_docker-master']
+    args: ["-c", "echo crazy > /workspace/tar-scratch-space/rules_docker-master/crazy.txt"]
+  - name: tar-it-up
+    image: ubuntu
+    command: ["/bin/bash"]
+    args: ["-c", "cd /workspace/tar-scratch-space/ && tar -cvf /workspace/customworkspace/rules_docker-master.tar rules_docker-master"]
 ```
 
 ### Specifying `Workspaces`
@@ -410,16 +409,16 @@ one writeable `Workspace`. For example:
 ```yaml
 spec:
   steps:
-  - name: write-message
-    image: ubuntu
-    script: |
-      #!/usr/bin/env bash
-      set -xe
-      echo hello! > $(workspaces.messages.path)/message
+    - name: write-message
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        echo hello! > $(workspaces.messages.path)/message
   workspaces:
-  - name: messages
-    description: The folder where we write the message to
-    mountPath: /custom/path/relative/to/root
+    - name: messages
+      description: The folder where we write the message to
+      mountPath: /custom/path/relative/to/root
 ```
 
 For more information, see [Using `Workspaces` in `Tasks`](workspaces.md#using-workspaces-in-tasks)
@@ -554,14 +553,14 @@ steps:
   - image: docker
     name: client
     script: |
-        #!/usr/bin/env bash
-        cat > Dockerfile << EOF
-        FROM ubuntu
-        RUN apt-get update
-        ENTRYPOINT ["echo", "hello"]
-        EOF
-        docker build -t hello . && docker run hello
-        docker images
+      #!/usr/bin/env bash
+      cat > Dockerfile << EOF
+      FROM ubuntu
+      RUN apt-get update
+      ENTRYPOINT ["echo", "hello"]
+      EOF
+      docker build -t hello . && docker run hello
+      docker images
     volumeMounts:
       - mountPath: /var/run/
         name: dind-socket
@@ -656,25 +655,25 @@ Referencing an `array` parameter in any other way will result in an error. For e
 type `array`, then the following example is an invalid `Step` because the string isn't isolated:
 
 ```yaml
- - name: build-step
-      image: gcr.io/cloud-builders/some-image
-      args: ["build", "additionalArg $(params.build-args[*])"]
+- name: build-step
+  image: gcr.io/cloud-builders/some-image
+  args: ["build", "additionalArg $(params.build-args[*])"]
 ```
 
 Similarly, referencing `build-args` in a non-`array` field is also invalid:
 
 ```yaml
- - name: build-step
-      image: "$(params.build-args[*])"
-      args: ["build", "args"]
+- name: build-step
+  image: "$(params.build-args[*])"
+  args: ["build", "args"]
 ```
 
 A valid reference to the `build-args` parameter is isolated and in an eligible field (`args`, in this case):
 
 ```yaml
- - name: build-step
-      image: gcr.io/cloud-builders/some-image
-      args: ["build", "$(params.build-args[*])", "additionalArg"]
+- name: build-step
+  image: gcr.io/cloud-builders/some-image
+  args: ["build", "$(params.build-args[*])", "additionalArg"]
 ```
 
 #### Substituting `Workspace` paths
@@ -715,12 +714,12 @@ contents from being executed:
 # Task.yaml
 spec:
   steps:
-  - image: an-image-that-runs-bash
-    env:
-    - name: SCRIPT_CONTENTS
-      value: $(params.script)
-    script: |
-      printf '%s' "${SCRIPT_CONTENTS}" > input-script
+    - image: an-image-that-runs-bash
+      env:
+        - name: SCRIPT_CONTENTS
+          value: $(params.script)
+      script: |
+        printf '%s' "${SCRIPT_CONTENTS}" > input-script
 ```
 
 This works by injecting Tekton's variable as an environment variable into the Step's
@@ -867,34 +866,34 @@ metadata:
   name: goreleaser
 spec:
   params:
-  - name: package
-    type: string
-    description: base package to build in
-  - name: github-token-secret
-    type: string
-    description: name of the secret holding the github-token
-    default: github-token
+    - name: package
+      type: string
+      description: base package to build in
+    - name: github-token-secret
+      type: string
+      description: name of the secret holding the github-token
+      default: github-token
   resources:
     inputs:
-    - name: source
-      type: git
-      targetPath: src/$(params.package)
+      - name: source
+        type: git
+        targetPath: src/$(params.package)
   steps:
-  - name: release
-    image: goreleaser/goreleaser
-    workingDir: /workspace/src/$(params.package)
-    command:
-    - goreleaser
-    args:
-    - release
-    env:
-    - name: GOPATH
-      value: /workspace
-    - name: GITHUB_TOKEN
-      valueFrom:
-        secretKeyRef:
-          name: $(params.github-token-secret)
-          key: bot-token
+    - name: release
+      image: goreleaser/goreleaser
+      workingDir: /workspace/src/$(params.package)
+      command:
+        - goreleaser
+      args:
+        - release
+      env:
+        - name: GOPATH
+          value: /workspace
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.github-token-secret)
+              key: bot-token
 ```
 
 #### Using a `Sidecar` in a `Task`
@@ -908,21 +907,21 @@ metadata:
   name: with-sidecar-task
 spec:
   params:
-  - name: sidecar-image
-    type: string
-    description: Image name of the sidecar container
-  - name: sidecar-env
-    type: string
-    description: Environment variable value
+    - name: sidecar-image
+      type: string
+      description: Image name of the sidecar container
+    - name: sidecar-env
+      type: string
+      description: Environment variable value
   sidecars:
-  - name: sidecar
-    image: $(params.sidecar-image)
-    env:
-    - name: SIDECAR_ENV
-      value: $(params.sidecar-env)
+    - name: sidecar
+      image: $(params.sidecar-image)
+      env:
+        - name: SIDECAR_ENV
+          value: $(params.sidecar-env)
   steps:
-  - name: test
-    image: hello-world
+    - name: test
+      image: hello-world
 ```
 
 ## Debugging
@@ -940,12 +939,12 @@ the name of every file stored in the `/workspace` directory to the build log. Fo
 - name: build-and-push-1
   image: ubuntu
   command:
-  - /bin/bash
+    - /bin/bash
   args:
-  - -c
-  - |
-    set -ex
-    find /workspace
+    - -c
+    - |
+      set -ex
+      find /workspace
 ```
 
 You can also choose to examine the *contents* of every file used by your `Task`:
@@ -954,12 +953,12 @@ You can also choose to examine the *contents* of every file used by your `Task`:
 - name: build-and-push-1
   image: ubuntu
   command:
-  - /bin/bash
+    - /bin/bash
   args:
-  - -c
-  - |
-    set -ex
-    find /workspace | xargs cat
+    - -c
+    - |
+      set -ex
+      find /workspace | xargs cat
 ```
 
 ### Inspecting the `Pod`
@@ -971,7 +970,6 @@ log into the `Pod` and add a `Step` that pauses the `Task` at the desired stage.
 - name: pause
   image: docker
   args: ["sleep", "6000"]
-
 ```
 
 ### Running Step Containers as a Non Root User
@@ -991,7 +989,7 @@ metadata:
   name: show-non-root-steps
 spec:
   steps:
-    # no securityContext specified so will use 
+    # no securityContext specified so will use
     # securityContext from TaskRun podTemplate
     - name: show-user-1001
       image: ubuntu
@@ -999,7 +997,7 @@ spec:
         - ps
       args:
         - "aux"
-    # securityContext specified so will run as  
+    # securityContext specified so will run as
     # user 2000 instead of 1001
     - name: show-user-2000
       image: ubuntu

--- a/docs/tekton-controller-performance-configuration.md
+++ b/docs/tekton-controller-performance-configuration.md
@@ -30,14 +30,14 @@ Sometimes, above default values can't meet performance requirements, then you ne
 spec:
   serviceAccountName: tekton-pipelines-controller
   containers:
-  - name: tekton-pipelines-controller
-    image: ko://github.com/tektoncd/pipeline/cmd/controller
-    args: [
-      "-kube-api-qps", "50",
-      "-kube-api-burst", "50",
-      "-threads-per-controller", "32",
-      # other flags defined here...
-    ]
+    - name: tekton-pipelines-controller
+      image: ko://github.com/tektoncd/pipeline/cmd/controller
+      args: [
+          "-kube-api-qps", "50",
+          "-kube-api-burst", "50",
+          "-threads-per-controller", "32",
+          # other flags defined here...
+        ]
 ```
 
 Now, the ThreadsPerController, QPS and Burst have been changed to be `32`, `50` and `50`.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -116,21 +116,21 @@ Below is an example `Task` definition that includes a `Workspace` called `messag
 ```yaml
 spec:
   steps:
-  - name: write-message
-    image: ubuntu
-    script: |
-      #!/usr/bin/env bash
-      set -xe
-      if [ "$(workspaces.messages.bound)" == "true" ] ; then
-        echo hello! > $(workspaces.messages.path)/message
-      fi
+    - name: write-message
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        if [ "$(workspaces.messages.bound)" == "true" ] ; then
+          echo hello! > $(workspaces.messages.path)/message
+        fi
   workspaces:
-  - name: messages
-    description: |
-      The folder where we write the message to. If no workspace
-      is provided then the message will not be written.
-    optional: true
-    mountPath: /custom/path/relative/to/root
+    - name: messages
+      description: |
+        The folder where we write the message to. If no workspace
+        is provided then the message will not be written.
+      optional: true
+      mountPath: /custom/path/relative/to/root
 ```
 
 #### Sharing `Workspaces` with `Sidecars`
@@ -143,24 +143,24 @@ a `ready` file which the `Step` is waiting for:
 ```yaml
 spec:
   workspaces:
-  - name: signals
+    - name: signals
   steps:
-  - image: alpine
-    script: |
-      while [ ! -f "$(workspaces.signals.path)/ready" ]; do
-        echo "Waiting for ready file..."
-        sleep 1
-      done
-      echo "Saw ready file!"
+    - image: alpine
+      script: |
+        while [ ! -f "$(workspaces.signals.path)/ready" ]; do
+          echo "Waiting for ready file..."
+          sleep 1
+        done
+        echo "Saw ready file!"
   sidecars:
-  - image: alpine
-    # Note: must explicitly include volumeMount for the workspace to be accessible in the Sidecar
-    volumeMounts:
-    - name: $(workspaces.signals.volume)
-      mountPath: $(workspaces.signals.path)
-    script: |
-      sleep 3
-      touch "$(workspaces.signals.path)/ready"
+    - image: alpine
+      # Note: must explicitly include volumeMount for the workspace to be accessible in the Sidecar
+      volumeMounts:
+        - name: $(workspaces.signals.volume)
+          mountPath: $(workspaces.signals.path)
+      script: |
+        sleep 3
+        touch "$(workspaces.signals.path)/ready"
 ```
 
 **Note:** `Sidecars` _must_ explicitly opt-in to receiving the `Workspace` volume. Injected `Sidecars` from
@@ -366,14 +366,14 @@ it will be deleted when the `PipelineRun` or `TaskRun` is deleted.
 
 ```yaml
 workspaces:
-- name: myworkspace
-  volumeClaimTemplate:
-    spec:
-      accessModes: 
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi
+  - name: myworkspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
 ```
 
 ##### `persistentVolumeClaim`
@@ -382,10 +382,10 @@ The `persistentVolumeClaim` field references an *existing* [`persistentVolumeCla
 
 ```yaml
 workspaces:
-- name: myworkspace
-  persistentVolumeClaim:
-    claimName: mypvc
-  subPath: my-subdir
+  - name: myworkspace
+    persistentVolumeClaim:
+      claimName: mypvc
+    subPath: my-subdir
 ```
 
 #### Using other types of `VolumeSources`
@@ -398,8 +398,8 @@ However, they work well for single `TaskRuns` where the data stored in the `empt
 
 ```yaml
 workspaces:
-- name: myworkspace
-  emptyDir: {}
+  - name: myworkspace
+    emptyDir: {}
 ```
 
 ##### `configMap`
@@ -413,9 +413,9 @@ Using a `configMap` as a `Workspace` has the following limitations:
 
 ```yaml
 workspaces:
-- name: myworkspace
-  configmap:
-    name: my-configmap
+  - name: myworkspace
+    configmap:
+      name: my-configmap
 ```
 
 ##### `secret`
@@ -429,9 +429,9 @@ Using a `secret` volume has the following limitations:
 
 ```yaml
 workspaces:
-- name: myworkspace
-  secret:
-    secretName: my-secret
+  - name: myworkspace
+    secret:
+      secretName: my-secret
 ```
 
 If you need support for a `VolumeSource` type not listed above, [open an issue](https://github.com/tektoncd/pipeline/issues) or


### PR DESCRIPTION
This PR aims to standardize the formatting of code blocks. Most importantly, it fixes a few cases of invalid indentation.

Most other changes are related to list indentation. 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

While reading the docs, I noticed a couple of issues and inconsistencies within code blocks. I asked myself whether this could be addressed in a somewhat automated manner, e.g. a script scanning files for code blocks and formatting them with something like `prettier`. 

I then wrote said script. It grew a little out of proportion, but it was fun. ([Here it is](https://github.com/eliasnorrby/code-block-formatter/blob/master/format-code-blocks.sh)) 

I realize this may be deemed trivial, but having written the script and all, I thought I'd open this PR anyway. 

## Notable changes:

### Incorrect indentation of collections

**Change**: These issues have been fixed.

Some blocks have incorrect indentation, like this one in `docs/tasks.md` at line 171:

```yaml
spec:
  steps:
  - name: step-with-limts
    resources:
      requests:
        memory: 1Gi
        cpu: 500m
      limits:
->       memory: 2Gi
        cpu: 800m
```

### Inconsistent indentation of lists

**Change**: yaml lists are now indented

Some lists are 2 space indented:

```yaml
- name: flags
  value:
    - "--set"
    - "arg1=foo"
    - "--randomflag"
    - "--someotherflag"
```

Whereas others are 0 space indented:

```yaml
- name: flags
  value:
  - "--set"
  - "arg1=foo"
  - "--randomflag"
  - "--someotherflag"
```

Some blocks even mix the two. I'm not aware of a widespread preference for either. I certainly don't have one - I only wish for consistency. As it turns out, `prettier` prefers indenting lists. In building my formatting script, I would have liked to provide the option to enforce either, but [prettier lacks a configuration option for this](https://github.com/prettier/prettier/issues/4723). I experimented with other means of formatting (i.e. ruamel.yaml) that prefer a 0 space indent, but they proved to cause too many other problems to be viable.


### Indicating excluded lines

I chose to use `# ...` over `...`, since that's still valid `yaml`. That is:

```yaml
- name: flags
  # ...
  value:
  - "--randomflag"
```

over

```yaml
- name: flags
  ...
  value:
  - "--randomflag"
```

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)
