### PR TITLE
Update docs to use Kubernetes 1.18 as the minimum version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -265,7 +265,7 @@ The recommended minimum development configuration is:
 
 <!-- TODO: Someone needs to validate the cluster-version-->
 1. Create a GKE cluster (with `--cluster-version=latest` but you can use any
-    version 1.17 or later):
+    version 1.18 or later):
 
     ```bash
     export PROJECT_ID=my-gcp-project
@@ -283,7 +283,7 @@ The recommended minimum development configuration is:
      --machine-type=n1-standard-4 \
      --image-type=cos \
      --num-nodes=1 \
-     --cluster-version=1.17
+     --cluster-version=1.18
     ```
 
     > **Note** The recommended [GCE machine type](https://cloud.google.com/compute/docs/machine-types) is `n1-standard-4`

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Tekton Pipelines are **Typed**:
 - Jump in with [the tutorial!](docs/tutorial.md)
 - Take a look at our [roadmap](roadmap.md)
 
-*Note that starting from the 0.20 release of Tekton, you need to have
-a cluster with **Kubernetes version 1.17 or later***.
+*Note that starting from the 0.24 release of Tekton, you need to have
+a cluster with **Kubernetes version 1.18 or later***.
 
 ### Read the docs
 

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -42,7 +42,7 @@ This document makes reference in a few places to different profiles for Tekton i
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
 
-There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.17 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
+There is no formal specification of the Kubernetes API and Resource Model. This document assumes Kubernetes 1.18 behavior; this behavior will typically be supported by many future Kubernetes versions. Additionally, this document may reference specific core Kubernetes resources; these references may be illustrative (i.e. an implementation on Kubernetes) or descriptive (i.e. this Kubernetes resource MUST be exposed). References to these core Kubernetes resources will be annotated as either illustrative or descriptive.
 
 ## Modifying This Specification
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,14 +22,14 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 
 ## Before you begin
 
-1. You must have a Kubernetes cluster running version 1.17 or later.
+1. You must have a Kubernetes cluster running version 1.18 or later.
 
    If you don't already have a cluster, you can create one for testing with `kind`.
    [Install `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and create a cluster by running [`kind create cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). This
    will create a cluster running locally, with RBAC enabled and your user granted
    the `cluster-admin` role.
 
-1. If you want to support high availability usecases, install a [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) on your cluster. 
+1. If you want to support high availability usecases, install a [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) on your cluster.
 
 1. Choose the version of Tekton Pipelines you want to install. You have the following options:
 
@@ -355,7 +355,7 @@ not running.
   disabled (`"false"`), which means it is disallowed to use the
   `bundle` field.
 
-- `disable-creds-init` - set this flag to `"true"` to [disable Tekton's built-in credential initialization](auth.md#disabling-tektons-built-in-auth) 
+- `disable-creds-init` - set this flag to `"true"` to [disable Tekton's built-in credential initialization](auth.md#disabling-tektons-built-in-auth)
 and use Workspaces to mount credentials from Secrets instead.
 The default is `false`. For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/3399).
 
@@ -397,7 +397,7 @@ Features currently in "alpha" are:
 If you want to run Tekton Pipelines in a way so that webhooks are resiliant against failures and support
 high concurrency scenarios, you need to run a [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) in
 your Kubernetes cluster. This is required by the [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-to compute replica count. 
+to compute replica count.
 
 See [HA Support for Tekton Pipeline Controllers](./enabling-ha.md) for instructions on configuring
 High Availability in the Tekton Pipelines Controller.

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -6,7 +6,7 @@ weight: 1400
 -->
 # Pod templates
 
-A Pod template defines a portion of a [`PodSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#pod-v1-core)
+A Pod template defines a portion of a [`PodSpec`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#pod-v1-core)
 configuration that Tekton can use as "boilerplate" for a Pod that runs your `Tasks` and `Pipelines`.
 
 You can specify a Pod template for `TaskRuns` and `PipelineRuns`. In the template, you can specify custom values for fields governing


### PR DESCRIPTION
# Changes

As of v0.24, Tekton Pipelines requires Kubernetes 1.18
(https://github.com/tektoncd/pipeline/releases/tag/v0.24.0), but the docs were not updated. This updates all references of Kubernetes 1.17 to 1.18 as necessary.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] ~[Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```