### PR TITLE
WIP Refactor ref resolution

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -85,3 +85,11 @@ data:
   # Setting this flag to "true" scopes when expressions to guard a Task only
   # instead of a Task and its dependent Tasks.
   scope-when-expressions-to-task: "false"
+  # Setting this flag to "true" prevents the TaskRun and PipelineRun
+  # reconcilers from performing resolution of tasks and pipelines from
+  # the cluster or Tekton Bundles. This resolution process can then be
+  # performed by external processes / other reconcilers.
+  #
+  # Warning: setting this flag to "true" without also introducing an external
+  # resolution mechanism will render TaskRuns and PipelineRuns inoperable.
+  experimental-disable-ref-resolution: "false"

--- a/internal/resolution/clients_test.go
+++ b/internal/resolution/clients_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+)
+
+// getClients is a test helper to construct the fakes needed for
+// testing ref resolution.
+func getClients(t *testing.T, conf *config.Config, d test.Data) (test.Assets, func()) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	if conf != nil {
+		ctx = config.ToContext(ctx, conf)
+	}
+
+	clients, informers := test.SeedTestData(t, ctx, d)
+
+	return test.Assets{
+		Ctx:       ctx,
+		Clients:   clients,
+		Informers: informers,
+	}, cancel
+}

--- a/internal/resolution/errors.go
+++ b/internal/resolution/errors.go
@@ -1,0 +1,48 @@
+package resolution
+
+import (
+	"errors"
+)
+
+// Error embeds both a short machine-readable string reason for resolution
+// problems alongside the original error generated during the resolution flow.
+type Error struct {
+	Reason   string
+	Original error
+}
+
+var _ error = &Error{}
+
+// Error returns the original error's message. This is intended to meet the error.Error interface.
+func (e *Error) Error() string {
+	return e.Original.Error()
+}
+
+// Unwrap returns the original error without the Reason annotation. This is
+// intended to support usage of errors.Is and errors.As with resolution.Errors.
+func (e *Error) Unwrap() error {
+	return e.Original
+}
+
+// NewError returns a resolution.Error with the given reason and underlying
+// original error.
+func NewError(reason string, err error) *Error {
+	return &Error{
+		Reason:   reason,
+		Original: err,
+	}
+}
+
+var (
+	// ErrorTaskRunAlreadyResolved is a sentinel value that consumers of the resolution package can use to determine if a taskrun
+	// was already resolved and, if so, customize their fallback behaviour.
+	ErrorTaskRunAlreadyResolved = NewError("TaskRunAlreadyResolved", errors.New("TaskRun is already resolved"))
+
+	// ErrorPipelineRunAlreadyResolved is a sentinel value that consumers of the resolution package can use to determine if a pipelinerun
+	// was already resolved and, if so, customize their fallback behaviour.
+	ErrorPipelineRunAlreadyResolved = NewError("PipelineRunAlreadyResolved", errors.New("PipelineRun is already resolved"))
+
+	// ErrorResourceNotResolved is a sentinel value to indicate that a TaskRun or PipelineRun
+	// has not been resolved yet.
+	ErrorResourceNotResolved = NewError("ResourceNotResolved", errors.New("Resource has not been resolved"))
+)

--- a/internal/resolution/errors_test.go
+++ b/internal/resolution/errors_test.go
@@ -1,0 +1,30 @@
+package resolution
+
+import (
+	"errors"
+	"testing"
+)
+
+type TestError struct{}
+
+var _ error = &TestError{}
+
+func (*TestError) Error() string {
+	return "test error"
+}
+
+func TestResolutionErrorUnwrap(t *testing.T) {
+	originalError := &TestError{}
+	resolutionError := NewError("", originalError)
+	if !errors.Is(resolutionError, &TestError{}) {
+		t.Errorf("resolution error expected to unwrap successfully")
+	}
+}
+
+func TestResolutionErrorMessage(t *testing.T) {
+	originalError := errors.New("this is just a test message")
+	resolutionError := NewError("", originalError)
+	if resolutionError.Error() != originalError.Error() {
+		t.Errorf("resolution error message expected to equal that of original error")
+	}
+}

--- a/internal/resolution/meta.go
+++ b/internal/resolution/meta.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CopyTaskMetaToTaskRun implements the default Tekton Pipelines behaviour
+// for copying meta information to a TaskRun from the Task it references.
+//
+// The labels and annotations from the task will all be copied to the taskrun
+// verbatim. This matches the expectations/behaviour of the current TaskRun
+// reconciler.
+func CopyTaskMetaToTaskRun(taskMeta *metav1.ObjectMeta, tr *v1beta1.TaskRun) {
+	needsLabels := len(taskMeta.Labels) > 0 || tr.Spec.TaskRef != nil
+	if tr.ObjectMeta.Labels == nil && needsLabels {
+		tr.ObjectMeta.Labels = map[string]string{}
+	}
+	for key, value := range taskMeta.Labels {
+		tr.ObjectMeta.Labels[key] = value
+	}
+
+	if tr.ObjectMeta.Annotations == nil {
+		tr.ObjectMeta.Annotations = make(map[string]string, len(taskMeta.Annotations))
+	}
+	for key, value := range taskMeta.Annotations {
+		tr.ObjectMeta.Annotations[key] = value
+	}
+
+	if tr.Spec.TaskRef != nil {
+		if tr.Spec.TaskRef.Kind == "ClusterTask" {
+			tr.ObjectMeta.Labels[pipeline.ClusterTaskLabelKey] = taskMeta.Name
+		} else {
+			tr.ObjectMeta.Labels[pipeline.TaskLabelKey] = taskMeta.Name
+		}
+	}
+}
+
+// CopyPipelineMetaToPipelineRun implements the default Tekton Pipelines
+// behaviour for copying meta information to a PipelineRun from the Pipeline it
+// references.
+//
+// The labels and annotations from the pipeline will all be copied to the
+// pipielinerun verbatim. This matches the expectations/behaviour of the
+// current PipelineRun reconciler.
+func CopyPipelineMetaToPipelineRun(pipelineMeta *metav1.ObjectMeta, pr *v1beta1.PipelineRun) {
+	if pr.ObjectMeta.Labels == nil {
+		pr.ObjectMeta.Labels = make(map[string]string, len(pipelineMeta.Labels)+1)
+	}
+	for key, value := range pipelineMeta.Labels {
+		pr.ObjectMeta.Labels[key] = value
+	}
+	pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pipelineMeta.Name
+
+	if pr.ObjectMeta.Annotations == nil {
+		pr.ObjectMeta.Annotations = make(map[string]string, len(pipelineMeta.Annotations))
+	}
+	for key, value := range pipelineMeta.Annotations {
+		pr.ObjectMeta.Annotations[key] = value
+	}
+}

