### PR TITLE
Set HOME="/tekton/home" for GCS PipelineResources

### DIFF
--- a/pkg/apis/resource/v1alpha1/storage/gcs.go
+++ b/pkg/apis/resource/v1alpha1/storage/gcs.go
@@ -119,6 +119,8 @@ func (s *GCSResource) GetOutputTaskModifier(ts *v1beta1.TaskSpec, path string) (
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts(s.Name, gcsSecretVolumeMountPath, s.Secrets)
 
+	envVars = append(envVars, corev1.EnvVar{Name: "HOME", Value: pipeline.HomeDir})
+
 	step := v1beta1.Step{Container: corev1.Container{
 		Name:         names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("upload-%s", s.Name)),
 		Image:        s.GsutilImage,
@@ -149,6 +151,7 @@ func (s *GCSResource) GetInputTaskModifier(ts *v1beta1.TaskSpec, path string) (v
 	}
 
 	envVars, secretVolumeMount := getSecretEnvVarsAndVolumeMounts(s.Name, gcsSecretVolumeMountPath, s.Secrets)
+	envVars = append(envVars, corev1.EnvVar{Name: "HOME", Value: pipeline.HomeDir})
 	steps := []v1beta1.Step{
 		CreateDirStep(s.ShellImage, s.Name, path),
 		{

--- a/pkg/apis/resource/v1alpha1/storage/gcs_test.go
+++ b/pkg/apis/resource/v1alpha1/storage/gcs_test.go
@@ -199,6 +199,9 @@ gsutil rsync -d -r gs://some-bucket /workspace
 				Env: []corev1.EnvVar{{
 					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 					Value: "/var/secret/secretName/key.json",
+				}, {
+					Name:  "HOME",
+					Value: "/tekton/home",
 				}},
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "volume-gcs-valid-secretName",
@@ -241,6 +244,9 @@ gsutil cp gs://some-bucket /workspace
 				Env: []corev1.EnvVar{{
 					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
 					Value: "/var/secret/secretName/key.json",
+				}, {
+					Name:  "HOME",
+					Value: "/tekton/home",
 				}},
 				VolumeMounts: []corev1.VolumeMount{{
 					Name:      "volume-gcs-valid-secretName",
@@ -288,7 +294,13 @@ func TestGetOutputTaskModifier(t *testing.T) {
 			Image:   "gcr.io/google.com/cloudsdktool/cloud-sdk",
 			Command: []string{"gsutil"},
 			Args:    []string{"rsync", "-d", "-r", "/workspace/", "gs://some-bucket"},
-			Env:     []corev1.EnvVar{{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"}},
+			Env: []corev1.EnvVar{{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: "/var/secret/secretName/key.json",
+			}, {
+				Name:  "HOME",
+				Value: "/tekton/home",
+			}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",
 				MountPath: "/var/secret/secretName",
@@ -315,9 +327,13 @@ func TestGetOutputTaskModifier(t *testing.T) {
 			Image:   "gcr.io/google.com/cloudsdktool/cloud-sdk",
 			Command: []string{"gsutil"},
 			Args:    []string{"cp", "/workspace/*", "gs://some-bucket"},
-			Env: []corev1.EnvVar{
-				{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secretName/key.json"},
-			},
+			Env: []corev1.EnvVar{{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: "/var/secret/secretName/key.json",
+			}, {
+				Name:  "HOME",
+				Value: "/tekton/home",
+			}},
 			VolumeMounts: []corev1.VolumeMount{{
 				Name:      "volume-gcs-valid-secretName",
 				MountPath: "/var/secret/secretName",
@@ -336,6 +352,10 @@ func TestGetOutputTaskModifier(t *testing.T) {
 			Image:   "gcr.io/google.com/cloudsdktool/cloud-sdk",
 			Command: []string{"gsutil"},
 			Args:    []string{"cp", "/workspace/*", "gs://some-bucket"},
+			Env: []corev1.EnvVar{{
+				Name:  "HOME",
+				Value: "/tekton/home",
+			}},
 		}}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -345,7 +365,7 @@ func TestGetOutputTaskModifier(t *testing.T) {
 				t.Fatalf("Expected error to be %t but got %v:", tc.wantErr, err)
 			}
 
-			if d := cmp.Diff(got.GetStepsToAppend(), tc.wantSteps); d != "" {
+			if d := cmp.Diff(tc.wantSteps, got.GetStepsToAppend()); d != "" {
 				t.Errorf("Error mismatch between upload containers spec %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -683,6 +683,10 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 				Container: corev1.Container{
 					Name:  "fetch-storage1-mz4c7",
 					Image: "gcr.io/google.com/cloudsdktool/cloud-sdk",
+					Env: []corev1.EnvVar{{
+						Name:  "HOME",
+						Value: pipeline.HomeDir,
+					}},
 				},
 			}},
 			Resources: &v1beta1.TaskResources{
@@ -726,7 +730,10 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 				Image:        "busybox",
 				Command:      []string{"cp", "-r", "prev-task-path/.", "/workspace/gcs-dir"},
 				VolumeMounts: []corev1.VolumeMount{{MountPath: "/pvc", Name: "pipelinerun-pvc"}},
-				Env:          []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "workspace"}},
+				Env: []corev1.EnvVar{{
+					Name:  "TEKTON_RESOURCE_NAME",
+					Value: "workspace",
+				}},
 			}}},
 			Volumes: []corev1.Volume{{
 				Name: "pipelinerun-pvc",
@@ -1081,6 +1088,7 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-input-resource
 				Container: corev1.Container{
 					Name:  "fetch-gcs-input-resource-mz4c7",
 					Image: "gcr.io/google.com/cloudsdktool/cloud-sdk",
+					Env:   []corev1.EnvVar{{Name: "HOME", Value: pipeline.HomeDir}},
 				},
 			}},
 			Resources: &v1beta1.TaskResources{
@@ -1156,6 +1164,7 @@ gsutil rsync -d -r gs://fake-bucket/rules.zip /workspace/gcs-input-resource
 					},
 					Env: []corev1.EnvVar{
 						{Name: "GOOGLE_APPLICATION_CREDENTIALS", Value: "/var/secret/secret-name/key.json"},
+						{Name: "HOME", Value: pipeline.HomeDir},
 					},
 				},
 			}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Dashboard noticed their nightly release pipeline no longer worked
after a Pipelines upgrade in dogfooding. [They tracked it to use of a GCS
pipeline resource; adding a HOME="/tekton/home" env var to the Task's
PodTemplate resolved the issue](https://github.com/tektoncd/dashboard/pull/2117).

Prior to this commit the GCS PipelineResource didn't get its HOME
explicitly set to /tekton/home.

After this commit the GCS PipelineResource always includes this env var in
the pre- and post- containers it adds to Task pods.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixed bug where GCS PipelineResource failed to upload unless HOME="/tekton/home" was explicitly set in task's pod template.
```

/kind bug