### PR TITLE
cleaning up task results constant

### DIFF
--- a/pkg/apis/pipeline/paths.go
+++ b/pkg/apis/pipeline/paths.go
@@ -19,7 +19,7 @@ package pipeline
 const (
 	// WorkspaceDir is the root directory used for PipelineResources and (by default) Workspaces
 	WorkspaceDir = "/workspace"
-	// DefaultResultPath is the path for task result
+	// DefaultResultPath is the path for a task result to create the result file
 	DefaultResultPath = "/tekton/results"
 	// HomeDir is the HOME directory of PipelineResources
 	HomeDir = "/tekton/home"

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -37,16 +37,15 @@ import (
 const (
 	homeDir = "/tekton/home"
 
-	// ResultsDir is the folder used by default to create the results file
-	ResultsDir = "/tekton/results"
-
 	// TaskRunLabelKey is the name of the label added to the Pod to identify the TaskRun
 	TaskRunLabelKey = pipeline.GroupName + pipeline.TaskRunLabelKey
 
 	// TektonHermeticEnvVar is the env var we set in containers to indicate they should be run hermetically
 	TektonHermeticEnvVar = "TEKTON_HERMETIC"
+
 	// ExecutionModeAnnotation is an experimental optional annotation to set the execution mode on a TaskRun
 	ExecutionModeAnnotation = "experimental.tekton.dev/execution-mode"
+
 	// ExecutionModeHermetic indicates hermetic execution mode
 	ExecutionModeHermetic = "hermetic"
 )
@@ -69,7 +68,7 @@ var (
 		MountPath: homeDir,
 	}, {
 		Name:      "tekton-internal-results",
-		MountPath: ResultsDir,
+		MountPath: pipeline.DefaultResultPath,
 	}}
 	implicitVolumes = []corev1.Volume{{
 		Name:         "tekton-internal-workspace",


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The task results path was defined in two separate packages, `pod` and `pipeline`. Deleting the one defined in `pod` and using the one defined in [paths.go](https://github.com/tektoncd/pipeline/blob/main/pkg/apis/pipeline/paths.go)


/kind cleanup


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