--- a/internal/resolution/meta_test.go
+++ b/internal/resolution/meta_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestCopyTaskMetaToTaskRun_Labels(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		taskMeta       metav1.ObjectMeta
+		expectedLabels map[string]string
+	}{{
+		name:           "empty task meta labels result in no change to taskrun",
+		taskMeta:       metav1.ObjectMeta{},
+		expectedLabels: nil,
+	}, {
+		name:           "non-empty labels copied verbatim to taskrun",
+		taskMeta:       metav1.ObjectMeta{Labels: map[string]string{"foo": "bar", "baz": "quux"}},
+		expectedLabels: map[string]string{"foo": "bar", "baz": "quux"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &v1beta1.TaskRun{}
+			CopyTaskMetaToTaskRun(&tc.taskMeta, tr)
+			if d := cmp.Diff(tc.expectedLabels, tr.ObjectMeta.Labels); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestCopyTaskMetaToTaskRun_TaskRef(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		taskRef        v1beta1.TaskRef
+		expectedLabels map[string]string
+	}{{
+		name:           "task ref with empty kind results in task label on taskrun",
+		taskRef:        v1beta1.TaskRef{Name: "foo"},
+		expectedLabels: map[string]string{pipeline.TaskLabelKey: "foo"},
+	}, {
+		name:           "task ref with task kind results in task label on taskrun",
+		taskRef:        v1beta1.TaskRef{Kind: "Task", Name: "foo"},
+		expectedLabels: map[string]string{pipeline.TaskLabelKey: "foo"},
+	}, {
+		name:           "task ref with clustertask kind results in clustertask label on taskrun",
+		taskRef:        v1beta1.TaskRef{Kind: "ClusterTask", Name: "foo"},
+		expectedLabels: map[string]string{pipeline.ClusterTaskLabelKey: "foo"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := v1beta1.TaskRun{
+				Spec: v1beta1.TaskRunSpec{TaskRef: &tc.taskRef},
+			}
+			CopyTaskMetaToTaskRun(&metav1.ObjectMeta{}, &tr)
+			if d := cmp.Diff(tc.expectedLabels, tr.Labels); d != "" {
+				diff.PrintWantGot(d)
+			}
+		})
+	}
+}
+
+func TestCopyTaskMetaToTaskRun_Annotations(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		taskMeta            metav1.ObjectMeta
+		expectedAnnotations map[string]string
+	}{{
+		name:                "nil task annotations still results in empty annotation map on taskrun",
+		taskMeta:            metav1.ObjectMeta{},
+		expectedAnnotations: map[string]string{},
+	}, {
+		name:                "empty task annotations results in empty annotation map on taskrun",
+		taskMeta:            metav1.ObjectMeta{Annotations: map[string]string{}},
+		expectedAnnotations: map[string]string{},
+	}, {
+		name:                "non-empty task annotations are copied verbatim to taskrun",
+		taskMeta:            metav1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}},
+		expectedAnnotations: map[string]string{"foo": "bar"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &v1beta1.TaskRun{}
+			CopyTaskMetaToTaskRun(&tc.taskMeta, tr)
+			if d := cmp.Diff(tc.expectedAnnotations, tr.ObjectMeta.Annotations); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestCopyPipelineMetaToPipelineRun_Labels(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		pipelineMeta   metav1.ObjectMeta
+		expectedLabels map[string]string
+	}{{
+		name:           "pipeline name always added as a pipelinerun label",
+		pipelineMeta:   metav1.ObjectMeta{Name: "foo"},
+		expectedLabels: map[string]string{pipeline.PipelineLabelKey: "foo"},
+	}, {
+		name:           "empty pipeline meta results in pipelinerun receiving empty name label",
+		pipelineMeta:   metav1.ObjectMeta{},
+		expectedLabels: map[string]string{pipeline.PipelineLabelKey: ""},
+	}, {
+		name:         "non-empty pipeline labels copied verbatim to pipelinerun",
+		pipelineMeta: metav1.ObjectMeta{Name: "foo", Labels: map[string]string{"foo": "bar", "baz": "quux"}},
+		expectedLabels: map[string]string{
+			"foo":                     "bar",
+			"baz":                     "quux",
+			pipeline.PipelineLabelKey: "foo",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1beta1.PipelineRun{}
+			CopyPipelineMetaToPipelineRun(&tc.pipelineMeta, pr)
+			if d := cmp.Diff(tc.expectedLabels, pr.ObjectMeta.Labels); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestCopyPipelineMetaToPipelineRun_Annotations(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		pipelineMeta        metav1.ObjectMeta
+		expectedAnnotations map[string]string
+	}{{
+		name:                "nil pipeline annotations still results in empty annotation map on pipelinerun",
+		pipelineMeta:        metav1.ObjectMeta{},
+		expectedAnnotations: map[string]string{},
+	}, {
+		name:                "empty pipeline annotations results in empty annotation map on pipelinerun",
+		pipelineMeta:        metav1.ObjectMeta{Annotations: map[string]string{}},
+		expectedAnnotations: map[string]string{},
+	}, {
+		name:                "non-empty pipeline annotations are copied verbatim to pipelinerun",
+		pipelineMeta:        metav1.ObjectMeta{Annotations: map[string]string{"foo": "bar"}},
+		expectedAnnotations: map[string]string{"foo": "bar"},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &v1beta1.PipelineRun{}
+			CopyPipelineMetaToPipelineRun(&tc.pipelineMeta, pr)
+			if d := cmp.Diff(tc.expectedAnnotations, pr.ObjectMeta.Annotations); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/internal/resolution/pipelinerun.go
+++ b/internal/resolution/pipelinerun.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type PipelineRunResolutionRequest struct {
+	KubeClientSet     kubernetes.Interface
+	PipelineClientSet clientset.Interface
+	PipelineRun       *v1beta1.PipelineRun
+
+	ResolvedPipelineMeta *metav1.ObjectMeta
+	ResolvedPipelineSpec *v1beta1.PipelineSpec
+}
+
+// PipelineRunResolutionRequest.Resolve implements the default resolution behaviour
+// for a Tekton Pipelines pipelinerun. It resolves the pipeline associated with the pipelinerun
+// from one of three places:
+//
+// - in-line in the pipelinerun's spec.pipelineSpec
+// - from the cluster via the pipelinerun's spec.pipelineRef
+// - (when relevant feature flag enabled) from a Tekton Bundle indicated by the pipelinerun's spec.pipelineRef.bundle field.
+//
+// If a pipeline is resolved correctly from the pipelinerun then the ResolvedPipelineMeta
+// and ResolvedPipelineSpec fields of the PipelineRunResolutionRequest will be
+// populated after this method returns.
+//
+// If an error occurs during any part in the resolution process it will be
+// returned with both a human-readable Message and a machine-readable Reason
+// embedded in a *resolution.Error.
+func (req *PipelineRunResolutionRequest) Resolve(ctx context.Context) error {
+	if req.PipelineRun.Status.PipelineSpec != nil {
+		return ErrorPipelineRunAlreadyResolved
+	}
+
+	pipelinerunKey := fmt.Sprintf("%s/%s", req.PipelineRun.Namespace, req.PipelineRun.Name)
+
+	getPipelineFunc, err := resources.GetPipelineFunc(ctx, req.KubeClientSet, req.PipelineClientSet, req.PipelineRun)
+	if err != nil {
+		return NewError(ReasonCouldntGetPipeline, fmt.Errorf("Error retrieving pipeline for pipelinerun %q: %w", pipelinerunKey, err))
+	}
+
+	pipelineMeta, pipelineSpec, err := resources.GetPipelineData(ctx, req.PipelineRun, getPipelineFunc)
+	if err != nil {
+		return NewError(ReasonCouldntGetPipeline, fmt.Errorf("Error retrieving pipeline for pipelinerun %q: %w", pipelinerunKey, err))
+	}
+
+	req.ResolvedPipelineMeta = pipelineMeta
+	req.ResolvedPipelineSpec = pipelineSpec
+
+	return nil
+}

--- a/internal/resolution/pipelinerun_test.go
+++ b/internal/resolution/pipelinerun_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	simplePipeline = v1beta1.Pipeline{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pipeline",
+			APIVersion: "tekton.dev/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pipeline",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineSpec{
+			Tasks: []v1beta1.PipelineTask{{
+				Name: "test",
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test-task",
+					Kind: "Task",
+				},
+			}},
+		},
+	}
+)
+
+func TestPipelineRunResolutionRequest_ResolvePipelineRef(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, nil, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	req := &PipelineRunResolutionRequest{
+		KubeClientSet:     assets.Clients.Kube,
+		PipelineClientSet: assets.Clients.Pipeline,
+		PipelineRun:       pr,
+	}
+
+	if err := req.Resolve(assets.Ctx); err != nil {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+
+	if d := cmp.Diff(&simplePipeline.Spec, req.ResolvedPipelineSpec); d != "" {
+		t.Errorf("%s", diff.PrintWantGot(d))
+	}
+}
+
+func TestPipelineRunResolutionRequest_ResolveInlinePipelineSpec(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineSpec: simplePipeline.Spec.DeepCopy(),
+		},
+	}
+
+	assets, cancel := getClients(t, nil, test.Data{
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	req := &PipelineRunResolutionRequest{
+		KubeClientSet:     assets.Clients.Kube,
+		PipelineClientSet: assets.Clients.Pipeline,
+		PipelineRun:       pr,
+	}
+
+	if err := req.Resolve(assets.Ctx); err != nil {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+
+	if d := cmp.Diff(&simplePipeline.Spec, req.ResolvedPipelineSpec); d != "" {
+		t.Errorf("%s", diff.PrintWantGot(d))
+	}
+}
+
+func TestPipelineRunResolutionRequest_ResolveBundle(t *testing.T) {
+	// Set up a fake registry to push an image to.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload the simple pipeline to the registry for our pipelineRunBundle PipelineRun.
+	ref, err := test.CreateImage(u.Host+"/"+simplePipeline.Name, &simplePipeline)
+	if err != nil {
+		t.Fatalf("failed to upload image with simple pipeline: %s", err.Error())
+	}
+
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name:   simplePipeline.Name,
+				Bundle: ref,
+			},
+		},
+	}
+
+	config := config.Config{
+		FeatureFlags: &config.FeatureFlags{
+			EnableTektonOCIBundles: true,
+		},
+	}
+	assets, cancel := getClients(t, &config, test.Data{
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	req := &PipelineRunResolutionRequest{
+		KubeClientSet:     nil,
+		PipelineClientSet: assets.Clients.Pipeline,
+		PipelineRun:       pr,
+	}
+
+	if err := req.Resolve(assets.Ctx); err != nil {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+
+	if d := cmp.Diff(&simplePipeline.Spec, req.ResolvedPipelineSpec); d != "" {
+		t.Errorf("%s", diff.PrintWantGot(d))
+	}
+}
+
+func TestPipelineRunResolutionRequest_AlreadyResolved(t *testing.T) {
+	tr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineSpec: simplePipeline.Spec.DeepCopy(),
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineSpec: simplePipeline.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	req := &PipelineRunResolutionRequest{
+		PipelineRun: tr,
+	}
+
+	err := req.Resolve(context.Background())
+	if err != ErrorPipelineRunAlreadyResolved {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+}

--- a/internal/resolution/status.go
+++ b/internal/resolution/status.go
@@ -1,0 +1,22 @@
+package resolution
+
+const (
+	// ReasonTaskRunResolutionFailed indicates that references within the
+	// TaskRun could not be resolved.
+	ReasonTaskRunResolutionFailed = "TaskRunResolutionFailed"
+
+	// ReasonCouldntGetTask indicates that a reference to a task did not
+	// successfully resolve to a task object. This is distinct from
+	// ReasonTaskRunResolutionFailed because it indicates a failure
+	// fetching the referenced Task rather than failure to interpret the
+	// reference.
+	ReasonCouldntGetTask = "CouldntGetTask"
+
+	// ReasonPipelineRunResolutionFailed indicates that references within the
+	// PipelineRun could not be resolved.
+	ReasonPipelineRunResolutionFailed = "PipelineRunResolutionFailed"
+
+	// ReasonCouldntGetPipeline indicates that a reference to a pipeline did
+	// not successfully resolve to a pipeline object.
+	ReasonCouldntGetPipeline = "CouldntGetPipeline"
+)

--- a/internal/resolution/taskrun.go
+++ b/internal/resolution/taskrun.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	resources "github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type TaskRunResolutionRequest struct {
+	KubeClientSet     kubernetes.Interface
+	PipelineClientSet clientset.Interface
+	TaskRun           *v1beta1.TaskRun
+
+	ResolvedTaskMeta *metav1.ObjectMeta
+	ResolvedTaskSpec *v1beta1.TaskSpec
+}
+
+// TaskRunResolutionRequest.Resolve implements the default resolution behaviour
+// for a Tekton Pipelines taskrun. It resolves the task associated with the taskrun
+// from one of three places:
+//
+// - in-line in the taskrun's spec.taskSpec
+// - from the cluster via the taskrun's spec.taskRef
+// - (when relevant feature flag enabled) from a Tekton Bundle indicated by the taskrun's spec.taskRef.bundle field.
+//
+// If a task is resolved correctly from the taskrun then the ResolvedTaskMeta
+// and ResolvedTaskSpec fields of the TaskRunResolutionRequest will be
+// populated after this method returns.
+//
+// If an error occurs during any part in the resolution process it will be
+// returned with both a human-readable Message and a machine-readable Reason
+// embedded in a *resolution.Error.
+func (req *TaskRunResolutionRequest) Resolve(ctx context.Context) error {
+	if req.TaskRun.Status.TaskSpec != nil {
+		return ErrorTaskRunAlreadyResolved
+	}
+
+	getTaskFunc, err := resources.GetTaskFuncFromTaskRun(ctx, req.KubeClientSet, req.PipelineClientSet, req.TaskRun)
+	if err != nil {
+		return NewError(ReasonTaskRunResolutionFailed, err)
+	}
+
+	taskMeta, taskSpec, err := resources.GetTaskData(ctx, req.TaskRun, getTaskFunc)
+	if err != nil {
+		return NewError(ReasonTaskRunResolutionFailed, err)
+	}
+
+	req.ResolvedTaskMeta = taskMeta
+	req.ResolvedTaskSpec = taskSpec
+
+	return nil
+}

--- a/internal/resolution/taskrun_test.go
+++ b/internal/resolution/taskrun_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test"
+	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	simpleTask = v1beta1.Task{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Task",
+			APIVersion: "tekton.dev/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Container: corev1.Container{
+					Name:    "step-1",
+					Command: []string{"echo"},
+					Args:    []string{"hello", "world"},
+				},
+			}},
+		},
+	}
+)
+
+func TestTaskRunResolutionRequest_ResolveTaskRef(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, nil, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	req := &TaskRunResolutionRequest{
+		KubeClientSet:     assets.Clients.Kube,
+		PipelineClientSet: assets.Clients.Pipeline,
+		TaskRun:           tr,
+	}
+
+	if err := req.Resolve(assets.Ctx); err != nil {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+
+	if d := cmp.Diff(&simpleTask.Spec, req.ResolvedTaskSpec); d != "" {
+		t.Errorf("%s", diff.PrintWantGot(d))
+	}
+}
+
+func TestTaskRunResolutionRequest_ResolveInlineTaskSpec(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskSpec: simpleTask.Spec.DeepCopy(),
+		},
+	}
+
+	assets, cancel := getClients(t, nil, test.Data{
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	req := &TaskRunResolutionRequest{
+		KubeClientSet:     assets.Clients.Kube,
+		PipelineClientSet: assets.Clients.Pipeline,
+		TaskRun:           tr,
+	}
+
+	if err := req.Resolve(assets.Ctx); err != nil {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+
+	if d := cmp.Diff(&simpleTask.Spec, req.ResolvedTaskSpec); d != "" {
+		t.Errorf("%s", diff.PrintWantGot(d))
+	}
+}
+
+func TestTaskRunResolutionRequest_ResolveBundle(t *testing.T) {
+	// Set up a fake registry to push an image to.
+	s := httptest.NewServer(registry.New())
+	defer s.Close()
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Upload the simple task to the registry for our taskRunBundle TaskRun.
+	ref, err := test.CreateImage(u.Host+"/"+simpleTask.Name, &simpleTask)
+	if err != nil {
+		t.Fatalf("failed to upload image with simple task: %s", err.Error())
+	}
+
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name:   simpleTask.Name,
+				Bundle: ref,
+			},
+		},
+	}
+
+	config := config.Config{
+		FeatureFlags: &config.FeatureFlags{
+			EnableTektonOCIBundles: true,
+		},
+	}
+	assets, cancel := getClients(t, &config, test.Data{
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	req := &TaskRunResolutionRequest{
+		KubeClientSet:     nil,
+		PipelineClientSet: assets.Clients.Pipeline,
+		TaskRun:           tr,
+	}
+
+	if err := req.Resolve(assets.Ctx); err != nil {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+
+	if d := cmp.Diff(&simpleTask.Spec, req.ResolvedTaskSpec); d != "" {
+		t.Errorf("%s", diff.PrintWantGot(d))
+	}
+}
+
+func TestTaskRunResolutionRequest_AlreadyResolved(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskSpec: simpleTask.Spec.DeepCopy(),
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskSpec: simpleTask.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	req := &TaskRunResolutionRequest{
+		TaskRun: tr,
+	}
+
+	err := req.Resolve(context.Background())
+	if err != ErrorTaskRunAlreadyResolved {
+		t.Fatalf("unexpected error resolving spec: %v", err)
+	}
+}

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -38,6 +38,7 @@ const (
 	enableCustomTasks                       = "enable-custom-tasks"
 	enableAPIFields                         = "enable-api-fields"
 	scopeWhenExpressionsToTask              = "scope-when-expressions-to-task"
+	experimentalDisableRefResolution        = "experimental-disable-ref-resolution"
 	DefaultDisableHomeEnvOverwrite          = true
 	DefaultDisableWorkingDirOverwrite       = true
 	DefaultDisableAffinityAssistant         = false
@@ -48,6 +49,7 @@ const (
 	DefaultEnableCustomTasks                = false
 	DefaultScopeWhenExpressionsToTask       = false
 	DefaultEnableAPIFields                  = StableAPIFields
+	DefaultExperimentalDisableRefResolution = false
 )
 
 // FeatureFlags holds the features configurations
@@ -63,6 +65,7 @@ type FeatureFlags struct {
 	EnableCustomTasks                bool
 	ScopeWhenExpressionsToTask       bool
 	EnableAPIFields                  string
+	ExperimentalDisableRefResolution bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -112,6 +115,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setEnabledAPIFields(cfgMap, DefaultEnableAPIFields, &tc.EnableAPIFields); err != nil {
+		return nil, err
+	}
+	if err := setFeature(experimentalDisableRefResolution, DefaultExperimentalDisableRefResolution, &tc.ExperimentalDisableRefResolution); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/pipeline/controller.go
+++ b/pkg/apis/pipeline/controller.go
@@ -26,4 +26,10 @@ const (
 
 	// RuncControllerName holds the name of the Custom Task controller
 	RunControllerName = "Run"
+
+	// TaskRunResolverControllerName holds the name of the TaskRun Resolver controller
+	TaskRunResolverControllerName = "TaskRunResolver"
+
+	// PipelineRunResolverControllerName holds the name of the PipelineRun Resolver controller
+	PipelineRunResolverControllerName = "PipelineRunResolver"
 )

--- a/pkg/reconciler/resolver/assets_test.go
+++ b/pkg/reconciler/resolver/assets_test.go
@@ -1,0 +1,195 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	cminformer "knative.dev/pkg/configmap/informer"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
+	"knative.dev/pkg/system"
+)
+
+// simpleTask is a reusable Task resource.
+var simpleTask = v1beta1.Task{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Task",
+		APIVersion: "tekton.dev/v1beta1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "test-task",
+		Namespace:   "default",
+		Labels:      map[string]string{"red-balloons": "99"},
+		Annotations: map[string]string{"green-balloons": "0"},
+	},
+	Spec: v1beta1.TaskSpec{
+		Steps: []v1beta1.Step{{
+			Container: corev1.Container{
+				Name:    "step-1",
+				Command: []string{"echo"},
+				Args:    []string{"hello", "world"},
+			},
+		}},
+	},
+}
+
+var simplePipeline = v1beta1.Pipeline{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "Pipeline",
+		APIVersion: "tekton.dev/v1beta1",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:        "test-pipeline",
+		Namespace:   "default",
+		Labels:      map[string]string{"foo": "bar"},
+		Annotations: map[string]string{"baz": "quux"},
+	},
+	Spec: v1beta1.PipelineSpec{
+		Tasks: []v1beta1.PipelineTask{{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		}},
+	},
+}
+
+// getPatchActions filters a list of Actions down to just the PatchActions for
+// a given resource (e.g. "taskruns" or "pipelineruns").
+func getPatchActions(actions []ktesting.Action, resourceKind string) []ktesting.PatchAction {
+	ret := []ktesting.PatchAction{}
+	for _, a := range actions {
+		if action, ok := a.(ktesting.PatchAction); ok {
+			if action.Matches("patch", resourceKind) {
+				ret = append(ret, action)
+			}
+		}
+	}
+	return ret
+}
+
+// getClients is a test helper to construct the fake clients
+// needed for testing resource patching.
+func getClients(t *testing.T, d test.Data) (test.Assets, func()) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+
+	clients, informers := test.SeedTestData(t, ctx, d)
+
+	return test.Assets{
+		Ctx:       ctx,
+		Clients:   clients,
+		Informers: informers,
+	}, cancel
+}
+
+// getTaskRunResolverController is a helper to return a
+// test.Assets object populated with the resolver reconciler
+// controller.
+func getTaskRunResolverController(t *testing.T, d test.Data) (test.Assets, func()) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	ensureConfigurationConfigMapsExist(&d)
+	c, informers := test.SeedTestData(t, ctx, d)
+	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
+
+	ctl := NewTaskRunResolverController()(ctx, configMapWatcher)
+	if err := configMapWatcher.Start(ctx.Done()); err != nil {
+		t.Fatalf("error starting configmap watcher: %v", err)
+	}
+
+	if la, ok := ctl.Reconciler.(pkgreconciler.LeaderAware); ok {
+		la.Promote(pkgreconciler.UniversalBucket(), func(pkgreconciler.Bucket, types.NamespacedName) {})
+	}
+
+	return test.Assets{
+		Logger:     logging.FromContext(ctx),
+		Controller: ctl,
+		Clients:    c,
+		Informers:  informers,
+		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Ctx:        ctx,
+	}, cancel
+}
+
+// getPipelineRunResolverController is a helper to return a
+// test.Assets object populated with the resolver reconciler
+// controller.
+func getPipelineRunResolverController(t *testing.T, d test.Data) (test.Assets, func()) {
+	ctx, _ := ttesting.SetupFakeContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	ensureConfigurationConfigMapsExist(&d)
+	c, informers := test.SeedTestData(t, ctx, d)
+	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
+
+	ctl := NewPipelineRunResolverController()(ctx, configMapWatcher)
+	if err := configMapWatcher.Start(ctx.Done()); err != nil {
+		t.Fatalf("error starting configmap watcher: %v", err)
+	}
+
+	if la, ok := ctl.Reconciler.(pkgreconciler.LeaderAware); ok {
+		la.Promote(pkgreconciler.UniversalBucket(), func(pkgreconciler.Bucket, types.NamespacedName) {})
+	}
+
+	return test.Assets{
+		Logger:     logging.FromContext(ctx),
+		Controller: ctl,
+		Clients:    c,
+		Informers:  informers,
+		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
+		Ctx:        ctx,
+	}, cancel
+}
+
+// ensureConfigurationConfigMapsExist sets up the expected minimum defaults for
+// configmaps passed to a resolver reconciler controller.
+func ensureConfigurationConfigMapsExist(d *test.Data) {
+	var defaultsExists, featureFlagsExists, artifactBucketExists, artifactPVCExists bool
+	for _, cm := range d.ConfigMaps {
+		if cm.Name == config.GetDefaultsConfigName() {
+			defaultsExists = true
+		}
+		if cm.Name == config.GetFeatureFlagsConfigName() {
+			featureFlagsExists = true
+		}
+		if cm.Name == config.GetArtifactBucketConfigName() {
+			artifactBucketExists = true
+		}
+		if cm.Name == config.GetArtifactPVCConfigName() {
+			artifactPVCExists = true
+		}
+	}
+	if !defaultsExists {
+		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{},
+		})
+	}
+	if !featureFlagsExists {
+		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{},
+		})
+	}
+	if !artifactBucketExists {
+		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactBucketConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{},
+		})
+	}
+	if !artifactPVCExists {
+		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactPVCConfigName(), Namespace: system.Namespace()},
+			Data:       map[string]string{},
+		})
+	}
+}

