### PR TITLE
Graceful Pipeline Run Termination

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -561,8 +561,9 @@ Task Runs:
 ## Cancelling a `PipelineRun`
 
 To cancel a `PipelineRun` that's currently executing, update its definition
-to mark it as cancelled. When you do so, the spawned `TaskRuns` are also marked
-as cancelled and all associated `Pods` are deleted. For example:
+to mark it as "PipelineRunCancelled". When you do so, the spawned `TaskRuns` are also marked
+as cancelled and all associated `Pods` are deleted. Pending final tasks are not scheduled. 
+For example:
 
 ```yaml
 apiVersion: tekton.dev/v1beta1
@@ -572,6 +573,46 @@ metadata:
 spec:
   # […]
   status: "PipelineRunCancelled"
+```
+
+Warning: "PipelineRunCancelled" status is deprecated and would be removed in V1, please use "Cancelled" instead.  
+
+## Gracefully cancelling a `PipelineRun`
+
+[Graceful pipeline run termination](https://github.com/tektoncd/community/blob/main/teps/0058-graceful-pipeline-run-termination.md)
+is currently an **_alpha feature_**.
+
+To gracefully cancel a `PipelineRun` that's currently executing, update its definition
+to mark it as "CancelledRunFinally". When you do so, the spawned `TaskRuns` are also marked
+as cancelled and all associated `Pods` are deleted. Final tasks are scheduled normally. 
+For example:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "CancelledRunFinally"
+```
+
+
+## Gracefully stopping a `PipelineRun`
+
+To gracefully stop a `PipelineRun` that's currently executing, update its definition
+to mark it as "StoppedRunFinally". When you do so, the spawned `TaskRuns` are completed normally,
+but no new non-final task is scheduled. Final tasks are executed afterwards.
+For example:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: go-example-git
+spec:
+  # […]
+  status: "StoppedRunFinally"
 ```
 
 ## Pending `PipelineRuns`

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containerd/containerd v1.3.0 h1:xjvXQWABwS2uiv3TWgQt5Uth60Gu86LTGZXMJkjc7rY=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/stargz-snapshotter/estargz v0.0.0-20201223015020-a9a0c2d64694 h1:OVQ4FVXeE6OjzuUifzER+7EulqTqw/94oKSqnooEowQ=
 github.com/containerd/stargz-snapshotter/estargz v0.0.0-20201223015020-a9a0c2d64694/go.mod h1:E9uVkkBKf0EaC39j2JVW9EzdNhYvpz6eQIjILHebruk=
@@ -192,8 +193,10 @@ github.com/docker/docker v20.10.2+incompatible h1:vFgEHPqWBTp4pTjdLwjAA4bSo3gvIG
 github.com/docker/docker v20.10.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -410,6 +413,7 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -538,6 +542,7 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/term v0.0.0-20200312100748-672ec06f55cd h1:aY7OQNf2XqY/JQ6qREWamhI/81os/agb2BAGpcx5yWI=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
@@ -545,6 +550,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
 github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
@@ -696,6 +702,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/internal/builder/v1beta1/pipeline.go
+++ b/internal/builder/v1beta1/pipeline.go
@@ -115,12 +115,27 @@ func PipelineDescription(desc string) PipelineSpecOp {
 	}
 }
 
-// PipelineRunCancelled sets the status to cancel the PipelineRunSpec.
+// PipelineRunCancelled sets the status to Cancelled in the PipelineRunSpec.
 func PipelineRunCancelled(spec *v1beta1.PipelineRunSpec) {
 	spec.Status = v1beta1.PipelineRunSpecStatusCancelled
 }
 
-// PipelineRunPending sets the status to pending to the PipelineRunSpec.
+// PipelineRunCancelledDeprecated sets the status to PipelineRunCancelled in the PipelineRunSpec.
+func PipelineRunCancelledDeprecated(spec *v1beta1.PipelineRunSpec) {
+	spec.Status = v1beta1.PipelineRunSpecStatusCancelledDeprecated
+}
+
+// PipelineRunCancelledRunFinally sets the status to cancel and run finally in the PipelineRunSpec.
+func PipelineRunCancelledRunFinally(spec *v1beta1.PipelineRunSpec) {
+	spec.Status = v1beta1.PipelineRunSpecStatusCancelledRunFinally
+}
+
+// PipelineRunStoppedRunFinally sets the status to stop and run finally in the PipelineRunSpec.
+func PipelineRunStoppedRunFinally(spec *v1beta1.PipelineRunSpec) {
+	spec.Status = v1beta1.PipelineRunSpecStatusStoppedRunFinally
+}
+
+// PipelineRunPending sets the status to pending in the PipelineRunSpec.
 func PipelineRunPending(spec *v1beta1.PipelineRunSpec) {
 	spec.Status = v1beta1.PipelineRunSpecStatusPending
 }

