### PR TITLE
Cleanup integraton tests for multi-arch case

### DIFF
--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -167,7 +167,7 @@ func getHelmDeployTask(namespace, helmDeployTaskName string) *v1beta1.Task {
 				Name: "chartname", Type: v1beta1.ParamTypeString, Default: &empty,
 			}},
 			Steps: []v1beta1.Step{{Container: corev1.Container{
-				Image: getTestImage(helmImage),
+				Image: "alpine/helm:3.5.4",
 				Args: []string{
 					"upgrade",
 					"--wait",
@@ -328,7 +328,7 @@ func removeAllHelmReleases(ctx context.Context, c *clients, t *testing.T, namesp
 		Spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{Container: corev1.Container{
 				Name:    "helm-remove-all",
-				Image:   getTestImage(helmImage),
+				Image:   "alpine/helm:3.5.4",
 				Command: []string{"/bin/sh"},
 				Args:    []string{"-c", fmt.Sprintf("helm ls --short --all --namespace %s | xargs -n1 helm delete --namespace %s", namespace, namespace)},
 			}}},

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -38,8 +38,6 @@ const (
 	registryImage
 	// kubectl image
 	kubectlImage
-	// helm image
-	helmImage
 	// kaniko executor image
 	kanikoImage
 	// dockerize image
@@ -68,7 +66,6 @@ func initImageNames() map[int]string {
 			busyboxImage:   "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977",
 			registryImage:  "ibmcom/registry:2.6.2.5",
 			kubectlImage:   "ibmcom/kubectl:v1.13.9",
-			helmImage:      "ibmcom/alpine-helm-s390x:latest",
 			kanikoImage:    "gcr.io/kaniko-project/executor:s390x-9ed158c1f63a059cde4fd5f8b95af51d452d9aa7",
 			dockerizeImage: "ibmcom/dockerize-s390x",
 		}
@@ -77,7 +74,6 @@ func initImageNames() map[int]string {
 			busyboxImage:   "busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977",
 			registryImage:  "ppc64le/registry:2",
 			kubectlImage:   "ibmcom/kubectl:v1.13.9",
-			helmImage:      "ibmcom/helm-ppc64le:latest",
 			kanikoImage:    "ibmcom/kaniko-project-executor-ppc64le:v0.17.1",
 			dockerizeImage: "ibmcom/dockerize-ppc64le",
 		}
@@ -86,7 +82,6 @@ func initImageNames() map[int]string {
 			busyboxImage:   "busybox@sha256:895ab622e92e18d6b461d671081757af7dbaa3b00e3e28e12505af7817f73649",
 			registryImage:  "registry",
 			kubectlImage:   "lachlanevenson/k8s-kubectl",
-			helmImage:      "alpine/helm:3.1.2",
 			kanikoImage:    "gcr.io/kaniko-project/executor:v1.3.0",
 			dockerizeImage: "jwilder/dockerize",
 		}
@@ -101,6 +96,7 @@ func getImagesMappingRE() map[*regexp.Regexp][]byte {
 
 	for existingImage, archSpecificImage := range imageNamesMapping {
 		imageMappingRE[regexp.MustCompile("(?im)image: "+existingImage+"$")] = []byte("image: " + archSpecificImage)
+		imageMappingRE[regexp.MustCompile("(?im)default: "+existingImage+"$")] = []byte("default: " + archSpecificImage)
 	}
 
 	return imageMappingRE
@@ -150,8 +146,6 @@ func initExcludedTests() sets.String {
 			// examples
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
-			"TestExamples/v1beta1/pipelineruns/pipelinerun",
-			"TestYamls/yamls/v1beta1/pipelineruns/pipelinerun.yaml",
 		)
 	case "ppc64le":
 		return sets.NewString(


### PR DESCRIPTION
# Changes

- unify usage of `alpine/helm` image, which is now the one for all architectures (the update is tested for `amd64`, `s390x` and `ppc64le`)
- remove several tests from skip list for `s390x` arch

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