--- a/pkg/reconciler/resolver/errors.go
+++ b/pkg/reconciler/resolver/errors.go
@@ -1,0 +1,34 @@
+package resolver
+
+import "fmt"
+
+type ErrorInvalidResourceKey struct {
+	key      string
+	original error
+}
+
+var _ error = &ErrorInvalidResourceKey{}
+
+func (e *ErrorInvalidResourceKey) Error() string {
+	return fmt.Sprintf("invalid resource key %q: %v", e.key, e.original)
+}
+
+func (e *ErrorInvalidResourceKey) Unwrap() error {
+	return e.original
+}
+
+type ErrorGettingResource struct {
+	kind     string
+	key      string
+	original error
+}
+
+var _ error = &ErrorGettingResource{}
+
+func (e *ErrorGettingResource) Error() string {
+	return fmt.Sprintf("error getting %s %q: %v", e.kind, e.key, e.original)
+}
+
+func (e *ErrorGettingResource) Unwrap() error {
+	return e.original
+}

--- a/pkg/reconciler/resolver/leader_aware.go
+++ b/pkg/reconciler/resolver/leader_aware.go
@@ -1,0 +1,48 @@
+package resolver
+
+import (
+	"github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/reconciler"
+)
+
+// buildTaskRunLeaderAwareFuncs constructs a LeaderAwareFuncs object to embed in a
+// TaskRun-aware controller so that it can meet knative's controller.LeaderAware interface.
+func buildTaskRunLeaderAwareFuncs(lister v1beta1.TaskRunLister) reconciler.LeaderAwareFuncs {
+	return reconciler.LeaderAwareFuncs{
+		PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+			all, err := lister.List(labels.Everything())
+			if err != nil {
+				return err
+			}
+			for _, elt := range all {
+				enq(bkt, types.NamespacedName{
+					Namespace: elt.GetNamespace(),
+					Name:      elt.GetName(),
+				})
+			}
+			return nil
+		},
+	}
+}
+
+// buildPipelineRunLeaderAwareFuncs constructs a LeaderAwareFuncs object to embed in a
+// PipelineRun-aware controller so that it can meet knative's controller.LeaderAware interface.
+func buildPipelineRunLeaderAwareFuncs(lister v1beta1.PipelineRunLister) reconciler.LeaderAwareFuncs {
+	return reconciler.LeaderAwareFuncs{
+		PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+			all, err := lister.List(labels.Everything())
+			if err != nil {
+				return err
+			}
+			for _, elt := range all {
+				enq(bkt, types.NamespacedName{
+					Namespace: elt.GetNamespace(),
+					Name:      elt.GetName(),
+				})
+			}
+			return nil
+		},
+	}
+}

