### PR TITLE
Only fetch the definitions once 🧙

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -207,8 +207,8 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, nil)
 	}
 
+	// If the pipelinerun is cancelled, cancel tasks and update status
 	if pr.IsCancelled() {
-		// If the pipelinerun is cancelled, cancel tasks and update status
 		err := cancelPipelineRun(ctx, logger, pr, c.PipelineClientSet)
 		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 	}
@@ -278,7 +278,7 @@ func (c *Reconciler) resolvePipelineState(
 	pst := resources.PipelineRunState{}
 	// Resolve each task individually because they each could have a different reference context (remote or local).
 	for _, task := range tasks {
-		fn, _, err := tresources.GetTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, task.TaskRef, pr.Namespace, pr.Spec.ServiceAccountName)
+		fn, err := tresources.GetTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, task.TaskRef, pr.Namespace, pr.Spec.ServiceAccountName)
 		if err != nil {
 			// This Run has failed, so we need to mark it as failed and stop reconciling it
 			pr.Status.MarkFailed(ReasonCouldntGetTask, "Pipeline %s/%s can't be Run; task %s could not be fetched: %s",

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -31,11 +31,40 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// GetTaskKind returns the referenced Task kind (Task, ClusterTask, ...) if the TaskRun is using TaskRef.
+func GetTaskKind(taskrun *v1beta1.TaskRun) v1beta1.TaskKind {
+	kind := v1alpha1.NamespacedTaskKind
+	if taskrun.Spec.TaskRef != nil && taskrun.Spec.TaskRef.Kind != "" {
+		kind = taskrun.Spec.TaskRef.Kind
+	}
+	return kind
+}
+
+// GetTaskFuncFromTaskRun is a factory function that will use the given TaskRef as context to return a valid GetTask function. It
+// also requires a kubeclient, tektonclient, namespace, and service account in case it needs to find that task in
+// cluster or authorize against an external repositroy. It will figure out whether it needs to look in the cluster or in
+// a remote image to fetch the  reference. It will also return the "kind" of the task being referenced.
+func GetTaskFuncFromTaskRun(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, taskrun *v1beta1.TaskRun) (GetTask, error) {
+	// if the spec is already in the status, do not try to fetch it again, just use it as source of truth
+	if taskrun.Status.TaskSpec != nil {
+		return func(_ context.Context, name string) (v1beta1.TaskObject, error) {
+			return &v1beta1.Task{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: taskrun.Namespace,
+				},
+				Spec: *taskrun.Status.TaskSpec,
+			}, nil
+		}, nil
+	}
+	return GetTaskFunc(ctx, k8s, tekton, taskrun.Spec.TaskRef, taskrun.Namespace, taskrun.Spec.ServiceAccountName)
+}
+
 // GetTaskFunc is a factory function that will use the given TaskRef as context to return a valid GetTask function. It
 // also requires a kubeclient, tektonclient, namespace, and service account in case it needs to find that task in
 // cluster or authorize against an external repositroy. It will figure out whether it needs to look in the cluster or in
 // a remote image to fetch the  reference. It will also return the "kind" of the task being referenced.
-func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, tr *v1beta1.TaskRef, namespace, saName string) (GetTask, v1beta1.TaskKind, error) {
+func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, tr *v1beta1.TaskRef, namespace, saName string) (GetTask, error) {
 	cfg := config.FromContextOrDefaults(ctx)
 	kind := v1alpha1.NamespacedTaskKind
 	if tr != nil && tr.Kind != "" {
@@ -84,7 +113,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			}
 
 			return nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
-		}, kind, nil
+		}, nil
 	default:
 		// Even if there is no task ref, we should try to return a local resolver.
 		local := &LocalTaskRefResolver{
@@ -92,7 +121,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			Kind:         kind,
 			Tektonclient: tekton,
 		}
-		return local.GetTask, kind, nil
+		return local.GetTask, nil
 	}
 }
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -271,7 +271,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	// and may not have had all of the assumed default specified.
 	tr.SetDefaults(contexts.WithUpgradeViaDefaulting(ctx))
 
-	getTaskfunc, kind, err := resources.GetTaskFunc(ctx, c.KubeClientSet, c.PipelineClientSet, tr.Spec.TaskRef, tr.Namespace, tr.Spec.ServiceAccountName)
+	getTaskfunc, err := resources.GetTaskFuncFromTaskRun(ctx, c.KubeClientSet, c.PipelineClientSet, tr)
 	if err != nil {
 		logger.Errorf("Failed to fetch task reference %s: %v", tr.Spec.TaskRef.Name, err)
 		tr.Status.SetCondition(&apis.Condition{
@@ -324,7 +324,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		inputs = tr.Spec.Resources.Inputs
 		outputs = tr.Spec.Resources.Outputs
 	}
-	rtr, err := resources.ResolveTaskResources(taskSpec, taskMeta.Name, kind, inputs, outputs, c.resourceLister.PipelineResources(tr.Namespace).Get)
+	rtr, err := resources.ResolveTaskResources(taskSpec, taskMeta.Name, resources.GetTaskKind(tr), inputs, outputs, c.resourceLister.PipelineResources(tr.Namespace).Get)
 	if err != nil {
 		if k8serrors.IsNotFound(err) && tknreconciler.IsYoungResource(tr) {
 			// For newly created resources, don't fail immediately.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Since we "dereference" fetched definition and store them into the
`status`, we can use this as a source of truth. This allows us to
fetch only once the definitions (Task, Pipeline) *and* has the benefit
to make the runs (PipelineRun, TaskRun) immune to change to what they
refer, while the are executing.

Without this change, if you run a PipelineRun that reference a
Pipeline that is deleted during execution, your PipelineRun will fail
at some point because it cannot fetch the definition anymore, even if
it stored them in its status. This is the case for TaskRun too.

Fixes #3916

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Only fetch the definition once, and then used the spec stored in the status as source of truth. 
This reduce the probable race condition when a `PipelineRun` or a `TaskRun` refers to a `Pipeline` or `Task` that changes during its execution.
```
