### PR TITLE
Fix Example with Completed and Succeeded Execution Status

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-when-expressions.yaml
@@ -163,6 +163,16 @@ spec:
             - name: echo
               image: ubuntu
               script: exit 1
+      - name: finally-task-should-be-skipped-5 # when expression using tasks execution status, evaluates to false
+        when:
+          - input: "$(tasks.status)"
+            operator: in
+            values: ["Succeeded"]
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: exit 1
       - name: finally-task-should-be-executed # when expression using execution status, tasks execution status, param, and results
         when:
           - input: "$(tasks.echo-file-exists.status)"
@@ -170,7 +180,7 @@ spec:
             values: ["Succeeded"]
           - input: "$(tasks.status)"
             operator: in
-            values: ["Succeeded"]
+            values: ["Completed"]
           - input: "$(tasks.check-file.results.exists)"
             operator: in
             values: ["yes"]


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Today, an example `pipeline` that demonstrates using the execution
status of `tasks` - `$(tasks.status)` - in `when` expressions in
`finally tasks` uses `Succeeded` in a `Task` that should be executed
but the status is actually `Completed`. This example would be confusing
to users as [reported on Slack](https://tektoncd.slack.com/archives/CK3HBG7CM/p1627916986006400) - thanks Hussein!

As explained in the [docs](https://github.com/tektoncd/pipeline/blob/release-v0.24.x/docs/pipelines.md#using-aggregate-execution-status-of-all-tasks):
- `Succeeded`: all `tasks` have succeeded
- `Failed`: one ore more `tasks` failed
- `Completed`: all `tasks` completed successfully including one or more
skipped `tasks`

In this change:
- correct the `task` that should be executed to check `Completed`
instead of `Succeeded`
- add a `finally task` that shows `Succeeded` would block execution
because the aggregate execution status is actually `Completed`

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```