--- a/pkg/reconciler/resolver/patch.go
+++ b/pkg/reconciler/resolver/patch.go
@@ -1,0 +1,96 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+)
+
+type metadataPatch struct {
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+type taskRunStatusPatch struct {
+	TaskSpec v1beta1.TaskSpec `json:"taskSpec"`
+}
+
+type pipelineRunStatusPatch struct {
+	PipelineSpec v1beta1.PipelineSpec `json:"pipelineSpec"`
+}
+
+// PatchResolvedTaskRun accepts a TaskRun with its task spec resolved and updates the
+// stored resource with the labels, annotations and resolved spec.
+func PatchResolvedTaskRun(ctx context.Context, kClient kubernetes.Interface, pClient clientset.Interface, tr *v1beta1.TaskRun) (*v1beta1.TaskRun, error) {
+	metadataBytes, err := json.Marshal(map[string]metadataPatch{
+		"metadata": {
+			Labels:      tr.ObjectMeta.Labels,
+			Annotations: tr.ObjectMeta.Annotations,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error constructing metadata patch: %w", err)
+	}
+
+	statusBytes, err := json.Marshal(map[string]taskRunStatusPatch{
+		"status": {
+			TaskSpec: *tr.Status.TaskSpec,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error constructing status patch: %w", err)
+	}
+
+	tr, err = pClient.TektonV1beta1().TaskRuns(tr.Namespace).Patch(ctx, tr.Name, types.MergePatchType, metadataBytes, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error patching metadata: %w", err)
+	}
+
+	tr, err = pClient.TektonV1beta1().TaskRuns(tr.Namespace).Patch(ctx, tr.Name, types.MergePatchType, statusBytes, metav1.PatchOptions{}, "status")
+	if err != nil {
+		return nil, fmt.Errorf("error patching status: %w", err)
+	}
+
+	return tr, nil
+}
+
+// PatchResolvedPipelineRun accepts a PipelineRun with its pipeline spec resolved and updates
+// the stored resource with the labels, annotations and resolved spec.
+func PatchResolvedPipelineRun(ctx context.Context, kClient kubernetes.Interface, pClient clientset.Interface, pr *v1beta1.PipelineRun) (*v1beta1.PipelineRun, error) {
+	metadataBytes, err := json.Marshal(map[string]metadataPatch{
+		"metadata": {
+			Labels:      pr.ObjectMeta.Labels,
+			Annotations: pr.ObjectMeta.Annotations,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error constructing metadata patch: %w", err)
+	}
+
+	statusBytes, err := json.Marshal(map[string]pipelineRunStatusPatch{
+		"status": {
+			PipelineSpec: *pr.Status.PipelineSpec,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error constructing status patch: %w", err)
+	}
+
+	pr, err = pClient.TektonV1beta1().PipelineRuns(pr.Namespace).Patch(ctx, pr.Name, types.MergePatchType, metadataBytes, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error patching metadata: %w", err)
+	}
+
+	pr, err = pClient.TektonV1beta1().PipelineRuns(pr.Namespace).Patch(ctx, pr.Name, types.MergePatchType, statusBytes, metav1.PatchOptions{}, "status")
+	if err != nil {
+		return nil, fmt.Errorf("error patching status: %w", err)
+	}
+
+	return pr, nil
+}

--- a/pkg/reconciler/resolver/patch_test.go
+++ b/pkg/reconciler/resolver/patch_test.go
@@ -1,0 +1,320 @@
+package resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestPatchResolvedTaskRunSuccess(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskSpec: simpleTask.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	tr, err := PatchResolvedTaskRun(assets.Ctx, assets.Clients.Kube, assets.Clients.Pipeline, tr)
+
+	if tr == nil || err != nil {
+		t.Fatalf("unexpected return result")
+	}
+
+	patchedMetadata := false
+	patchedStatus := false
+	for _, a := range getPatchActions(assets.Clients.Pipeline.Actions(), "taskruns") {
+		if a.GetSubresource() == "status" {
+			got := map[string]struct {
+				TaskSpec *v1beta1.TaskSpec `json:"taskSpec"`
+			}{}
+			if err := json.Unmarshal(a.GetPatch(), &got); err != nil {
+				t.Fatalf("invalid status patch json: %v", err)
+			}
+			if _, hasStatusPatch := got["status"]; hasStatusPatch {
+				patchedStatus = true
+			}
+		} else {
+			got := map[string]metav1.ObjectMeta{}
+			if err := json.Unmarshal(a.GetPatch(), &got); err != nil {
+				t.Fatalf("invalid metadata patch json: %v", err)
+			}
+			if _, hasMetadataPatch := got["metadata"]; hasMetadataPatch {
+				patchedMetadata = true
+			}
+		}
+	}
+
+	if !patchedMetadata {
+		t.Errorf("expected metadata patch")
+	}
+	if !patchedStatus {
+		t.Errorf("expected status patch")
+	}
+}
+
+func TestPatchResolvedPipelineRunSuccess(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: simplePipeline.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineSpec: simplePipeline.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	pr, err := PatchResolvedPipelineRun(assets.Ctx, assets.Clients.Kube, assets.Clients.Pipeline, pr)
+
+	if pr == nil || err != nil {
+		t.Fatalf("unexpected return result")
+	}
+
+	patchedMetadata := false
+	patchedStatus := false
+
+	for _, a := range getPatchActions(assets.Clients.Pipeline.Actions(), "pipelineruns") {
+		if a.GetSubresource() == "status" {
+			got := map[string]struct {
+				PipelineSpec *v1beta1.PipelineSpec `json:"pipelineSpec"`
+			}{}
+			if err := json.Unmarshal(a.GetPatch(), &got); err != nil {
+				t.Fatalf("invalid status patch json: %v", err)
+			}
+			if _, hasStatusPatch := got["status"]; hasStatusPatch {
+				patchedStatus = true
+			}
+		} else {
+			got := map[string]metav1.ObjectMeta{}
+			if err := json.Unmarshal(a.GetPatch(), &got); err != nil {
+				t.Fatalf("invalid metadata patch json: %v", err)
+			}
+			if _, hasMetadataPatch := got["metadata"]; hasMetadataPatch {
+				patchedMetadata = true
+			}
+		}
+	}
+
+	if !patchedMetadata {
+		t.Errorf("expected metadata patch")
+	}
+	if !patchedStatus {
+		t.Errorf("expected status patch")
+	}
+}
+
+func TestPatchResolvedTaskRunMetadataError(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskSpec: simpleTask.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch TaskRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			t.Fatalf("unexpected patch of subresource %q", action.GetSubresource())
+		}
+		return true, nil, testError
+	})
+
+	tr, err := PatchResolvedTaskRun(assets.Ctx, assets.Clients.Kube, assets.Clients.Pipeline, tr)
+
+	if !errors.Is(err, testError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPatchResolvedPipelineRunMetadataError(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: simplePipeline.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineSpec: simplePipeline.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch PipelineRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			t.Fatalf("unexpected patch of subresource %q", action.GetSubresource())
+		}
+		return true, nil, testError
+	})
+
+	pr, err := PatchResolvedPipelineRun(assets.Ctx, assets.Clients.Kube, assets.Clients.Pipeline, pr)
+
+	if pr != nil {
+		t.Errorf("non-nil pipelinerun returned by patcher")
+	}
+
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPatchResolvedTaskRunStatusSpecError(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskSpec: simpleTask.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch PipelineRun status.pipelineSpec.
+	assets.Clients.Pipeline.PrependReactor("patch", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return true, nil, testError
+		}
+		return false, nil, nil
+	})
+
+	tr, err := PatchResolvedTaskRun(assets.Ctx, assets.Clients.Kube, assets.Clients.Pipeline, tr)
+
+	if tr != nil {
+		t.Errorf("non-nil taskrun returned by patcher")
+	}
+
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPatchResolvedPipelineRunStatusSpecError(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: simplePipeline.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineSpec: simplePipeline.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	assets, cancel := getClients(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch TaskRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return true, nil, testError
+		}
+		return false, nil, nil
+	})
+
+	pr, err := PatchResolvedPipelineRun(assets.Ctx, assets.Clients.Kube, assets.Clients.Pipeline, pr)
+
+	if pr != nil {
+		t.Errorf("non-nil pipelinerun returned by patcher")
+	}
+
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/reconciler/resolver/pipelinerun_resolver_controller.go
+++ b/pkg/reconciler/resolver/pipelinerun_resolver_controller.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun"
+	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+)
+
+// NewPipelineRunResolverController returns a func that itself returns a
+// knative controller implementation suitable for resolving Tekton
+// PipelineRuns.  Resolving PipelineRuns is the process of taking a
+// PipelineRun and determining which Pipeline it is attempting to run.
+func NewPipelineRunResolverController() func(context.Context, configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		logger := logging.FromContext(ctx)
+		kubeclientset := kubeclient.Get(ctx)
+		pipelineclientset := pipelineclient.Get(ctx)
+		pipelinerunInformer := pipelineruninformer.Get(ctx)
+
+		lister := pipelinerunInformer.Lister()
+
+		r := &PipelineRunResolverReconciler{
+			LeaderAwareFuncs: buildPipelineRunLeaderAwareFuncs(lister),
+
+			kubeClientSet:     kubeclientset,
+			pipelineClientSet: pipelineclientset,
+			pipelinerunLister: pipelinerunInformer.Lister(),
+		}
+
+		configStore := config.NewStore(logger.Named("config-store"))
+		configStore.WatchConfigs(cmw)
+		r.configStore = configStore
+
+		ctrType := reflect.TypeOf(r).Elem()
+		ctrTypeName := fmt.Sprintf("%s.%s", ctrType.PkgPath(), ctrType.Name())
+		ctrTypeName = strings.ReplaceAll(ctrTypeName, "/", ".")
+		impl := controller.NewImpl(r, logger, ctrTypeName)
+
+		logger.Info("Setting up resolver controller event handlers")
+
+		pipelinerunInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: acceptPipelineRunWithUnpopulatedStatusSpec,
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc: impl.Enqueue,
+			},
+		})
+
+		return impl
+	}
+}
+
+// acceptPipelineRunWithUnpopulatedStatusSpec is a filter func that is used to
+// limit the pipelineruns that the resolver reconciler sees. Only the pipelineruns
+// without a populated status.pipelineSpec field are passed to the resolver
+// reconciler.
+func acceptPipelineRunWithUnpopulatedStatusSpec(obj interface{}) bool {
+	pr, ok := obj.(*v1beta1.PipelineRun)
+	return ok && pr.Status.PipelineSpec == nil
+}

