### PR TITLE
Add debug with breakpoint configuration to PipelineRun

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -21,7 +21,12 @@ weight: 11
 ## Overview
 
 `Debug` spec is used for troubleshooting and breakpointing runtime resources. This doc helps understand the inner 
-workings of debug in Tekton. Currently only the `TaskRun` resource is supported. 
+workings of debug in Tekton. Debugging is supported in the `TaskRun`. 
+
+
+## Debugging PipelineRuns
+
+To see how to configure a `PipelineRun` to enable debugging of a `TaskRun` follow the [PipelineRun Debugging Documentation](pipelineruns.md#debugging-pipelineruns). The rest of the documentation assumes debugging of a `TaskRun`.
 
 ## Debugging TaskRuns
 

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -23,6 +23,7 @@ weight: 500
   - [Monitoring execution status](#monitoring-execution-status)
   - [Cancelling a `PipelineRun`](#cancelling-a-pipelinerun)
   - [Pending `PipelineRuns`](#pending-pipelineruns)
+  - [Debugging `PipelineRuns`](#debugging-pipelineruns)
 
 
 
@@ -638,6 +639,28 @@ spec:
 ```
 
 To start the PipelineRun, clear the `.spec.status` field. Alternatively, update the value to `PipelineRunCancelled` to cancel it.
+                      
+
+### Debugging `PipelineRuns`
+
+#### Breakpoint on Failure
+
+You can configure a TaskRun created by a `PipelineRun` to enable debug as follows:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: test-case-run
+spec:
+  taskRunSpecs:
+  - pipelineTaskName: my-task 
+    debug:
+      breakpoint: ["onFailure"]
+...
+```
+
+Then refer to the [TaskRun Debugging Documentation](taskruns.md#debugging-a-taskrun) for details of how to debug the `TaskRun`
 
 ---
 

--- a/internal/builder/v1beta1/task.go
+++ b/internal/builder/v1beta1/task.go
@@ -599,6 +599,14 @@ func TaskRunSpecStatus(status v1beta1.TaskRunSpecStatus) TaskRunSpecOp {
 	}
 }
 
+// TaskRunSpecDebugBreakpoint sets the debug breakpoints in the Spec,
+// used for enabling breakpoints on TaskRuns
+func TaskRunSpecDebugBreakpoint(breakpoints []string) TaskRunSpecOp {
+	return func(spec *v1beta1.TaskRunSpec) {
+		spec.Debug = &v1beta1.TaskRunDebug{Breakpoint: breakpoints}
+	}
+}
+
 // TaskRefKind set the specified kind to the TaskRef.
 func TaskRefKind(kind v1beta1.TaskKind) TaskRefOp {
 	return func(ref *v1beta1.TaskRef) {

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2398,11 +2398,16 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template"),
 						},
 					},
+					"debug": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template"},
+			"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.Template", "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.TaskRunDebug"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -488,6 +488,9 @@ type PipelineTaskRunSpec struct {
 	PipelineTaskName       string       `json:"pipelineTaskName,omitempty"`
 	TaskServiceAccountName string       `json:"taskServiceAccountName,omitempty"`
 	TaskPodTemplate        *PodTemplate `json:"taskPodTemplate,omitempty"`
+
+	// +optional
+	Debug *TaskRunDebug `json:"debug,omitempty"`
 }
 
 // GetTaskRunSpec returns the task specific spec for a given
@@ -505,6 +508,9 @@ func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSp
 			}
 			if task.TaskServiceAccountName != "" {
 				s.TaskServiceAccountName = task.TaskServiceAccountName
+			}
+			if task.Debug != nil {
+				s.Debug = task.Debug
 			}
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1453,6 +1453,9 @@
       "description": "PipelineTaskRunSpec  can be used to configure specific specs for a concrete Task",
       "type": "object",
       "properties": {
+        "debug": {
+          "$ref": "#/definitions/v1beta1.TaskRunDebug"
+        },
         "pipelineTaskName": {
           "type": "string"
         },

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1146,6 +1146,11 @@ func (in *PipelineTaskRunSpec) DeepCopyInto(out *PipelineTaskRunSpec) {
 		*out = new(pod.Template)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Debug != nil {
+		in, out := &in.Debug, &out.Debug
+		*out = new(TaskRunDebug)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -765,6 +765,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 			Annotations:     combineTaskRunAndTaskSpecAnnotations(pr, rprt.PipelineTask),
 		},
 		Spec: v1beta1.TaskRunSpec{
+			Debug:              taskRunSpec.Debug,
 			Params:             rprt.PipelineTask.Params,
 			ServiceAccountName: taskRunSpec.TaskServiceAccountName,
 			Timeout:            getTimeoutFunc(ctx, pr, rprt),

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -807,6 +807,98 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 	}
 }
 
+func TestReconcile_PipelineRunWithDebug(t *testing.T) {
+	// TestReconcile_PipelineSpecTaskSpec runs "Reconcile" on a PipelineRun that has an embedded PipelineSpec that has an embedded TaskSpec.
+	// It verifies that a TaskRun is created, it checks the resulting API actions, status and events.
+	names.TestingSeed()
+
+	prs := []*v1beta1.PipelineRun{
+		tb.PipelineRun("test-pipeline-run-success",
+			tb.PipelineRunNamespace("foo"),
+			tb.PipelineRunSpec("test-pipeline",
+				tb.PipelineRunPipelineSpec(
+					tb.PipelineTask("unit-test-task-spec", "", tb.PipelineTaskSpec(v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{Container: corev1.Container{
+							Name:  "mystep",
+							Image: "myimage"}}},
+					})),
+				),
+				tb.PipelineTaskRunSpecs(
+					[]v1beta1.PipelineTaskRunSpec{
+						{
+							PipelineTaskName:       "unit-test-task-spec",
+							TaskServiceAccountName: "my-sa",
+							Debug:                  &v1beta1.TaskRunDebug{Breakpoint: []string{"onFailure"}},
+						},
+					},
+				),
+			),
+		),
+	}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		ConfigMaps: []*corev1.ConfigMap{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
+				Data: map[string]string{
+					"enable-api-fields": config.AlphaAPIFields,
+				},
+			},
+		},
+	}
+	prt := newPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	wantEvents := []string{
+		"Normal Started",
+		"Normal Running Tasks Completed: 0",
+	}
+	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-success", wantEvents, false)
+
+	actions := clients.Pipeline.Actions()
+	if len(actions) < 2 {
+		t.Fatalf("Expected client to have at least two action implementation but it has %d", len(actions))
+	}
+
+	// Check that the expected TaskRun was created
+	actual := getTaskRunCreations(t, actions)[0]
+	expectedTaskRun := tb.TaskRun("test-pipeline-run-success-unit-test-task-spec-9l9zj",
+		tb.TaskRunNamespace("foo"),
+		tb.TaskRunOwnerReference("PipelineRun", "test-pipeline-run-success",
+			tb.OwnerReferenceAPIVersion("tekton.dev/v1beta1"),
+			tb.Controller, tb.BlockOwnerDeletion,
+		),
+		tb.TaskRunLabel("tekton.dev/pipeline", "test-pipeline-run-success"),
+		tb.TaskRunLabel("tekton.dev/pipelineRun", "test-pipeline-run-success"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.PipelineTaskLabelKey, "unit-test-task-spec"),
+		tb.TaskRunLabel(pipeline.GroupName+pipeline.MemberOfLabelKey, v1beta1.PipelineTasks),
+		tb.TaskRunSpec(
+			tb.TaskRunTaskSpec(tb.Step("myimage", tb.StepName("mystep"))),
+			tb.TaskRunServiceAccountName("my-sa"),
+			tb.TaskRunSpecDebugBreakpoint([]string{"onFailure"}),
+		),
+	)
+
+	// ignore IgnoreUnexported ignore both after and before steps fields
+	if d := cmp.Diff(expectedTaskRun, actual, cmpopts.SortSlices(func(x, y v1beta1.TaskSpec) bool { return len(x.Steps) == len(y.Steps) })); d != "" {
+		t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRun, diff.PrintWantGot(d))
+	}
+
+	// test taskrun is able to recreate correct pipeline-pvc-name
+	if expectedTaskRun.GetPipelineRunPVCName() != "test-pipeline-run-success-pvc" {
+		t.Errorf("expected to see TaskRun PVC name set to %q created but got %s", "test-pipeline-run-success-pvc", expectedTaskRun.GetPipelineRunPVCName())
+	}
+
+	if len(reconciledRun.Status.TaskRuns) != 1 {
+		t.Errorf("Expected PipelineRun status to include both TaskRun status items that can run immediately: %v", reconciledRun.Status.TaskRuns)
+	}
+
+	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-task-spec-9l9zj"]; !exists {
+		t.Errorf("Expected PipelineRun status to include TaskRun status but was %v", reconciledRun.Status.TaskRuns)
+	}
+}
+
 // TestReconcile_InvalidPipelineRuns runs "Reconcile" on several PipelineRuns that are invalid in different ways.
 // It verifies that reconcile fails, how it fails and which events are triggered.
 func TestReconcile_InvalidPipelineRuns(t *testing.T) {


### PR DESCRIPTION
Based on TEP-0042, this commit will allow users to enable the `debug.breakpoints` property on any `TaskRun` resources generated by a `PipelineRun`

the reconciler will pass any `debug.breakpoints` properties from the PipelineRun's taskRunSpecs over to the generated resolved `TaskRun` instances so that per Task debugging can be enabled

Signed-off-by: James Strachan <james.strachan@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
