### PR TITLE
Add metadata to our publish task for Tekton Chains to observe & sign

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: publish-release
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
     - name: package
@@ -52,6 +54,10 @@ spec:
         value: "$(params.imageRegistryRegions)"
       - name: OUTPUT_RELEASE_DIR
         value: "$(workspaces.output.path)/$(params.versionTag)"
+  results:
+  # IMAGES result is picked up by Tekton Chains to sign the release.
+  # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
+  - name: IMAGES
   steps:
 
   - name: create-ko-yaml
@@ -177,6 +183,8 @@ spec:
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
 
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
         if [[ "$(params.releaseAsLatest)" == "true" ]]
         then
           crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
@@ -193,6 +201,7 @@ spec:
           else
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
           fi
         done
       done


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/4153

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds an annotation to indicate that build provenance should be
generated and an `IMAGES` result composed of a comma-separated list of
imageNames+digest to be signed.

This change is based on
https://github.com/tektoncd/chains/blob/main/release/publish.yaml and
https://github.com/tektoncd/plumbing/blob/main/docs/signing.md

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Tekton Pipelines releases are now signed by Tekton Chains.
```