### PR TITLE
adding label `memberOf` to identify a taskRun in the pipeline

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -81,6 +81,12 @@ Tekton automatically adds labels to Tekton entities as described in the followin
 			<td>Name of the <code>TaskRun</code> that created the <code>Pod</code>.</td>
 		</tr>
 		<tr>
+			<td><code>tekton.dev/memberOf</code></td>
+			<td><code>TaskRuns</code> that are created automatically during the execution of a <code>PipelineRun</code>.</td>
+			<td><code>TaskRuns, Pods</code></td>
+			<td><code>tasks</code> or <code>finally</code> depending on the <code>PipelineTask</code>'s membership in the <code>Pipeline</code>.</td>
+		</tr>
+		<tr>
 			<td><code>app.kubernetes.io/instance</code>, <code>app.kubernetes.io/component</code></td>
 			<td><code>Pods</code>, <code>StatefulSets</code> (Affinity Assistant)</td>
 			<td>No propagation.</td>

--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -48,6 +48,10 @@ const (
 
 	// RunKey is used as the label identifier for a Run
 	RunKey = "/run"
+
+	// MemberOfLabelKey is used as the label identifier for a PipelineTask
+	// Set to Tasks/Finally depending on the position of the PipelineTask
+	MemberOfLabelKey = "/memberOf"
 )
 
 var (

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -35,6 +35,10 @@ import (
 const (
 	// PipelineTasksAggregateStatus is a param representing aggregate status of all dag pipelineTasks
 	PipelineTasksAggregateStatus = "tasks.status"
+	// PipelineTasks is a value representing a task is a member of "tasks" section of the pipeline
+	PipelineTasks = "tasks"
+	// PipelineFinallyTasks is a value representing a task is a member of "finally" section of the pipeline
+	PipelineFinallyTasks = "finally"
 )
 
 // +genclient

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -907,6 +907,22 @@ func getTaskrunLabels(pr *v1beta1.PipelineRun, pipelineTaskName string, includeP
 	if pipelineTaskName != "" {
 		labels[pipeline.GroupName+pipeline.PipelineTaskLabelKey] = pipelineTaskName
 	}
+	if pr.Status.PipelineSpec != nil {
+		// check if a task is part of the "tasks" section, add a label to identify it during the runtime
+		for _, f := range pr.Status.PipelineSpec.Tasks {
+			if pipelineTaskName == f.Name {
+				labels[pipeline.GroupName+pipeline.MemberOfLabelKey] = v1beta1.PipelineTasks
+				break
+			}
+		}
+		// check if a task is part of the "finally" section, add a label to identify it during the runtime
+		for _, f := range pr.Status.PipelineSpec.Finally {
+			if pipelineTaskName == f.Name {
+				labels[pipeline.GroupName+pipeline.MemberOfLabelKey] = v1beta1.PipelineFinallyTasks
+				break
+			}
+		}
+	}
 	return labels
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -403,6 +403,7 @@ func TestReconcile(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-success"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "unit-test-1"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("unit-test-task"),
 			tb.TaskRunServiceAccountName("test-sa"),
@@ -512,9 +513,10 @@ func TestReconcile_CustomTask(t *testing.T) {
 					BlockOwnerDeletion: &trueb,
 				}},
 				Labels: map[string]string{
-					"tekton.dev/pipeline":     pipelineRunName,
-					"tekton.dev/pipelineRun":  pipelineRunName,
-					"tekton.dev/pipelineTask": pipelineTaskName,
+					"tekton.dev/pipeline":                          pipelineRunName,
+					"tekton.dev/pipelineRun":                       pipelineRunName,
+					"tekton.dev/pipelineTask":                      pipelineTaskName,
+					pipeline.GroupName + pipeline.MemberOfLabelKey: v1beta1.PipelineTasks,
 				},
 				Annotations: map[string]string{},
 			},
@@ -571,9 +573,10 @@ func TestReconcile_CustomTask(t *testing.T) {
 					BlockOwnerDeletion: &trueb,
 				}},
 				Labels: map[string]string{
-					"tekton.dev/pipeline":     pipelineRunName,
-					"tekton.dev/pipelineRun":  pipelineRunName,
-					"tekton.dev/pipelineTask": pipelineTaskName,
+					"tekton.dev/pipeline":                          pipelineRunName,
+					"tekton.dev/pipelineRun":                       pipelineRunName,
+					"tekton.dev/pipelineTask":                      pipelineTaskName,
+					pipeline.GroupName + pipeline.MemberOfLabelKey: v1beta1.PipelineTasks,
 				},
 				Annotations: map[string]string{},
 			},
