### PR TITLE
Remove field name from error returned during feature gate validation

### DIFF
--- a/pkg/apis/pipeline/v1beta1/version_validation.go
+++ b/pkg/apis/pipeline/v1beta1/version_validation.go
@@ -32,7 +32,7 @@ func ValidateEnabledAPIFields(ctx context.Context, featureName, wantVersion stri
 	if currentVersion != wantVersion {
 		var errs *apis.FieldError
 		message := fmt.Sprintf(`%s requires "enable-api-fields" feature gate to be %q but it is %q`, featureName, wantVersion, currentVersion)
-		return errs.Also(apis.ErrGeneric(message, "workspaces"))
+		return errs.Also(apis.ErrGeneric(message))
 	}
 	var errs *apis.FieldError = nil
 	return errs


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


Prior to this commit the feature gate validation returned a validation error
with its field path set to "workspaces". This isn't correct - the validation
can guard any field.

This commit removes the "workspaces" field path from the validation error
returned by the feature gate validation.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

/kind misc