### PR TITLE
Graceful Termination: Cancelled `Task` is Failed (even with `Retries`)

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -562,7 +562,9 @@ Task Runs:
 
 To cancel a `PipelineRun` that's currently executing, update its definition
 to mark it as "PipelineRunCancelled". When you do so, the spawned `TaskRuns` are also marked
-as cancelled and all associated `Pods` are deleted. Pending final tasks are not scheduled. 
+as cancelled, all associated `Pods` are deleted, and their `Retries` are not executed.
+Pending final tasks are not scheduled.
+
 For example:
 
 ```yaml
@@ -584,7 +586,9 @@ is currently an **_alpha feature_**.
 
 To gracefully cancel a `PipelineRun` that's currently executing, update its definition
 to mark it as "CancelledRunFinally". When you do so, the spawned `TaskRuns` are also marked
-as cancelled and all associated `Pods` are deleted. Final tasks are scheduled normally. 
+as cancelled, all associated `Pods` are deleted, and their `Retries` are not executed.
+Final tasks are scheduled normally.
+
 For example:
 
 ```yaml

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -117,7 +117,7 @@ func (t ResolvedPipelineRunTask) IsFailure() bool {
 	c := t.TaskRun.Status.GetCondition(apis.ConditionSucceeded)
 	retriesDone := len(t.TaskRun.Status.RetriesStatus)
 	retries := t.PipelineTask.Retries
-	return c.IsFalse() && retriesDone >= retries
+	return c.IsFalse() && (retriesDone >= retries || c.Reason == v1beta1.TaskRunReasonCancelled.String())
 }
 
 // IsCancelled returns true only if the run is cancelled


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

`Finally Tasks` are executed only when all `Tasks` are _Done_, where
_Done_ means a `Task` is _Skipped_, _Succeeded_ or _Failed_. But a
`Task` is considered _Failed_ only when its `Retries` are all done.

Today, when a `Task` with `Retries` is `Cancelled`, it's not considered
_Failed_ if its `Retries` are not yet done. This is problematic because
if a `PipelineRun` is _Gracefully Cancelled_, where it should run
`Finally Tasks`, and it has a running `Task` with `Retries`:
- the `Task` with `Retries` be cancelled, but won't be considered
_Failed_ because its `Retries` are not done
- this would block the execution of `Finally Tasks`
- the `PipelineRun` would hang (stay running) until it times out

In this change, we modify `Is_Failure` to consider that either all
`Retries` are done or `Reason` for failure is `Cancellation`. With this
change, we can unblock execution of the `Finally Tasks` during _Graceful
Termination_.

In addition, the [documentation](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#configuring-a-pipeline) notes that "`Retries` - Specifies the
number of times to retry the execution of a Task after a failure.
_Does not apply to execution cancellations_."

Fixes https://github.com/tektoncd/pipeline/issues/4125

Related: 
- [TEP-0058: Graceful Pipeline Run Termination](https://github.com/tektoncd/community/blob/main/teps/0058-graceful-pipeline-run-termination.md)
- https://github.com/tektoncd/pipeline/pull/3915

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
graceful termination of `pipelineruns` with running `taskruns` with `retries` will be observed, because cancelled `taskruns` with remaining `retries` will be considered `failed`
```