### PR TITLE
Encode scripts as base 64 to avoid k8s mangling "$$"

### DIFF
--- a/cmd/entrypoint/subcommands/cp.go
+++ b/cmd/entrypoint/subcommands/cp.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"io"
+	"os"
+)
+
+const CopyCommand = "cp"
+
+// Owner has permission to write and execute, and anybody has
+// permission to execute.
+const dstPermissions = 0311
+
+// cp copies a files from src to dst.
+func cp(src, dst string) error {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	d, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE, dstPermissions)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	_, err = io.Copy(d, s)
+	return err
+}

--- a/cmd/entrypoint/subcommands/cp_test.go
+++ b/cmd/entrypoint/subcommands/cp_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCp(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "cp-test-*")
+	if err != nil {
+		t.Fatalf("error creating temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	src := filepath.Join(tmp, "foo.txt")
+	dst := filepath.Join(tmp, "bar.txt")
+
+	if err = ioutil.WriteFile(src, []byte("hello world"), 0700); err != nil {
+		t.Fatalf("error writing source file: %v", err)
+	}
+
+	if err := cp(src, dst); err != nil {
+		t.Errorf("error copying: %v", err)
+	}
+
+	info, err := os.Lstat(dst)
+	if err != nil {
+		t.Fatalf("error statting destination file: %v", err)
+	}
+
+	if info.Mode().Perm() != dstPermissions {
+		t.Errorf("expected permissions %#o for destination file but found %#o", dstPermissions, info.Mode().Perm())
+	}
+}
+
+func TestCpMissingFile(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "cp-test-*")
+	if err != nil {
+		t.Fatalf("error creating temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	src := filepath.Join(tmp, "doesnt-exist.txt")
+	dst := filepath.Join(tmp, "bar.txt")
+	err = cp(src, dst)
+	if err == nil {
+		t.Errorf("unexpected success copying missing file")
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf(`expected "file does not exist" error but received %v`, err)
+	}
+}

--- a/cmd/entrypoint/subcommands/decode_script.go
+++ b/cmd/entrypoint/subcommands/decode_script.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+const DecodeScriptCommand = "decode-script"
+
+// decodeScript rewrites a script file from base64 back into its original content from
+// the Step definition.
+func decodeScript(scriptPath string) error {
+	decodedBytes, permissions, err := decodeScriptFromFile(scriptPath)
+	if err != nil {
+		return fmt.Errorf("error decoding script file %q: %w", scriptPath, err)
+	}
+	err = ioutil.WriteFile(scriptPath, decodedBytes, permissions)
+	if err != nil {
+		return fmt.Errorf("error writing decoded script file %q: %w", scriptPath, err)
+	}
+	return nil
+}
+
+// decodeScriptFromFile reads the script at scriptPath, decodes it from
+// base64, and returns the decoded bytes w/ the permissions to use when re-writing
+// or an error.
+func decodeScriptFromFile(scriptPath string) ([]byte, os.FileMode, error) {
+	scriptFile, err := os.Open(scriptPath)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error reading from script file %q: %w", scriptPath, err)
+	}
+	defer scriptFile.Close()
+
+	encoded := bytes.NewBuffer(nil)
+	if _, err = io.Copy(encoded, scriptFile); err != nil {
+		return nil, 0, fmt.Errorf("error reading from script file %q: %w", scriptPath, err)
+	}
+
+	fileInfo, err := scriptFile.Stat()
+	if err != nil {
+		return nil, 0, fmt.Errorf("error statting script file %q: %w", scriptPath, err)
+	}
+	perms := fileInfo.Mode().Perm()
+
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(encoded.Len()))
+	n, err := base64.StdEncoding.Decode(decoded, encoded.Bytes())
+	if err != nil {
+		return nil, 0, fmt.Errorf("error decoding script file %q: %w", scriptPath, err)
+	}
+	return decoded[0:n], perms, nil
+}