--- a/pkg/reconciler/resolver/pipelinerun_resolver_reconciler.go
+++ b/pkg/reconciler/resolver/pipelinerun_resolver_reconciler.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/tektoncd/pipeline/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
+)
+
+type PipelineRunResolverReconciler struct {
+	// Implements reconciler.LeaderAware
+	reconciler.LeaderAwareFuncs
+
+	kubeClientSet     kubernetes.Interface
+	pipelineClientSet clientset.Interface
+	pipelinerunLister listers.PipelineRunLister
+	configStore       reconciler.ConfigStore
+}
+
+var _ controller.Reconciler = &PipelineRunResolverReconciler{}
+
+func (r *PipelineRunResolverReconciler) Reconcile(ctx context.Context, key string) error {
+	if r.configStore != nil {
+		ctx = r.configStore.ToContext(ctx)
+	}
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return controller.NewPermanentError(&ErrorInvalidResourceKey{key: key, original: err})
+	}
+
+	pr, err := r.pipelinerunLister.PipelineRuns(namespace).Get(name)
+	if err != nil {
+		return &ErrorGettingResource{kind: "pipelinerun", key: key, original: err}
+	}
+
+	_, err = ResolvePipelineRun(ctx, r.kubeClientSet, r.pipelineClientSet, pr)
+	if err == resolution.ErrorPipelineRunAlreadyResolved {
+		return nil
+	} else if err != nil {
+		updateErr := UpdatePipelineRunWithError(ctx, r.pipelineClientSet, pr.Namespace, pr.Name, err)
+		log.Printf("UPDATE PIPELINERUN WITH ERR UPDATEERR: %v", updateErr)
+		if updateErr != nil {
+			// Don't return a permanent error here - it needs to be
+			// reconciled again in case the underlying resource is
+			// still in a transitional state.
+			return err
+		}
+		return controller.NewPermanentError(err)
+	}
+
+	if _, err := PatchResolvedPipelineRun(ctx, r.kubeClientSet, r.pipelineClientSet, pr); err != nil {
+		// We don't mark the pipelinerun failed here because error
+		// responses from the api server might be transient.
+		return err
+	}
+
+	return nil
+}
+
+func ResolvePipelineRun(ctx context.Context, kClient kubernetes.Interface, pClient clientset.Interface, pr *v1beta1.PipelineRun) (*v1beta1.PipelineRun, error) {
+	req := resolution.PipelineRunResolutionRequest{
+		KubeClientSet:     kClient,
+		PipelineClientSet: pClient,
+		PipelineRun:       pr,
+	}
+
+	if err := req.Resolve(ctx); err != nil {
+		return nil, err
+	}
+
+	resolution.CopyPipelineMetaToPipelineRun(req.ResolvedPipelineMeta, pr)
+	pr.Status.PipelineSpec = req.ResolvedPipelineSpec
+
+	return pr, nil
+}
+
+// UpdatePipelineRunWithError updates a PipelineRun with a resolution error.
+// Available publicly so that unit tests can leverage resolution machinery
+// without relying on Patch, which our current fakes don't support.
+//
+// Returns an error if updating the PipelineRun doesn't work.
+func UpdatePipelineRunWithError(ctx context.Context, client clientset.Interface, namespace, name string, resolutionError error) error {
+	key := fmt.Sprintf("%s/%s", namespace, name)
+	reason, err := PipelineRunResolutionReasonError(resolutionError)
+	latestGenerationPR, err := client.TektonV1beta1().PipelineRuns(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		logging.FromContext(ctx).Warnf("error getting pipelinerun %q to update it as failed: %v", key, err)
+		return err
+	}
+
+	latestGenerationPR.Status.MarkFailed(reason, resolutionError.Error())
+	_, err = client.TektonV1beta1().PipelineRuns(namespace).UpdateStatus(ctx, latestGenerationPR, metav1.UpdateOptions{})
+	if err != nil {
+		logging.FromContext(ctx).Warnf("error marking pipelinerun %q as failed: %v", key, err)
+		return err
+	}
+	return nil
+}
+
+// PipelineRunResolutionReasonError extracts the reason and underlying error
+// embedded in the given resolution.Error, or returns some sane defaults
+// if the error isn't a resolution.Error.
+func PipelineRunResolutionReasonError(err error) (string, error) {
+	reason := resolution.ReasonPipelineRunResolutionFailed
+	resolutionError := err
+
+	if e, ok := err.(*resolution.Error); ok {
+		reason = e.Reason
+		resolutionError = e.Unwrap()
+	}
+
+	return reason, resolutionError
+}

