### PR TITLE
Update docs with 0.27.0 info

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ Tekton Pipelines are **Typed**:
 - Jump in with [the tutorial!](docs/tutorial.md)
 - Take a look at our [roadmap](roadmap.md)
 
-*Note that starting from the 0.24 release of Tekton, you need to have
-a cluster with **Kubernetes version 1.18 or later***.
+*Note that starting from the 0.27 release of Tekton, you need to have
+a cluster with **Kubernetes version 1.19 or later***.
 
 ### Read the docs
 
 | Version | Docs | Examples |
 | ------- | ---- | -------- |
 | [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
+| [v0.27.0](https://github.com/tektoncd/pipeline/releases/tag/v0.27.0) | [Docs @ v0.27.0](https://github.com/tektoncd/pipeline/tree/v0.27.0/docs#tekton-pipelines) | [Examples @ v0.27.0](https://github.com/tektoncd/pipeline/tree/v0.27.0/examples#examples) |
 | [v0.26.0](https://github.com/tektoncd/pipeline/releases/tag/v0.26.0) | [Docs @ v0.26.0](https://github.com/tektoncd/pipeline/tree/v0.26.0/docs#tekton-pipelines) | [Examples @ v0.26.0](https://github.com/tektoncd/pipeline/tree/v0.26.0/examples#examples) |
 | [v0.25.0](https://github.com/tektoncd/pipeline/releases/tag/v0.25.0) | [Docs @ v0.25.0](https://github.com/tektoncd/pipeline/tree/v0.25.0/docs#tekton-pipelines) | [Examples @ v0.25.0](https://github.com/tektoncd/pipeline/tree/v0.25.0/examples#examples) |
 | [v0.24.3](https://github.com/tektoncd/pipeline/releases/tag/v0.24.3) | [Docs @ v0.24.3](https://github.com/tektoncd/pipeline/tree/v0.24.3/docs#tekton-pipelines) | [Examples @ v0.24.3](https://github.com/tektoncd/pipeline/tree/v0.24.3/examples#examples) |

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 
 ## Before you begin
 
-1. You must have a Kubernetes cluster running version 1.18 or later.
+1. You must have a Kubernetes cluster running version 1.19 or later.
 
    If you don't already have a cluster, you can create one for testing with `kind`.
    [Install `kind`](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) and create a cluster by running [`kind create cluster`](https://kind.sigs.k8s.io/docs/user/quick-start/#creating-a-cluster). This

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -138,7 +138,7 @@ the pipelines repo, a terminal window and a text editor.
 
     1. Publish the GitHub release once all notes are correct and in order.
 
-1. Edit `README.md` on `master` branch, add entry to docs table with latest release links.
+1. Edit `README.md` on `main` branch, add entry to docs table with latest release links.
 
 1. Push & make PR for updated `README.md`
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds links to the 0.27.0 version of the docs.

This commit also updates mentions of kubernetes version requirements from 1.18 to 1.19.

This commit also updates an old reference to the "master" branch of pipelines, replacing it with "main".

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
