### PR TITLE
Use `controller.FilterController(&v1beta1.TaskRun{})`

### DIFF
--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -97,7 +97,7 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 		taskRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-			FilterFunc: controller.FilterGroupKind(v1beta1.Kind("TaskRun")),
+			FilterFunc: controller.FilterController(&v1beta1.TaskRun{}),
 			Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 		})
 


### PR DESCRIPTION
# Changes

I'd updated the `PipelineRun` controller to use this, but missed this place in the `TaskRun` controller.  This is made possible by `TaskRun` implementing `kmeta.OwnerRefable`.

/kind cleanup


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
