### PR TITLE
Replace tmpfile with scriptfile in script init container

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -556,12 +556,12 @@ func TestPodBuild(t *testing.T) {
 					Image:        "busybox",
 					Command:      []string{"sh"},
 					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
-					Args: []string{"-c", `tmpfile="/tekton/scripts/sidecar-script-0-9l9zj"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+					Args: []string{"-c", `scriptfile="/tekton/scripts/sidecar-script-0-9l9zj"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCmVjaG8gaGVsbG8gZnJvbSBzaWRlY2Fy
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
+/tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
 				},
 			},
@@ -784,18 +784,18 @@ print("Hello from Python")`,
 					Name:    "place-scripts",
 					Image:   images.ShellImage,
 					Command: []string{"sh"},
-					Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+					Args: []string{"-c", `scriptfile="/tekton/scripts/script-0-9l9zj"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCmVjaG8gaGVsbG8gZnJvbSBzdGVwIG9uZQ==
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
-tmpfile="/tekton/scripts/script-1-mz4c7"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+/tekton/tools/entrypoint decode-script "${scriptfile}"
+scriptfile="/tekton/scripts/script-1-mz4c7"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvdXNyL2Jpbi9lbnYgcHl0aG9uCnByaW50KCJIZWxsbyBmcm9tIFB5dGhvbiIp
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
+/tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
 					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
 				},
@@ -903,12 +903,12 @@ _EOF_
 				Name:    "place-scripts",
 				Image:   images.ShellImage,
 				Command: []string{"sh"},
-				Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+				Args: []string{"-c", `scriptfile="/tekton/scripts/script-0-9l9zj"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCiQk
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
+/tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
 				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
 			}},

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -112,22 +112,22 @@ func convertListOfSteps(steps []v1beta1.Step, initContainer *corev1.Container, p
 
 		// Append to the place-scripts script to place the
 		// script file in a known location in the scripts volume.
-		tmpFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", namePrefix, i)))
+		scriptFile := filepath.Join(scriptsDir, names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%d", namePrefix, i)))
 		heredoc := "_EOF_" // underscores because base64 doesnt include them in its alphabet
-		initContainer.Args[1] += fmt.Sprintf(`tmpfile="%s"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '%s'
+		initContainer.Args[1] += fmt.Sprintf(`scriptfile="%s"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '%s'
 %s
 %s
-/tekton/tools/entrypoint decode-script "${tmpfile}"
-`, tmpFile, heredoc, script, heredoc)
+/tekton/tools/entrypoint decode-script "${scriptfile}"
+`, scriptFile, heredoc, script, heredoc)
 
 		// Set the command to execute the correct script in the mounted
 		// volume.
 		// A previous merge with stepTemplate may have populated
 		// Command and Args, even though this is not normally valid, so
 		// we'll clear out the Args and overwrite Command.
-		steps[i].Command = []string{tmpFile}
+		steps[i].Command = []string{scriptFile}
 		steps[i].VolumeMounts = append(steps[i].VolumeMounts, scriptsVolumeMount)
 		containers = append(containers, steps[i].Container)
 	}

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -158,24 +158,24 @@ script-3`,
 		Name:    "place-scripts",
 		Image:   images.ShellImage,
 		Command: []string{"sh"},
-		Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+		Args: []string{"-c", `scriptfile="/tekton/scripts/script-0-9l9zj"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0x
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
-tmpfile="/tekton/scripts/script-2-mz4c7"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+/tekton/tools/entrypoint decode-script "${scriptfile}"
+scriptfile="/tekton/scripts/script-2-mz4c7"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 CiMhL2Jpbi9zaApzY3JpcHQtMw==
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
-tmpfile="/tekton/scripts/script-3-mssqb"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+/tekton/tools/entrypoint decode-script "${scriptfile}"
+scriptfile="/tekton/scripts/script-3-mssqb"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
+/tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
 	}
@@ -247,24 +247,24 @@ sidecar-1`,
 		Name:    "place-scripts",
 		Image:   images.ShellImage,
 		Command: []string{"sh"},
-		Args: []string{"-c", `tmpfile="/tekton/scripts/script-0-9l9zj"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+		Args: []string{"-c", `scriptfile="/tekton/scripts/script-0-9l9zj"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0x
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
-tmpfile="/tekton/scripts/script-2-mz4c7"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+/tekton/tools/entrypoint decode-script "${scriptfile}"
+scriptfile="/tekton/scripts/script-2-mz4c7"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0z
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
-tmpfile="/tekton/scripts/sidecar-script-0-mssqb"
-touch ${tmpfile} && chmod +x ${tmpfile}
-cat > ${tmpfile} << '_EOF_'
+/tekton/tools/entrypoint decode-script "${scriptfile}"
+scriptfile="/tekton/scripts/sidecar-script-0-mssqb"
+touch ${scriptfile} && chmod +x ${scriptfile}
+cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNpZGVjYXItMQ==
 _EOF_
-/tekton/tools/entrypoint decode-script "${tmpfile}"
+/tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
 		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit script blocks were written to a file
named with a variable called "tmpfile". This wasn't very
explicit and made understanding taskrun pod yaml a bit
harder.

This commit changes the variable name from "tmpfile" to
"scriptfile" to more explicitly declare the variable's
purpose.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
