### PR TITLE
support referencing array params in when expression values

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -451,6 +451,15 @@ tasks:
         values: ["true"]
     taskRef:
       name: lint-source
+---
+tasks:
+  - name: deploy-in-blue
+    when:
+      - input: "blue"
+        operator: in
+        values: ["$(params.deployments[*])"]
+    taskRef:
+      name: deployment
 ```
 
 For an end-to-end example, see [PipelineRun with `when` expressions](../examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml).

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -9,6 +9,9 @@ spec:
       - name: path
         type: string
         description: The path of the file to be created
+      - name: branches
+        type: array
+        description: The list of branch names
     workspaces:
       - name: source
         description: |
@@ -67,6 +70,16 @@ spec:
             - name: echo
               image: ubuntu
               script: 'echo file exists'
+      - name: sample-task-with-array-values
+        when:
+          - input: "main"
+            operator: in
+            values: ["$(params.branches[*])"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: alpine
+              script: 'echo hello'
       - name: task-should-be-skipped-1
         when:
           - input: "$(tasks.check-file.results.exists)" # when expression using task result, evaluates to false
@@ -98,6 +111,16 @@ spec:
           steps:
             - name: echo
               image: ubuntu
+              script: exit 1
+      - name: task-should-be-skipped-4 # task with when expression using array parameter, evaluates to false
+        when:
+          - input: "master"
+            operator: in
+            values: ["$(params.branches[*])"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: alpine
               script: exit 1
     finally:
       - name: finally-task-should-be-skipped-1 # when expression using execution status, evaluates to false
@@ -162,6 +185,10 @@ spec:
   params:
     - name: path
       value: README.md
+    - name: branches
+      value:
+        - main
+        - hotfix
   workspaces:
     - name: source
       volumeClaimTemplate:

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -187,3 +187,22 @@ func TestArrayOrString_MarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestArrayReference(t *testing.T) {
+	tests := []struct {
+		name, p, expectedResult string
+	}{{
+		name:           "valid array parameter expression with star notation returns param name",
+		p:              "$(params.arrayParam[*])",
+		expectedResult: "arrayParam",
+	}, {
+		name:           "invalid array parameter without dollar notation returns the input as is",
+		p:              "params.arrayParam[*]",
+		expectedResult: "params.arrayParam[*]",
+	}}
+	for _, tt := range tests {
+		if d := cmp.Diff(tt.expectedResult, v1beta1.ArrayReference(tt.p)); d != "" {
+			t.Errorf(diff.PrintWantGot(d))
+		}
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
+
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	"k8s.io/apimachinery/pkg/selection"
 )
@@ -59,12 +61,19 @@ func (we *WhenExpression) hasVariable() bool {
 	return false
 }
 
-func (we *WhenExpression) applyReplacements(replacements map[string]string) WhenExpression {
+func (we *WhenExpression) applyReplacements(replacements map[string]string, arrayReplacements map[string][]string) WhenExpression {
 	replacedInput := substitution.ApplyReplacements(we.Input, replacements)
 
 	var replacedValues []string
 	for _, val := range we.Values {
-		replacedValues = append(replacedValues, substitution.ApplyReplacements(val, replacements))
+		// arrayReplacements holds a list of array parameters with a pattern - params.arrayParam1
+		// array params are referenced using $(params.arrayParam1[*])
+		// check if the param exist in the arrayReplacements to replace it with a list of values
+		if _, ok := arrayReplacements[fmt.Sprintf("%s.%s", ParamsPrefix, ArrayReference(val))]; ok {
+			replacedValues = append(replacedValues, substitution.ApplyArrayReplacements(val, replacements, arrayReplacements)...)
+		} else {
+			replacedValues = append(replacedValues, substitution.ApplyReplacements(val, replacements))
+		}
 	}
 
 	return WhenExpression{Input: replacedInput, Operator: we.Operator, Values: replacedValues}
@@ -109,10 +118,10 @@ func (wes WhenExpressions) HaveVariables() bool {
 
 // ReplaceWhenExpressionsVariables interpolates variables, such as Parameters and Results, in
 // the Input and Values.
-func (wes WhenExpressions) ReplaceWhenExpressionsVariables(replacements map[string]string) WhenExpressions {
+func (wes WhenExpressions) ReplaceWhenExpressionsVariables(replacements map[string]string, arrayReplacements map[string][]string) WhenExpressions {
 	replaced := wes
 	for i := range wes {
-		replaced[i] = wes[i].applyReplacements(replacements)
+		replaced[i] = wes[i].applyReplacements(replacements, arrayReplacements)
 	}
 	return replaced
 }

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -93,7 +93,7 @@ func ApplyTaskResults(targets PipelineRunState, resolvedResultRefs ResolvedResul
 		if resolvedPipelineRunTask.PipelineTask != nil {
 			pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
 			pipelineTask.Params = replaceParamValues(pipelineTask.Params, stringReplacements, nil)
-			pipelineTask.WhenExpressions = pipelineTask.WhenExpressions.ReplaceWhenExpressionsVariables(stringReplacements)
+			pipelineTask.WhenExpressions = pipelineTask.WhenExpressions.ReplaceWhenExpressionsVariables(stringReplacements, nil)
 			resolvedPipelineRunTask.PipelineTask = pipelineTask
 		}
 	}
@@ -105,7 +105,7 @@ func ApplyPipelineTaskStateContext(state PipelineRunState, replacements map[stri
 		if resolvedPipelineRunTask.PipelineTask != nil {
 			pipelineTask := resolvedPipelineRunTask.PipelineTask.DeepCopy()
 			pipelineTask.Params = replaceParamValues(pipelineTask.Params, replacements, nil)
-			pipelineTask.WhenExpressions = pipelineTask.WhenExpressions.ReplaceWhenExpressionsVariables(replacements)
+			pipelineTask.WhenExpressions = pipelineTask.WhenExpressions.ReplaceWhenExpressionsVariables(replacements, nil)
 			resolvedPipelineRunTask.PipelineTask = pipelineTask
 		}
 	}
@@ -137,12 +137,12 @@ func ApplyReplacements(p *v1beta1.PipelineSpec, replacements map[string]string, 
 			c := p.Tasks[i].Conditions[j]
 			c.Params = replaceParamValues(c.Params, replacements, arrayReplacements)
 		}
-		p.Tasks[i].WhenExpressions = p.Tasks[i].WhenExpressions.ReplaceWhenExpressionsVariables(replacements)
+		p.Tasks[i].WhenExpressions = p.Tasks[i].WhenExpressions.ReplaceWhenExpressionsVariables(replacements, arrayReplacements)
 	}
 
 	for i := range p.Finally {
 		p.Finally[i].Params = replaceParamValues(p.Finally[i].Params, replacements, arrayReplacements)
-		p.Finally[i].WhenExpressions = p.Finally[i].WhenExpressions.ReplaceWhenExpressionsVariables(replacements)
+		p.Finally[i].WhenExpressions = p.Finally[i].WhenExpressions.ReplaceWhenExpressionsVariables(replacements, arrayReplacements)
 	}
 
 	return p


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Array params are referenced using $(params.arrayParam[*]). When expressions `values` is a list of `string` and was designed to reference and resolve an array parameter. But the implementation was limiting the array param usage in the when expression `values`. Adding support for the array params in when expressions.

/kind bug

Closes #4061 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
When expression values can have array parameter reference now, such as, values: [$(params.arrayParam[*])]
```
