### PR TITLE
😅 Fix issue where AddSidecarVolumeMount unit tests did not actually run

### DIFF
--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -962,6 +962,9 @@ func TestAddSidecarVolumeMount(t *testing.T) {
 	}} {
 		sidecar := v1beta1.Sidecar{}
 		sidecar.Container.VolumeMounts = tc.sidecarMounts
-		workspace.AddSidecarVolumeMount(&v1beta1.Sidecar{}, corev1.VolumeMount{})
+		workspace.AddSidecarVolumeMount(&sidecar, tc.volumeMount)
+		if d := cmp.Diff(tc.expectedSidecar, sidecar); d != "" {
+			t.Error(diff.PrintWantGot(d))
+		}
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit the unit tests for AddSidecarVolumeMount did not
execute. The body of the test was effectively a no-op.

This updates the unit test to actually perform the checks intended
when the tests were written. Thankfully the tests pass without any
other changes.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```