### PR TITLE
Use tektoncd/results repo for git-init symbolic ref tests

### DIFF
--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -89,11 +89,11 @@ func TestGitPipelineRun(t *testing.T) {
 		sslVerify: "false",
 	}, {
 		name:     "non-master repo with default revision",
-		repo:     "https://github.com/spring-projects/spring-petclinic",
+		repo:     "https://github.com/tektoncd/results",
 		revision: "",
 	}, {
 		name:     "non-master repo with main revision",
-		repo:     "https://github.com/spring-projects/spring-petclinic",
+		repo:     "https://github.com/tektoncd/results",
 		revision: "main",
 	}} {
 		tc := tc // capture range variable

--- a/test/v1alpha1/git_checkout_test.go
+++ b/test/v1alpha1/git_checkout_test.go
@@ -87,11 +87,11 @@ func TestGitPipelineRun(t *testing.T) {
 		sslVerify: "false",
 	}, {
 		name:     "non-master repo with default revision",
-		repo:     "https://github.com/spring-projects/spring-petclinic",
+		repo:     "https://github.com/tektoncd/results",
 		revision: "",
 	}, {
 		name:     "non-master repo with main revision",
-		repo:     "https://github.com/spring-projects/spring-petclinic",
+		repo:     "https://github.com/tektoncd/results",
 		revision: "main",
 	}} {
 		tc := tc // capture range variable


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/2854

Prior to this commit we were pointing one of our integration tests
at a Spring project repo. We did this to test our git-init code
with a repo that uses "main" as its main branch instead of "master".

Now that we have switched many/all of our repos over to "main"
instead of "master" we can use them for testing instead. This means
we haven't tied our tests to an external third party repo that might
change / be removed without our realizing it.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```