### PR TITLE
Modify wrong equirement of kubernetes Version for Installation of v0.24.0

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -15,7 +15,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 
 ## Before you begin
 
-1. You must have a Kubernetes cluster running version 1.17 or later.
+1. You must have a Kubernetes cluster running version 1.18 or later.
 
    If you don't already have a cluster, you can create one for testing with `kind`.
    [Install `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and create a cluster by running [`kind create cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). This


### PR DESCRIPTION
# Changes

v0.24.0 Release Note says it requires v1.18 k8s. It seems to modify the k8s requirements version info at install.md for v0.24.0.
/kind documentation

# Release Notes
**Release Note**
![스크린샷, 2021-07-07 11-43-15](https://user-images.githubusercontent.com/51406068/124694658-af6a7500-df1c-11eb-869e-356f944d1ef6.png)


**Installation Doc**
![스크린샷, 2021-07-07 11-43-45](https://user-images.githubusercontent.com/51406068/124694676-b72a1980-df1c-11eb-9df3-4f98abe587ec.png)


<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

