### PR TITLE
(cleanup) use skipping reason instead of existence of variables

### DIFF
--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -54,13 +54,6 @@ func (we *WhenExpression) isTrue() bool {
 	return !we.isInputInValues()
 }
 
-func (we *WhenExpression) hasVariable() bool {
-	if _, hasVariable := we.GetVarSubstitutionExpressions(); hasVariable {
-		return true
-	}
-	return false
-}
-
 func (we *WhenExpression) applyReplacements(replacements map[string]string, arrayReplacements map[string][]string) WhenExpression {
 	replacedInput := substitution.ApplyReplacements(we.Input, replacements)
 
@@ -103,17 +96,6 @@ func (wes WhenExpressions) AllowsExecution() bool {
 		}
 	}
 	return true
-}
-
-// HaveVariables indicates whether When Expressions contains variables, such as Parameters
-// or Results in the Inputs or Values.
-func (wes WhenExpressions) HaveVariables() bool {
-	for _, we := range wes {
-		if we.hasVariable() {
-			return true
-		}
-	}
-	return false
 }
 
 // ReplaceWhenExpressionsVariables interpolates variables, such as Parameters and Results, in

--- a/pkg/apis/pipeline/v1beta1/when_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/when_types_test.go
@@ -88,66 +88,6 @@ func TestAllowsExecution(t *testing.T) {
 	}
 }
 
-func TestHaveVariables(t *testing.T) {
-	tests := []struct {
-		name            string
-		whenExpressions WhenExpressions
-		expected        bool
-	}{{
-		name: "doesn't have variable",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "foo",
-				Operator: selection.In,
-				Values:   []string{"foo", "bar"},
-			},
-		},
-		expected: false,
-	}, {
-		name: "have variable - input",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "$(params.foobar)",
-				Operator: selection.NotIn,
-				Values:   []string{"foobar"},
-			},
-		},
-		expected: true,
-	}, {
-		name: "have variable - values",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "foobar",
-				Operator: selection.In,
-				Values:   []string{"$(params.foobar)"},
-			},
-		},
-		expected: true,
-	}, {
-		name: "have variable - multiple when expressions",
-		whenExpressions: WhenExpressions{
-			{
-				Input:    "foo",
-				Operator: selection.NotIn,
-				Values:   []string{"bar"},
-			}, {
-				Input:    "foobar",
-				Operator: selection.In,
-				Values:   []string{"$(params.foobar)"},
-			},
-		},
-		expected: true,
-	}}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := tc.whenExpressions.HaveVariables()
-			if d := cmp.Diff(tc.expected, got); d != "" {
-				t.Errorf("Error evaluating HaveVariables() for When Expressions in test case %s", diff.PrintWantGot(d))
-			}
-		})
-	}
-}
-
 func TestReplaceWhenExpressionsVariables(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -423,7 +423,7 @@ func (facts *PipelineRunFacts) GetSkippedTasks() []v1beta1.SkippedTask {
 			}
 			// include the when expressions only when the finally task was skipped because
 			// its when expressions evaluated to false (not because results variables were missing)
-			if !rprt.PipelineTask.WhenExpressions.HaveVariables() {
+			if rprt.IsFinallySkipped(facts).SkippingReason == WhenExpressionsSkip {
 				skippedTask.WhenExpressions = rprt.PipelineTask.WhenExpressions
 			}
 			skipped = append(skipped, skippedTask)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

today, we use existence of variables to determine whether to add
`when` expressions to the skipped `tasks` status for finally tasks
(we only add them when they are resolved, have no variables)

we recently added skipping reason in https://github.com/tektoncd/pipeline/pull/4085

now that we have skipping reason, we can use it to check that the reason
for skipping is that `when` expressions evaluated to false before
including the resolved `when` expressions to the skipped `tasks` status

we plan to explore adding skipping reason to the skipped `tasks` status
in the future, but for now this change reuses this new functionality

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```

/cc @pritidesai 