### PR TITLE
Implement implicit parameter resolution.

### DIFF
--- a/config/200-role.yaml
+++ b/config/200-role.yaml
@@ -52,7 +52,7 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-    resourceNames: ["config-logging", "config-observability", "config-leader-election"]
+    resourceNames: ["config-logging", "config-observability", "config-leader-election", "feature-flags"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["list", "watch"]

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -100,6 +100,8 @@ spec:
           value: config-observability
         - name: CONFIG_LEADERELECTION_NAME
           value: config-leader-election
+        - name: CONFIG_FEATURE_FLAGS_NAME
+          value: feature-flags
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
         - name: WEBHOOK_SECRET_NAME

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -246,6 +246,75 @@ case is when your CI system autogenerates `PipelineRuns` and it has `Parameters`
 provide to all `PipelineRuns`. Because you can pass in extra `Parameters`, you don't have to
 go through the complexity of checking each `Pipeline` and providing only the required params.
 
+#### Implicit Parameters
+
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+
+When using an inlined spec, parameters from the parent `PipelineRun` will be
+available to any inlined specs without needing to be explicitly defined. This
+allows authors to simplify specs by automatically propagating top-level
+parameters down to other inlined resources.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: echo-
+spec:
+  params:
+    - name: MESSAGE
+      value: "Good Morning!"
+  pipelineSpec:
+    tasks:
+      - name: echo-message
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "$(params.MESSAGE)"
+```
+
+On creation, this will resolve to a fully-formed spec and will be returned back
+to clients to avoid ambiguity:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: echo-
+spec:
+  params:
+  - name: MESSAGE
+    value: Good Morning!
+  pipelineSpec:
+    params:
+    - name: MESSAGE
+      type: string
+    tasks:
+    - name: echo-message
+      params:
+      - name: MESSAGE
+        value: $(params.MESSAGE)
+      taskSpec:
+        params:
+        - name: MESSAGE
+          type: string
+        spec: null
+        steps:
+        - name: echo
+          image: ubuntu
+          script: |
+            #!/usr/bin/env bash
+            echo "$(params.MESSAGE)"
+```
+
+Note that all implicit Parameters will be passed through to inlined resources
+(i.e. PipelineRun -> Pipeline -> Tasks) even if they are not used.
+Extra parameters passed this way should generally be safe (since they aren't
+actually used), but may result in more verbose specs being returned by the API.
+
 ### Specifying custom `ServiceAccount` credentials
 
 You can execute the `Pipeline` in your `PipelineRun` with a specific set of credentials by

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -163,6 +163,69 @@ spec:
 
 **Note:** If a parameter does not have an implicit default value, you must explicitly set its value.
 
+#### Implicit Parameters
+
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+
+When using an inlined `taskSpec`, parameters from the parent `TaskRun` will be
+available to the `Task` without needing to be explicitly defined.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: hello-
+spec:
+  params:
+    - name: message
+      value: "hello world!"
+  taskSpec:
+    # There are no explicit params defined here.
+    # They are derived from the TaskRun params above.
+    steps:
+    - name: default
+      image: ubuntu
+      script: |
+        echo $(params.message)
+```
+
+On creation, this will resolve to a fully-formed spec and will be returned back
+to clients to avoid ambiguity:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: hello-
+spec:
+  params:
+    - name: message
+      value: "hello world!"
+  taskSpec:
+    params:
+    - name: message
+      type: string
+    steps:
+    - name: default
+      image: ubuntu
+      script: |
+        echo $(params.message)
+```
+
+Note that all implicit Parameters will be passed through to inlined resource,
+even if they are not used. Extra parameters passed this way should generally
+be safe (since they aren't actually used), but may result in more verbose specs
+being returned by the API.
+
+#### Extra Parameters
+
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+
+You can pass in extra `Parameters` if needed depending on your use cases. An example use
+case is when your CI system autogenerates `TaskRuns` and it has `Parameters` it wants to
+provide to all `TaskRuns`. Because you can pass in extra `Parameters`, you don't have to
+go through the complexity of checking each `Task` and providing only the required params.
+
 ### Specifying `Resources`
 
 If a `Task` requires [`Resources`](tasks.md#specifying-resources) (that is, `inputs` and `outputs`) you must

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-implicit-params.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-implicit-params.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: echo-
+spec:
+  pipelineSpec:
+    tasks:
+      - name: echo-message
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "$(params.MESSAGE)"
+  params:
+    - name: MESSAGE
+      value: "Good Morning!"

--- a/examples/v1beta1/taskruns/alpha/implicit-params.yaml
+++ b/examples/v1beta1/taskruns/alpha/implicit-params.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: hello-
+spec:
+  params:
+    - name: message
+      value: "hello world!"
+  taskSpec:
+    # There are no explicit params defined here. They are derived from the TaskRun.
+    steps:
+    - name: default
+      image: ubuntu
+      script: |
+        echo $(params.message)

--- a/pkg/apis/pipeline/v1beta1/param_context.go
+++ b/pkg/apis/pipeline/v1beta1/param_context.go
@@ -1,0 +1,172 @@
+// Copyright 2021 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+// paramCtxKey is the unique identifier for referencing param information from
+// a context.Context. See [context.Context.Value](https://pkg.go.dev/context#Context)
+// for more details.
+var paramCtxKey struct{}
+
+// paramCtxVal is the data type stored in the param context.
+// This maps param names -> ParamSpec.
+type paramCtxVal map[string]ParamSpec
+
+// AddContextParams adds the given Params to the param context. This only
+// preserves the fields included in ParamSpec - Name and Type.
+func AddContextParams(ctx context.Context, in []Param) context.Context {
+	if in == nil {
+		return ctx
+	}
+
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields != "alpha" {
+		return ctx
+	}
+
+	out := paramCtxVal{}
+	// Copy map to ensure that contexts are unique.
+	v := ctx.Value(paramCtxKey)
+	if v != nil {
+		for n, cps := range v.(paramCtxVal) {
+			out[n] = cps
+		}
+	}
+	for _, p := range in {
+		// The user may have omitted type data. Fill this in in to normalize data.
+		if v := p.Value; v.Type == "" {
+			if len(v.ArrayVal) > 0 {
+				p.Value.Type = ParamTypeArray
+			}
+			if v.StringVal != "" {
+				p.Value.Type = ParamTypeString
+			}
+		}
+		out[p.Name] = ParamSpec{
+			Name: p.Name,
+			Type: p.Value.Type,
+		}
+	}
+	return context.WithValue(ctx, paramCtxKey, out)
+}
+
+// AddContextParamSpec adds the given ParamSpecs to the param context.
+func AddContextParamSpec(ctx context.Context, in []ParamSpec) context.Context {
+	if in == nil {
+		return ctx
+	}
+
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields != "alpha" {
+		return ctx
+	}
+
+	out := paramCtxVal{}
+	// Copy map to ensure that contexts are unique.
+	v := ctx.Value(paramCtxKey)
+	if v != nil {
+		for n, ps := range v.(paramCtxVal) {
+			out[n] = ps
+		}
+	}
+	for _, p := range in {
+		cps := ParamSpec{
+			Name:        p.Name,
+			Type:        p.Type,
+			Description: p.Description,
+			Default:     p.Default,
+		}
+		out[p.Name] = cps
+	}
+	return context.WithValue(ctx, paramCtxKey, out)
+}
+
+// GetContextParams returns the current context parameters overlayed with a
+// given set of params. Overrides should generally be the current layer you
+// are trying to evaluate. Any context params not in the overrides will default
+// to a generic pass-through param of the given type (i.e. $(params.name) or
+// $(params.name[*])).
+func GetContextParams(ctx context.Context, overlays ...Param) []Param {
+	pv := paramCtxVal{}
+	v := ctx.Value(paramCtxKey)
+	if v == nil && len(overlays) == 0 {
+		return nil
+	}
+	if v != nil {
+		pv = v.(paramCtxVal)
+	}
+	out := make([]Param, 0, len(pv))
+
+	// Overlays take precedence over any context params. Keep track of
+	// these and automatically add them to the output.
+	overrideSet := make(map[string]Param, len(overlays))
+	for _, p := range overlays {
+		overrideSet[p.Name] = p
+		out = append(out, p)
+	}
+
+	// Include the rest of the context params.
+	for _, ps := range pv {
+		// Don't do anything for any overlay params - these are already
+		// included.
+		if _, ok := overrideSet[ps.Name]; ok {
+			continue
+		}
+
+		// If there is no overlay, pass through the param to the next level.
+		// e.g. for strings $(params.name), for arrays $(params.name[*]).
+		p := Param{
+			Name: ps.Name,
+		}
+		if ps.Type == ParamTypeString {
+			p.Value = ArrayOrString{
+				Type:      ParamTypeString,
+				StringVal: fmt.Sprintf("$(params.%s)", ps.Name),
+			}
+		} else {
+			p.Value = ArrayOrString{
+				Type:     ParamTypeArray,
+				ArrayVal: []string{fmt.Sprintf("$(params.%s[*])", ps.Name)},
+			}
+		}
+		out = append(out, p)
+	}
+
+	return out
+}
+
+// GetContextParamSpecs returns the current context ParamSpecs.
+func GetContextParamSpecs(ctx context.Context) []ParamSpec {
+	v := ctx.Value(paramCtxKey)
+	if v == nil {
+		return nil
+	}
+
+	pv := v.(paramCtxVal)
+	out := make([]ParamSpec, 0, len(pv))
+	for _, ps := range pv {
+		out = append(out, ParamSpec{
+			Name:        ps.Name,
+			Type:        ps.Type,
+			Description: ps.Description,
+			Default:     ps.Default,
+		})
+	}
+	return out
+}

--- a/pkg/apis/pipeline/v1beta1/param_context_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_context_test.go
@@ -1,0 +1,314 @@
+// Copyright 2021 The Tekton Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+func TestAddContextParams(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no-alpha", func(t *testing.T) {
+		ctx := AddContextParams(ctx, []Param{{Name: "a"}})
+		if v := ctx.Value(paramCtxKey); v != nil {
+			t.Errorf("expected no param context values, got %v", v)
+		}
+	})
+
+	// Enable Alpha features.
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+	ctx = config.ToContext(ctx, cfg)
+
+	// These test cases should run sequentially. Each step will modify the
+	// above context.
+	for _, tc := range []struct {
+		name   string
+		params []Param
+		want   paramCtxVal
+	}{
+		{
+			name:   "add-string-param",
+			params: []Param{{Name: "a", Value: *NewArrayOrString("foo")}},
+			want: paramCtxVal{
+				"a": ParamSpec{
+					Name: "a",
+					Type: ParamTypeString,
+				},
+			},
+		},
+		{
+			name:   "add-array-param",
+			params: []Param{{Name: "b", Value: *NewArrayOrString("bar", "baz")}},
+			want: paramCtxVal{
+				"a": ParamSpec{
+					Name: "a",
+					Type: ParamTypeString,
+				},
+				"b": ParamSpec{
+					Name: "b",
+					Type: ParamTypeArray,
+				},
+			},
+		},
+		{
+			name: "existing-param",
+			params: []Param{
+				{Name: "a", Value: *NewArrayOrString("foo1")},
+				{Name: "b", Value: *NewArrayOrString("bar1", "baz1")},
+			},
+			want: paramCtxVal{
+				"a": ParamSpec{
+					Name: "a",
+					Type: ParamTypeString,
+				},
+				"b": ParamSpec{
+					Name: "b",
+					Type: ParamTypeArray,
+				},
+			},
+		},
+		{
+			// This test case doesn't really make sense for typical use-cases,
+			// but exists to document the behavior of how this would be
+			// handled. The param context is simply responsible for propagating
+			// the param values through, regardless of their underlying value.
+			// Later validation should make sure these values make sense.
+			name:   "empty-param",
+			params: []Param{{}},
+			want: paramCtxVal{
+				"": ParamSpec{},
+				"a": ParamSpec{
+					Name: "a",
+					Type: ParamTypeString,
+				},
+				"b": ParamSpec{
+					Name: "b",
+					Type: ParamTypeArray,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx = AddContextParams(ctx, tc.params)
+			got := ctx.Value(paramCtxKey)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("-want,+got: %s", diff)
+			}
+		})
+	}
+}
+
+func TestAddContextParamSpec(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no-alpha", func(t *testing.T) {
+		ctx := AddContextParamSpec(ctx, []ParamSpec{{Name: "a"}})
+		if v := ctx.Value(paramCtxKey); v != nil {
+			t.Errorf("expected no param context values, got %v", v)
+		}
+	})
+
+	// Enable Alpha features.
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+	ctx = config.ToContext(ctx, cfg)
+
+	// These test cases should run sequentially. Each step will modify the
+	// above context.
+	for _, tc := range []struct {
+		name   string
+		params []ParamSpec
+		want   paramCtxVal
+	}{
+		{
+			name: "add-paramspec",
+			params: []ParamSpec{{
+				Name: "a",
+			}},
+			want: paramCtxVal{
+				"a": ParamSpec{
+					Name: "a",
+				},
+			},
+		},
+		{
+			name: "edit-paramspec",
+			params: []ParamSpec{{
+				Name:        "a",
+				Type:        ParamTypeArray,
+				Default:     NewArrayOrString("foo", "bar"),
+				Description: "tacocat",
+			}},
+			want: paramCtxVal{
+				"a": ParamSpec{
+					Name:        "a",
+					Type:        ParamTypeArray,
+					Default:     NewArrayOrString("foo", "bar"),
+					Description: "tacocat",
+				},
+			},
+		},
+		{
+			// This test case doesn't really make sense for typical use-cases,
+			// but exists to document the behavior of how this would be
+			// handled. The param context is simply responsible for propagating
+			// the ParamSpec values through, regardless of their underlying
+			// value. Later validation should make sure these values make
+			// sense.
+			name:   "empty-param",
+			params: []ParamSpec{{}},
+			want: paramCtxVal{
+				"": ParamSpec{},
+				"a": ParamSpec{
+					Name:        "a",
+					Type:        ParamTypeArray,
+					Default:     NewArrayOrString("foo", "bar"),
+					Description: "tacocat",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx = AddContextParamSpec(ctx, tc.params)
+			got := ctx.Value(paramCtxKey)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("-want,+got: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetContextParams(t *testing.T) {
+	ctx := context.Background()
+	want := []ParamSpec{
+		{
+			Name:        "a",
+			Type:        ParamTypeString,
+			Default:     NewArrayOrString("foo"),
+			Description: "tacocat",
+		},
+		{
+			Name:        "b",
+			Type:        ParamTypeArray,
+			Default:     NewArrayOrString("bar"),
+			Description: "racecar",
+		},
+	}
+	t.Run("no-alpha", func(t *testing.T) {
+		ctx := AddContextParamSpec(ctx, want)
+		if v := GetContextParamSpecs(ctx); v != nil {
+			t.Errorf("expected no param context values, got %v", v)
+		}
+	})
+
+	// Enable Alpha features.
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+	ctx = config.ToContext(ctx, cfg)
+
+	ctx = AddContextParamSpec(ctx, want)
+
+	for _, tc := range []struct {
+		name    string
+		overlay []Param
+		want    []Param
+	}{
+		{
+			name: "from-context",
+			want: []Param{
+				{
+					Name:  "a",
+					Value: *NewArrayOrString("$(params.a)"),
+				},
+				{
+					Name: "b",
+					Value: ArrayOrString{
+						Type:     ParamTypeArray,
+						ArrayVal: []string{"$(params.b[*])"},
+					},
+				},
+			},
+		},
+		{
+			name: "with-overlay",
+			overlay: []Param{{
+				Name:  "a",
+				Value: *NewArrayOrString("tacocat"),
+			}},
+			want: []Param{
+				{
+					Name:  "a",
+					Value: *NewArrayOrString("tacocat"),
+				},
+				{
+					Name: "b",
+					Value: ArrayOrString{
+						Type:     ParamTypeArray,
+						ArrayVal: []string{"$(params.b[*])"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GetContextParams(ctx, tc.overlay...)
+			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(x, y Param) bool { return x.Name < y.Name })); diff != "" {
+				t.Errorf("-want,+got: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetContextParamSpecs(t *testing.T) {
+	ctx := context.Background()
+	want := []ParamSpec{
+		{
+			Name:        "a",
+			Type:        ParamTypeString,
+			Default:     NewArrayOrString("foo"),
+			Description: "tacocat",
+		},
+		{
+			Name:        "b",
+			Type:        ParamTypeArray,
+			Default:     NewArrayOrString("bar"),
+			Description: "racecar",
+		},
+	}
+	t.Run("no-alpha", func(t *testing.T) {
+		ctx := AddContextParamSpec(ctx, want)
+		if v := GetContextParamSpecs(ctx); v != nil {
+			t.Errorf("expected no param context values, got %v", v)
+		}
+	})
+
+	// Enable Alpha features.
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+	ctx = config.ToContext(ctx, cfg)
+
+	ctx = AddContextParamSpec(ctx, want)
+	got := GetContextParamSpecs(ctx)
+	if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(x, y ParamSpec) bool { return x.Name < y.Name })); diff != "" {
+		t.Errorf("-want,+got: %s", diff)
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -50,6 +50,9 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	prs.PodTemplate = mergePodTemplateWithDefault(prs.PodTemplate, defaultPodTemplate)
 
 	if prs.PipelineSpec != nil {
+		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+			ctx = AddContextParams(ctx, prs.Params)
+		}
 		prs.PipelineSpec.SetDefaults(ctx)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/task_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/task_defaults.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"knative.dev/pkg/apis"
 )
 
@@ -32,5 +33,9 @@ func (t *Task) SetDefaults(ctx context.Context) {
 func (ts *TaskSpec) SetDefaults(ctx context.Context) {
 	for i := range ts.Params {
 		ts.Params[i].SetDefaults(ctx)
+	}
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+		ctx = AddContextParamSpec(ctx, ts.Params)
+		ts.Params = GetContextParamSpecs(ctx)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -64,6 +64,9 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 
 	// If this taskrun has an embedded task, apply the usual task defaults
 	if trs.TaskSpec != nil {
+		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+			ctx = AddContextParams(ctx, trs.Params)
+		}
 		trs.TaskSpec.SetDefaults(ctx)
 	}
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -496,7 +496,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 
 	for _, rprt := range pipelineRunFacts.State {
 		if !rprt.IsCustomTask() {
-			err := taskrun.ValidateResolvedTaskResources(rprt.PipelineTask.Params, rprt.ResolvedTaskResources)
+			err := taskrun.ValidateResolvedTaskResources(ctx, rprt.PipelineTask.Params, rprt.ResolvedTaskResources)
 			if err != nil {
 				logger.Errorf("Failed to validate pipelinerun %q with error %v", pr.Name, err)
 				pr.Status.MarkFailed(ReasonFailedValidation, err.Error())

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -339,7 +339,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
-	if err := ValidateResolvedTaskResources(tr.Spec.Params, rtr); err != nil {
+	if err := ValidateResolvedTaskResources(ctx, tr.Spec.Params, rtr); err != nil {
 		logger.Errorf("TaskRun %q resources are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is the implementation of
[TEP-0023](https://github.com/tektoncd/community/blob/main/teps/0023-implicit-mapping.md).

This adds information to the defaulting context to allow parameters to
be passed down the stack during evaluation. This functionality is gated
behind the alpha feature flag.

Additionally, Tasks are now allowed to accept more params than are
actually used. This should generally be safe, since extra params that
are provided should not affect the behavior of the Task itself.

/kind feature

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
- Tasks can now accept more parameters than are actually used.
- Parameters can now be implicitly propagated to inlined specs (alpha feature flag must be enabled) -
  e.g. an inlined Task can access parameters of its parent PipelineRun without
  needing to explicitly define each param.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:



For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