--- a/cmd/entrypoint/subcommands/decode_script_test.go
+++ b/cmd/entrypoint/subcommands/decode_script_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"encoding/base64"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDecodeScript(t *testing.T) {
+	encoded := "IyEvdXNyL2Jpbi9lbnYgc2gKZWNobyAiSGVsbG8gV29ybGQhIgo="
+	decoded := `#!/usr/bin/env sh
+echo "Hello World!"
+`
+	mode := os.FileMode(0600)
+	expectedPermissions := os.FileMode(0600)
+
+	tmp, err := ioutil.TempDir("", "decode-script-test-*")
+	if err != nil {
+		t.Fatalf("error creating temp file: %v", err)
+	}
+	src := filepath.Join(tmp, "script.txt")
+	defer func() {
+		if err := os.Remove(src); err != nil {
+			t.Errorf("temporary script file %q was not cleaned up: %v", src, err)
+		}
+	}()
+	if err = ioutil.WriteFile(src, []byte(encoded), mode); err != nil {
+		t.Fatalf("error writing encoded script: %v", err)
+	}
+
+	if err = decodeScript(src); err != nil {
+		t.Errorf("unexpected error decoding script: %v", err)
+	}
+
+	file, err := os.Open(src)
+	if err != nil {
+		t.Fatalf("unexpected error opening decoded script: %v", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatalf("unexpected error statting decoded script: %v", err)
+	}
+	mod := info.Mode()
+	b, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatalf("unexpected error reading content of decoded script: %v", err)
+	}
+	if string(b) != decoded {
+		t.Errorf("expected decoded value %q received %q", decoded, string(b))
+	}
+	if mod != expectedPermissions {
+		t.Errorf("expected mode %#o received %#o", expectedPermissions, mod)
+	}
+}
+
+func TestDecodeScriptMissingFileError(t *testing.T) {
+	b, mod, err := decodeScriptFromFile("/path/to/non-existent/file")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("expected error %q received %q", os.ErrNotExist, err)
+	}
+	if b != nil || mod != 0 {
+		t.Errorf("unexpected non-zero bytes or file mode returned")
+	}
+}
+
+func TestDecodeScriptInvalidBase64(t *testing.T) {
+	invalidData := []byte("!")
+	expectedError := base64.CorruptInputError(0)
+
+	src, err := ioutil.TempFile("", "decode-script-test-*")
+	if err != nil {
+		t.Fatalf("error creating temp file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(src.Name()); err != nil {
+			t.Errorf("temporary file %q was not cleaned up: %v", src.Name(), err)
+		}
+	}()
+	if _, err := src.Write(invalidData); err != nil {
+		t.Fatalf("error writing invalid base64 data: %v", err)
+	}
+	src.Close()
+
+	b, mod, err := decodeScriptFromFile(src.Name())
+	if b != nil || mod != 0 {
+		t.Errorf("unexpected non-zero bytes or file mode returned")
+	}
+	if !errors.Is(err, expectedError) {
+		t.Errorf("expected error %q received %q", expectedError, err)
+	}
+}

--- a/cmd/entrypoint/subcommands/subcommands.go
+++ b/cmd/entrypoint/subcommands/subcommands.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subcommands
+
+import (
+	"fmt"
+)
+
+type SubcommandSuccessful struct {
+	message string
+}
+
+func (err SubcommandSuccessful) Error() string {
+	return err.message
+}
+
+type SubcommandError struct {
+	subcommand string
+	message    string
+}
+
+func (err SubcommandError) Error() string {
+	return fmt.Sprintf("%s error: %s", err.subcommand, err.message)
+}
+
+// Process takes the set of arguments passed to entrypoint and executes any
+// subcommand that the args call for. An error is returned to the caller to
+// indicate that a subcommand was matched and to pass back its success/fail
+// state. The returned error will be nil if no subcommand was matched to the
+// passed args, SubcommandSuccessful if args matched and the subcommand
+// succeeded, or any other error if the args matched but the subcommand failed.
+func Process(args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case CopyCommand:
+		// If invoked in "cp mode" (`entrypoint cp <src> <dst>`), simply copy
+		// the src path to the dst path. This is used to place the entrypoint
+		// binary in the tools directory, without requiring the cp command to
+		// exist in the base image.
+		if len(args) == 3 {
+			src, dst := args[1], args[2]
+			if err := cp(src, dst); err != nil {
+				return SubcommandError{subcommand: CopyCommand, message: err.Error()}
+			}
+			return SubcommandSuccessful{message: fmt.Sprintf("Copied %s to %s", src, dst)}
+		}
+	case DecodeScriptCommand:
+		// If invoked in "decode-script" mode (`entrypoint decode-script <src>`),
+		// read the script at <src> and overwrite it with its decoded content.
+		if len(args) == 2 {
+			src := args[1]
+			if err := decodeScript(src); err != nil {
+				return SubcommandError{subcommand: DecodeScriptCommand, message: err.Error()}
+			}
+			return SubcommandSuccessful{message: fmt.Sprintf("Decoded script %s", src)}
+		}
+	default:
+	}
+	return nil
+}

