### PR TITLE
Implement timeout for custom tasks.

### DIFF
--- a/docs/runs.md
+++ b/docs/runs.md
@@ -180,17 +180,21 @@ Supporting timeouts is optional but recommended.
 
 #### Developer guide for custom controllers supporting `Timeout`
 
-1. A tektoncd owned controller will never directly update the status of the
+1. Tekton controllers will never directly update the status of the
    `Run`, it is the responsibility of the custom task controller to support
-   timeout.
+   timeout. If timeouts are not supported, it's the responsibility of the custom
+   task controller to reject `Run`s that specify a timeout value.
 2. On a `pipelineRun` or `pipelineTask` timeout, the status of the
-   `Run.Spec.Status` is updated to `RunCancelled`. It is upto the custom task
-   controller, to respond to it. An existing controller, which does not yet
+   `Run.Spec.Status` is updated to `RunCancelled`. It is up to the custom task
+   controller to respond to it. An existing controller, which does not yet
    support timeout, will be able to cleanup, if it supports a cancel.
 3. A Custom Task author can watch for this status update
    (i.e. `Run.Spec.Status == RunCancelled`) and or `Run.HasTimedOut()` and take
-   any corresponding actions ( i.e. a clean up e.g., cancel a cloud build, stop
+   any corresponding actions (i.e. a clean up e.g., cancel a cloud build, stop
    the waiting timer, tear down the approval listener).
+4. Once resources or timers are cleaned up it is good practice to set a
+   `conditions` on the `Run`'s `status` of `Succeeded/False` with a `Reason`
+   of `RunTimedOut`.
 
 ### Specifying `Parameters`
 

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -18,7 +18,9 @@ package v1alpha1
 
 import (
 	"fmt"
+	"time"
 
+	apisconfig "github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	runv1alpha1 "github.com/tektoncd/pipeline/pkg/apis/run/v1alpha1"
@@ -64,6 +66,11 @@ type RunSpec struct {
 	// +optional
 	PodTemplate *PodTemplate `json:"podTemplate,omitempty"`
 
+	// Time after which the custom-task times out.
+	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
+	// +optional
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
 	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
 	// +optional
 	Workspaces []v1beta1.WorkspaceBinding `json:"workspaces,omitempty"`
@@ -95,6 +102,8 @@ func (rs RunSpec) GetParam(name string) *v1beta1.Param {
 const (
 	// RunReasonCancelled must be used in the Condition Reason to indicate that a Run was cancelled.
 	RunReasonCancelled = "RunCancelled"
+	// RunReasonTimedOut must be used in the Condition Reason to indicate that a Run was timed out.
+	RunReasonTimedOut = "RunTimedOut"
 	// RunReasonWorkspaceNotSupported can be used in the Condition Reason to indicate that the
 	// Run contains a workspace which is not supported by this custom task.
 	RunReasonWorkspaceNotSupported = "RunWorkspaceNotSupported"
@@ -188,8 +197,30 @@ func (r *Run) IsSuccessful() bool {
 	return r.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 }
 
-// GetRunKey return the taskrun key for timeout handler map
+// GetRunKey return the run's key for timeout handler map
 func (r *Run) GetRunKey() string {
-	// The address of the pointer is a threadsafe unique identifier for the taskrun
+	// The address of the pointer is a threadsafe unique identifier for the run
 	return fmt.Sprintf("%s/%p", "Run", r)
+}
+
+// HasTimedOut returns true if the Run's running time is beyond the allowed timeout
+func (r *Run) HasTimedOut() bool {
+	if r.Status.StartTime == nil || r.Status.StartTime.IsZero() {
+		return false
+	}
+	timeout := r.GetTimeout()
+	// If timeout is set to 0 or defaulted to 0, there is no timeout.
+	if timeout == apisconfig.NoTimeoutDuration {
+		return false
+	}
+	runtime := time.Since(r.Status.StartTime.Time)
+	return runtime > timeout
+}
+
+func (r *Run) GetTimeout() time.Duration {
+	// Use the platform default if no timeout is set
+	if r.Spec.Timeout == nil {
+		return apisconfig.DefaultTimeoutMinutes * time.Minute
+	}
+	return r.Spec.Timeout.Duration
 }

--- a/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1alpha1/zz_generated.deepcopy.go
@@ -715,6 +715,11 @@ func (in *RunSpec) DeepCopyInto(out *RunSpec) {
 		*out = new(pod.Template)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.Workspaces != nil {
 		in, out := &in.Workspaces, &out.Workspaces
 		*out = make([]v1beta1.WorkspaceBinding, len(*in))

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -224,9 +224,6 @@ func (pt PipelineTask) validateCustomTask() (errs *apis.FieldError) {
 	if pt.Resources != nil {
 		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support PipelineResources", "resources"))
 	}
-	if pt.Timeout != nil {
-		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support timeout", "timeout"))
-	}
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -19,12 +19,10 @@ package v1beta1
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/test/diff"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
@@ -205,17 +203,6 @@ func TestPipelineTask_ValidateCustomTask(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `invalid value: custom tasks do not support PipelineResources`,
 			Paths:   []string{"resources"},
-		},
-	}, {
-		name: "custom task doesn't support timeout",
-		task: PipelineTask{
-			Name:    "foo",
-			Timeout: &metav1.Duration{Duration: time.Duration(3)},
-			TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example"},
-		},
-		expectedError: apis.FieldError{
-			Message: `invalid value: custom tasks do not support timeout`,
-			Paths:   []string{"timeout"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -52,7 +52,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sApiLables "k8s.io/apimachinery/pkg/labels"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
@@ -1175,14 +1175,14 @@ func (c *Reconciler) updatePipelineRunStatusFromInformer(ctx context.Context, pr
 	// Pipeline and PipelineRun.  The user could change them during the lifetime of the PipelineRun so the
 	// current labels may not be set on the previously created TaskRuns.
 	pipelineRunLabels := getTaskrunLabels(pr, "", false)
-	taskRuns, err := c.taskRunLister.TaskRuns(pr.Namespace).List(k8sApiLables.SelectorFromSet(pipelineRunLabels))
+	taskRuns, err := c.taskRunLister.TaskRuns(pr.Namespace).List(k8slabels.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
 		logger.Errorf("could not list TaskRuns %#v", err)
 		return err
 	}
 	updatePipelineRunStatusFromTaskRuns(logger, pr, taskRuns)
 
-	runs, err := c.runLister.Runs(pr.Namespace).List(k8sApiLables.SelectorFromSet(pipelineRunLabels))
+	runs, err := c.runLister.Runs(pr.Namespace).List(k8slabels.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
 		logger.Errorf("could not list Runs %#v", err)
 		return err

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -51,7 +52,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
+	k8sApiLables "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
@@ -561,6 +562,10 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 		return err
 	}
 
+	if err := c.processRunTimeouts(ctx, pr, pipelineRunState); err != nil {
+		return err
+	}
+
 	// Reset the skipped status to trigger recalculation
 	pipelineRunFacts.ResetSkippedCache()
 
@@ -579,12 +584,38 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	pr.Status.TaskRuns = pipelineRunFacts.State.GetTaskRunsStatus(pr)
 	pr.Status.Runs = pipelineRunFacts.State.GetRunsStatus(pr)
 	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks()
-
 	if after.Status == corev1.ConditionTrue {
 		pr.Status.PipelineResults = resources.ApplyTaskResultsToPipelineResults(pipelineSpec.Results, pr.Status.TaskRuns, pr.Status.Runs)
 	}
 
 	logger.Infof("PipelineRun %s status is being set to %s", pr.Name, after)
+	return nil
+}
+
+// processRunTimeouts custom tasks are requested to cancel, if they have timed out. Custom tasks can do any cleanup
+// during this step.
+func (c *Reconciler) processRunTimeouts(ctx context.Context, pr *v1beta1.PipelineRun, pipelineState resources.PipelineRunState) error {
+	errs := []string{}
+	logger := logging.FromContext(ctx)
+	if pr.IsCancelled() {
+		return nil
+	}
+	for _, rprt := range pipelineState {
+		if rprt.IsCustomTask() {
+			if rprt.Run != nil && !rprt.Run.IsCancelled() && (pr.IsTimedOut() || (rprt.Run.HasTimedOut() && !rprt.Run.IsDone())) {
+				logger.Infof("Cancelling run task: %s due to timeout.", rprt.RunName)
+				err := cancelRun(ctx, rprt.RunName, pr.Namespace, c.PipelineClientSet)
+				if err != nil {
+					errs = append(errs,
+						fmt.Errorf("failed to patch Run `%s` with cancellation: %s", rprt.RunName, err).Error())
+				}
+			}
+		}
+	}
+	if len(errs) > 0 {
+		e := strings.Join(errs, "\n")
+		return fmt.Errorf("error(s) from processing cancel request for timed out Run(s) of PipelineRun %s: %s", pr.Name, e)
+	}
 	return nil
 }
 
@@ -640,7 +671,11 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 		}
 		if rprt.ResolvedConditionChecks == nil || rprt.ResolvedConditionChecks.IsSuccess() {
 			if rprt.IsCustomTask() {
-				rprt.Run, err = c.createRun(ctx, rprt, pr)
+				if rprt.IsFinalTask(pipelineRunFacts) {
+					rprt.Run, err = c.createRun(ctx, rprt, pr, getFinallyTaskRunTimeout)
+				} else {
+					rprt.Run, err = c.createRun(ctx, rprt, pr, getTaskRunTimeout)
+				}
 				if err != nil {
 					recorder.Eventf(pr, corev1.EventTypeWarning, "RunCreationFailed", "Failed to create Run %q: %v", rprt.RunName, err)
 					return fmt.Errorf("error creating Run called %s for PipelineTask %s from PipelineRun %s: %w", rprt.RunName, rprt.PipelineTask.Name, pr.Name, err)
@@ -758,7 +793,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 	return c.PipelineClientSet.TektonV1beta1().TaskRuns(pr.Namespace).Create(ctx, tr, metav1.CreateOptions{})
 }
 
-func (c *Reconciler) createRun(ctx context.Context, rprt *resources.ResolvedPipelineRunTask, pr *v1beta1.PipelineRun) (*v1alpha1.Run, error) {
+func (c *Reconciler) createRun(ctx context.Context, rprt *resources.ResolvedPipelineRunTask, pr *v1beta1.PipelineRun, getTimeoutFunc getTimeoutFunc) (*v1alpha1.Run, error) {
 	logger := logging.FromContext(ctx)
 	taskRunSpec := pr.GetTaskRunSpec(rprt.PipelineTask.Name)
 	r := &v1alpha1.Run{
@@ -773,6 +808,7 @@ func (c *Reconciler) createRun(ctx context.Context, rprt *resources.ResolvedPipe
 			Ref:                rprt.PipelineTask.TaskRef,
 			Params:             rprt.PipelineTask.Params,
 			ServiceAccountName: taskRunSpec.TaskServiceAccountName,
+			Timeout:            getTimeoutFunc(ctx, pr, rprt),
 			PodTemplate:        taskRunSpec.TaskPodTemplate,
 		},
 	}
@@ -1139,14 +1175,14 @@ func (c *Reconciler) updatePipelineRunStatusFromInformer(ctx context.Context, pr
 	// Pipeline and PipelineRun.  The user could change them during the lifetime of the PipelineRun so the
 	// current labels may not be set on the previously created TaskRuns.
 	pipelineRunLabels := getTaskrunLabels(pr, "", false)
-	taskRuns, err := c.taskRunLister.TaskRuns(pr.Namespace).List(labels.SelectorFromSet(pipelineRunLabels))
+	taskRuns, err := c.taskRunLister.TaskRuns(pr.Namespace).List(k8sApiLables.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
 		logger.Errorf("could not list TaskRuns %#v", err)
 		return err
 	}
 	updatePipelineRunStatusFromTaskRuns(logger, pr, taskRuns)
 
-	runs, err := c.runLister.Runs(pr.Namespace).List(labels.SelectorFromSet(pipelineRunLabels))
+	runs, err := c.runLister.Runs(pr.Namespace).List(k8sApiLables.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
 		logger.Errorf("could not list Runs %#v", err)
 		return err

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -18,6 +18,7 @@ package pipelinerun
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -45,6 +46,7 @@ import (
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	"github.com/tektoncd/pipeline/test/names"
+	"gomodules.xyz/jsonpatch/v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -523,6 +525,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 					Name:  "param1",
 					Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "value1"},
 				}},
+				Timeout: &metav1.Duration{Duration: time.Hour},
 				Ref: &v1beta1.TaskRef{
 					APIVersion: "example.dev/v0",
 					Kind:       "Example",
@@ -593,6 +596,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 					},
 				},
 				ServiceAccountName: "default",
+				Timeout:            &metav1.Duration{Duration: time.Hour},
 			},
 		},
 	}, {
@@ -654,6 +658,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 					Kind:       "Example",
 				},
 				ServiceAccountName: "default",
+				Timeout:            &metav1.Duration{Duration: time.Hour},
 				Workspaces: []v1beta1.WorkspaceBinding{{
 					Name:    "taskws",
 					SubPath: "foo/bar",
@@ -1561,6 +1566,209 @@ func TestReconcileOnCancelledPipelineRun(t *testing.T) {
 	// This PipelineRun should still be complete and false, and the status should reflect that
 	if !reconciledRun.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
 		t.Errorf("Expected PipelineRun status to be complete and false, but was %v", reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
+	}
+}
+
+func TestReconcileForCustomTaskWithPipelineTaskTimedOut(t *testing.T) {
+	names.TestingSeed()
+	// TestReconcileForCustomTaskWithPipelineTaskTimedOut runs "Reconcile" on a PipelineRun.
+	// It verifies that reconcile is successful, and the individual
+	// custom task which has timed out, is patched as cancelled.
+	ps := []*v1beta1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("test"),
+		tb.PipelineSpec(tb.PipelineTask("hello-world-1", "hello-world"))),
+	}
+	prName := "test-pipeline-run-custom-task-with-timeout"
+	prs := []*v1beta1.PipelineRun{tb.PipelineRun(prName,
+		tb.PipelineRunNamespace("test"),
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccountName("test-sa"),
+		),
+	)}
+	ps[0].Spec.Tasks[0].TaskRef = &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example"}
+	startedRun := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline-run-custom-task-with-timeout-hello-world-1",
+			Namespace: "test",
+			OwnerReferences: []metav1.OwnerReference{{
+				Kind: "PipelineRun",
+				Name: prName,
+			}},
+			Labels: map[string]string{
+				pipeline.GroupName + pipeline.PipelineLabelKey:     "test-pipeline",
+				pipeline.GroupName + pipeline.PipelineRunLabelKey:  prName,
+				pipeline.GroupName + pipeline.PipelineTaskLabelKey: "hello-world-1",
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: v1alpha1.RunSpec{
+			Timeout: &metav1.Duration{Duration: time.Minute},
+			Ref: &v1beta1.TaskRef{
+				APIVersion: "example.dev/v0",
+				Kind:       "Example",
+			},
+		},
+		Status: v1alpha1.RunStatus{
+			RunStatusFields: v1alpha1.RunStatusFields{
+				StartTime: &metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
+			},
+			Status: duckv1.Status{
+				Conditions: []apis.Condition{
+					{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionUnknown,
+					},
+				},
+			},
+		},
+	}
+	runs := []*v1alpha1.Run{startedRun}
+	cms := []*corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data: map[string]string{
+				"enable-custom-tasks": "true",
+			},
+		},
+	}
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		ConfigMaps:   cms,
+		Runs:         runs,
+	}
+	prt := newPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	wantEvents := []string{
+		"Normal Started",
+		"Normal Running Tasks Completed: 0 \\(Failed: 0, Cancelled 0\\), Incomplete: 1, Skipped: 0",
+	}
+	_, clients := prt.reconcileRun("test", prName, wantEvents, false)
+
+	actions := clients.Pipeline.Actions()
+	if len(actions) < 2 {
+		t.Fatalf("Expected client to have at least two action implementation but it has %d", len(actions))
+	}
+
+	// The patch operation to cancel the run must be executed.
+	got := []jsonpatch.Operation{}
+	for _, a := range actions {
+		if action, ok := a.(ktesting.PatchAction); ok {
+			if a.(ktesting.PatchAction).Matches("patch", "runs") {
+				err := json.Unmarshal(action.GetPatch(), &got)
+				if err != nil {
+					t.Fatalf("Expected to get a patch operation for cancel,"+
+						" but got error: %v\n", err)
+				}
+				break
+			}
+		}
+	}
+	want := []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/status",
+		Value:     "RunCancelled",
+	}}
+	if d := cmp.Diff(got, want); d != "" {
+		t.Fatalf("Expected cancel patch operation, but got a mismatch %s", diff.PrintWantGot(d))
+	}
+}
+
+func TestReconcileForCustomTaskWithPipelineRunTimedOut(t *testing.T) {
+	names.TestingSeed()
+	// TestReconcileForCustomTaskWithPipelineRunTimedOut runs "Reconcile" on a
+	// PipelineRun that has timed out.
+	// It verifies that reconcile is successful, and the custom task has also timed
+	// out and patched as cancelled.
+	pipelineName := "test-pipeline"
+	ps := []*v1beta1.Pipeline{tb.Pipeline(pipelineName,
+		tb.PipelineNamespace("test"), tb.PipelineSpec(
+			tb.PipelineTask("hello-world-1", "hello-world"),
+		))}
+
+	prName := "test-pipeline-run-custom-task"
+	prs := []*v1beta1.PipelineRun{tb.PipelineRun(prName,
+		tb.PipelineRunNamespace("test"),
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccountName("test-sa"),
+			tb.PipelineRunTimeout(12*time.Hour),
+		),
+		tb.PipelineRunStatus(
+			tb.PipelineRunStartTime(time.Now().AddDate(0, 0, -1))),
+	)}
+	ps[0].Spec.Tasks[0].TaskRef = &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example"}
+
+	cms := []*corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data: map[string]string{
+				"enable-custom-tasks": "true",
+			},
+		},
+	}
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		ConfigMaps:   cms,
+	}
+	prt := newPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	wantEvents := []string{
+		fmt.Sprintf("Warning Failed PipelineRun \"%s\" failed to finish within \"12h0m0s\"", prName),
+	}
+	runName := "test-pipeline-run-custom-task-hello-world-1-9l9zj"
+
+	reconciledRun, clients := prt.reconcileRun("test", prName, wantEvents, false)
+
+	postReconcileRun, err := clients.Pipeline.TektonV1alpha1().Runs("test").Get(prt.TestAssets.Ctx, runName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Run get request failed, %v", err)
+	}
+
+	gotTimeoutValue := postReconcileRun.GetTimeout()
+	expectedTimeoutValue := time.Second
+
+	if d := cmp.Diff(gotTimeoutValue, expectedTimeoutValue); d != "" {
+		t.Fatalf("Expected timeout for created Run, but got a mismatch %s", diff.PrintWantGot(d))
+	}
+
+	if reconciledRun.Status.CompletionTime == nil {
+		t.Errorf("Expected a CompletionTime on already timedout PipelineRun but was nil")
+	}
+
+	// The PipelineRun should be timed out.
+	if reconciledRun.Status.GetCondition(apis.ConditionSucceeded).Reason != "PipelineRunTimeout" {
+		t.Errorf("Expected PipelineRun to be timed out, but condition reason is %s",
+			reconciledRun.Status.GetCondition(apis.ConditionSucceeded))
+	}
+
+	actions := clients.Pipeline.Actions()
+	if len(actions) < 2 {
+		t.Fatalf("Expected client to have at least two action implementation but it has %d", len(actions))
+	}
+
+	// The patch operation to cancel the run must be executed.
+	got := []jsonpatch.Operation{}
+	for _, a := range actions {
+		if action, ok := a.(ktesting.PatchAction); ok {
+			if a.(ktesting.PatchAction).Matches("patch", "runs") {
+				err := json.Unmarshal(action.GetPatch(), &got)
+				if err != nil {
+					t.Fatalf("Expected to get a patch operation for cancel,"+
+						" but got error: %v\n", err)
+				}
+				break
+			}
+		}
+	}
+	want := []jsonpatch.JsonPatchOperation{{
+		Operation: "add",
+		Path:      "/spec/status",
+		Value:     "RunCancelled",
+	}}
+	if d := cmp.Diff(got, want); d != "" {
+		t.Fatalf("Expected RunCancelled patch operation, but got a mismatch %s", diff.PrintWantGot(d))
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Tekton shall give custom task controller an opportunity to respect timeout and do a proper cleanup. It depends on the individual custom task controller implementation - how exactly it responds.

closes #3962

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

Tekton controllers does not forcibly update the `.status` of a Run directly, that responsibility belongs to the Custom Task controller.

1. Run can be created with a timeout now, and it is upto the custom task controller to support it or not.

2. Custom tasks inside a PipelineRun with pipeline wide timeout and/or pipeline task level timeout is updated to run with same policy as it is for task runs. On timeout, the run's status is updated with "RunCancelled".

Added relevant tests.

Corresponding TEP update at: https://github.com/tektoncd/community/pull/433

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note

Added timeout support for custom task. 
e.g.

        apiVersion: tekton.dev/v1alpha1
        kind: Run
        metadata:
          generateName: simpletasklooprun
        spec:
          timeout: 10s # set timeouts here.
          params:
            - name: word
              value:
                - jump
                - land
                - roll
            - name: suffix
              value: ing
          ref:
            apiVersion: custom.tekton.dev/v1alpha1
            kind: TaskLoop
            name: simpletaskloop

Existing custom task controller, can either support the new field or ignore it.
```
