### PR TITLE
Fix list of proposed kind labels for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ In addition, categorize the changes you're making using the "/kind" Prow command
 
 /kind <kind>
 
-Supported kinds are: bug, cleanup, design, documentation, failing-test, feature, flake, misc, question, tep
+Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
 -->
 
 # Submitter Checklist


### PR DESCRIPTION
# Changes

kind/failing-test is not supported kind label at this moment, so better to remove if from the list with suggested labels to avoid error in check-pr-has-kind-label job.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

