### PR TITLE
Drop the tracker.

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -42,7 +42,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/tracker"
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
@@ -99,7 +98,6 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 		logger.Info("Setting up event handlers")
 		pipelineRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
-		c.tracker = tracker.New(impl.EnqueueKey, 30*time.Minute)
 		taskRunInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: controller.FilterController(&v1beta1.PipelineRun{}),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -40,7 +40,6 @@ import (
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/tracker"
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
@@ -96,8 +95,6 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 
 		logger.Info("Setting up event handlers")
 		taskRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
-
-		c.tracker = tracker.New(impl.EnqueueKey, controller.GetTrackerLease(ctx))
 
 		podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 			FilterFunc: controller.FilterGroupKind(v1beta1.Kind("TaskRun")),

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -55,7 +55,6 @@ import (
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/logging"
 	pkgreconciler "knative.dev/pkg/reconciler"
-	"knative.dev/pkg/tracker"
 )
 
 // Reconciler implements controller.Reconciler for Configuration resources.
@@ -70,7 +69,6 @@ type Reconciler struct {
 	clusterTaskLister listers.ClusterTaskLister
 	resourceLister    resourcelisters.PipelineResourceLister
 	cloudEventClient  cloudevent.CEClient
-	tracker           tracker.Interface
 	entrypointCache   podconvert.EntrypointCache
 	metrics           *Recorder
 	pvcHandler        volumeclaim.PvcHandler
@@ -440,16 +438,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 			logger.Errorf("Failed to create task run pod for taskrun %q: %v", tr.Name, newErr)
 			return newErr
 		}
-	}
-
-	if err := c.tracker.TrackReference(tracker.Reference{
-		APIVersion: "v1",
-		Kind:       "Pod",
-		Namespace:  tr.Namespace,
-		Name:       tr.Name,
-	}, tr); err != nil {
-		logger.Errorf("Failed to create tracker for build pod %q for taskrun %q: %v", tr.Name, tr.Name, err)
-		return err
 	}
 
 	if podconvert.IsPodExceedingNodeResources(pod) {


### PR DESCRIPTION
# Changes

Tekton's use of the `tracker` is redundant with the informer events it already has configured, and the tracker lease the pipeline run controller is using is probably too small to actually be effective for long-running pipelines.

The tracker is built around the premise that resyncs happen to "refresh" things, and so to be safe the tracker lease should be a multiple of the resync period.  The pipeline controller is currently hardcoding `30m`, but the default resync period is `10h`, so anything taking longer than `30m` via the tracker will actually drop events.  The controller also seems to track a `TaskRun` with the name of the `PipelineRun`, which also feels wrong...  🤔 

Fortunately, I believe that both usages of the tracker are wholly redundant with informer events on owned resources anyhow, so this change should just remove unneeded complexity.

For additional background, the purpose of the tracked isn't to track owned resources, but rather to track resources referenced via `corev1.ObjectReference` (or equivalent).  We use this in Knative to track changes to Addressable resources that some resource might be delivering events to (e.g. maybe the address changed, or it is no longer Ready).

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```


cc @dlorenc @imjasonh @vdemeester @afrittoli 