### PR TITLE
Switch `Errorf` to `Fatalf` in retry tests.

### DIFF
--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -89,9 +89,9 @@ func TestTaskRunRetry(t *testing.T) {
 	// There should only be one TaskRun created.
 	trs, err := c.TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		t.Errorf("Failed to list TaskRuns: %v", err)
+		t.Fatalf("Failed to list TaskRuns: %v", err)
 	} else if len(trs.Items) != 1 {
-		t.Errorf("Found %d TaskRuns, want 1", len(trs.Items))
+		t.Fatalf("Found %d TaskRuns, want 1", len(trs.Items))
 	}
 
 	// The TaskRun status should have N retriesStatuses, all failures.

--- a/test/v1alpha1/retry_test.go
+++ b/test/v1alpha1/retry_test.go
@@ -90,9 +90,9 @@ func TestTaskRunRetry(t *testing.T) {
 	// There should only be one TaskRun created.
 	trs, err := c.TaskRunClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		t.Errorf("Failed to list TaskRuns: %v", err)
+		t.Fatalf("Failed to list TaskRuns: %v", err)
 	} else if len(trs.Items) != 1 {
-		t.Errorf("Found %d TaskRuns, want 1", len(trs.Items))
+		t.Fatalf("Found %d TaskRuns, want 1", len(trs.Items))
 	}
 
 	// The TaskRun status should have N retriesStatuses, all failures.


### PR DESCRIPTION
These are bounds checks, and if they fail because the length is zero, then the test will panic just below.  This creates a much nicer failure mode for the test.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

