### PR TITLE
Test multiple scripts in one task executing with different UIDs

### DIFF
--- a/examples/v1alpha1/taskruns/step-script.yaml
+++ b/examples/v1alpha1/taskruns/step-script.yaml
@@ -18,6 +18,11 @@ spec:
       env:
       - name: FOO
         value: foooooooo
+      # Test that Pods with containers run as different UIDs
+      # are able to run scripts regardless of any specific
+      # Step's UID.
+      securityContext:
+        runAsUser: 2000
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail
@@ -30,6 +35,8 @@ spec:
 
     - name: place-file
       image: ubuntu
+      securityContext:
+        runAsUser: 8000
       script: |
         #!/usr/bin/env bash
         echo "echo Hello from script file" > /workspace/hello
@@ -42,6 +49,8 @@ spec:
 
     - name: contains-eof
       image: ubuntu
+      securityContext:
+        runAsUser: 16000
       script: |
         #!/usr/bin/env bash
         cat > file << EOF

--- a/examples/v1beta1/taskruns/step-script.yaml
+++ b/examples/v1beta1/taskruns/step-script.yaml
@@ -17,6 +17,11 @@ spec:
       env:
       - name: FOO
         value: foooooooo
+      # Test that Pods with containers run as different UIDs
+      # are able to run scripts regardless of any specific
+      # Step's UID.
+      securityContext:
+        runAsUser: 2000
       script: |
         #!/usr/bin/env bash
         set -euxo pipefail
@@ -29,6 +34,8 @@ spec:
 
     - name: place-file
       image: ubuntu
+      securityContext:
+        runAsUser: 8000
       script: |
         #!/usr/bin/env bash
         echo "echo Hello from script file" > /workspace/hello
@@ -41,6 +48,8 @@ spec:
 
     - name: contains-eof
       image: ubuntu
+      securityContext:
+        runAsUser: 16000
       script: |
         #!/usr/bin/env bash
         cat > file << EOF


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit we weren't testing whether scripts were executable
when UIDs differed from Step to Step in a single Task.

This commit updates the step-script examples to vary the UID of each
Step. A failure of one of these would indicate a regression has
been introduced in the permissions of the shell scripts that Tekton
generates and places in the /tekton/scripts directory.

I added this test originally in https://github.com/tektoncd/pipeline/pull/3888
to determine whether changing the script implementation
was introducing incorrect behaviour.

/kind testing

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Added test for running Scripts with differing securityContexts in the same Task.
```