### PR TITLE
Change the way we run e2e tests with feature gates in pipelines

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -52,11 +52,14 @@ function run_e2e() {
   go_test_e2e -tags=examples -timeout=20m ./test/ || failed=1
 }
 
-set_feature_gate "stable"
-run_e2e
+if [ "$PIPELINE_FEATURE_GATE" == "" ]; then
+  set_feature_gate "stable"
+  run_e2e
+else
+  set_feature_gate "$PIPELINE_FEATURE_GATE"
+  run_e2e
+fi
 
-set_feature_gate "alpha"
-run_e2e
 
 (( failed )) && fail_test
 success


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit pipelines ran e2e tests for both "stable" and
"alpha" feature gates in a single prow job. This makes the tests
take twice as long as running running either individually.

In a [parallel commit to Plumbing](https://github.com/tektoncd/plumbing/pull/833) we are introducing a new prow job
that is specifically for running alpha e2e tests. This means both
the alpha and stable tests can be run concurrently and hopefully
should reduce the iteration time on PRs - failures should show up
sooner.

The alpha feature gate prow job will set the PIPELINE_FEATURE_GATE
env var when it is initiated. Our e2e script recognizes this var
and sets the feature-flags configmap accordingly. If the env var
is not set then we default to running under "stable" feature gate.

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
