### PR TITLE
Fix Windows image entrypoint paths for parity with Linux

### DIFF
--- a/images/windows/entrypoint/Dockerfile
+++ b/images/windows/entrypoint/Dockerfile
@@ -6,11 +6,11 @@ COPY . c:/gopath/src/github.com/tektoncd/pipeline
 
 WORKDIR c:/gopath/src/github.com/tektoncd/pipeline
 
-RUN go build -o c:/gopath/bin/entrypoint.exe ./cmd/entrypoint
+RUN go build -o c:/gopath/bin/entrypoint ./cmd/entrypoint
 
 FROM ${BASE_IMAGE}
 
-COPY --from=builder c:/gopath/bin/entrypoint.exe c:/ProgramData/tektoncd/pipeline/entrypoint.exe
+COPY --from=builder c:/gopath/bin/entrypoint c:/ko-app/entrypoint
 
 # Copy kodata into the image
 # NOTE: The COPY instruction does not follow symbolic links
@@ -20,4 +20,4 @@ COPY ./.git/refs c:/ProgramData/tektoncd/pipeline/data/refs/
 
 COPY ./third_party c:/ProgramData/tektoncd/pipeline/data/third-party/
 
-ENTRYPOINT ["c:/ProgramData/tektoncd/pipeline/entrypoint.exe"]
+ENTRYPOINT ["c:/ko-app/entrypoint"]

--- a/images/windows/nop/Dockerfile
+++ b/images/windows/nop/Dockerfile
@@ -6,11 +6,11 @@ COPY . c:/gopath/src/github.com/tektoncd/pipeline
 
 WORKDIR c:/gopath/src/github.com/tektoncd/pipeline
 
-RUN go build -o c:/gopath/bin/nop.exe ./cmd/nop
+RUN go build -o c:/gopath/bin/nop ./cmd/nop
 
 FROM ${BASE_IMAGE}
 
-COPY --from=builder c:/gopath/bin/nop.exe c:/ProgramData/tektoncd/pipeline/nop.exe
+COPY --from=builder c:/gopath/bin/nop c:/ko-app/nop
 
 # Copy kodata into the image
 # NOTE: The COPY instruction does not follow symbolic links
@@ -20,4 +20,4 @@ COPY ./.git/refs c:/ProgramData/tektoncd/pipeline/data/refs/
 
 COPY ./third_party c:/ProgramData/tektoncd/pipeline/data/third-party/
 
-ENTRYPOINT ["c:/ProgramData/tektoncd/pipeline/nop.exe"]
+ENTRYPOINT ["c:/ko-app/nop"]


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Tekton expects to find the entrypoint binary in `/ko-app/entrypoint`
which is equivalent to `C:\ko-app\entrypoint` on Windows. See
`pkg/pod/entrypoint.go:orderContainers()`. Currently entrypoint is
stored in `C:\ProgramData\tektoncd\pipeline\entrypoint.exe` causing
this to break on Windows. To avoid the need for platform-specific
logic in the controller, and for parity with Linux, this change
updates 'entrypoint' and 'nop' images for Windows to store binaries
in `C:\ko-app\`.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```