--- a/pkg/reconciler/resolver/pipelinerun_resolver_reconciler_test.go
+++ b/pkg/reconciler/resolver/pipelinerun_resolver_reconciler_test.go
@@ -1,0 +1,349 @@
+package resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/controller"
+)
+
+func TestPipelineRunResolver_ReconcileMissingPipelineRun(t *testing.T) {
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		PipelineRuns: []*v1beta1.PipelineRun{},
+	})
+
+	defer cancel()
+
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, "test/foo")
+
+	e := &ErrorGettingResource{}
+	if !errors.As(err, &e) {
+		t.Errorf("received incorrect error: %v", err)
+	}
+}
+
+func TestPipelineRunResolver_ReconcileInvalidResourceKey(t *testing.T) {
+	assets, cancel := getPipelineRunResolverController(t, test.Data{})
+
+	defer cancel()
+
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, "i/n/v/a/l/i/d/k/e/y")
+
+	e := &ErrorInvalidResourceKey{}
+	if !errors.As(err, &e) {
+		t.Errorf("received incorrect error: %v", err)
+	}
+
+	if !controller.IsPermanentError(err) {
+		t.Errorf("expected permanent controller error for invalid key")
+	}
+}
+
+func TestPipelineRunResolver_ReconcileAlreadyResolved(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: simplePipeline.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineSpec: simplePipeline.Spec.DeepCopy(),
+		},
+		Status: v1beta1.PipelineRunStatus{
+			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				PipelineSpec: simplePipeline.Spec.DeepCopy(),
+			},
+		},
+	}
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if err != nil {
+		t.Errorf("expected nil error, received: %v", err)
+	}
+}
+
+func TestPipelineRunResolver_PatchesResourceStatus(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: simplePipeline.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineSpec: simplePipeline.Spec.DeepCopy(),
+		},
+	}
+
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actions := assets.Clients.Pipeline.Actions()
+	for _, a := range getPatchActions(actions, "pipelineruns") {
+		got := map[string]struct {
+			PipelineSpec *v1beta1.PipelineSpec `json:"pipelineSpec"`
+		}{}
+		if err := json.Unmarshal(a.GetPatch(), &got); err == nil {
+			if _, hasStatus := got["status"]; hasStatus {
+				if d := cmp.Diff(&simplePipeline.Spec, got["status"].PipelineSpec); d != "" {
+					t.Errorf(diff.PrintWantGot(d))
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("no status patch found")
+}
+
+func TestPipelineRunResolver_PatchesResourceMetadata(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: simplePipeline.Namespace,
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+	}
+
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedMetadata := &metav1.ObjectMeta{
+		Labels: map[string]string{
+			"tekton.dev/pipeline": "test-pipeline",
+		},
+		Annotations: map[string]string{},
+	}
+	for key, val := range simplePipeline.Labels {
+		expectedMetadata.Labels[key] = val
+	}
+	for key, val := range simplePipeline.Annotations {
+		expectedMetadata.Annotations[key] = val
+	}
+
+	actions := assets.Clients.Pipeline.Actions()
+	for _, a := range getPatchActions(actions, "pipelineruns") {
+		got := map[string]*metav1.ObjectMeta{}
+		if err := json.Unmarshal(a.GetPatch(), &got); err == nil {
+			if _, hasMetadata := got["metadata"]; hasMetadata {
+				if d := cmp.Diff(expectedMetadata, got["metadata"]); d != "" {
+					t.Errorf(diff.PrintWantGot(d))
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("no metadata patch found")
+}
+
+func TestPipelineRunResolveError_ErrorDuringPipelineRunGet(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+	}
+
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned by the reconciler")
+
+	// Return error when resolver tries to get PipelineRef'd Pipeline, leading
+	// resolver to try and update the PipelineRun with that error detail.
+	assets.Clients.Pipeline.PrependReactor("get", "pipelines", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, testError
+	})
+
+	// Return error when resolver tries to get the PipelineRun to update it
+	// with the error detail.
+	assets.Clients.Pipeline.PrependReactor("get", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("GET PipelineRun disallowed for this test")
+	})
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if PipelineRun GET fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPipelineRunResolveError_ErrorDuringPipelineRunUpdate(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+	}
+
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned by the reconciler")
+
+	// Return error when resolver tries to get PipelineRef'd Pipeline, leading
+	// resolver to try and update the PipelineRun with that error detail.
+	assets.Clients.Pipeline.PrependReactor("get", "pipelines", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, testError
+	})
+
+	// Return error when resolver tries to update the PipelineRun status
+	// with the error detail.
+	assets.Clients.Pipeline.PrependReactor("update", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			t.Fatalf("expected update only on PipelineRun's status")
+		}
+		return true, nil, errors.New("UPDATE of PipelineRun status disallowed for this test")
+	})
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if PipelineRun status UPDATE fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPipelineRunResolver_PatchMetadataError(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+	}
+
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch PipelineRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			t.Fatalf("unexpected patch of subresource %q", action.GetSubresource())
+		}
+		return true, nil, testError
+	})
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if TaksRun metadata PATCH fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPipelineRunResolver_PatchStatusSpecError(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name: simplePipeline.Name,
+			},
+		},
+	}
+
+	assets, cancel := getPipelineRunResolverController(t, test.Data{
+		Pipelines:    []*v1beta1.Pipeline{simplePipeline.DeepCopy()},
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch PipelineRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "pipelineruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return true, nil, testError
+		}
+		return false, nil, nil
+	})
+
+	key := fmt.Sprintf("%s/%s", pr.Namespace, pr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if TaksRun status.spec PATCH fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/reconciler/resolver/taskrun_resolver_controller.go
+++ b/pkg/reconciler/resolver/taskrun_resolver_controller.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	pipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
+	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
+	"k8s.io/client-go/tools/cache"
+	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+)
+
+// NewTaskRunResolverController returns a func that itself returns a knative
+// controller implementation suitable for resolving Tekton TaskRuns.
+// Resolving TaskRuns is the process of taking a TaskRun and determining
+// which Task it is attempting to run.
+func NewTaskRunResolverController() func(context.Context, configmap.Watcher) *controller.Impl {
+	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+		logger := logging.FromContext(ctx)
+		kubeclientset := kubeclient.Get(ctx)
+		pipelineclientset := pipelineclient.Get(ctx)
+		taskrunInformer := taskruninformer.Get(ctx)
+
+		lister := taskrunInformer.Lister()
+
+		r := &TaskRunResolverReconciler{
+			LeaderAwareFuncs: buildTaskRunLeaderAwareFuncs(lister),
+
+			kubeClientSet:     kubeclientset,
+			pipelineClientSet: pipelineclientset,
+			taskrunLister:     taskrunInformer.Lister(),
+		}
+
+		configStore := config.NewStore(logger.Named("config-store"))
+		configStore.WatchConfigs(cmw)
+		r.configStore = configStore
+
+		ctrType := reflect.TypeOf(r).Elem()
+		ctrTypeName := fmt.Sprintf("%s.%s", ctrType.PkgPath(), ctrType.Name())
+		ctrTypeName = strings.ReplaceAll(ctrTypeName, "/", ".")
+		impl := controller.NewImpl(r, logger, ctrTypeName)
+
+		logger.Info("Setting up resolver controller event handlers")
+
+		taskrunInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+			FilterFunc: acceptTaskRunWithUnpopulatedStatusSpec,
+			Handler: cache.ResourceEventHandlerFuncs{
+				AddFunc: impl.Enqueue,
+			},
+		})
+
+		return impl
+	}
+}
+
+// acceptTaskRunWithUnpopulatedStatusSpec is a filter func that is used to
+// limit the taskruns that the resolver reconciler sees. Only the taskruns
+// without a populated status.taskSpec field are passed to the resolver
+// reconciler.
+func acceptTaskRunWithUnpopulatedStatusSpec(obj interface{}) bool {
+	tr, ok := obj.(*v1beta1.TaskRun)
+	return ok && tr.Status.TaskSpec == nil
+}

