### PR TITLE
Add Dockerfiles for Windows entrypoint and nop images

### DIFF
--- a/images/windows/entrypoint/Dockerfile
+++ b/images/windows/entrypoint/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
+
+FROM golang:1.16.4 AS builder
+
+COPY . c:/gopath/src/github.com/tektoncd/pipeline
+
+WORKDIR c:/gopath/src/github.com/tektoncd/pipeline
+
+RUN go build -o c:/gopath/bin/entrypoint.exe ./cmd/entrypoint
+
+FROM ${BASE_IMAGE}
+
+COPY --from=builder c:/gopath/bin/entrypoint.exe c:/ProgramData/tektoncd/pipeline/entrypoint.exe
+
+# Copy kodata into the image
+# NOTE: The COPY instruction does not follow symbolic links
+COPY ./.git/HEAD ./LICENSE c:/ProgramData/tektoncd/pipeline/data/
+
+COPY ./.git/refs c:/ProgramData/tektoncd/pipeline/data/refs/
+
+COPY ./third_party c:/ProgramData/tektoncd/pipeline/data/third-party/
+
+ENTRYPOINT ["c:/ProgramData/tektoncd/pipeline/entrypoint.exe"]

--- a/images/windows/nop/Dockerfile
+++ b/images/windows/nop/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
+
+FROM golang:1.16.4 AS builder
+
+COPY . c:/gopath/src/github.com/tektoncd/pipeline
+
+WORKDIR c:/gopath/src/github.com/tektoncd/pipeline
+
+RUN go build -o c:/gopath/bin/nop.exe ./cmd/nop
+
+FROM ${BASE_IMAGE}
+
+COPY --from=builder c:/gopath/bin/nop.exe c:/ProgramData/tektoncd/pipeline/nop.exe
+
+# Copy kodata into the image
+# NOTE: The COPY instruction does not follow symbolic links
+COPY ./.git/HEAD ./LICENSE c:/ProgramData/tektoncd/pipeline/data/
+
+COPY ./.git/refs c:/ProgramData/tektoncd/pipeline/data/refs/
+
+COPY ./third_party c:/ProgramData/tektoncd/pipeline/data/third-party/
+
+ENTRYPOINT ["c:/ProgramData/tektoncd/pipeline/nop.exe"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

This change adds two new Dockerfiles under 'images/windows/'. These
can be used to build Windows images for the entrypoint and nop
binaries. Docker is used to build these images because Ko does
not currently support building for Windows.

Related issue: https://github.com/tektoncd/pipeline/issues/3951

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
