### PR TITLE
Revert "Fix issue with "$$" in Script blocks"

### DIFF
--- a/examples/v1alpha1/taskruns/step-script.yaml
+++ b/examples/v1alpha1/taskruns/step-script.yaml
@@ -97,22 +97,3 @@ spec:
         [[ $# == 2 ]]
         [[ $1 == "hello" ]]
         [[ $2 == "world" ]]
-
-    # Test that multiple dollar signs next to each other are not replaced by Kubernetes
-    - name: dollar-signs-allowed
-      image: python
-      script: |
-        #!/usr/bin/env python3
-        if '$' != '\u0024':
-          print('single dollar signs ($) are not passed through as expected :(')
-          exit(1)
-        if '$$' != '\u0024\u0024':
-          print('double dollar signs ($$) are not passed through as expected :(')
-          exit(2)
-        if '$$$' != '\u0024\u0024\u0024':
-          print('three dollar signs ($$$) are not passed through as expected :(')
-          exit(3)
-        if '$$$$' != '\u0024\u0024\u0024\u0024':
-          print('four dollar signs ($$$$) are not passed through as expected :(')
-          exit(3)
-        print('dollar signs appear to be handled correctly! :)')

--- a/examples/v1beta1/taskruns/step-script.yaml
+++ b/examples/v1beta1/taskruns/step-script.yaml
@@ -96,22 +96,3 @@ spec:
         [[ $# == 2 ]]
         [[ $1 == "hello" ]]
         [[ $2 == "world" ]]
-
-    # Test that multiple dollar signs next to each other are not replaced by Kubernetes
-    - name: dollar-signs-allowed
-      image: python
-      script: |
-        #!/usr/bin/env python3
-        if '$' != '\u0024':
-          print('single dollar signs ($) are not passed through as expected :(')
-          exit(1)
-        if '$$' != '\u0024\u0024':
-          print('double dollar signs ($$) are not passed through as expected :(')
-          exit(2)
-        if '$$$' != '\u0024\u0024\u0024':
-          print('three dollar signs ($$$) are not passed through as expected :(')
-          exit(3)
-        if '$$$$' != '\u0024\u0024\u0024\u0024':
-          print('four dollar signs ($$$$) are not passed through as expected :(')
-          exit(3)
-        print('dollar signs appear to be handled correctly! :)')

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -890,67 +890,6 @@ script-heredoc-randomly-generated-78c5n
 			}),
 		},
 	}, {
-		desc: "step with script that uses two dollar signs",
-		ts: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Name:  "one",
-					Image: "image",
-				},
-				Script: "#!/bin/sh\n$$",
-			}},
-		},
-		want: &corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyNever,
-			InitContainers: []corev1.Container{
-				{
-					Name:    "place-scripts",
-					Image:   images.ShellImage,
-					Command: []string{"sh"},
-					Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-mz4c7'
-#!/bin/sh
-$$$$
-script-heredoc-randomly-generated-mz4c7
-`},
-					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
-				},
-				{
-					Name:         "place-tools",
-					Image:        images.EntrypointImage,
-					Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
-					VolumeMounts: []corev1.VolumeMount{toolsMount},
-				}},
-			Containers: []corev1.Container{{
-				Name:    "step-one",
-				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
-				Args: []string{
-					"-wait_file",
-					"/tekton/downward/ready",
-					"-wait_file_content",
-					"-post_file",
-					"/tekton/tools/0",
-					"-termination_path",
-					"/tekton/termination",
-					"-entrypoint",
-					"/tekton/scripts/script-0-9l9zj",
-					"--",
-				},
-				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, toolsMount, downwardMount, {
-					Name:      "tekton-creds-init-home-0",
-					MountPath: "/tekton/creds",
-				}}, implicitVolumeMounts...),
-				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
-				TerminationMessagePath: "/tekton/termination",
-			}},
-			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume, corev1.Volume{
-				Name:         "tekton-creds-init-home-0",
-				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
-			}),
-		},
-	}, {
 		desc: "using another scheduler",
 		ts: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -107,12 +107,6 @@ func convertListOfSteps(steps []v1beta1.Step, initContainer *corev1.Container, p
 		// non-nil init container.
 		*placeScripts = true
 
-		// Kubernetes replaces instances of "$$" with "$". So we double-up
-		// on these instances in our args and Kubernetes reduces them back down
-		// to the expected number of dollar signs. This is a workaround for
-		// https://github.com/kubernetes/kubernetes/issues/101137
-		script = strings.ReplaceAll(script, "$$", "$$$$")
-
 		// Append to the place-scripts script to place the
 		// script file in a known location in the scripts volume.
 		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", namePrefix, i)))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This reverts commit 9a9f8963b02ef3a32184636468cc9bcf4dcd462b.

Attempting to fix instances of "$$" introduced a new bug in the way
bash scripts are interpreted: https://github.com/tektoncd/pipeline/issues/3935

Cherry-picked from https://github.com/tektoncd/pipeline/pull/3938

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Revert fix for instances of "$$" in script blocks. Kubernetes replaces "$$" with a single "$" and your scripts need to deal appropriately with these instances.
```