@@ -640,9 +643,10 @@ func TestReconcile_CustomTask(t *testing.T) {
 					BlockOwnerDeletion: &trueb,
 				}},
 				Labels: map[string]string{
-					"tekton.dev/pipeline":     pipelineRunName,
-					"tekton.dev/pipelineRun":  pipelineRunName,
-					"tekton.dev/pipelineTask": pipelineTaskName,
+					"tekton.dev/pipeline":                          pipelineRunName,
+					"tekton.dev/pipelineRun":                       pipelineRunName,
+					"tekton.dev/pipelineTask":                      pipelineTaskName,
+					pipeline.GroupName + pipeline.MemberOfLabelKey: v1beta1.PipelineTasks,
 				},
 				Annotations: map[string]string{
 					"pipeline.tekton.dev/affinity-assistant": getAffinityAssistantName("pipelinews", pipelineRunName),
@@ -774,6 +778,7 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-success"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "unit-test-task-spec"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunSpec(tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep"))),
 			tb.TaskRunServiceAccountName(config.DefaultServiceAccountValue)),
 	)
@@ -2458,6 +2463,7 @@ func TestReconcilePropagateLabels(t *testing.T) {
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-with-labels"),
 		tb.TaskRunLabel("PipelineRunLabel", "PipelineRunValue"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("hello-world"),
 			tb.TaskRunServiceAccountName("test-sa"),
@@ -2528,6 +2534,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 			tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 			tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 			tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-0"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		),
 		tb.TaskRun(taskRunNames[1],
 			tb.TaskRunNamespace("foo"),
@@ -2542,6 +2549,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 			tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 			tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 			tb.TaskRunLabel("tekton.dev/pipelineTask", "hello-world-1"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		),
 	}
 	for i := range ps[0].Spec.Tasks {
@@ -2739,6 +2747,7 @@ func TestReconcilePropagateAnnotations(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-with-annotations"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("hello-world"),
@@ -3002,6 +3011,7 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline-run"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("hello-world"),
@@ -3212,6 +3222,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 			tb.TaskRunOwnerReference("kind", "name"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline-run-with-conditions"),
 			tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline"),
+			tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 			tb.TaskRunSpec(tb.TaskRunTaskRef("hello-world")),
 			tb.TaskRunStatus(tb.StatusCondition(apis.Condition{
 				Type:   apis.ConditionSucceeded,
@@ -3267,6 +3278,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "task-3"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline-run-with-conditions"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("hello-world"),
@@ -3289,6 +3301,7 @@ func makeExpectedTr(condName, ccName string, labels, annotations map[string]stri
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline-run"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.ConditionCheckKey, ccName),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.ConditionNameKey, condName),
 		tb.TaskRunLabels(labels),
@@ -3378,6 +3391,7 @@ func TestReconcileWithWhenExpressionsWithParameters(t *testing.T) {
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, "test-pipeline"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "hello-world-1"),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, "test-pipeline-run"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunAnnotation("PipelineRunAnnotation", "PipelineRunValue"),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("hello-world-1"),
@@ -3507,6 +3521,7 @@ func TestReconcileWithWhenExpressionsWithTaskResults(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 		tb.TaskRunLabel("tekton.dev/pipelineTask", "b-task"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("b-task"),
 			tb.TaskRunServiceAccountName("test-sa-0"),
@@ -3921,6 +3936,7 @@ func TestReconcileWithTaskResults(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 		tb.TaskRunLabel("tekton.dev/pipelineTask", "b-task"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("b-task"),
 			tb.TaskRunServiceAccountName("test-sa-0"),
@@ -3997,6 +4013,7 @@ func TestReconcileWithTaskResultsEmbeddedNoneStarted(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline-run-different-service-accs"),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-different-service-accs"),
 		tb.TaskRunLabel("tekton.dev/pipelineTask", "a-task"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("a-task", tb.TaskRefKind(v1beta1.NamespacedTaskKind)),
 			tb.TaskRunServiceAccountName("test-sa-0"),
@@ -5534,6 +5551,7 @@ func TestReconciler_ReconcileKind_PipelineTaskContext(t *testing.T) {
 		tb.TaskRunLabel("tekton.dev/pipeline", pipelineName),
 		tb.TaskRunLabel("tekton.dev/pipelineRun", pipelineRunName),
 		tb.TaskRunLabel("tekton.dev/pipelineTask", "finaltask"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineFinallyTasks),
 		tb.TaskRunSpec(
 			tb.TaskRunTaskRef("finaltask"),
 			tb.TaskRunServiceAccountName("test-sa"),
@@ -5764,9 +5782,10 @@ func TestReconcileWithTaskResultsInFinalTasks(t *testing.T) {
 				BlockOwnerDeletion: &trueb,
 			}},
 			Labels: map[string]string{
-				"tekton.dev/pipeline":     "test-pipeline",
-				"tekton.dev/pipelineRun":  "test-pipeline-run-final-task-results",
-				"tekton.dev/pipelineTask": "final-task-1",
+				"tekton.dev/pipeline":                          "test-pipeline",
+				"tekton.dev/pipelineRun":                       "test-pipeline-run-final-task-results",
+				"tekton.dev/pipelineTask":                      "final-task-1",
+				pipeline.GroupName + pipeline.MemberOfLabelKey: v1beta1.PipelineFinallyTasks,
 			},
 			Annotations: map[string]string{},
 		},
@@ -5953,6 +5972,7 @@ func TestReconcile_RemotePipelineRef(t *testing.T) {
 				"tekton.dev/pipeline":                              "test-pipeline",
 				"tekton.dev/pipelineRun":                           "test-pipeline-run-success",
 				pipeline.GroupName + pipeline.PipelineTaskLabelKey: "unit-test-1",
+				pipeline.GroupName + pipeline.MemberOfLabelKey:     v1beta1.PipelineTasks,
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion:         "tekton.dev/v1beta1",
@@ -6060,6 +6080,7 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 				"tekton.dev/pipeline":                              "test-pipeline-run-success",
 				"tekton.dev/pipelineRun":                           "test-pipeline-run-success",
 				pipeline.GroupName + pipeline.PipelineTaskLabelKey: "unit-test-1",
+				pipeline.GroupName + pipeline.MemberOfLabelKey:     v1beta1.PipelineTasks,
 			},
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: "tekton.dev/v1beta1",
@@ -6263,6 +6284,7 @@ func getTaskRunWithTaskSpec(tr, pr, p, t string, labels, annotations map[string]
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineLabelKey, p),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineRunLabelKey, pr),
 		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, t),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
 		tb.TaskRunLabels(labels),
 		tb.TaskRunAnnotations(annotations),
 		tb.TaskRunSpec(tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep"))),


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A label named *memberOf* is added to all the taskRuns/Runs created while executing the pipeline based on their respective membership. A  `taskRun` will have a label `tekton.dev/memberOf=tasks` for the `task` defined under "tasks" section and a `taskRun` will have a label `tekton.dev/memberOf=finally` for the `task` defined under "finally" section. 

**Implementation Iterations**

Iteration1:

A label is added to a `taskRun` for a `task` which is part of the `finally` section. The label added with a pattern `tekton.dev/finallyTask` and set to `true` for a `finally` task.


Closes #3721 
Closes #3715 

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
A taskRun/pod created for a finally task can be identified with a label tekton.dev/finallyTask which is set to true.
```