### PR TITLE
Remove condition test builder

### DIFF
--- a/test/v1alpha1/pipelinerun_test.go
+++ b/test/v1alpha1/pipelinerun_test.go
@@ -29,6 +29,7 @@ import (
 	tb "github.com/tektoncd/pipeline/internal/builder/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/artifacts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -556,8 +557,18 @@ func getPipelineWithFailingCondition(suffix int) *v1alpha1.Pipeline {
 }
 
 func getFailingCondition(namespace string) *v1alpha1.Condition {
-	return tb.Condition(cond1Name, tb.ConditionNamespace(namespace), tb.ConditionSpec(tb.ConditionSpecCheck("", "ubuntu",
-		tb.Command("/bin/bash"), tb.Args("exit 1"))))
+
+	return &resource.Condition{
+		ObjectMeta: metav1.ObjectMeta{Name: cond1Name, Namespace: namespace},
+		Spec: resource.ConditionSpec{
+			Container: &corev1.Container{
+				Name:    "",
+				Image:   "ubuntu",
+				Command: "/bin/bash",
+				Args:    "exit 1",
+			},
+		},
+	}
 }
 
 func getConditionalPipelineRun(suffix int, namespace string) *v1alpha1.PipelineRun {


### PR DESCRIPTION
Signed-off-by: Tyler Auerbeck <tauerbec@redhat.com>

# Changes
- Small change to remove last usage of tb.Condition builder

Part of #3178 

/kind cleanup
/area testing

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [y] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [y] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [y] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [y] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
