### PR TITLE
cleaning up duplicate const from test - pipelineRunTimeout

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -29,13 +29,10 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
 )
-
-const pipelineRunTimeout = 10 * time.Minute
 
 var (
 	defaultKoDockerRepoRE = regexp.MustCompile("gcr.io/christiewilson-catfactory")


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`pipelineRunTimeout` was defined twice in a single `test` package, (1) `test/pipelinerun_test.go` and
(2) `test/examples_test.go`. Deleting the duplicate definitions and keeping it under `test/pipelinerun_test.go` with other constants.

_Didn't cause any issues or failure, was just annoying to see a red flag in my IDE_ 🤣 

/kind cleanup


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
NONE
```