--- a/pkg/reconciler/resolver/taskrun_resolver_reconciler.go
+++ b/pkg/reconciler/resolver/taskrun_resolver_reconciler.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"context"
+
+	"github.com/tektoncd/pipeline/internal/resolution"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
+)
+
+type TaskRunResolverReconciler struct {
+	// Implements reconciler.LeaderAware
+	reconciler.LeaderAwareFuncs
+
+	kubeClientSet     kubernetes.Interface
+	pipelineClientSet clientset.Interface
+	taskrunLister     listers.TaskRunLister
+	configStore       reconciler.ConfigStore
+}
+
+const defaultTaskRunResolutionErrorReason = resolution.ReasonTaskRunResolutionFailed
+
+var _ controller.Reconciler = &TaskRunResolverReconciler{}
+
+func (r *TaskRunResolverReconciler) Reconcile(ctx context.Context, key string) error {
+	if r.configStore != nil {
+		ctx = r.configStore.ToContext(ctx)
+	}
+
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		return controller.NewPermanentError(&ErrorInvalidResourceKey{key: key, original: err})
+	}
+
+	tr, err := r.taskrunLister.TaskRuns(namespace).Get(name)
+	if err != nil {
+		return &ErrorGettingResource{kind: "taskrun", key: key, original: err}
+	}
+
+	if _, err := ResolveTaskRun(ctx, r.kubeClientSet, r.pipelineClientSet, tr); err == resolution.ErrorTaskRunAlreadyResolved {
+		// Nothing to do: another process has already resolved the taskrun.
+		return nil
+	} else if err != nil {
+		resolutionError := err
+
+		latestGenerationTR, err := r.pipelineClientSet.TektonV1beta1().TaskRuns(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			logging.FromContext(ctx).Warnf("error getting taskrun %q to update it as failed: %v", key, err)
+			return resolutionError
+		}
+
+		MarkTaskRunResolutionError(latestGenerationTR, resolutionError)
+
+		latestGenerationTR, err = r.pipelineClientSet.TektonV1beta1().TaskRuns(namespace).UpdateStatus(ctx, latestGenerationTR, metav1.UpdateOptions{})
+		if err != nil {
+			logging.FromContext(ctx).Warnf("error updating taskrun %q as failed: %v", key, err)
+			return resolutionError
+		}
+
+		return controller.NewPermanentError(resolutionError)
+	}
+
+	if _, err := PatchResolvedTaskRun(ctx, r.kubeClientSet, r.pipelineClientSet, tr); err != nil {
+		// We don't mark the taskrun failed here because error
+		// responses from the api server might be transient.
+		return err
+	}
+
+	return nil
+}
+
+// ResolveTaskRun executes default resolution behaviour: first fetching the
+// task that the taskrun references and then copying metadata over from task to
+// taskrun.
+//
+// This func is public so that unit tests can leverage resolution machinery
+// without creating an entire resolver controller and, more importantly,
+// without requiring a faked api server to handle patch requests, which our
+// current fake does not.
+func ResolveTaskRun(ctx context.Context, kClient kubernetes.Interface, pClient clientset.Interface, tr *v1beta1.TaskRun) (*v1beta1.TaskRun, error) {
+	req := resolution.TaskRunResolutionRequest{
+		KubeClientSet:     kClient,
+		PipelineClientSet: pClient,
+		TaskRun:           tr,
+	}
+
+	if err := req.Resolve(ctx); err != nil {
+		return nil, err
+	}
+
+	resolution.CopyTaskMetaToTaskRun(req.ResolvedTaskMeta, tr)
+	tr.Status.TaskSpec = req.ResolvedTaskSpec
+
+	return tr, nil
+}
+
+// MarkTaskRunResolutionError updates a TaskRun's condition with error
+// information.
+//
+// This func is public so that unit tests can leverage resolution machinery
+// without creating an entire resolver controller and, more importantly,
+// without requiring a faked api server to handle patch requests, which our
+// current fake does not.
+func MarkTaskRunResolutionError(tr *v1beta1.TaskRun, err error) {
+	reason := defaultTaskRunResolutionErrorReason
+	if e, ok := err.(*resolution.Error); ok {
+		reason = e.Reason
+	}
+	tr.Status.MarkResourceFailed(v1beta1.TaskRunReason(reason), err)
+}

