### PR TITLE
Add OSRequirement to TaskSpec to support mixed-node clusters

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -104,6 +104,13 @@ type TaskSpec struct {
 
 	// Results are values that this Task can output
 	Results []TaskResult `json:"results,omitempty"`
+
+	// OSRequirement indicates an Operating System requirement for the task.
+	// If a value is supplied, a nodeSelector will be added to the PodTemplate
+	// of a TaskRun with the key "kubernetes.io/os". Some example values
+	// are: "linux" or "windows".
+	// +optional
+	OSRequirement string `json:"osRequirement,omitempty"`
 }
 
 // TaskResult used to describe the results of a task

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -366,6 +366,17 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		}
 	}
 
+	// Convert the os requirement from Task to a nodeSelector on TaskRun
+	if taskSpec.OSRequirement != "" {
+		if tr.Spec.PodTemplate == nil {
+			tr.Spec.PodTemplate = &pod.Template{}
+		}
+		if tr.Spec.PodTemplate.NodeSelector == nil {
+			tr.Spec.PodTemplate.NodeSelector = make(map[string]string, 1)
+		}
+		tr.Spec.PodTemplate.NodeSelector["kubernetes.io/os"] = taskSpec.OSRequirement
+	}
+
 	// Initialize the cloud events if at least a CloudEventResource is defined
 	// and they have not been initialized yet.
 	// FIXME(afrittoli) This resource specific logic will have to be replaced


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

This commit adds a new field to TaskSpec making it easy for a user
to define a specific OS requirement for a given task. This is
necessary for K8s clusters which contain mixed operating systems
(such as Linux and Windows).

Related:
TEP - https://github.com/tektoncd/community/pull/383

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
An Operating System requirement can now be specified in a TaskSpec by setting spec.osRequirement
```