### PR TITLE
Invalidate passing `Results` between `Finally Tasks`

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1969,10 +1969,13 @@ func TestValidatePipelineWithFinalTasks_Failure(t *testing.T) {
 				}},
 			},
 		},
-		expectedError: apis.FieldError{
+		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
 			Message: `invalid value: no runAfter allowed under spec.finally, final task final-task-1 has runAfter specified`,
 			Paths:   []string{"spec.finally[0]"},
-		},
+		}).Also(&apis.FieldError{
+			Message: `invalid value: no conditions allowed under spec.finally, final task final-task-2 has conditions specified`,
+			Paths:   []string{"spec.finally[1]"},
+		}),
 	}, {
 		name: "invalid pipeline - workspace bindings in final task relying on a non-existent pipeline workspace",
 		p: &Pipeline{
@@ -2154,8 +2157,26 @@ func TestValidateFinalTasks_Failure(t *testing.T) {
 			}},
 		}},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid task result reference, final task param param1 has task result reference from a final task`,
-			Paths:   []string{"finally[1].params"},
+			Message: `invalid value: invalid task result reference, final task has task result reference from a final task final-task-1`,
+			Paths:   []string{"finally[1].params[param1].value"},
+		},
+	}, {
+		name: "invalid pipeline with final tasks having task results reference from a final task",
+		finalTasks: []PipelineTask{{
+			Name:    "final-task-1",
+			TaskRef: &TaskRef{Name: "final-task"},
+		}, {
+			Name:    "final-task-2",
+			TaskRef: &TaskRef{Name: "final-task"},
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.final-task-1.results.output)",
+				Operator: selection.In,
+				Values:   []string{"result"},
+			}},
+		}},
+		expectedError: apis.FieldError{
+			Message: `invalid value: invalid task result reference, final task has task result reference from a final task final-task-1`,
+			Paths:   []string{"finally[1].when[0]"},
 		},
 	}, {
 		name: "invalid pipeline with final tasks having task results reference from non existent dag task",
@@ -2167,8 +2188,8 @@ func TestValidateFinalTasks_Failure(t *testing.T) {
 			}},
 		}},
 		expectedError: apis.FieldError{
-			Message: `invalid value: invalid task result reference, final task param param1 has task result reference from a task which is not defined in the pipeline`,
-			Paths:   []string{"finally[0].params"},
+			Message: `invalid value: invalid task result reference, final task has task result reference from a task no-dag-task-1 which is not defined in the pipeline`,
+			Paths:   []string{"finally[0].params[param1].value"},
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
Today, passing `Results` between `Finally Tasks` through `when`
expressions is not invalidated

This change invalidates passing `Results` between `Finally Tasks` through
`when` expressions

`Finally Tasks` should be executed in parallel after all `Tasks` are
done, therefore we cannot have dependencies between `Finally Tasks`

A `Pipeline` that passes a `Result` from one `Finally Task` to another
`Finally Task` should fail due to validation error

Further details in:
- [TEP-0004: Task Results in Final Tasks](https://github.com/tektoncd/community/blob/main/teps/0004-task-results-in-final-tasks.md)
- [Documentation: Consuming Results in Finally Tasks](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#consuming-task-execution-results-in-finally)

This change also refactors the invalidation of `Finally Tasks` to ensure
that we capture all the reasons to fail due to invalidation instead of
only one reason -- to ensure all invalid syntax in `Finally Tasks` are
reported to the user at the first execution

Fixes https://github.com/tektoncd/pipeline/issues/4130

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
- passing `Results` between `Finally Tasks` is invalidated
- when a `Pipeline` has validation errors in `Finally Tasks`, all of them will be returned in the first execution of the `Pipeline` instead of one by one
```
/kind bug
