### PR TITLE
TEP-0069: Support retries for custom task in a pipeline.

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -41,6 +41,12 @@ data:
     # minutes to use for TaskRun and PipelineRun, if none is specified.
     default-timeout-minutes: "60"  # 60 minutes
 
+    # default-short-timeout-seconds contains the default number of
+    # seconds to wait for custom task to respond, on timeout it is assumed
+    # custom task does not support the feature. It is used to
+    # quickly timeout a retry in a custom-task.
+    default-short-timeout-seconds: "30"  # 30 seconds
+
     # default-service-account contains the default service account name
     # to use for TaskRun and PipelineRun, if none is specified.
     default-service-account: "default"

--- a/docs/runs.md
+++ b/docs/runs.md
@@ -153,6 +153,11 @@ the `example.dev` API group,  with the version `v1alpha1`.
    behaviour is supported then, appropriate validation error should be
    updated to the `Run`'s status.
 
+4. A custom task controller can support `retries` by watching the `/spec/status`
+   of `Run`. If it is `RunRetry` then start executing retry and clear its
+   status to let `tektoncd` controller know that the custom task has started
+   retrying.
+
 ### Specifying `Parameters`
 
 If a custom task supports [`parameters`](tasks.md#parameters), you can use the

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -36,17 +36,19 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 	testCases := []testCase{
 		{
 			expectedConfig: &config.Defaults{
-				DefaultTimeoutMinutes:      50,
-				DefaultServiceAccount:      "tekton",
-				DefaultManagedByLabelValue: "something-else",
+				DefaultShortTimeoutSecondsValue: 30,
+				DefaultTimeoutMinutes:           50,
+				DefaultServiceAccount:           "tekton",
+				DefaultManagedByLabelValue:      "something-else",
 			},
 			fileName: config.GetDefaultsConfigName(),
 		},
 		{
 			expectedConfig: &config.Defaults{
-				DefaultTimeoutMinutes:      50,
-				DefaultServiceAccount:      "tekton",
-				DefaultManagedByLabelValue: config.DefaultManagedByLabelValue,
+				DefaultShortTimeoutSecondsValue: 30,
+				DefaultTimeoutMinutes:           50,
+				DefaultServiceAccount:           "tekton",
+				DefaultManagedByLabelValue:      config.DefaultManagedByLabelValue,
 				DefaultPodTemplate: &pod.Template{
 					NodeSelector: map[string]string{
 						"label": "value",
@@ -79,9 +81,10 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 func TestNewDefaultsFromEmptyConfigMap(t *testing.T) {
 	DefaultsConfigEmptyName := "config-defaults-empty"
 	expectedConfig := &config.Defaults{
-		DefaultTimeoutMinutes:      60,
-		DefaultManagedByLabelValue: "tekton-pipelines",
-		DefaultServiceAccount:      "default",
+		DefaultShortTimeoutSecondsValue: 30,
+		DefaultTimeoutMinutes:           60,
+		DefaultManagedByLabelValue:      "tekton-pipelines",
+		DefaultServiceAccount:           "default",
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigEmptyName, expectedConfig)
 }
@@ -118,6 +121,16 @@ func TestEquals(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "different default short timeout",
+			left: &config.Defaults{
+				DefaultShortTimeoutSecondsValue: 10,
+			},
+			right: &config.Defaults{
+				DefaultShortTimeoutSecondsValue: 20,
+			},
+			expected: false,
+		},
+		{
 			name: "different default timeout",
 			left: &config.Defaults{
 				DefaultTimeoutMinutes: 10,
@@ -134,6 +147,16 @@ func TestEquals(t *testing.T) {
 			},
 			right: &config.Defaults{
 				DefaultTimeoutMinutes: 20,
+			},
+			expected: true,
+		},
+		{
+			name: "same default short timeout",
+			left: &config.Defaults{
+				DefaultShortTimeoutSecondsValue: 20,
+			},
+			right: &config.Defaults{
+				DefaultShortTimeoutSecondsValue: 20,
 			},
 			expected: true,
 		},

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -53,9 +53,13 @@ type RunSpec struct {
 	// +optional
 	Params []v1beta1.Param `json:"params,omitempty"`
 
-	// Used for cancelling a run (and maybe more later on)
+	// Used for cancelling/retrying a run (and maybe more later on)
 	// +optional
 	Status RunSpecStatus `json:"status,omitempty"`
+
+	// Used for propagating retries count to custom tasks
+	// +optional
+	Retries int `json:"retries,omitempty"`
 
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
@@ -80,6 +84,9 @@ const (
 	// RunSpecStatusCancelled indicates that the user wants to cancel the run,
 	// if not already cancelled or terminated
 	RunSpecStatusCancelled RunSpecStatus = "RunCancelled"
+
+	// RunSpecStatusRetry indicates that custom task needs to honor the retry request
+	RunSpecStatusRetry RunSpecStatus = "RunRetry"
 )
 
 // TODO(jasonhall): Move this to a Params type so other code can use it?
@@ -171,6 +178,11 @@ func (r *Run) HasPipelineRunOwnerReference() bool {
 // IsCancelled returns true if the Run's spec status is set to Cancelled state
 func (r *Run) IsCancelled() bool {
 	return r.Spec.Status == RunSpecStatusCancelled
+}
+
+// IsRetry returns true if the Run's spec status is set to Retry state
+func (r *Run) IsRetry() bool {
+	return r.Spec.Status == RunSpecStatusRetry
 }
 
 // IsDone returns true if the Run's status indicates that it is done.

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -168,6 +168,17 @@ func TestRunIsCancelled(t *testing.T) {
 	}
 }
 
+func TestRunIsRetry(t *testing.T) {
+	run := v1alpha1.Run{
+		Spec: v1alpha1.RunSpec{
+			Status: v1alpha1.RunSpecStatusRetry,
+		},
+	}
+	if !run.IsRetry() {
+		t.Fatal("Expected run status to be retry")
+	}
+}
+
 // TestRunStatusExtraFields tests that extraFields in a RunStatus can be parsed
 // from YAML.
 func TestRunStatus(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -218,9 +218,6 @@ func (pt PipelineTask) validateCustomTask() (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support conditions - use when expressions instead", "conditions"))
 	}
 	// TODO(#3133): Support these features if possible.
-	if pt.Retries > 0 {
-		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support retries", "retries"))
-	}
 	if pt.Resources != nil {
 		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support PipelineResources", "resources"))
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -185,17 +185,6 @@ func TestPipelineTask_ValidateCustomTask(t *testing.T) {
 			Paths:   []string{"conditions"},
 		},
 	}, {
-		name: "custom task doesn't support retries",
-		task: PipelineTask{
-			Name:    "foo",
-			Retries: 3,
-			TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example"},
-		},
-		expectedError: apis.FieldError{
-			Message: `invalid value: custom tasks do not support retries`,
-			Paths:   []string{"retries"},
-		},
-	}, {
 		name: "custom task doesn't support pipeline resources",
 		task: PipelineTask{
 			Name:      "foo",

--- a/pkg/apis/run/v1alpha1/runstatus_types.go
+++ b/pkg/apis/run/v1alpha1/runstatus_types.go
@@ -58,6 +58,10 @@ type RunStatusFields struct {
 	// +optional
 	Results []RunResult `json:"results,omitempty"`
 
+	// RetriesStatus contains the history of RunStatus, in case of a retry.
+	// +optional
+	RetriesStatus []RunStatus `json:"retriesStatus,omitempty"`
+
 	// ExtraFields holds arbitrary fields provided by the custom task
 	// controller.
 	ExtraFields runtime.RawExtension `json:"extraFields,omitempty"`

--- a/pkg/apis/run/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/run/v1alpha1/zz_generated.deepcopy.go
@@ -54,6 +54,13 @@ func (in *RunStatusFields) DeepCopyInto(out *RunStatusFields) {
 		*out = make([]RunResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.RetriesStatus != nil {
+		in, out := &in.RetriesStatus, &out.RetriesStatus
+		*out = make([]RunStatus, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.ExtraFields.DeepCopyInto(&out.ExtraFields)
 	return
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -109,7 +109,12 @@ func (t ResolvedPipelineRunTask) IsSuccessful() bool {
 // IsFailure returns true only if the run has failed and will not be retried.
 func (t ResolvedPipelineRunTask) IsFailure() bool {
 	if t.IsCustomTask() {
-		return t.Run != nil && t.Run.IsDone() && !t.Run.IsSuccessful()
+		if t.Run == nil {
+			return false
+		}
+		retriesDone := len(t.Run.Status.RetriesStatus)
+		retries := t.PipelineTask.Retries
+		return t.Run.IsDone() && !t.Run.IsSuccessful() && retriesDone >= retries
 	}
 	if t.TaskRun == nil {
 		return false
@@ -141,7 +146,6 @@ func (t ResolvedPipelineRunTask) IsCancelled() bool {
 func (t ResolvedPipelineRunTask) IsStarted() bool {
 	if t.IsCustomTask() {
 		return t.Run != nil && t.Run.Status.GetCondition(apis.ConditionSucceeded) != nil
-
 	}
 	return t.TaskRun != nil && t.TaskRun.Status.GetCondition(apis.ConditionSucceeded) != nil
 }


### PR DESCRIPTION

# Changes 

1. Add field `Retries` to `RunSpec`, an integer count which acts as a FYI to
    custom task controller.
 2. Add a new `RunRetry`, in addition to `RunCancelled` status to `RunSpecStatus`
    i.e. `v1alpha1.RunSpecStatusRetry`
 3. Add a field `RetriesStatus` to `RunStatusFields`, to maintain the retry
    history for a `Run`, similar to `v1beta1.TaskRunStatusFields.RetriesStatus`
 4. Add a config map entry (default-short-timeout-seconds) to `config-defaults` in
order to make short timeout configurable.

 Proposed algorithm for performing a retry for custom task.

 - Step 1. A `pipelineTask` consisting of a custom task X, is configured with
   `retries` count.

 - Step 2. On failure of task X, `pipelinerun` controller sees a request for a
   retry. It then communicates the same to custom task `Run` by patching
   `/spec/status` with a `v1alpha1.RunSpecStatusRetry` i.e. `RunRetry`. Similar
   to request a custom task to cancel.

 - Step 3. In addition to patching the `pipelinerun` controller also enqueue a timer
   `time.After(default-short-timeout-seconds)` (default: 30 seconds).
   On completion of timeout (i.e. 30s), it checks if `/spec/status` is `RunRetry`,
   then it assumes that custom task does not support retry.
     - a) if custom task does not supports retry as above, It sets no. of `retry done`
     to the `retries` count configured - i.e. exhaust all retries.
     - b) if custom task does support retry, update retry history.

 - Step 4. The custom task that wants to support the retry, has to update
   - a) `status.conditions` to indicate it is `Running`.
   - b) clear `/spec/status` if it is `RunRetry`.

 _A task may retry and immediately fail, so controller cannot fully rely on
 `status.conditions`._

 Docs changes
 1. Removed the limitation that retries are not supported for custom task.
 2. Add a short user guide for custom task developer.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/kind feature


<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Custom task can be configured with retry. e.g.

            spec:
              pipelineSpec:
                tasks:
                  - name: task-loop-with-retry
                    retries: 2 # retries parameter of a PipelineTask in Pipeline definition.
                    runAfter:
                      - first-task
                    params:
                      - name: word
                        value:
                          - jump
                          - land
                          - roll
                      - name: suffix
                        value: ing
                    taskRef:
                      apiVersion: custom.tekton.dev/v1alpha1
                      kind: TaskLoop
                      name: simpletaskloop
```