### PR TITLE
Skip *heavy* validation on deletion 🙃

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
@@ -29,5 +29,8 @@ func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return t.Spec.Validate(ctx)
 }

--- a/pkg/apis/pipeline/v1alpha1/condition_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation.go
@@ -32,6 +32,9 @@ func (c Condition) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(c.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return c.Spec.Validate(ctx).ViaField("Spec")
 }
 

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -39,6 +39,9 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(p.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return p.Spec.Validate(ctx)
 }
 

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_validation.go
@@ -32,6 +32,9 @@ func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(pr.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return pr.Spec.Validate(ctx)
 }
 

--- a/pkg/apis/pipeline/v1alpha1/run_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation.go
@@ -31,6 +31,9 @@ func (r *Run) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(r.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return r.Spec.Validate(ctx)
 }
 

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -37,6 +37,9 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return t.Spec.Validate(ctx)
 }
 

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -34,6 +34,9 @@ func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(tr.GetObjectMeta()).ViaField("metadata"); err != nil {
 		return err
 	}
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return tr.Spec.Validate(ctx)
 }
 

--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -27,5 +27,8 @@ var _ apis.Validatable = (*ClusterTask)(nil)
 
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -36,6 +36,9 @@ var _ apis.Validatable = (*Pipeline)(nil)
 // that any references resources exist, that is done at run time.
 func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(p.GetObjectMeta()).ViaField("metadata")
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return errs.Also(p.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -132,6 +132,12 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
+	}, {
+		name: "do not validate spec on delete",
+		p: &Pipeline{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipeline"},
+		},
+		wc: apis.WithinDelete,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -32,6 +32,10 @@ var _ apis.Validatable = (*PipelineRun)(nil)
 func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(pr.GetObjectMeta()).ViaField("metadata")
 
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+
 	if pr.IsPending() && pr.HasStarted() {
 		errs = errs.Also(apis.ErrInvalidValue("PipelineRun cannot be Pending after it is started", "spec.status"))
 	}

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -36,6 +36,9 @@ var _ apis.Validatable = (*Task)(nil)
 
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -56,6 +56,32 @@ var invalidSteps = []v1beta1.Step{{Container: corev1.Container{
 	Image: "myimage",
 }}}
 
+func TestTaskValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		t    *v1beta1.Task
+		wc   func(context.Context) context.Context
+	}{{
+		name: "do not validate spec on delete",
+		t: &v1beta1.Task{
+			ObjectMeta: metav1.ObjectMeta{Name: "task"},
+		},
+		wc: apis.WithinDelete,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.wc != nil {
+				ctx = tt.wc(ctx)
+			}
+			err := tt.t.Validate(ctx)
+			if err != nil {
+				t.Errorf("Task.Validate() returned error for valid Task: %v", err)
+			}
+		})
+	}
+}
+
 func TestTaskSpecValidate(t *testing.T) {
 	type fields struct {
 		Params       []v1beta1.ParamSpec

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -33,6 +33,9 @@ var _ apis.Validatable = (*TaskRun)(nil)
 // Validate taskrun
 func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(tr.GetObjectMeta()).ViaField("metadata")
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return errs.Also(tr.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
@@ -34,7 +34,9 @@ func (r *PipelineResource) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(r.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
 	}
-
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return r.Spec.Validate(ctx)
 }
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When deleting an object, we don't need to pursue all the validation
that we do at creation. It reduces the work to be done as part of the
validation *and* allows invalid version of the resource (from previous
versions for example) to be deleted safely.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

The main reasoning for this change is to not face issues to reduce the situation where an upgrade makes object not deletable (because of *newly* invalid field). One example that happen in triggers is upgrading from 0.10.x to 0.12.x make `EventListener` not deletable at all.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
Skip *heavy* validation on deletion in the webhook
```
