### PR TITLE
Passes pipelines/tasks from bundles through defaulting before execution

### DIFF
--- a/internal/builder/v1alpha1/pipeline.go
+++ b/internal/builder/v1alpha1/pipeline.go
@@ -76,6 +76,14 @@ func Pipeline(name string, ops ...PipelineOp) *v1alpha1.Pipeline {
 	return p
 }
 
+// PipelineType will add a TypeMeta to the pipeline's definition.
+func PipelineType(t *v1alpha1.Pipeline) {
+	t.TypeMeta = metav1.TypeMeta{
+		Kind:       "Pipeline",
+		APIVersion: "tekton.dev/v1alpha1",
+	}
+}
+
 // PipelineNamespace sets the namespace on the Pipeline
 func PipelineNamespace(namespace string) PipelineOp {
 	return func(t *v1alpha1.Pipeline) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_interface.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_interface.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package v1beta1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
 
 // PipelineObject is implemented by Pipeline and ClusterPipeline
 type PipelineObject interface {
+	apis.Defaultable
 	PipelineMetadata() metav1.ObjectMeta
 	PipelineSpec() PipelineSpec
 	Copy() PipelineObject

--- a/pkg/apis/pipeline/v1beta1/task_interface.go
+++ b/pkg/apis/pipeline/v1beta1/task_interface.go
@@ -16,10 +16,14 @@ limitations under the License.
 
 package v1beta1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
 
 // TaskObject is implemented by Task and ClusterTask
 type TaskObject interface {
+	apis.Defaultable
 	TaskMetadata() metav1.ObjectMeta
 	TaskSpec() TaskSpec
 	Copy() TaskObject

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -5881,6 +5881,7 @@ func TestReconcile_RemotePipelineRef(t *testing.T) {
 			Resources:          &v1beta1.TaskRunResources{},
 			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 			TaskRef: &v1beta1.TaskRef{
+				Kind:   "Task",
 				Name:   "unit-test-task",
 				Bundle: ref,
 			},

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -69,12 +69,14 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 				return nil, err
 			}
 			if pipeline, ok := obj.(v1beta1.PipelineObject); ok {
+				pipeline.SetDefaults(ctx)
 				return pipeline, nil
 			}
 
 			if pipeline, ok := obj.(*v1alpha1.Pipeline); ok {
 				betaPipeline := &v1beta1.Pipeline{}
 				err := pipeline.ConvertTo(ctx, betaPipeline)
+				betaPipeline.SetDefaults(ctx)
 				return betaPipeline, err
 			}
 

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -96,6 +96,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			// If the resolved object is already a v1beta1.{Cluster}Task, it should be returnable as a
 			// v1beta1.TaskObject.
 			if ti, ok := obj.(v1beta1.TaskObject); ok {
+				ti.SetDefaults(ctx)
 				return ti, nil
 			}
 
@@ -105,10 +106,12 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			case *v1alpha1.Task:
 				betaTask := &v1beta1.Task{}
 				err := tt.ConvertTo(ctx, betaTask)
+				betaTask.SetDefaults(ctx)
 				return betaTask, err
 			case *v1alpha1.ClusterTask:
 				betaTask := &v1beta1.ClusterTask{}
 				err := tt.ConvertTo(ctx, betaTask)
+				betaTask.SetDefaults(ctx)
 				return betaTask, err
 			}
 

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/registry"
+	ta "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	tb "github.com/tektoncd/pipeline/internal/builder/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -152,6 +153,30 @@ func TestGetTaskFunc(t *testing.T) {
 				Bundle: u.Host + "/remote-task",
 			},
 			expected:     tb.Task("simple", tb.TaskType),
+			expectedKind: v1beta1.NamespacedTaskKind,
+		}, {
+			name:       "remote-task-without-defaults",
+			localTasks: []runtime.Object{},
+			remoteTasks: []runtime.Object{
+				tb.Task("simple", tb.TaskType, tb.TaskNamespace("default"), tb.TaskSpec(tb.TaskParam("foo", ""), tb.Step("something"))),
+			},
+			ref: &v1beta1.TaskRef{
+				Name:   "simple",
+				Bundle: u.Host + "/remote-task-without-defaults",
+			},
+			expected:     tb.Task("simple", tb.TaskType, tb.TaskNamespace("default"), tb.TaskSpec(tb.TaskParam("foo", v1beta1.ParamTypeString), tb.Step("something"))),
+			expectedKind: v1beta1.NamespacedTaskKind,
+		}, {
+			name:       "remote-v1alpha1-task-without-defaults",
+			localTasks: []runtime.Object{},
+			remoteTasks: []runtime.Object{
+				ta.Task("simple", ta.TaskType, ta.TaskNamespace("default"), ta.TaskSpec(ta.TaskParam("foo", ""), ta.Step("something"))),
+			},
+			ref: &v1alpha1.TaskRef{
+				Name:   "simple",
+				Bundle: u.Host + "/remote-v1alpha1-task-without-defaults",
+			},
+			expected:     tb.Task("simple", tb.TaskNamespace("default"), tb.TaskSpec(tb.TaskParam("foo", v1alpha1.ParamTypeString), tb.Step("something"))),
 			expectedKind: v1beta1.NamespacedTaskKind,
 		}, {
 			name: "local-task",


### PR DESCRIPTION
for pipeline/tasks from yaml webhook does the defaulting but for pipeline/tasks
fetched from bundles, defaulting was not taking place due to
which validation error use to occur at execution.
This adds the defaulting for pipelines/tasks fetched from bundles.

Fixes #3874 

Signed-off-by: Shivam Mukhade <smukhade@redhat.com>

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
