### PR TITLE
`when` expressions in skipped `tasks` status

### DIFF
--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -54,13 +54,6 @@ func (we *WhenExpression) isTrue() bool {
 	return !we.isInputInValues()
 }
 
-func (we *WhenExpression) hasVariable() bool {
-	if _, hasVariable := we.GetVarSubstitutionExpressions(); hasVariable {
-		return true
-	}
-	return false
-}
-
 func (we *WhenExpression) applyReplacements(replacements map[string]string, arrayReplacements map[string][]string) WhenExpression {
 	replacedInput := substitution.ApplyReplacements(we.Input, replacements)
 
@@ -103,17 +96,6 @@ func (wes WhenExpressions) AllowsExecution() bool {
 		}
 	}
 	return true
-}
-
-// HaveVariables indicates whether When Expressions contains variables, such as Parameters
-// or Results in the Inputs or Values.
-func (wes WhenExpressions) HaveVariables() bool {
-	for _, we := range wes {
-		if we.hasVariable() {
-			return true
-		}
-	}
-	return false
 }
 
 // ReplaceWhenExpressionsVariables interpolates variables, such as Parameters and Results, in

--- a/pkg/apis/pipeline/v1beta1/when_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/when_types_test.go
@@ -88,66 +88,6 @@ func TestAllowsExecution(t *testing.T) {
 	}
 }
 
-func TestHaveVariables(t *testing.T) {
-	tests := []struct {
-		name            string
-		whenExpressions WhenExpressions
-		expected        bool
-	}{{
-		name: "doesn't have variable",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "foo",
-				Operator: selection.In,
-				Values:   []string{"foo", "bar"},
-			},
-		},
-		expected: false,
-	}, {
-		name: "have variable - input",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "$(params.foobar)",
-				Operator: selection.NotIn,
-				Values:   []string{"foobar"},
-			},
-		},
-		expected: true,
-	}, {
-		name: "have variable - values",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "foobar",
-				Operator: selection.In,
-				Values:   []string{"$(params.foobar)"},
-			},
-		},
-		expected: true,
-	}, {
-		name: "have variable - multiple when expressions",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "foo",
-				Operator: selection.NotIn,
-				Values:   []string{"bar"},
-			}, {
-				Input:    "foobar",
-				Operator: selection.In,
-				Values:   []string{"$(params.foobar)"},
-			},
-		},
-		expected: true,
-	}}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := tc.whenExpressions.HaveVariables()
-			if d := cmp.Diff(tc.expected, got); d != "" {
-				t.Errorf("Error evaluating HaveVariables() for When Expressions in test case %s", diff.PrintWantGot(d))
-			}
-		})
-	}
-}
-
 func TestReplaceWhenExpressionsVariables(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -3941,11 +3941,6 @@ func TestReconcileWithWhenExpressionsScopedToTask(t *testing.T) {
 	}, {
 		// was attempted, but has missing results references
 		Name: "e-task",
-		WhenExpressions: v1beta1.WhenExpressions{{
-			Input:    "$(tasks.a-task.results.aResult)",
-			Operator: "in",
-			Values:   []string{"aResultValue"},
-		}},
 	}, {
 		Name: "f-task",
 	}}

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -110,6 +110,7 @@ func TestPipelineLevelFinally_OneDAGTaskFailed_InvalidTaskResult_Failure(t *test
 	dag := map[string]pipelineTask{
 		"dagtask1": {
 			TaskName: task.Name,
+			RunAfter: []string{"dagtask2", "dagtask3", "dagtask4", "dagtask5"},
 		},
 		"dagtask2": {
 			TaskName: delayedTask.Name,
@@ -828,6 +829,7 @@ type pipelineTask struct {
 	Condition string
 	Param     []v1beta1.Param
 	When      v1beta1.WhenExpressions
+	RunAfter  []string
 }
 
 func getPipeline(t *testing.T, namespace string, dag map[string]pipelineTask, f map[string]pipelineTask) *v1beta1.Pipeline {
@@ -848,6 +850,9 @@ func getPipeline(t *testing.T, namespace string, dag map[string]pipelineTask, f 
 		}
 		if len(v.When) != 0 {
 			task.WhenExpressions = v.When
+		}
+		if len(v.RunAfter) != 0 {
+			task.RunAfter = v.RunAfter
 		}
 		pt = append(pt, task)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

today, `when` expressions are included in skipped `tasks` regardless of
reason for skipping. for dag `tasks`, they are included even when they
are unresolved, while for finally tasks, they are included only when
they are resolved.

now that we have skipping reason, we want to check that the reason for
skipping is that `when` expressions evaluated to false before including
the resolved `when` expressions to the skipped `tasks` status.

we may explore adding the skipping reason to the skipped `tasks` status
in the future, but for now this change ensures that the status is
providing useful information to the users. it also brings consistency in
how we add `when` expressions to skipped `tasks` status in both
dag `tasks` and finally `tasks`.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```