--- a/pkg/reconciler/resolver/taskrun_resolver_reconciler_test.go
+++ b/pkg/reconciler/resolver/taskrun_resolver_reconciler_test.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/controller"
+
+	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
+)
+
+func TestTaskRunResolver_ReconcileMissingTaskRun(t *testing.T) {
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		TaskRuns: []*v1beta1.TaskRun{},
+	})
+
+	defer cancel()
+
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, "test/foo")
+
+	e := &ErrorGettingResource{}
+	if !errors.As(err, &e) {
+		t.Errorf("received incorrect error: %v", err)
+	}
+}
+
+func TestTaskRunResolver_ReconcileInvalidResourceKey(t *testing.T) {
+	assets, cancel := getTaskRunResolverController(t, test.Data{})
+
+	defer cancel()
+
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, "i/n/v/a/l/i/d/k/e/y")
+
+	e := &ErrorInvalidResourceKey{}
+	if !errors.As(err, &e) {
+		t.Errorf("received incorrect error: %v", err)
+	}
+
+	if !controller.IsPermanentError(err) {
+		t.Errorf("expected permanent controller error for invalid key")
+	}
+}
+
+func TestTaskRunResolver_ReconcileAlreadyResolved(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{Name: simpleTask.Name},
+		},
+		Status: v1beta1.TaskRunStatus{
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskSpec: &simpleTask.Spec,
+			},
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if err != nil {
+		t.Errorf("expected nil error, received: %v", err)
+	}
+}
+
+func TestTaskRunResolver_PatchesResourceStatus(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskSpec: simpleTask.Spec.DeepCopy(),
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actions := assets.Clients.Pipeline.Actions()
+	for _, a := range getPatchActions(actions, "taskruns") {
+		got := map[string]struct {
+			TaskSpec *v1beta1.TaskSpec `json:"taskSpec"`
+		}{}
+		if err := json.Unmarshal(a.GetPatch(), &got); err == nil {
+			if _, hasStatus := got["status"]; hasStatus {
+				if d := cmp.Diff(&simpleTask.Spec, got["status"].TaskSpec); d != "" {
+					t.Errorf(diff.PrintWantGot(d))
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("no status patch found")
+}
+
+func TestTaskRunResolver_PatchesResourceMetadata(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedMetadata := &metav1.ObjectMeta{
+		Labels:      map[string]string{"tekton.dev/task": simpleTask.Name},
+		Annotations: map[string]string{},
+	}
+	for key, val := range simpleTask.Labels {
+		expectedMetadata.Labels[key] = val
+	}
+	for key, val := range simpleTask.Annotations {
+		expectedMetadata.Annotations[key] = val
+	}
+
+	actions := assets.Clients.Pipeline.Actions()
+	for _, a := range getPatchActions(actions, "taskruns") {
+		got := map[string]*metav1.ObjectMeta{}
+		if err := json.Unmarshal(a.GetPatch(), &got); err == nil {
+			if _, hasMetadata := got["metadata"]; hasMetadata {
+				if d := cmp.Diff(expectedMetadata, got["metadata"]); d != "" {
+					t.Errorf(diff.PrintWantGot(d))
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("no metadata patch found")
+}
+
+func TestTaskRunResolveError_ErrorDuringTaskRunGet(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned by the reconciler")
+
+	// Return error when resolver tries to get taskRef'd Task, leading
+	// resolver to try and update the TaskRun with that error detail.
+	assets.Clients.Pipeline.PrependReactor("get", "tasks", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, testError
+	})
+
+	// Return error when resolver tries to get the TaskRun to update it
+	// with the error detail.
+	assets.Clients.Pipeline.PrependReactor("get", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("GET taskrun disallowed for this test")
+	})
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if TaskRun GET fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestTaskRunResolveError_ErrorDuringTaskRunUpdate(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned by the reconciler")
+
+	// Return error when resolver tries to get taskRef'd Task, leading
+	// resolver to try and update the TaskRun with that error detail.
+	assets.Clients.Pipeline.PrependReactor("get", "tasks", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, testError
+	})
+
+	// Return error when resolver tries to update the TaskRun status
+	// with the error detail.
+	assets.Clients.Pipeline.PrependReactor("update", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "status" {
+			t.Fatalf("expected update only on taskrun's status")
+		}
+		return true, nil, errors.New("UPDATE of taskrun status disallowed for this test")
+	})
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if TaskRun status UPDATE fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestTaskRunResolver_PatchMetadataError(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch TaskRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() != "" {
+			t.Fatalf("unexpected patch of subresource %q", action.GetSubresource())
+		}
+		return true, nil, testError
+	})
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if TaksRun metadata PATCH fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTaskRunResolver_PatchStatusSpecError(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tr",
+			Namespace: "default",
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: simpleTask.Name,
+			},
+		},
+	}
+
+	assets, cancel := getTaskRunResolverController(t, test.Data{
+		Tasks:    []*v1beta1.Task{simpleTask.DeepCopy()},
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+
+	defer cancel()
+
+	testError := errors.New("this error should be returned when patching")
+
+	// Return error when resolver tries to patch TaskRun metadata.
+	assets.Clients.Pipeline.PrependReactor("patch", "taskruns", func(action ktesting.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return true, nil, testError
+		}
+		return false, nil, nil
+	})
+
+	key := fmt.Sprintf("%s/%s", tr.Namespace, tr.Name)
+	err := assets.Controller.Reconciler.Reconcile(assets.Ctx, key)
+
+	if controller.IsPermanentError(err) {
+		t.Errorf("controller is not supposed to make permanent error if TaksRun status.spec PATCH fails")
+	}
+	if !errors.Is(err, testError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/3305

This PR refactors the way task and pipelinerun resolution works. The intention with this PR is to be entirely backwards-compatible with the existing way resolution works. In other words, I'm not trying to introduce new behaviours with these commits, just set the stage for future possible improvements.

I'm pushing this up now to start getting feedback from interested parties. I've still got a ways to go in terms of getting new unit tests updated and introduced. I'm hopeful that integration tests shouldn't be too badly affected. 🤞 

There are two commits as part of this PR to aid reviewers:

1. Remove task and pipeline spec resolution from the existing reconcilers
2. Move ref resolution to new reconcilers

I'll squash these once we're happy to move ahead.

Prior to this commit the taskrun and pipelinerun reconcilers were responsible for resolving specs from taskRef / taskSpec / pipelineRef / pipelineSpec / bundles.

The first commit in this PR updates the existing taskrun/pipelinerun reconcilers to ignore any taskrun or pipelinerun that doesn't have a spec cached in their status. This means all taskruns and pipelineruns are ignored - the logic for populating status from a spec has been removed entirely from the controller.

The second commit in this PR introduces 2 new controllers whose sole responsibility is to resolve specs from taskruns and pipelineruns. Resolved specs then get written to the status field of the runs and the "old" reconcilers are able to pick them up and begin actuating them as usual.

The new resolver reconcilers are also currently responsible for propagating labels and annotations from the task / pipeline to the taskrun / pipelinerun. This is because our existing taskrun/pipelinerun reconcilers expect only the _spec_ to be embedded in their status fields, not the entire task/pipeline objects. The knock-on effect of this is that the metadata from the resolved task/pipeline is lost by the time the taskrun/pipelinerun reconciler receive them.

One final thing this commit introduces is a library, `internal/resolution` that may eventually be available for downstream projects to implement their own task and pipeline resolvers. At the moment all it does is expose the default resolution behaviour of Tekton Pipelines as a func + a couple of useful helper methods for propagating labels/annotations. This would allow someone implementing their own resolver reconciler to generally adhere to the Tekton Pipelines "resolution contract" with only 100 lines or so of Go. It's not yet intended for external consumption but I think it's an interesting direction we can take future work on tekton's built-in resolution code and provides a nice enough separation of concerns in our own codebase.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Resolution of tasks and pipelines from taskruns and pipelineruns has been refactored into new reconcilers. There should be no visible behavioral differences to the way taskruns and pipelineruns are executed as a result of this change but we are laying the groundwork for future improvements and extensions.
```