--- a/internal/builder/v1beta1/pipeline_test.go
+++ b/internal/builder/v1beta1/pipeline_test.go
@@ -469,6 +469,69 @@ func TestPipelineRunWithFinalTask(t *testing.T) {
 	}
 }
 
+func TestPipelineRunCancelled(t *testing.T) {
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunSpec("pears", tb.PipelineRunCancelled))
+
+	expectedPipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "pears"},
+			Status:      v1beta1.PipelineRunSpecStatusCancelled,
+			Timeout:     &metav1.Duration{Duration: 1 * time.Hour},
+		},
+	}
+
+	if diff := cmp.Diff(expectedPipelineRun, pipelineRun); diff != "" {
+		t.Fatalf("PipelineRun diff -want, +got: %s", diff)
+	}
+}
+
+func TestPipelineRunCancelledRunFinally(t *testing.T) {
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunSpec("pears", tb.PipelineRunCancelledRunFinally))
+
+	expectedPipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "pears"},
+			Status:      v1beta1.PipelineRunSpecStatusCancelledRunFinally,
+			Timeout:     &metav1.Duration{Duration: 1 * time.Hour},
+		},
+	}
+
+	if diff := cmp.Diff(expectedPipelineRun, pipelineRun); diff != "" {
+		t.Fatalf("PipelineRun diff -want, +got: %s", diff)
+	}
+}
+
+func TestPipelineRunStoppedRunFinally(t *testing.T) {
+	pipelineRun := tb.PipelineRun("pear", tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunSpec("pears", tb.PipelineRunStoppedRunFinally))
+
+	expectedPipelineRun := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pear",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "pears"},
+			Status:      v1beta1.PipelineRunSpecStatusStoppedRunFinally,
+			Timeout:     &metav1.Duration{Duration: 1 * time.Hour},
+		},
+	}
+
+	if diff := cmp.Diff(expectedPipelineRun, pipelineRun); diff != "" {
+		t.Fatalf("PipelineRun diff -want, +got: %s", diff)
+	}
+}
+
 func getTaskSpec() v1beta1.TaskSpec {
 	return v1beta1.TaskSpec{
 		Steps: []v1beta1.Step{{Container: corev1.Container{

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -101,7 +101,7 @@ type PipelineRunSpecStatus = v1beta1.PipelineRunSpecStatus
 const (
 	// PipelineRunSpecStatusCancelled indicates that the user wants to cancel the task,
 	// if not already cancelled or terminated
-	PipelineRunSpecStatusCancelled = v1beta1.PipelineRunSpecStatusCancelled
+	PipelineRunSpecStatusCancelled = v1beta1.PipelineRunSpecStatusCancelledDeprecated
 )
 
 // PipelineResourceRef can be used to refer to a specific instance of a Resource

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -135,6 +135,28 @@ func TestPipelineRunIsCancelled(t *testing.T) {
 	}
 }
 
+func TestPipelineRunIsGracefullyCancelled(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		Spec: v1beta1.PipelineRunSpec{
+			Status: v1beta1.PipelineRunSpecStatusCancelledRunFinally,
+		},
+	}
+	if !pr.IsGracefullyCancelled() {
+		t.Fatal("Expected pipelinerun status to be gracefully cancelled")
+	}
+}
+
+func TestPipelineRunIsGracefullyStopped(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		Spec: v1beta1.PipelineRunSpec{
+			Status: v1beta1.PipelineRunSpecStatusStoppedRunFinally,
+		},
+	}
+	if !pr.IsGracefullyStopped() {
+		t.Fatal("Expected pipelinerun status to be gracefully stopped")
+	}
+}
+
 func TestPipelineRunHasVolumeClaimTemplate(t *testing.T) {
 	pr := &v1beta1.PipelineRun{
 		Spec: v1beta1.PipelineRunSpec{

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -59,6 +59,39 @@ func init() {
 
 // cancelPipelineRun marks the PipelineRun as cancelled and any resolved TaskRun(s) too.
 func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface) error {
+	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
+
+	// If we successfully cancelled all the TaskRuns and Runs, we can consider the PipelineRun cancelled.
+	if len(errs) == 0 {
+		reason := ReasonCancelled
+		if pr.Spec.Status == v1beta1.PipelineRunSpecStatusCancelledDeprecated {
+			reason = ReasonCancelledDeprecated
+		}
+
+		pr.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  reason,
+			Message: fmt.Sprintf("PipelineRun %q was cancelled", pr.Name),
+		})
+		// update pr completed time
+		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	} else {
+		e := strings.Join(errs, "\n")
+		// Indicate that we failed to cancel the PipelineRun
+		pr.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  ReasonCouldntCancel,
+			Message: fmt.Sprintf("PipelineRun %q was cancelled but had errors trying to cancel TaskRuns and/or Runs: %s", pr.Name, e),
+		})
+		return fmt.Errorf("error(s) from cancelling TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+	}
+	return nil
+}
+
+// cancelPipelineTaskRuns patches `TaskRun` and `Run` with canceled status
+func cancelPipelineTaskRuns(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface) []string {
 	errs := []string{}
 
 	// Loop over the TaskRuns in the PipelineRun status.
@@ -80,17 +113,16 @@ func cancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1bet
 			continue
 		}
 	}
-	// If we successfully cancelled all the TaskRuns and Runs, we can consider the PipelineRun cancelled.
-	if len(errs) == 0 {
-		pr.Status.SetCondition(&apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionFalse,
-			Reason:  ReasonCancelled,
-			Message: fmt.Sprintf("PipelineRun %q was cancelled", pr.Name),
-		})
-		// update pr completed time
-		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
-	} else {
+
+	return errs
+}
+
+// gracefullyCancelPipelineRun marks any non-final resolved TaskRun(s) as cancelled and runs finally.
+func gracefullyCancelPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface) error {
+	errs := cancelPipelineTaskRuns(ctx, logger, pr, clientSet)
+
+	// If we successfully cancelled all the TaskRuns and Runs, we can proceed with the PipelineRun reconciliation to trigger finally.
+	if len(errs) > 0 {
 		e := strings.Join(errs, "\n")
 		// Indicate that we failed to cancel the PipelineRun
 		pr.Status.SetCondition(&apis.Condition{

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -95,6 +95,14 @@ func TestCancelPipelineRun(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
 		},
+	}, {
+		name: "deprecated-state",
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
+			Spec: v1beta1.PipelineRunSpec{
+				Status: v1beta1.PipelineRunSpecStatusCancelledDeprecated,
+			},
+		},
 	}}
 	for _, tc := range testCases {
 		tc := tc

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -79,6 +79,20 @@ func (t ResolvedPipelineRunTask) IsDone(facts *PipelineRunFacts) bool {
 	return t.Skip(facts) || t.IsSuccessful() || t.IsFailure()
 }
 
+// IsRunning returns true only if the task is neither succeeded, cancelled nor failed
+func (t ResolvedPipelineRunTask) IsRunning() bool {
+	if t.IsCustomTask() {
+		if t.Run == nil {
+			return false
+		}
+	} else {
+		if t.TaskRun == nil {
+			return false
+		}
+	}
+	return !t.IsSuccessful() && !t.IsFailure() && !t.IsCancelled()
+}
+
 // IsCustomTask returns true if the PipelineTask references a Custom Task.
 func (t ResolvedPipelineRunTask) IsCustomTask() bool {
 	return t.CustomTask
@@ -163,7 +177,8 @@ func (t *ResolvedPipelineRunTask) skip(facts *PipelineRunFacts) bool {
 		return false
 	}
 
-	if t.conditionsSkip() || t.whenExpressionsSkip(facts) || t.parentTasksSkip(facts) || facts.IsStopping() {
+	if t.conditionsSkip() || t.whenExpressionsSkip(facts) || t.parentTasksSkip(facts) ||
+		facts.IsStopping() || facts.IsGracefullyCancelled() || facts.IsGracefullyStopped() {
 		return true
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1008,7 +1008,13 @@ func TestIsSkipped(t *testing.T) {
 	}
 }
 
-func getExpectedMessage(status corev1.ConditionStatus, successful, incomplete, skipped, failed, cancelled int) string {
+func getExpectedMessage(runName string, specStatus v1beta1.PipelineRunSpecStatus, status corev1.ConditionStatus,
+	successful, incomplete, skipped, failed, cancelled int) string {
+	if status == corev1.ConditionFalse &&
+		(specStatus == v1beta1.PipelineRunSpecStatusCancelledRunFinally ||
+			specStatus == v1beta1.PipelineRunSpecStatusStoppedRunFinally) {
+		return fmt.Sprintf("PipelineRun %q was cancelled", runName)
+	}
 	if status == corev1.ConditionFalse || status == corev1.ConditionTrue {
 		return fmt.Sprintf("Tasks Completed: %d (Failed: %d, Cancelled %d), Skipped: %d",
 			successful+failed+cancelled, failed, cancelled, skipped)

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -42,140 +42,154 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 	// the retrying TaskRun to retry.
 	for _, numRetries := range []int{0, 1} {
 		numRetries := numRetries // capture range variable
-		t.Run(fmt.Sprintf("retries=%d", numRetries), func(t *testing.T) {
-			ctx := context.Background()
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			c, namespace := setup(ctx, t)
-			t.Parallel()
+		for _, specStatus := range []string{v1beta1.PipelineRunSpecStatusCancelledDeprecated, v1beta1.PipelineRunSpecStatusCancelled} {
+			specStatus := specStatus // capture status variable
+			t.Run(fmt.Sprintf("retries=%d,status=%s", numRetries, specStatus), func(t *testing.T) {
+				ctx := context.Background()
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				requirements := []func(context.Context, *testing.T, *clients, string){}
+				if specStatus == v1beta1.PipelineRunSpecStatusCancelled {
+					requirements = append(requirements, requireAnyGate(map[string]string{
+						"enable-api-fields": "alpha",
+					}))
+				}
+				c, namespace := setup(ctx, t, requirements...)
+				t.Parallel()
 
-			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
-			defer tearDown(ctx, t, c, namespace)
+				knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
+				defer tearDown(ctx, t, c, namespace)
 
-			pipelineRun := &v1beta1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{Name: helpers.ObjectNameForTest(t), Namespace: namespace},
-				Spec: v1beta1.PipelineRunSpec{
-					PipelineSpec: &v1beta1.PipelineSpec{
-						Tasks: []v1beta1.PipelineTask{{
-							Name:    "task",
-							Retries: numRetries,
-							TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
-								Steps: []v1beta1.Step{{
-									Container: corev1.Container{
-										Image: "busybox",
-									},
-									Script: "sleep 5000",
+				pipelineRun := &v1beta1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{Name: helpers.ObjectNameForTest(t), Namespace: namespace},
+					Spec: v1beta1.PipelineRunSpec{
+						PipelineSpec: &v1beta1.PipelineSpec{
+							Tasks: []v1beta1.PipelineTask{{
+								Name:    "task",
+								Retries: numRetries,
+								TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+									Steps: []v1beta1.Step{{
+										Container: corev1.Container{
+											Image: "busybox",
+										},
+										Script: "sleep 5000",
+									}},
 								}},
 							}},
-						}},
+						},
 					},
-				},
-			}
-
-			t.Logf("Creating PipelineRun in namespace %s", namespace)
-			if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
-			}
-
-			t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
-			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
-				t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
-			}
-
-			taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
-			if err != nil {
-				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
-			}
-
-			var wg sync.WaitGroup
-			t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRun.Name, namespace)
-			for _, taskrunItem := range taskrunList.Items {
-				wg.Add(1)
-				go func(name string) {
-					defer wg.Done()
-					err := WaitForTaskRunState(ctx, c, name, Running(name), "TaskRunRunning")
-					if err != nil {
-						t.Errorf("Error waiting for TaskRun %s to be running: %v", name, err)
-					}
-				}(taskrunItem.Name)
-			}
-			wg.Wait()
-
-			pr, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
-			if err != nil {
-				t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
-			}
-
-			patches := []jsonpatch.JsonPatchOperation{{
-				Operation: "add",
-				Path:      "/spec/status",
-				Value:     v1beta1.PipelineRunSpecStatusCancelled,
-			}}
-			patchBytes, err := json.Marshal(patches)
-			if err != nil {
-				t.Fatalf("failed to marshal patch bytes in order to cancel")
-			}
-			if _, err := c.PipelineRunClient.Patch(ctx, pr.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
-				t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRun.Name, err)
-			}
-
-			t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
-			if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, FailedWithReason("PipelineRunCancelled", pipelineRun.Name), "PipelineRunCancelled"); err != nil {
-				t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRun.Name, err)
-			}
-
-			t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
-			for _, taskrunItem := range taskrunList.Items {
-				wg.Add(1)
-				go func(name string) {
-					defer wg.Done()
-					err := WaitForTaskRunState(ctx, c, name, FailedWithReason("TaskRunCancelled", name), "TaskRunCancelled")
-					if err != nil {
-						t.Errorf("Error waiting for TaskRun %s to be finished: %v", name, err)
-					}
-				}(taskrunItem.Name)
-			}
-			wg.Wait()
-
-			var trName []string
-			taskrunList, err = c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
-			if err != nil {
-				t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
-			}
-			for _, taskrunItem := range taskrunList.Items {
-				trName = append(trName, taskrunItem.Name)
-			}
-
-			matchKinds := map[string][]string{"PipelineRun": {pipelineRun.Name}}
-			// Expected failure events: 1 for the pipelinerun cancel
-			expectedNumberOfEvents := 1
-			t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)
-			events, err := collectMatchingEvents(ctx, c.KubeClient, namespace, matchKinds, "Failed")
-			if err != nil {
-				t.Fatalf("Failed to collect matching events: %q", err)
-			}
-			if len(events) < expectedNumberOfEvents {
-				collectedEvents := make([]string, 0, len(events))
-				for _, event := range events {
-					collectedEvents = append(collectedEvents, fmt.Sprintf("%#v", event))
 				}
-				t.Fatalf("Expected %d number of failed events from pipelinerun but got %d; list of received events : %s", expectedNumberOfEvents, len(events), strings.Join(collectedEvents, ", "))
-			}
-			matchKinds = map[string][]string{"TaskRun": trName}
-			// Expected failure events: 1 for each TaskRun
-			expectedNumberOfEvents = len(trName)
-			t.Logf("Making sure %d events were created from taskruns with kinds %v", expectedNumberOfEvents, matchKinds)
-			events, err = collectMatchingEvents(ctx, c.KubeClient, namespace, matchKinds, "Failed")
-			if err != nil {
-				t.Fatalf("Failed to collect matching events: %q", err)
-			}
-			if len(events) < expectedNumberOfEvents {
-				collectedEvents := make([]string, 0, len(events))
-				for _, event := range events {
-					collectedEvents = append(collectedEvents, fmt.Sprintf("%#v", event))
+
+				t.Logf("Creating PipelineRun in namespace %s", namespace)
+				if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 				}
-				t.Fatalf("Expected %d number of failed events from taskrun but got %d; list of received events : %s", expectedNumberOfEvents, len(events), strings.Join(collectedEvents, ", "))
-			}
-		})
+
+				t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
+				if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+					t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
+				}
+
+				taskrunList, err := c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+				if err != nil {
+					t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
+				}
+
+				var wg sync.WaitGroup
+				t.Logf("Waiting for TaskRuns from PipelineRun %s in namespace %s to be running", pipelineRun.Name, namespace)
+				for _, taskrunItem := range taskrunList.Items {
+					wg.Add(1)
+					go func(name string) {
+						defer wg.Done()
+						err := WaitForTaskRunState(ctx, c, name, Running(name), "TaskRunRunning")
+						if err != nil {
+							t.Errorf("Error waiting for TaskRun %s to be running: %v", name, err)
+						}
+					}(taskrunItem.Name)
+				}
+				wg.Wait()
+
+				pr, err := c.PipelineRunClient.Get(ctx, pipelineRun.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get PipelineRun `%s`: %s", pipelineRun.Name, err)
+				}
+
+				patches := []jsonpatch.JsonPatchOperation{{
+					Operation: "add",
+					Path:      "/spec/status",
+					Value:     specStatus,
+				}}
+				patchBytes, err := json.Marshal(patches)
+				if err != nil {
+					t.Fatalf("failed to marshal patch bytes in order to cancel")
+				}
+				if _, err := c.PipelineRunClient.Patch(ctx, pr.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}, ""); err != nil {
+					t.Fatalf("Failed to patch PipelineRun `%s` with cancellation: %s", pipelineRun.Name, err)
+				}
+
+				expectedReason := v1beta1.PipelineRunReasonCancelled.String()
+				if specStatus == v1beta1.PipelineRunSpecStatusCancelledDeprecated {
+					expectedReason = "PipelineRunCancelled"
+				}
+				expectedCondition := FailedWithReason(expectedReason, pipelineRun.Name)
+				t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
+				if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, expectedCondition, expectedReason); err != nil {
+					t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRun.Name, err)
+				}
+
+				t.Logf("Waiting for TaskRuns in PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
+				for _, taskrunItem := range taskrunList.Items {
+					wg.Add(1)
+					go func(name string) {
+						defer wg.Done()
+						err := WaitForTaskRunState(ctx, c, name, FailedWithReason("TaskRunCancelled", name), "TaskRunCancelled")
+						if err != nil {
+							t.Errorf("Error waiting for TaskRun %s to be finished: %v", name, err)
+						}
+					}(taskrunItem.Name)
+				}
+				wg.Wait()
+
+				var trName []string
+				taskrunList, err = c.TaskRunClient.List(ctx, metav1.ListOptions{LabelSelector: "tekton.dev/pipelineRun=" + pipelineRun.Name})
+				if err != nil {
+					t.Fatalf("Error listing TaskRuns for PipelineRun %s: %s", pipelineRun.Name, err)
+				}
+				for _, taskrunItem := range taskrunList.Items {
+					trName = append(trName, taskrunItem.Name)
+				}
+
+				matchKinds := map[string][]string{"PipelineRun": {pipelineRun.Name}}
+				// Expected failure events: 1 for the pipelinerun cancel
+				expectedNumberOfEvents := 1
+				t.Logf("Making sure %d events were created from pipelinerun with kinds %v", expectedNumberOfEvents, matchKinds)
+				events, err := collectMatchingEvents(ctx, c.KubeClient, namespace, matchKinds, "Failed")
+				if err != nil {
+					t.Fatalf("Failed to collect matching events: %q", err)
+				}
+				if len(events) < expectedNumberOfEvents {
+					collectedEvents := make([]string, 0, len(events))
+					for _, event := range events {
+						collectedEvents = append(collectedEvents, fmt.Sprintf("%#v", event))
+					}
+					t.Fatalf("Expected %d number of failed events from pipelinerun but got %d; list of received events : %s", expectedNumberOfEvents, len(events), strings.Join(collectedEvents, ", "))
+				}
+				matchKinds = map[string][]string{"TaskRun": trName}
+				// Expected failure events: 1 for each TaskRun
+				expectedNumberOfEvents = len(trName)
+				t.Logf("Making sure %d events were created from taskruns with kinds %v", expectedNumberOfEvents, matchKinds)
+				events, err = collectMatchingEvents(ctx, c.KubeClient, namespace, matchKinds, "Failed")
+				if err != nil {
+					t.Fatalf("Failed to collect matching events: %q", err)
+				}
+				if len(events) < expectedNumberOfEvents {
+					collectedEvents := make([]string, 0, len(events))
+					for _, event := range events {
+						collectedEvents = append(collectedEvents, fmt.Sprintf("%#v", event))
+					}
+					t.Fatalf("Expected %d number of failed events from taskrun but got %d; list of received events : %s", expectedNumberOfEvents, len(events), strings.Join(collectedEvents, ", "))
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
The implementation of TEP-0058: Graceful Pipeline Run Termination.

The new `spec.Status` values:

- `StoppedRunFinally` - To "stop" (i.e. let the tasks complete, then execute finally tasks) a Pipeline
- `CancelledRunFinally` - To "cancel" (i.e. interrupt any executing non finally tasks, then execute finally tasks)
- `Cancelled` - Same as today's `PipelineRunCancelled` - i.e. interrupt any executing tasks without running finally tasks

`PipelineRunCancelled` is deprecated (replaced by `Cancelled`)

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
# The new PipelineRun spec statuses have been added to control the way who a PipelineRun is being canceled or stopped.

- "StoppedRunFinally" - To stop (i.e. let the tasks complete, then execute finally tasks) a PipelineRun
- "CancelledRunFinally" - To cancel (i.e. interrupt any executing non finally tasks, then execute finally tasks)
- "Cancelled" - replaces today's "PipelineRunCancelled" - i.e. interrupt any executing tasks without running finally tasks

Support for existing statuses has been left unchanged.

The status "PipelineRunCancelled" is deprecated and replaced by "Cancelled" (it would be removed in v1).

The new states are released as alpha API features.

[1] https://github.com/tektoncd/community/blob/main/teps/0058-graceful-pipeline-run-termination.md
```
