### PR TITLE
Disable gocritic in pipelines

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
   - gofmt
   - goimports
   - gosec
-  - gocritic
   - golint
   - misspell
 output:


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The test-runner docker image from plumbing now includes a newer version
of golangci-lint (1.39.0) which apparently switched on or changed some gocritic
configuration *somewhere*.

There are a _lot_ of syntax issues in pipelines that gocritic does not like,
including many in the generated code of `pkg/client`. Rather than hand-edit
everything or figure out all the flags required to disable the features this
commit simply disables gocritic so that PRs can get moving again.

We can re-enable it once we figure out what the necessary flags are to get
it working (or we fix all the syntax issues).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
