### PR TITLE
Document behaviour of script field when "$$" and "$(X)" are used

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -261,6 +261,18 @@ steps:
     #!/usr/bin/env bash
     /bin/my-binary
 ```
+
+**Note:** Kubernetes processes the contents of the `script` field using rules applied to
+`args` fields of containers. This can result in some unexpected behaviour:
+1. Instances of two dollar signs can be replaced in your scripts with a single dollar sign.
+   In other words, "$$" is replaced with "$".
+2. Usage of Kubernetes variable references such as `$(MY_ENV_VAR)` will not work as expected.
+   An init container writes your script to disk before your `Step` can execute it and the `env`
+   of the init container differs from that of your `Step`.
+
+For more information about Kubernetes variable references see the
+[Kubernetes docs for the args field](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#entrypoint).
+
 #### Specifying a timeout
 
 A `Step` can specify a `timeout` field.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

There are some nuances and slightly confusing behaviour present in
the way our `script` field works. These relate to the way Kubernetes
processes the `args` field of containers in order to replace variable
references of form `$(X)`.

This commit documents the way Kubernetes' variable reference code
can mangle the contents of Tekton's `script` blocks.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Documented some ways that script fields of Tasks can have their contents slightly mangled by Kubernetes' variable reference feature
```