### PR TITLE
Updates to pipeline tutorial to handle skaffold Dockerfile and keep the yq syntax working

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -212,7 +212,7 @@ spec:
         type: image
   steps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:v0.16.0
+      image: gcr.io/kaniko-project/executor:latest
       # specifying DOCKER_CONFIG is required to allow kaniko to detect docker credential
       env:
         - name: "DOCKER_CONFIG"
@@ -223,6 +223,7 @@ spec:
         - --dockerfile=$(params.pathToDockerFile)
         - --destination=$(resources.outputs.builtImage.url)
         - --context=$(params.pathToContext)
+        - --build-arg=BASE=alpine:3
 ```
 
 ### Configuring `Task` execution credentials
@@ -438,7 +439,7 @@ spec:
         type: image
   steps:
     - name: replace-image
-      image: mikefarah/yq
+      image: mikefarah/yq:3.4.1
       command: ["yq"]
       args:
         - "w"


### PR DESCRIPTION
# Changes

```release-note
1. Updated kaniko executor image to latest
2. Added --build-arg=BASE=alpine:3 to have kaniko correctly handle the skaffold leeroy-web Dockerfile (had the issue described in https://github.com/GoogleContainerTools/kaniko/issues/1271  before)
3. Changed mikefarah/yq image to 3.4.1 (the latest working with the provided command) in deploy-using-kubectl task to get this working (ver. 4 changed the syntax completely: https://mikefarah.gitbook.io/yq/upgrading-from-v3, so the command gave a syntax error)
```



/kind documentation



