### PR TITLE
Add support for experiemental hermetic execution mode to TaskRuns

### DIFF
--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 
 	"github.com/tektoncd/pipeline/pkg/entrypoint"
+	"github.com/tektoncd/pipeline/pkg/pod"
 )
 
 // TODO(jasonhall): Test that original exit code is propagated and that
@@ -57,6 +58,10 @@ func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 	// dedicated PID group used to forward signals to
 	// main process and all children
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if os.Getenv("TEKTON_RESOURCE_NAME") == "" && os.Getenv(pod.TektonHermeticEnvVar) == "1" {
+		dropNetworking(cmd)
+	}
 
 	// Start defined command
 	if err := cmd.Start(); err != nil {

--- a/docs/hermetic.md
+++ b/docs/hermetic.md
@@ -1,0 +1,51 @@
+<!--
+---
+linkTitle: "Hermetic"
+weight: 10
+---
+-->
+# Hermetic Execution Mode
+A Hermetic Build is a release engineering best practice for increasing the reliability and consistency of software builds.
+They are self-contained, and do not depend on anything outside of the build environment.
+This means they do not have network access, and cannot fetch dependencies at runtime.
+
+When hermetic execution mode is enabled, all TaskRun steps will be run without access to a network.
+_Note: hermetic execution mode does NOT apply to sidecar containers_ 
+
+Hermetic execution mode is currently an alpha experimental feature. 
+
+## Enabling Hermetic Execution Mode
+To enable hermetic execution mode:
+1. Make sure `enable-api-fields` is set to `"alpha"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior) for details
+1. Set the following annotation on any TaskRun you want to run hermetically:
+
+```yaml
+experimental.tekton.dev/execution-mode: hermetic
+```
+
+## Sample Hermetic TaskRun
+This example TaskRun demonstrates running a container in a hermetic environment.
+
+The Step attempts to install curl, but this step **SHOULD FAIL** if the hermetic environment is working as expected.
+
+```yaml
+kind: TaskRun
+apiVersion: tekton.dev/v1beta1
+metadata:
+  generateName: hermetic-should-fail
+  annotations:
+    experimental.tekton.dev/execution-mode: hermetic
+spec:
+  timeout: 60s
+  taskSpec:
+    steps:
+    - name: hermetic
+      image: ubuntu
+      script: |
+        #!/usr/bin/env bash
+        apt-get update
+        apt-get install -y curl
+```
+
+## Further Details
+To learn more about hermetic execution mode, check out the [TEP](https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md).

--- a/docs/install.md
+++ b/docs/install.md
@@ -383,6 +383,7 @@ Features currently in "alpha" are:
 - [Tekton Bundles](./taskruns.md#tekton-bundles)
 - [Custom Tasks](./runs.md)
 - [Isolated Step & Sidecar Workspaces](./workspaces.md#isolated-workspaces)
+- [Hermetic Execution Mode](./hermetic.md)
 
 ## Configuring High Availability
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -24,6 +24,7 @@ weight: 2
   - [Monitoring `Results`](#monitoring-results)
 - [Cancelling a `TaskRun`](#cancelling-a-taskrun)
 - [Events](events.md#taskruns)
+- [Running a TaskRun Hermetically](hermetic.md)
 - [Code examples](#code-examples)
   - [Example `TaskRun` with a referenced `Task`](#example-taskrun-with-a-referenced-task)
   - [Example `TaskRun` with an embedded `Task`](#example-taskrun-with-an-embedded-task)

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ go test ./...
 # Integration tests (against your current kube cluster)
 go test -v -count=1 -tags=e2e -timeout=20m ./test
 
-#conformance tests  (against your current kube cluster)
+# Conformance tests  (against your current kube cluster)
 go test -v -count=1 -tags=conformance -timeout=10m ./test
 ```
 

--- a/test/hermetic_taskrun_test.go
+++ b/test/hermetic_taskrun_test.go
@@ -1,0 +1,93 @@
+// +build e2e
+
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestHermeticTaskRun make sure that the hermetic execution mode actually drops network from a TaskRun step
+// it does this by first running the TaskRun normally to make sure it passes
+// Then, it enables hermetic mode and makes sure the same TaskRun fails because it no longer has access to a network.
+func TestHermeticTaskRun(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	c, namespace := setup(ctx, t, requireAnyGate(map[string]string{"enable-api-fields": "alpha"}))
+	t.Parallel()
+	defer tearDown(ctx, t, c, namespace)
+
+	// first, run the task run with hermetic=false to prove that it succeeds
+	regularTaskRunName := "not-hermetic"
+	regularTaskRun := taskRun(regularTaskRunName, namespace, "")
+	t.Logf("Creating TaskRun %s, hermetic=false", regularTaskRunName)
+	if _, err := c.TaskRunClient.Create(ctx, regularTaskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", regularTaskRunName, err)
+	}
+	if err := WaitForTaskRunState(ctx, c, regularTaskRunName, Succeed(regularTaskRunName), "TaskRunCompleted"); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to finish: %s", regularTaskRunName, err)
+	}
+
+	// now, run the task mode with hermetic mode
+	// it should fail, since it shouldn't be able to access any network
+	hermeticTaskRunName := "hermetic-should-fail"
+	hermeticTaskRun := taskRun(hermeticTaskRunName, namespace, "hermetic")
+	t.Logf("Creating TaskRun %s, hermetic=true", hermeticTaskRunName)
+	if _, err := c.TaskRunClient.Create(ctx, hermeticTaskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", regularTaskRun.Name, err)
+	}
+	if err := WaitForTaskRunState(ctx, c, hermeticTaskRunName, Failed(hermeticTaskRunName), "Failed"); err != nil {
+		t.Fatalf("Error waiting for TaskRun %s to fail: %s", hermeticTaskRunName, err)
+	}
+}
+
+func taskRun(name, namespace, executionMode string) *v1beta1.TaskRun {
+	return &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"experimental.tekton.dev/execution-mode": executionMode,
+			},
+		},
+		Spec: v1beta1.TaskRunSpec{
+			Timeout: &metav1.Duration{Duration: time.Minute},
+			TaskSpec: &v1beta1.TaskSpec{
+				Steps: []v1beta1.Step{
+					{
+						Container: corev1.Container{
+							Name:  "access-network",
+							Image: "ubuntu",
+						},
+						Script: `#!/bin/bash
+set -ex
+apt-get update
+apt-get install -y curl`,
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
# Changes


This PR adds support for an experimental hermetic execution mode. If users specify this on their TaskRun, then all user step containers are run without network access. Any containers created or injected by tekton are not affected, and sidecar containers are not affected (since they aren't controller by the entrypointer, we can't make them hermetic as of now).

This PR also adds an integration test to make sure that network access isn't available when hermetic mode is enabled!

TEP: https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md


/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

Add support for experimental hermetic execution mode to TaskRuns


```release-note
Add support for experimental hermetic execution mode to TaskRuns
```

cc @dlorenc 