### PR TITLE
Small entrypoint unit test fixes prior to 0.27 release

### DIFF
--- a/cmd/entrypoint/post_writer_test.go
+++ b/cmd/entrypoint/post_writer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -27,7 +28,7 @@ func TestRealPostWriter_WriteFileContent(t *testing.T) {
 				if _, err := os.Stat(tt.file); err != nil {
 					t.Fatalf("Failed to create a file %q", tt.file)
 				}
-				b, err := os.ReadFile(tt.file)
+				b, err := ioutil.ReadFile(tt.file)
 				if err != nil {
 					t.Fatalf("Failed to read the file %q", tt.file)
 				}

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -86,6 +86,13 @@ func TestEntrypointerFailures(t *testing.T) {
 				fr = &fakeRunner{}
 			}
 			fpw := &fakePostWriter{}
+			terminationPath := "termination"
+			if terminationFile, err := ioutil.TempFile("", "termination"); err != nil {
+				t.Fatalf("unexpected error creating temporary termination file: %v", err)
+			} else {
+				terminationPath = terminationFile.Name()
+				defer os.Remove(terminationFile.Name())
+			}
 			err := Entrypointer{
 				Entrypoint:      "echo",
 				WaitFiles:       c.waitFiles,
@@ -94,7 +101,7 @@ func TestEntrypointerFailures(t *testing.T) {
 				Waiter:          fw,
 				Runner:          fr,
 				PostWriter:      fpw,
-				TerminationPath: "termination",
+				TerminationPath: terminationPath,
 				Timeout:         &c.timeout,
 			}.Go()
 			if err == nil {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

post_writer_test.go previously used os.ReadFile which was only introduced in Go
1.16. This commit replaces os.ReadFile with ioutil.ReadFile for compatibility
with older Go versions.

entrypointer_test.go previously wrote a termination file to the developer's git
repo which meant it showed up running `git status`.  This commit creates a
random TempFile for termination paths which are then cleaned up at the end of
the test.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```