### PR TITLE
Take advantage of `kmeta.OwnerRefable`.

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -28,14 +28,6 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var (
-	groupVersionKind = schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    pipeline.PipelineRunControllerName,
-	}
-)
-
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -143,9 +135,9 @@ type PipelineRunList struct {
 // and produces logs.
 type PipelineTaskRun = v1beta1.PipelineTaskRun
 
-// GetOwnerReference gets the pipeline run as owner reference for any related objects
-func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
-	return *metav1.NewControllerRef(pr, groupVersionKind)
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*PipelineRun) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.PipelineRunControllerName)
 }
 
 // IsDone returns true if the PipelineRun's status indicates that it is done.

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -29,14 +29,6 @@ import (
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 )
 
-var (
-	runGroupVersionKind = schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    pipeline.RunControllerName,
-	}
-)
-
 // EmbeddedRunSpec allows custom task definitions to be embedded
 type EmbeddedRunSpec struct {
 	runtime.TypeMeta `json:",inline"`
@@ -160,9 +152,9 @@ type RunList struct {
 	Items           []Run `json:"items"`
 }
 
-// GetOwnerReference gets the task run as owner reference for any related objects
-func (r *Run) GetOwnerReference() metav1.OwnerReference {
-	return *metav1.NewControllerRef(r, runGroupVersionKind)
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*Run) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.RunControllerName)
 }
 
 // HasPipelineRunOwnerReference returns true of Run has

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -28,14 +28,6 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var (
-	taskRunGroupVersionKind = schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    pipeline.TaskRunControllerName,
-	}
-)
-
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {
 	// +optional
@@ -169,9 +161,9 @@ type TaskRunList struct {
 	Items           []TaskRun `json:"items"`
 }
 
-// GetOwnerReference gets the task run as owner reference for any related objects
-func (tr *TaskRun) GetOwnerReference() metav1.OwnerReference {
-	return *metav1.NewControllerRef(tr, taskRunGroupVersionKind)
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*TaskRun) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.TaskRunControllerName)
 }
 
 // GetPipelineRunPVCName for taskrun gets pipelinerun

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -31,12 +31,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-var groupVersionKind = schema.GroupVersionKind{
-	Group:   SchemeGroupVersion.Group,
-	Version: SchemeGroupVersion.Version,
-	Kind:    pipeline.PipelineRunControllerName,
-}
-
 // +genclient
 // +genreconciler:krshapedlogic=false
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -68,9 +62,9 @@ func (pr *PipelineRun) GetStatusCondition() apis.ConditionAccessor {
 	return &pr.Status
 }
 
-// GetOwnerReference gets the pipeline run as owner reference for any related objects
-func (pr *PipelineRun) GetOwnerReference() metav1.OwnerReference {
-	return *metav1.NewControllerRef(pr, groupVersionKind)
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*PipelineRun) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.PipelineRunControllerName)
 }
 
 // IsDone returns true if the PipelineRun's status indicates that it is done.

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -32,14 +32,6 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
-var (
-	taskRunGroupVersionKind = schema.GroupVersionKind{
-		Group:   SchemeGroupVersion.Group,
-		Version: SchemeGroupVersion.Version,
-		Kind:    pipeline.TaskRunControllerName,
-	}
-)
-
 // TaskRunSpec defines the desired state of TaskRun
 type TaskRunSpec struct {
 	// +optional
@@ -237,9 +229,9 @@ type TaskRunResult struct {
 	Value string `json:"value"`
 }
 
-// GetOwnerReference gets the task run as owner reference for any related objects
-func (tr *TaskRun) GetOwnerReference() metav1.OwnerReference {
-	return *metav1.NewControllerRef(tr, taskRunGroupVersionKind)
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*TaskRun) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.TaskRunControllerName)
 }
 
 // GetStatusCondition returns the task run status as a ConditionAccessor

--- a/pkg/artifacts/artifact_storage_test.go
+++ b/pkg/artifacts/artifact_storage_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/kmeta"
 )
 
 var (
@@ -101,7 +102,7 @@ var (
 
 func getPersistentVolumeClaim(size string, storageClassName *string) *corev1.PersistentVolumeClaim {
 	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: pipelinerun.Namespace, OwnerReferences: []metav1.OwnerReference{pipelinerun.GetOwnerReference()}},
+		ObjectMeta: metav1.ObjectMeta{Name: "pipelineruntest-pvc", Namespace: pipelinerun.Namespace, OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pipelinerun)}},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 			Resources:        corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse(size)}},

--- a/pkg/artifacts/artifacts_storage.go
+++ b/pkg/artifacts/artifacts_storage.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 )
 
@@ -220,7 +221,7 @@ func getPVCSpec(pr *v1beta1.PipelineRun, pvcSize resource.Quantity, storageClass
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       pr.Namespace,
 			Name:            GetPVCName(pr),
-			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pr)},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -542,7 +542,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 
 		if pr.HasVolumeClaimTemplate() {
 			// create workspace PVC from template
-			if err = c.pvcHandler.CreatePersistentVolumeClaimsForWorkspaces(ctx, pr.Spec.Workspaces, pr.GetOwnerReference(), pr.Namespace); err != nil {
+			if err = c.pvcHandler.CreatePersistentVolumeClaimsForWorkspaces(ctx, pr.Spec.Workspaces, *kmeta.NewControllerRef(pr), pr.Namespace); err != nil {
 				logger.Errorf("Failed to create PVC for PipelineRun %s: %v", pr.Name, err)
 				pr.Status.MarkFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
 					"Failed to create PVC for PipelineRun %s/%s Workspaces correctly: %s",
@@ -736,7 +736,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            rprt.TaskRunName,
 			Namespace:       pr.Namespace,
-			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pr)},
 			Labels:          combineTaskRunAndTaskSpecLabels(pr, rprt.PipelineTask),
 			Annotations:     combineTaskRunAndTaskSpecAnnotations(pr, rprt.PipelineTask),
 		},
