### PR TITLE
Set fake AWS credentials on controller to workaround aws-sdk bug

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -93,6 +93,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # These phony AWS credentials are here to work around a bug in the aws go sdk
+        # that causes extremely long delays in the execution of tasks after the initial
+        # deployment of the Tekton Pipelines controller.
+        - name: AWS_ACCESS_KEY_ID
+          value: foobarbaz
+        - name: AWS_SECRET_ACCESS_KEY
+          value: foobarbaz
+        - name: AWS_DEFAULT_REGION
+          value: foobarbaz
+
         # If you are changing these names, you will also need to update
         # the controller's Role in 200-role.yaml to include the new
         # values in the "configmaps" "get" rule.


### PR DESCRIPTION
Workaround for issue https://github.com/tektoncd/pipeline/issues/4087 while we look into better solutions.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Several issues have now reared their head which are directly caused
by an update to the aws-sdk. The update results in extremely long
delays in the execution of tasks after the Pipelines controller is
first deployed in a cluster. The aws-sdk is initialized through
a transitive dependency that pipelines pulls in via k8schain or go-containerregistry.

Here are the recent issues directly related to this bug:

- https://github.com/tektoncd/pipeline/issues/3627 (Since December!)
- https://github.com/tektoncd/pipeline/issues/4084

One quick way to work around this problem is to set fake AWS
credentials in the environment of the deployed controller. This
apparently causes the aws-sdk to skip whatever process it has
introduced that causes massive delays in execution. So this commit
does exactly that - set fake aws creds in the deployments env vars.

This is an unfortunate hack to try and mitigate the problem until
a better solution presents itself. Ideally go-containerregistry or
k8s-pkg-credentialprovider would provide a way for us to disable
AWS SDK initialization to avoid this misbehaviour.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Work around a bug in the AWS go SDK that causes extremely long delays in task startup times.
```