--- a/cmd/entrypoint/subcommands/subcommands_test.go
+++ b/cmd/entrypoint/subcommands/subcommands_test.go
@@ -1,0 +1,70 @@
+package subcommands
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const helloWorldBase64 = "aGVsbG8gd29ybGQK"
+
+// TestProcessSuccessfulSubcommands checks that input args matching the format
+// expected by subcommands results in successfully running those subcommands.
+func TestProcessSuccessfulSubcommands(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "cp-test-*")
+	if err != nil {
+		t.Fatalf("error creating temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmp)
+	src := filepath.Join(tmp, "foo.txt")
+	dst := filepath.Join(tmp, "bar.txt")
+
+	srcFile, err := os.OpenFile(src, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		t.Fatalf("error opening temp file for writing: %v", err)
+	}
+	defer srcFile.Close()
+	if _, err := srcFile.Write([]byte(helloWorldBase64)); err != nil {
+		t.Fatalf("error writing source file: %v", err)
+	}
+
+	returnValue := Process([]string{CopyCommand, src, dst})
+	if _, ok := returnValue.(SubcommandSuccessful); !ok {
+		t.Errorf("unexpected return value from cp command: %v", returnValue)
+	}
+
+	returnValue = Process([]string{DecodeScriptCommand, src})
+	if _, ok := returnValue.(SubcommandSuccessful); !ok {
+		t.Errorf("unexpected return value from decode-script command: %v", returnValue)
+	}
+}
+
+// TestProcessIgnoresNonSubcommands checks that any input to Process which
+// does not exactly match the requirements of a configured subcommand
+// correctly passes back a nil result.
+func TestProcessIgnoresNonSubcommands(t *testing.T) {
+	if err := Process([]string{"not", "a", "matching", "subcommand"}); err != nil {
+		t.Errorf("unexpected error processing unmatched subcommand: %v", err)
+	}
+
+	if err := Process([]string{}); err != nil {
+		t.Errorf("unexpected error processing 0 args: %v", err)
+	}
+
+	if err := Process([]string{CopyCommand}); err != nil {
+		t.Errorf("unexpected error processing decode-script command with 0 additional args: %v", err)
+	}
+
+	if err := Process([]string{CopyCommand, "foo.txt", "bar.txt", "baz.txt"}); err != nil {
+		t.Errorf("unexpected error processing cp command with invalid number of args: %v", err)
+	}
+
+	if err := Process([]string{DecodeScriptCommand}); err != nil {
+		t.Errorf("unexpected error processing decode-script command with 0 additional args: %v", err)
+	}
+
+	if err := Process([]string{DecodeScriptCommand, "foo.txt", "bar.txt"}); err != nil {
+		t.Errorf("unexpected error processing decode-script command with invalid number of args: %v", err)
+	}
+}

--- a/examples/v1alpha1/taskruns/step-script.yaml
+++ b/examples/v1alpha1/taskruns/step-script.yaml
@@ -97,3 +97,37 @@ spec:
         [[ $# == 2 ]]
         [[ $1 == "hello" ]]
         [[ $2 == "world" ]]
+
+    # Test that multiple dollar signs next to each other are not replaced by Kubernetes
+    - name: dollar-signs-allowed
+      image: python
+      script: |
+        #!/usr/bin/env python3
+        if '$' != '\u0024':
+          print('single dollar signs ($) are not passed through as expected :(')
+          exit(1)
+        if '$$' != '\u0024\u0024':
+          print('double dollar signs ($$) are not passed through as expected :(')
+          exit(2)
+        if '$$$' != '\u0024\u0024\u0024':
+          print('three dollar signs ($$$) are not passed through as expected :(')
+          exit(3)
+        if '$$$$' != '\u0024\u0024\u0024\u0024':
+          print('four dollar signs ($$$$) are not passed through as expected :(')
+          exit(4)
+        print('dollar signs appear to be handled correctly! :)')
+
+    # Test that bash scripts with variable evaluations work as expected
+    - name: bash-variable-evaluations
+      image: bash:5.1.8
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        var1=var1_value
+        var2=var1
+        echo $(eval echo \$$var2) > tmpfile
+        eval_result=$(cat tmpfile)
+        if [ "$eval_result" != "var1_value" ] ; then
+          echo "unexpected eval result: $eval_result"
+          exit 1
+        fi

--- a/examples/v1beta1/taskruns/step-script.yaml
+++ b/examples/v1beta1/taskruns/step-script.yaml
@@ -96,3 +96,37 @@ spec:
         [[ $# == 2 ]]
         [[ $1 == "hello" ]]
         [[ $2 == "world" ]]
+
+    # Test that multiple dollar signs next to each other are not replaced by Kubernetes
+    - name: dollar-signs-allowed
+      image: python
+      script: |
+        #!/usr/bin/env python3
+        if '$' != '\u0024':
+          print('single dollar signs ($) are not passed through as expected :(')
+          exit(1)
+        if '$$' != '\u0024\u0024':
+          print('double dollar signs ($$) are not passed through as expected :(')
+          exit(2)
+        if '$$$' != '\u0024\u0024\u0024':
+          print('three dollar signs ($$$) are not passed through as expected :(')
+          exit(3)
+        if '$$$$' != '\u0024\u0024\u0024\u0024':
+          print('four dollar signs ($$$$) are not passed through as expected :(')
+          exit(4)
+        print('dollar signs appear to be handled correctly! :)')
+
+    # Test that bash scripts with variable evaluations work as expected
+    - name: bash-variable-evaluations
+      image: bash:5.1.8
+      script: |
+        #!/usr/bin/env bash
+        set -xe
+        var1=var1_value
+        var2=var1
+        echo $(eval echo \$$var2) > tmpfile
+        eval_result=$(cat tmpfile)
+        if [ "$eval_result" != "var1_value" ] ; then
+          echo "unexpected eval result: $eval_result"
+          exit 1
+        fi

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -154,7 +154,9 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	if err != nil {
 		return nil, err
 	}
-	initContainers = append(initContainers, entrypointInit)
+	// place the entrypoint first in case other init containers rely on its
+	// features (e.g. decode-script).
+	initContainers = append([]corev1.Container{entrypointInit}, initContainers...)
 	volumes = append(volumes, toolsVolume, downwardVolume)
 
 	limitRangeMin, err := getLimitRangeMinimum(ctx, taskRun.Namespace, b.KubeClient)

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -160,26 +160,24 @@ script-3`,
 		Command: []string{"sh"},
 		Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-mz4c7'
-#!/bin/sh
-script-1
-script-heredoc-randomly-generated-mz4c7
-tmpfile="/tekton/scripts/script-2-mssqb"
+cat > ${tmpfile} << '_EOF_'
+IyEvYmluL3NoCnNjcmlwdC0x
+_EOF_
+/tekton/tools/entrypoint decode-script "${tmpfile}"
+tmpfile="/tekton/scripts/script-2-mz4c7"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-78c5n'
-
-#!/bin/sh
-script-3
-script-heredoc-randomly-generated-78c5n
-tmpfile="/tekton/scripts/script-3-6nl7g"
+cat > ${tmpfile} << '_EOF_'
+CiMhL2Jpbi9zaApzY3JpcHQtMw==
+_EOF_
+/tekton/tools/entrypoint decode-script "${tmpfile}"
+tmpfile="/tekton/scripts/script-3-mssqb"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-j2tds'
-#!/bin/sh
-set -xe
-no-shebang
-script-heredoc-randomly-generated-j2tds
+cat > ${tmpfile} << '_EOF_'
+IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
+_EOF_
+/tekton/tools/entrypoint decode-script "${tmpfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -189,12 +187,12 @@ script-heredoc-randomly-generated-j2tds
 		Image: "step-2",
 	}, {
 		Image:        "step-3",
-		Command:      []string{"/tekton/scripts/script-2-mssqb"},
+		Command:      []string{"/tekton/scripts/script-2-mz4c7"},
 		Args:         []string{"my", "args"},
 		VolumeMounts: append(preExistingVolumeMounts, scriptsVolumeMount),
 	}, {
 		Image:   "step-3",
-		Command: []string{"/tekton/scripts/script-3-6nl7g"},
+		Command: []string{"/tekton/scripts/script-3-mssqb"},
 		Args:    []string{"my", "args"},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "pre-existing-volume-mount", MountPath: "/mount/path"},
@@ -251,24 +249,24 @@ sidecar-1`,
 		Command: []string{"sh"},
 		Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-mz4c7'
-#!/bin/sh
-script-1
-script-heredoc-randomly-generated-mz4c7
-tmpfile="/tekton/scripts/script-2-mssqb"
+cat > ${tmpfile} << '_EOF_'
+IyEvYmluL3NoCnNjcmlwdC0x
+_EOF_
+/tekton/tools/entrypoint decode-script "${tmpfile}"
+tmpfile="/tekton/scripts/script-2-mz4c7"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'script-heredoc-randomly-generated-78c5n'
-#!/bin/sh
-script-3
-script-heredoc-randomly-generated-78c5n
-tmpfile="/tekton/scripts/sidecar-script-0-6nl7g"
+cat > ${tmpfile} << '_EOF_'
+IyEvYmluL3NoCnNjcmlwdC0z
+_EOF_
+/tekton/tools/entrypoint decode-script "${tmpfile}"
+tmpfile="/tekton/scripts/sidecar-script-0-mssqb"
 touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << 'sidecar-script-heredoc-randomly-generated-j2tds'
-#!/bin/sh
-sidecar-1
-sidecar-script-heredoc-randomly-generated-j2tds
+cat > ${tmpfile} << '_EOF_'
+IyEvYmluL3NoCnNpZGVjYXItMQ==
+_EOF_
+/tekton/tools/entrypoint decode-script "${tmpfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -278,7 +276,7 @@ sidecar-script-heredoc-randomly-generated-j2tds
 		Image: "step-2",
 	}, {
 		Image:   "step-3",
-		Command: []string{"/tekton/scripts/script-2-mssqb"},
+		Command: []string{"/tekton/scripts/script-2-mz4c7"},
 		Args:    []string{"my", "args"},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "pre-existing-volume-mount", MountPath: "/mount/path"},
@@ -289,7 +287,7 @@ sidecar-script-heredoc-randomly-generated-j2tds
 
 	wantSidecars := []corev1.Container{{
 		Image:        "sidecar-1",
-		Command:      []string{"/tekton/scripts/sidecar-script-0-6nl7g"},
+		Command:      []string{"/tekton/scripts/sidecar-script-0-mssqb"},
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 	}}
 	if d := cmp.Diff(wantInit, gotInit); d != "" {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3871

Kubernetes replaces instances of "$$" in container args fields with "$". This can muck up the contents of script fields because scripts are passed into a TaskRun Pod as an arg to an init container. In particular, `$$` is used for the current process id in bash scripts.

Prior to this commit we [tried to prevent the replacement](https://github.com/tektoncd/pipeline/pull/3888) from happening by:

1. putting scripts into annotations on a pod and projecting them using downward
API
    - con: the max size of the annotations map is capped to ~250kB. The aggregate size of all scripts in a single Task therefore becomes constrained by this. Any other systems using annotations will reduce the available headroom. Backwards incompatible.

2. replacing instances of "$$" in scripts with "$$$$" for k8s to then process
back to "$$"
    - con: k8s doesn't actually process _all_ instances of "$$". For example, if you write an arg with format "echo $(eval \$$foo)" then k8s will see the first "$(", assume it's a variable reference, and pass it through verbatim. So user's scripts with bash variable become broken by tekton's new replacement. Backwards incompatible.

This commit takes a third approach, proposed by @MartinKanters, encoding scripts as base64 in the controller and then having them decoded in the init container. This bypasses Kubernetes' args processing completely because dollar
signs aren't used in the default base64 alphabet.

This approach avoids introducing a backwards-incompatible limit to the aggregate script size and doesn't mangle existing bash scripts with variable replacements.

The most noticeable trade-offs we now make are:

1. Tiny scripts can be up to 300% bigger, but as scripts get longer the max increase gets closer to 133%.
2. Also the TaskRun's `initContainer` YAML is a bit less human readable:

```
    initContainers:
    - args:
      - -c
      - |
        tmpfile="/tekton/scripts/script-0-f8fmf"
        touch ${tmpfile} && chmod +x ${tmpfile}
        cat > ${tmpfile} << '_EOF_'
        IyEvYmluL3NoCnNldCAteGUKZWNobyAibm8gc2hlYmFuZyI=
        _EOF_
        /tekton/tools/entrypoint decode-script "${tmpfile}"
```

The entrypoint is extended to decode base64 files so that the `shellImage`
(which is used to write scripts to disk for Step containers) is not required
to package a `base64` binary.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Scripts in Tasks are now written into the Task's pod using base64 to avoid kubernetes' built-in arg processing. This means they're a little larger than they were prior to this release but otherwise should continue working as expected.
```