### PR TITLE
Merge *Run's PodTemplate with Default 🧙

### DIFF
--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -13,7 +13,10 @@ You can specify a Pod template for `TaskRuns` and `PipelineRuns`. In the templat
 the execution of individual `Tasks` or for all `Tasks` executed by a given `PipelineRun`.
 
 You also have the option to define a global Pod template [in your Tekton config](./install.md#customizing-basic-execution-parameters).
-However, this global template is overridden by any templates you specify in your `TaskRuns` and `PipelineRuns`.
+However, this global template is going to be merged with any templates
+you specify in your `TaskRuns` and `PipelineRuns`. Any field that is
+present in both the global template and the `TaskRun`'s or
+`PipelineRun`'s template will be taken from the `TaskRun` or `PipelineRun`.
 
 See the following for examples of specifying a Pod template:
 - [Specifying a Pod template for a `TaskRun`](./taskruns.md#specifying-a-pod-template)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -47,9 +47,7 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	}
 
 	defaultPodTemplate := cfg.Defaults.DefaultPodTemplate
-	if prs.PodTemplate == nil {
-		prs.PodTemplate = defaultPodTemplate
-	}
+	prs.PodTemplate = mergePodTemplateWithDefault(prs.PodTemplate, defaultPodTemplate)
 
 	if prs.PipelineSpec != nil {
 		prs.PipelineSpec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -60,12 +60,66 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	}
 
 	defaultPodTemplate := cfg.Defaults.DefaultPodTemplate
-	if trs.PodTemplate == nil {
-		trs.PodTemplate = defaultPodTemplate
-	}
+	trs.PodTemplate = mergePodTemplateWithDefault(trs.PodTemplate, defaultPodTemplate)
 
 	// If this taskrun has an embedded task, apply the usual task defaults
 	if trs.TaskSpec != nil {
 		trs.TaskSpec.SetDefaults(ctx)
+	}
+}
+
+func mergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
+	switch {
+	case defaultTpl == nil:
+		// No configured default, just return the template
+		return tpl
+	case tpl == nil:
+		// No template, just return the default template
+		return defaultTpl
+	default:
+		// Otherwise, merge fields
+		if tpl.NodeSelector == nil {
+			tpl.NodeSelector = defaultTpl.NodeSelector
+		}
+		if tpl.Tolerations == nil {
+			tpl.Tolerations = defaultTpl.Tolerations
+		}
+		if tpl.SecurityContext == nil {
+			tpl.SecurityContext = defaultTpl.SecurityContext
+		}
+		if tpl.Volumes == nil {
+			tpl.Volumes = defaultTpl.Volumes
+		}
+		if tpl.RuntimeClassName == nil {
+			tpl.RuntimeClassName = defaultTpl.RuntimeClassName
+		}
+		if tpl.AutomountServiceAccountToken == nil {
+			tpl.AutomountServiceAccountToken = defaultTpl.AutomountServiceAccountToken
+		}
+		if tpl.DNSPolicy == nil {
+			tpl.DNSPolicy = defaultTpl.DNSPolicy
+		}
+		if tpl.DNSConfig == nil {
+			tpl.DNSConfig = defaultTpl.DNSConfig
+		}
+		if tpl.EnableServiceLinks == nil {
+			tpl.EnableServiceLinks = defaultTpl.EnableServiceLinks
+		}
+		if tpl.PriorityClassName == nil {
+			tpl.PriorityClassName = defaultTpl.PriorityClassName
+		}
+		if tpl.SchedulerName == "" {
+			tpl.SchedulerName = defaultTpl.SchedulerName
+		}
+		if tpl.ImagePullSecrets == nil {
+			tpl.ImagePullSecrets = defaultTpl.ImagePullSecrets
+		}
+		if tpl.HostAliases == nil {
+			tpl.HostAliases = defaultTpl.HostAliases
+		}
+		if tpl.HostNetwork == false && defaultTpl.HostNetwork == true {
+			tpl.HostNetwork = true
+		}
+		return tpl
 	}
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Right, now when you specify a default pod template and also specify
pod template at pipelinerun/taskrun level. The default pod template is
getting overridden by the one at the pipelinerun/taskrun level.

This changes this behavior by only overriding the `PodTemplate` field
that are defined by the `TaskRun` and not the whole
`PodTemplate`. This means it is possible to define a `NodeSelector`
widely (through the default) without it being overriden when the user
sets a `SecurityContext` on his `TaskRun`.

This is also done on the `PipelineRun` PodTemplate.

Closes #3569

/cc @sbwsg @afrittoli @pritidesai @skaegi @bobcatfish 

*This probably need a bit more unit tests, but I think it's worth opening to discuss if the approach is correct (for each fields)*

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
TaskRun and PipelineRun's PodTemplate are now merge with the default PodTemplate. This means any field that is not specified in a TaskRun or PipelineRun's PodTemplate will come from the configured default PodTemplate (if defined).
```

