### PR TITLE
Add missing frontmatter to some docs (release-v0.24.x patch)

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Authentication"
-weight: 7
+weight: 1000
 ---
 -->
 # Authentication at Run Time

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Conditions"
-weight: 11
+weight: 2100
 ---
 -->
 # Conditions

--- a/docs/container-contract.md
+++ b/docs/container-contract.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Container Contract"
-weight: 8
+weight: 1700
 ---
 -->
 # Container Contract

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Deprecations"
-weight: 16
+weight: 5000
 ---
 -->
 

--- a/docs/enabling-ha.md
+++ b/docs/enabling-ha.md
@@ -1,3 +1,10 @@
+<!--
+---
+linkTitle: "HA Support"
+weight: 1500
+---
+-->
+
 # HA Support for Tekton Pipeline Controllers
 
   - [Overview](#overview)

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Events"
-weight: 2
+weight: 700
 ---
 -->
 # Events in Tekton

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,3 +1,10 @@
+<!--
+---
+linkTitle: "Installation"
+weight: 100
+---
+-->
+
 # Installing Tekton Pipelines
 
 This guide explains how to install Tekton Pipelines. It covers the following topics:

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Labels"
-weight: 10
+weight: 1300
 ---
 -->
 # Labels

--- a/docs/logs.md
+++ b/docs/logs.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Logs"
-weight: 9
+weight: 1100
 ---
 -->
 # Execution Logs

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Pipeline Metrics"
-weight: 14
+weight: 1200
 ---
 -->
 # Pipeline Controller Metrics

--- a/docs/migrating-from-knative-build.md
+++ b/docs/migrating-from-knative-build.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Migrating from Knative Build"
-weight: 13
+weight: 4100
 ---
 -->
 # Migrating from Knative Build

--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -1,3 +1,10 @@
+<!--
+---
+linkTitle: "Migrating from Tekton v1alpha1"
+weight: 4000
+---
+-->
+
 # Migrating From Tekton `v1alpha1` to Tekton `v1beta1`
 
 - [Changes to fields](#changes-to-fields)

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "PipelineRuns"
-weight: 4
+weight: 500
 ---
 -->
 # PipelineRuns

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Pipelines"
-weight: 3
+weight: 400
 ---
 -->
 # Pipelines

--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Pod templates"
-weight: 12
+weight: 1400
 ---
 -->
 # Pod templates

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "PipelineResources"
-weight: 6
+weight: 2000
 ---
 -->
 # PipelineResources

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Runs"
-weight: 2
+weight: 800
 ---
 -->
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "TaskRuns"
-weight: 2
+weight: 300
 ---
 -->
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Tasks"
-weight: 1
+weight: 200
 ---
 -->
 # Tasks

--- a/docs/tekton-bundle-contracts.md
+++ b/docs/tekton-bundle-contracts.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Tekton Bundles Contract"
-weight: 8
+weight: 1800
 ---
 -->
 

--- a/docs/tekton-controller-performance-configuration.md
+++ b/docs/tekton-controller-performance-configuration.md
@@ -1,3 +1,10 @@
+<!--
+---
+linkTitle: "Tekton Controller Performance Configuration"
+weight: 1600
+---
+-->
+
 # Tekton Controller Performance Configuration
 Configure ThreadsPerController, QPS and Burst
 

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Variable Substitutions"
-weight: 15
+weight: 900
 ---
 -->
 # Variable Substitutions Supported by `Tasks` and `Pipelines`

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,7 +1,7 @@
 <!--
 ---
 linkTitle: "Workspaces"
-weight: 5
+weight: 600
 ---
 -->
 # Workspaces


### PR DESCRIPTION
:information_source: This PR targets a release branch, not `main`.

# Changes

Patch a previous release branch with the changes introduced in #3958, i.e:

Some documentation files had no frontmatter block, making them invisible
in the sidebar navigation on the website (since they were missing the
linkTitle property).

Update weights to adjust the order of links:
- Installation to the top
- Deprecations at the bottom
- Migration guides just before Deprecations

See tektoncd/website#271 for more background.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [:no_good_man:] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [:no_good_man:] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
