### PR TITLE
Add "alpha" feature gate tests (integration & examples) to our CI

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -186,8 +186,12 @@ spec:
       touch "$(workspaces.signals.path)/ready"
 ```
 
-**Note:** `Sidecars` _must_ explicitly opt-in to receiving the `Workspace` volume. Injected `Sidecars` from
-non-Tekton sources will not receive access to `Workspaces`.
+**Note:** Starting in Pipelines v0.24.0 `Sidecars` automatically get access to `Workspaces`.This is an
+alpha feature and requires Pipelines to have [the "alpha" feature gate enabled](./install.md#alpha-features).
+
+If a Sidecar already has a `volumeMount` at the location expected for a `workspace` then that `workspace` is
+not bound to the Sidecar. This preserves backwards-compatibility with any existing uses of the `volumeMount`
+trick described above.
 
 #### Isolating `Workspaces` to Specific `Steps` or `Sidecars`
 

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -158,8 +158,7 @@ func mountAsSharedWorkspace(ts v1beta1.TaskSpec, volumeMount corev1.VolumeMount)
 	ts.StepTemplate.VolumeMounts = append(ts.StepTemplate.VolumeMounts, volumeMount)
 
 	for i := range ts.Sidecars {
-		sidecar := &ts.Sidecars[i]
-		sidecar.VolumeMounts = append(sidecar.VolumeMounts, volumeMount)
+		AddSidecarVolumeMount(&ts.Sidecars[i], volumeMount)
 	}
 }
 
@@ -192,4 +191,15 @@ func mountAsIsolatedWorkspace(ts v1beta1.TaskSpec, workspaceName string, volumeM
 			}
 		}
 	}
+}
+
+// AddSidecarVolumeMount is a helper to add a volumeMount to the sidecar unless its
+// MountPath would conflict with another of the sidecar's existing volume mounts.
+func AddSidecarVolumeMount(sidecar *v1beta1.Sidecar, volumeMount corev1.VolumeMount) {
+	for j := range sidecar.VolumeMounts {
+		if sidecar.VolumeMounts[j].MountPath == volumeMount.MountPath {
+			return
+		}
+	}
+	sidecar.VolumeMounts = append(sidecar.VolumeMounts, volumeMount)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3896

Prior to this commit the integration tests run against PRs were only those for "stable" features.

This PR adds additional integration test runs for "alpha" features as well. `test/e2e-scripts.sh` now patches the feature-flags ConfigMap before executing integration tests and examples tests, first with "enable-api-fields: stable" and then with "enable-api-fields: alpha".

As part of switching on alpha tests two issues have also been fixed with alpha features:

1. Sidecar workspaces could collide with existing volumeMounts attached
    to the sidecar if the mountpath of the workspace matched an existing
    volumeMount. This has been fixed by preventing the additional workspace
    volumeMount if one already exists at that mountpath.

2. Tekton bundles integration tests needed to be updated to account
    for validation errors that are returned when a bundle is invalid.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Pipelines now e2e tests every commit against both the "stable" and "alpha" feature gates.
```