### PR TITLE
Fix misplaced fields in API spec

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -128,6 +128,8 @@ Standard Kubernetes [meta.v1/ObjectMeta](https://kubernetes.io/docs/reference/ge
 | `startTime`           | string                 | REQUIRED    |
 | `completionTime`*     | string                 | REQUIRED    |
 | `steps`               | `[]StepState`          | REQUIRED    |
+| `taskResults`         | `[]TaskRunResult`      | REQUIRED    |
+| `taskSpec`            | `TaskSpec`             | REQUIRED    |
 | `observedGeneration`  | int64                  | RECOMMENDED |
 
 \* `startTime` and `completionTime` MUST be populated by the implementation, in [RFC3339](https://tools.ietf.org/html/rfc3339).
@@ -267,8 +269,6 @@ List responses have the following fields (based on [`meta.v1/ListMeta`](https://
 | `waiting`*    | `ContainerStateWaiting`    | REQUIRED    |
 | `running`*    | `ContainerStateRunning`    | REQUIRED    |
 | `terminated`* | `ContainerStateTerminated` | REQUIRED    |
-| `taskResults` | `[]TaskRunResult`          | REQUIRED    |
-| `taskSpec`    | `TaskSpec`                 | REQUIRED    |
 
 \* Only one of `waiting`, `running` or `terminated` can be returned at a time.
 


### PR DESCRIPTION
The `taskSpec` and `taskResults` field is present on the TaskRun `.status`, not on `.status.steps`.

/kind docs
/assign @jerop 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [y] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [y] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [y] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [n/a] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```