### PR TITLE
Add "format" support for mustParse test helpers 🧙

### DIFF
--- a/test/yaml.go
+++ b/test/yaml.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -30,38 +31,38 @@ func mustParseYAML(t *testing.T, yaml string, i runtime.Object) {
 	}
 }
 
-func mustParseTaskRun(t *testing.T, yaml string) *v1beta1.TaskRun {
+func mustParseTaskRun(t *testing.T, yaml string, args ...interface{}) *v1beta1.TaskRun {
 	var tr v1beta1.TaskRun
-	yaml = `apiVersion: tekton.dev/v1beta1
+	yaml = fmt.Sprintf(`apiVersion: tekton.dev/v1beta1
 kind: TaskRun
-` + yaml
+`+yaml, args...)
 	mustParseYAML(t, yaml, &tr)
 	return &tr
 }
 
-func mustParseTask(t *testing.T, yaml string) *v1beta1.Task {
+func mustParseTask(t *testing.T, yaml string, args ...interface{}) *v1beta1.Task {
 	var task v1beta1.Task
-	yaml = `apiVersion: tekton.dev/v1beta1
+	yaml = fmt.Sprintf(`apiVersion: tekton.dev/v1beta1
 kind: Task
-` + yaml
+`+yaml, args...)
 	mustParseYAML(t, yaml, &task)
 	return &task
 }
 
-func mustParsePipelineRun(t *testing.T, yaml string) *v1beta1.PipelineRun {
+func mustParsePipelineRun(t *testing.T, yaml string, args ...interface{}) *v1beta1.PipelineRun {
 	var pr v1beta1.PipelineRun
-	yaml = `apiVersion: tekton.dev/v1beta1
+	yaml = fmt.Sprintf(`apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
-` + yaml
+`+yaml, args...)
 	mustParseYAML(t, yaml, &pr)
 	return &pr
 }
 
-func mustParsePipeline(t *testing.T, yaml string) *v1beta1.Pipeline {
+func mustParsePipeline(t *testing.T, yaml string, args ...interface{}) *v1beta1.Pipeline {
 	var pipeline v1beta1.Pipeline
-	yaml = `apiVersion: tekton.dev/v1beta1
+	yaml = fmt.Sprintf(`apiVersion: tekton.dev/v1beta1
 kind: Pipeline
-` + yaml
+`+yaml, args...)
 	mustParseYAML(t, yaml, &pipeline)
 	return &pipeline
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Allow using `mastParse` in a similar fashion to `fmt.Sprintf`, adding
support for formating and replacing variables in there.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @tektoncd/core-maintainers @imjasonh 

The alternative (which is also really viable) is to not change it and rely on users doing `fmt.Sprintf` prior to passing the yaml.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
