### PR TITLE
Validate run for both ref and spec as nil.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/run_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation.go
@@ -44,6 +44,9 @@ func (rs *RunSpec) Validate(ctx context.Context) *apis.FieldError {
 	if rs.Ref != nil && rs.Spec != nil {
 		return apis.ErrMultipleOneOf("spec.ref", "spec.spec")
 	}
+	if rs.Ref == nil && rs.Spec == nil {
+		return apis.ErrMissingOneOf("spec.ref", "spec.spec")
+	}
 	if rs.Ref != nil {
 		if rs.Ref.APIVersion == "" {
 			return apis.ErrMissingField("spec.ref.apiVersion")

--- a/pkg/apis/pipeline/v1alpha1/run_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation_test.go
@@ -49,12 +49,22 @@ func TestRun_Invalid(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "temp",
 			},
-			Spec: v1alpha1.RunSpec{
-				Ref:  nil,
-				Spec: nil,
-			},
+			Spec: v1alpha1.RunSpec{},
 		},
 		want: apis.ErrMissingField("spec"),
+	}, {
+		name: "Both spec and ref missing",
+		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref:                nil,
+				Spec:               nil,
+				ServiceAccountName: "test-sa",
+			},
+		},
+		want: apis.ErrMissingOneOf("spec.ref", "spec.spec"),
 	}, {
 		name: "Both Ref and Spec",
 		run: &v1alpha1.Run{


### PR DESCRIPTION
Previously we had the check for an empty RunSpec but a RunSpec
could be missing both Ref and Spec and yet contain some other
field. This validation check was missing.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Added validation for both Ref and spec missing.
And a test to test then newly added validation.

https://github.com/tektoncd/pipeline/pull/3901#issuecomment-848190336
/kind bug
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