@@ -777,7 +777,7 @@ func (c *Reconciler) createRun(ctx context.Context, rprt *resources.ResolvedPipe
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            rprt.RunName,
 			Namespace:       pr.Namespace,
-			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pr)},
 			Labels:          getTaskrunLabels(pr, rprt.PipelineTask.Name, true),
 			Annotations:     getTaskrunAnnotations(pr),
 		},
@@ -835,7 +835,7 @@ func getTaskrunWorkspaces(pr *v1beta1.PipelineRun, rprt *resources.ResolvedPipel
 			if b.PersistentVolumeClaim != nil || b.VolumeClaimTemplate != nil {
 				pipelinePVCWorkspaceName = pipelineWorkspaceName
 			}
-			workspaces = append(workspaces, taskWorkspaceByWorkspaceVolumeSource(b, taskWorkspaceName, pipelineTaskSubPath, pr.GetOwnerReference()))
+			workspaces = append(workspaces, taskWorkspaceByWorkspaceVolumeSource(b, taskWorkspaceName, pipelineTaskSubPath, *kmeta.NewControllerRef(pr)))
 		} else {
 			workspaceIsOptional := false
 			if rprt.ResolvedTaskResources != nil && rprt.ResolvedTaskResources.TaskSpec != nil {
@@ -1116,7 +1116,7 @@ func (c *Reconciler) makeConditionCheckContainer(ctx context.Context, rprt *reso
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            rcc.ConditionCheckName,
 			Namespace:       pr.Namespace,
-			OwnerReferences: []metav1.OwnerReference{pr.GetOwnerReference()},
+			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pr)},
 			Labels:          labels,
 			Annotations:     annotations,
 		},

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -58,6 +58,7 @@ import (
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/reconciler"
@@ -3634,7 +3635,7 @@ func TestReconcileWithVolumeClaimTemplateWorkspace(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: w.VolumeClaimTemplate.Name,
 				},
-			}, w, pr.GetOwnerReference())
+			}, w, *kmeta.NewControllerRef(pr))
 			_, err := clients.Kube.CoreV1().PersistentVolumeClaims(pr.Namespace).Get(prt.TestAssets.Ctx, expectedPVCName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("expected PVC %s to exist but instead got error when getting it: %v", expectedPVCName, err)

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -95,10 +95,7 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 		}
 
 		logger.Info("Setting up event handlers")
-		taskRunInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-			AddFunc:    impl.Enqueue,
-			UpdateFunc: controller.PassNew(impl.Enqueue),
-		})
+		taskRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -421,7 +421,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 
 	if pod == nil {
 		if tr.HasVolumeClaimTemplate() {
-			if err := c.pvcHandler.CreatePersistentVolumeClaimsForWorkspaces(ctx, tr.Spec.Workspaces, tr.GetOwnerReference(), tr.Namespace); err != nil {
+			if err := c.pvcHandler.CreatePersistentVolumeClaimsForWorkspaces(ctx, tr.Spec.Workspaces, *kmeta.NewControllerRef(tr), tr.Namespace); err != nil {
 				logger.Errorf("Failed to create PVC for TaskRun %s: %v", tr.Name, err)
 				tr.Status.MarkResourceFailed(volumeclaim.ReasonCouldntCreateWorkspacePVC,
 					fmt.Errorf("Failed to create PVC for TaskRun %s workspaces correctly: %s",
@@ -429,7 +429,7 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 				return controller.NewPermanentError(err)
 			}
 
-			taskRunWorkspaces := applyVolumeClaimTemplates(tr.Spec.Workspaces, tr.GetOwnerReference())
+			taskRunWorkspaces := applyVolumeClaimTemplates(tr.Spec.Workspaces, *kmeta.NewControllerRef(tr))
 			// This is used by createPod below. Changes to the Spec are not updated.
 			tr.Spec.Workspaces = taskRunWorkspaces
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2969,7 +2969,7 @@ func TestReconcileWorkspaceWithVolumeClaimTemplate(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: w.VolumeClaimTemplate.Name,
 			},
-		}, w, ttt.GetOwnerReference())
+		}, w, *kmeta.NewControllerRef(ttt))
 		_, err = clients.Kube.CoreV1().PersistentVolumeClaims(taskRun.Namespace).Get(testAssets.Ctx, expectedPVCName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("expected PVC %s to exist but instead got error when getting it: %v", expectedPVCName, err)


### PR DESCRIPTION
# Changes

I noticed that the tekton `controller.go` files were inconsistently using `controller.HandleAll` (cosmetic), but also that several of the `impl.EnqueueControllerOf` lines in the PipelineRun controller weren't filtering on the kind of the owner (can cause unnecessary reconciliation).

For the latter, we also introduced a nice new helper `controller.FilterController(&v1beta1.TaskRun)` that takes advantage of `kmeta.OwnerRefable` to filter on the GVK in the owner reference.

This spiraled a bit because it turns out Tekton wasn't taking advantage of `kmeta.OwnerRefable` or `kmeta.NewControllerRef`!  So the majority of the churn in this change is:
 - `GetOwnerReference` -> `GetGroupVersionKind` (implements `kmeta.OwnerRefable`)
 - `foo.GetOwnerReference()` -> `*kmeta.NewControllerRef(foo)`

As some background, our `kmeta.NewControllerRef` API was modeled after this from API machinery: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#NewControllerRef

We added our own variant to drop the tedious GVK requirement, since the first argument should be sufficient (thus `kmeta.OwnerRefable`).

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

cc @dlorenc @imjasonh @vdemeester @afrittoli 