### PR TITLE
Fix lint issues

### DIFF
--- a/cmd/entrypoint/namespaces.go
+++ b/cmd/entrypoint/namespaces.go
@@ -6,6 +6,6 @@ import "os/exec"
 
 // The implementation of this currently only works on Linux.
 // This is a placeholder for compilation/testing.
-func dropNetworking(cmd *exec.Cmd) {
+func dropNetworking(cmd *exec.Cmd) { //nolint:deadcode
 	panic("only implemented on linux")
 }

--- a/cmd/kubeconfigwriter/main.go
+++ b/cmd/kubeconfigwriter/main.go
@@ -70,7 +70,7 @@ func createKubeconfigFile(resource *cluster.Resource, logger *zap.SugaredLogger,
 	if passwordFromEnv := os.Getenv("PASSWORD"); passwordFromEnv != "" {
 		resource.Password = passwordFromEnv
 	}
-	//only one authentication technique per user is allowed in a kubeconfig, so clear out the password if a token is provided
+	// only one authentication technique per user is allowed in a kubeconfig, so clear out the password if a token is provided
 	user := resource.Username
 	pass := resource.Password
 	clientKeyData := resource.ClientKeyData

--- a/hack/spec-gen/main.go
+++ b/hack/spec-gen/main.go
@@ -66,14 +66,14 @@ func main() {
 }
 
 func swaggify(name string) string {
-	name = strings.Replace(name, "./pkg/apis/pipeline/", "", -1)
-	name = strings.Replace(name, "./pkg/apis/resource/", "", -1)
-	name = strings.Replace(name, "github.com/tektoncd/pipeline/pkg/apis/pipeline/", "", -1)
-	name = strings.Replace(name, "github.com/tektoncd/pipeline/pkg/apis/resource/", "", -1)
-	name = strings.Replace(name, "k8s.io/api/core/", "", -1)
-	name = strings.Replace(name, "k8s.io/apimachinery/pkg/apis/meta/", "", -1)
-	name = strings.Replace(name, "knative.dev/pkg/apis.", "knative/", -1)
-	name = strings.Replace(name, "knative.dev/pkg/apis/duck/v1beta1.", "knative/", -1)
-	name = strings.Replace(name, "/", ".", -1)
+	name = strings.ReplaceAll(name, "./pkg/apis/pipeline/", "")
+	name = strings.ReplaceAll(name, "./pkg/apis/resource/", "")
+	name = strings.ReplaceAll(name, "github.com/tektoncd/pipeline/pkg/apis/pipeline/", "")
+	name = strings.ReplaceAll(name, "github.com/tektoncd/pipeline/pkg/apis/resource/", "")
+	name = strings.ReplaceAll(name, "k8s.io/api/core/", "")
+	name = strings.ReplaceAll(name, "k8s.io/apimachinery/pkg/apis/meta/", "")
+	name = strings.ReplaceAll(name, "knative.dev/pkg/apis.", "knative/")
+	name = strings.ReplaceAll(name, "knative.dev/pkg/apis/duck/v1beta1.", "knative/")
+	name = strings.ReplaceAll(name, "/", ".")
 	return name
 }

--- a/pkg/apis/resource/v1alpha1/cluster/cluster_resource.go
+++ b/pkg/apis/resource/v1alpha1/cluster/cluster_resource.go
@@ -54,7 +54,7 @@ type Resource struct {
 	ClientKeyData []byte `json:"clientKeyData"`
 	// ClientCertificateData contains PEM-encoded data from a client cert file for TLS.
 	ClientCertificateData []byte `json:"clientCertificateData"`
-	//Secrets holds a struct to indicate a field name and corresponding secret name to populate it
+	// Secrets holds a struct to indicate a field name and corresponding secret name to populate it
 	Secrets []resource.SecretParam `json:"secrets"`
 
 	KubeconfigWriterImage string `json:"-"`

--- a/pkg/apis/resource/v1alpha1/git/git_resource.go
+++ b/pkg/apis/resource/v1alpha1/git/git_resource.go
@@ -39,7 +39,7 @@ type Resource struct {
 	Type resource.PipelineResourceType `json:"type"`
 	URL  string                        `json:"url"`
 	// Git revision (branch, tag, commit SHA) to clone, and optionally the refspec to fetch from.
-	//See https://git-scm.com/docs/gitrevisions#_specifying_revisions for more information.
+	// See https://git-scm.com/docs/gitrevisions#_specifying_revisions for more information.
 	Revision   string `json:"revision"`
 	Refspec    string `json:"refspec"`
 	Submodules bool   `json:"submodules"`

--- a/pkg/apis/resource/v1alpha1/storage/gcs.go
+++ b/pkg/apis/resource/v1alpha1/storage/gcs.go
@@ -45,7 +45,7 @@ type GCSResource struct {
 	Type     resourcev1alpha1.PipelineResourceType `json:"type"`
 	Location string                                `json:"location"`
 	TypeDir  bool                                  `json:"typeDir"`
-	//Secret holds a struct to indicate a field name and corresponding secret name to populate it
+	// Secret holds a struct to indicate a field name and corresponding secret name to populate it
 	Secrets []resourcev1alpha1.SecretParam `json:"secrets"`
 
 	ShellImage  string `json:"-"`

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -30,7 +30,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//RFC3339 with millisecond
+// RFC3339 with millisecond
 const (
 	timeFormat = "2006-01-02T15:04:05.000Z07:00"
 )

--- a/pkg/jsonpath/expand_test.go
+++ b/pkg/jsonpath/expand_test.go
@@ -254,12 +254,12 @@ func TestContainerEnvMapping(t *testing.T) {
 		{
 			name:     "nested var references",
 			input:    "$(VAR_A$(VAR_B))",
-			expected: expectedError, //"$(VAR_A$(VAR_B))" -- in Tekton this is a bad JSONPath expression
+			expected: expectedError, // "$(VAR_A$(VAR_B))" -- in Tekton this is a bad JSONPath expression
 		},
 		{
 			name:     "nested var references second type",
 			input:    "$(VAR_A$(VAR_B)",
-			expected: "$(VAR_AB", //"$(VAR_A$(VAR_B)"
+			expected: "$(VAR_AB", // "$(VAR_A$(VAR_B)"
 		},
 		{
 			name:     "value is a reference",
@@ -299,7 +299,7 @@ func TestContainerEnvMapping(t *testing.T) {
 		{
 			name:     "undefined vars are passed through",
 			input:    "$(VAR_DNE)",
-			expected: expectedError, //"$(VAR_DNE)" -- in Tekton a missing key is an error
+			expected: expectedError, // "$(VAR_DNE)" -- in Tekton a missing key is an error
 		},
 		{
 			name:     "multiple (even) operators, var undefined",
@@ -314,7 +314,7 @@ func TestContainerEnvMapping(t *testing.T) {
 		{
 			name:     "multiple (odd) operators, var undefined",
 			input:    "$$$$$$$(GOOD_ODDS)",
-			expected: expectedError, //"$$$$(GOOD_ODDS)" -- in Tekton a missing key is an error
+			expected: expectedError, // "$$$$(GOOD_ODDS)" -- in Tekton a missing key is an error
 		},
 		{
 			name:     "multiple (odd) operators, var defined",
@@ -369,7 +369,7 @@ func TestContainerEnvMapping(t *testing.T) {
 		{
 			name:     "escaped operators in variable names are not escaped",
 			input:    "$('foo$$var')",
-			expected: "foo$$var", //"$(foo$$var)" -- (reworked valid testcase) in Tekton a missing key is an error
+			expected: "foo$$var", // "$(foo$$var)" -- (reworked valid testcase) in Tekton a missing key is an error
 		},
 		{
 			name:     "newline not expanded",

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -917,7 +917,7 @@ script-heredoc-randomly-generated-mz4c7
 					"/tekton/scripts/script-0-9l9zj",
 					"--",
 				},
-				Env: append(implicitEnvVars),
+				Env: implicitEnvVars,
 				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, toolsMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -111,7 +111,7 @@ func convertListOfSteps(steps []v1beta1.Step, initContainer *corev1.Container, p
 		// on these instances in our args and Kubernetes reduces them back down
 		// to the expected number of dollar signs. This is a workaround for
 		// https://github.com/kubernetes/kubernetes/issues/101137
-		script = strings.Replace(script, "$$", "$$$$", -1)
+		script = strings.ReplaceAll(script, "$$", "$$$$")
 
 		// Append to the place-scripts script to place the
 		// script file in a known location in the scripts volume.

--- a/pkg/pod/status.go
+++ b/pkg/pod/status.go
@@ -64,7 +64,7 @@ const (
 	// ReasonExceededNodeResources or isPodHitConfigError
 	ReasonPending = "Pending"
 
-	//timeFormat is RFC3339 with millisecond
+	// timeFormat is RFC3339 with millisecond
 	timeFormat = "2006-01-02T15:04:05.000Z07:00"
 )
 

--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -46,7 +46,7 @@ type Node struct {
 
 // Graph represents the Pipeline Graph
 type Graph struct {
-	//Nodes represent map of PipelineTask name to Node in Pipeline Graph
+	// Nodes represent map of PipelineTask name to Node in Pipeline Graph
 	Nodes map[string]*Node
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -697,7 +697,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 
 	tr, _ := c.taskRunLister.TaskRuns(pr.Namespace).Get(rprt.TaskRunName)
 	if tr != nil {
-		//is a retry
+		// is a retry
 		addRetryHistory(tr)
 		clearStatus(tr)
 		tr.Status.SetCondition(&apis.Condition{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -136,7 +136,7 @@ func ensureConfigurationConfigMapsExist(d *test.Data) {
 // getPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
-	//unregisterMetrics()
+	// unregisterMetrics()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	ensureConfigurationConfigMapsExist(&d)

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -189,7 +189,7 @@ func ApplyTaskResultsToPipelineResults(
 			finalValue := pipelineResult.Value
 			for variable, value := range stringReplacements {
 				v := fmt.Sprintf("$(%s)", variable)
-				finalValue = strings.Replace(finalValue, v, value, -1)
+				finalValue = strings.ReplaceAll(finalValue, v, value)
 			}
 			runResults = append(runResults, v1beta1.PipelineRunResult{
 				Name:  pipelineResult.Name,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1060,10 +1060,10 @@ func TestGetResourcesFromBindings(t *testing.T) {
 }
 
 func TestGetResourcesFromBindings_Missing(t *testing.T) {
-	//p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
+	// p := tb.Pipeline("pipelines", "namespace", tb.PipelineSpec(
 	//	tb.PipelineDeclaredResource("git-resource", "git"),
 	//	tb.PipelineDeclaredResource("image-resource", "image"),
-	//))
+	// ))
 	pr := tb.PipelineRun("pipelinerun", tb.PipelineRunSpec("pipeline",
 		tb.PipelineRunResourceBinding("git-resource", tb.PipelineResourceBindingRef("sweet-resource")),
 	))

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -285,7 +285,7 @@ func ensureConfigurationConfigMapsExist(d *test.Data) {
 // getTaskRunController returns an instance of the TaskRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
-	//unregisterMetrics()
+	// unregisterMetrics()
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	ensureConfigurationConfigMapsExist(&d)

--- a/pkg/termination/parse.go
+++ b/pkg/termination/parse.go
@@ -40,7 +40,7 @@ func ParseMessage(logger *zap.SugaredLogger, msg string) ([]v1beta1.PipelineReso
 
 	for i, rr := range r {
 		if rr == (v1beta1.PipelineResourceResult{}) {
-			//Erase incorrect result
+			// Erase incorrect result
 			r[i] = r[len(r)-1]
 			r = r[:len(r)-1]
 			logger.Errorf("termination message contains non taskrun or pipelineresource result keys")

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -67,7 +67,7 @@ func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
 	return nil
 }
 
-//MessageLengthError indicate the length of termination message of container is beyond 4096 which is the max length read by kubenates
+// MessageLengthError indicate the length of termination message of container is beyond 4096 which is the max length read by kubenates
 type MessageLengthError string
 
 const (

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -98,8 +98,8 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"cadatakey": []byte("Y2EtY2VydAo="), //ca-cert
-			"tokenkey":  []byte("dG9rZW4K"),     //token
+			"cadatakey": []byte("Y2EtY2VydAo="), // ca-cert
+			"tokenkey":  []byte("dG9rZW4K"),     // token
 		},
 	}
 }

--- a/test/init_test.go
+++ b/test/init_test.go
@@ -122,7 +122,7 @@ func initializeLogsAndMetrics(t *testing.T) {
 		flag.Set("alsologtostderr", "true")
 		logging.InitializeLogger()
 
-		//if knativetest.Flags.EmitMetrics {
+		// if knativetest.Flags.EmitMetrics {
 		logging.InitializeMetricExporter(t.Name())
 		//}
 	})

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -36,11 +36,11 @@ const (
 	busyboxImage = iota
 	// Registry image
 	registryImage
-	//kubectl image
+	// kubectl image
 	kubectlImage
-	//helm image
+	// helm image
 	helmImage
-	//kaniko executor image
+	// kaniko executor image
 	kanikoImage
 	// dockerize image
 	dockerizeImage
@@ -147,7 +147,7 @@ func initExcludedTests() sets.String {
 	switch getTestArch() {
 	case "s390x":
 		return sets.NewString(
-			//examples
+			// examples
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/pipelineruns/pipelinerun",
@@ -155,7 +155,7 @@ func initExcludedTests() sets.String {
 		)
 	case "ppc64le":
 		return sets.NewString(
-			//examples
+			// examples
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/pipelineruns/pipelinerun",

--- a/test/v1alpha1/cluster_resource_test.go
+++ b/test/v1alpha1/cluster_resource_test.go
@@ -95,8 +95,8 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
-			"cadatakey": []byte("Y2EtY2VydAo="), //ca-cert
-			"tokenkey":  []byte("dG9rZW4K"),     //token
+			"cadatakey": []byte("Y2EtY2VydAo="), // ca-cert
+			"tokenkey":  []byte("dG9rZW4K"),     // token
 		},
 	}
 }

--- a/test/v1alpha1/init_test.go
+++ b/test/v1alpha1/init_test.go
@@ -122,7 +122,7 @@ func initializeLogsAndMetrics(t *testing.T) {
 		flag.Set("alsologtostderr", "true")
 		logging.InitializeLogger()
 
-		//if knativetest.Flags.EmitMetrics {
+		// if knativetest.Flags.EmitMetrics {
 		logging.InitializeMetricExporter(t.Name())
 		//}
 	})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Some new lint issues popped up with the 1.39.0 version of GolangCI.
Fix gocritic issues related to:
- space missing between "//" and body of the comment
- use convenience function ReplaceAll

Ignore error for not-used dropNetworking function which is provided
for non-linux builds. This might come in handy soon with windows
builds.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [o] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [o] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```