### PR TITLE
Cherry pick onError:fail rename and release signing metadata in to 0.27.x branch

### DIFF
--- a/cmd/entrypoint/main.go
+++ b/cmd/entrypoint/main.go
@@ -44,7 +44,7 @@ var (
 	timeout             = flag.Duration("timeout", time.Duration(0), "If specified, sets timeout for step")
 	breakpointOnFailure = flag.Bool("breakpoint_on_failure", false, "If specified, expect steps to not skip on failure")
 	onError             = flag.String("on_error", "", "Set to \"continue\" to ignore an error and continue when a container terminates with a non-zero exit code."+
-		" Set to \"fail\" to declare a failure with a step error and stop executing the rest of the steps.")
+		" Set to \"stopAndFail\" to declare a failure with a step error and stop executing the rest of the steps.")
 	stepMetadataDir     = flag.String("step_metadata_dir", "", "If specified, create directory to store the step metadata e.g. /tekton/steps/<step-name>/")
 	stepMetadataDirLink = flag.String("step_metadata_dir_link", "", "creates a symbolic link to the specified step_metadata_dir e.g. /tekton/steps/<step-index>/")
 )

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -296,7 +296,7 @@ When a `step` in a `task` results in a failure, the rest of the steps in the `ta
 declared a failure. If you would like to ignore such step errors and continue executing the rest of the steps in
 the task, you can specify `onError` for such a `step`.
 
-`onError` can be set to either `continue` or `fail` as part of the step definition. If `onError` is
+`onError` can be set to either `continue` or `stopAndFail` as part of the step definition. If `onError` is
 set to `continue`, the entrypoint sets the original failed exit code of the [script](#running-scripts-within-steps)
 in the container terminated state. A `step` with `onError` set to `continue` does not fail the `taskRun` and continues
 executing the rest of the steps in a task.

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -3092,7 +3092,7 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 					},
 					"onError": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OnError defines the exiting behavior of a container on error can be set to [ continue | fail ] fail indicates exit the taskRun if the container exits with non-zero exit code continue indicates continue executing the rest of the steps irrespective of the container exit code",
+							Description: "OnError defines the exiting behavior of a container on error can be set to [ continue | stopAndFail ] stopAndFail indicates exit the taskRun if the container exits with non-zero exit code continue indicates continue executing the rest of the steps irrespective of the container exit code",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1768,7 +1768,7 @@
           "default": ""
         },
         "onError": {
-          "description": "OnError defines the exiting behavior of a container on error can be set to [ continue | fail ] fail indicates exit the taskRun if the container exits with non-zero exit code continue indicates continue executing the rest of the steps irrespective of the container exit code",
+          "description": "OnError defines the exiting behavior of a container on error can be set to [ continue | stopAndFail ] stopAndFail indicates exit the taskRun if the container exits with non-zero exit code continue indicates continue executing the rest of the steps irrespective of the container exit code",
           "type": "string"
         },
         "ports": {

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -143,8 +143,8 @@ type Step struct {
 	Workspaces []WorkspaceUsage `json:"workspaces,omitempty"`
 
 	// OnError defines the exiting behavior of a container on error
-	// can be set to [ continue | fail ]
-	// fail indicates exit the taskRun if the container exits with non-zero exit code
+	// can be set to [ continue | stopAndFail ]
+	// stopAndFail indicates exit the taskRun if the container exits with non-zero exit code
 	// continue indicates continue executing the rest of the steps irrespective of the container exit code
 	OnError string `json:"onError,omitempty"`
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -223,11 +223,11 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 
 	if s.OnError != "" {
 		errs = errs.Also(ValidateEnabledAPIFields(ctx, "step onError", config.AlphaAPIFields).ViaField("steps"))
-		if s.OnError != "continue" && s.OnError != "fail" {
+		if s.OnError != "continue" && s.OnError != "stopAndFail" {
 			errs = errs.Also(&apis.FieldError{
 				Message: fmt.Sprintf("invalid value: %v", s.OnError),
 				Paths:   []string{"onError"},
-				Details: "Task step onError must be either continue or fail",
+				Details: "Task step onError must be either continue or stopAndFail",
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1150,9 +1150,9 @@ func TestStepOnError(t *testing.T) {
 			},
 		}},
 	}, {
-		name: "valid step - valid onError usage - set to fail - alpha API",
+		name: "valid step - valid onError usage - set to stopAndFail - alpha API",
 		steps: []v1beta1.Step{{
-			OnError: "fail",
+			OnError: "stopAndFail",
 			Container: corev1.Container{
 				Image: "image",
 				Args:  []string{"arg"},
@@ -1170,7 +1170,7 @@ func TestStepOnError(t *testing.T) {
 		expectedError: &apis.FieldError{
 			Message: fmt.Sprintf("invalid value: onError"),
 			Paths:   []string{"onError"},
-			Details: "Task step onError must be either continue or fail",
+			Details: "Task step onError must be either continue or stopAndFail",
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -39,7 +39,7 @@ import (
 const (
 	timeFormat      = "2006-01-02T15:04:05.000Z07:00"
 	ContinueOnError = "continue"
-	FailOnError     = "fail"
+	FailOnError     = "stopAndFail"
 )
 
 // Entrypointer holds fields for running commands with redirected
@@ -76,7 +76,7 @@ type Entrypointer struct {
 	// BreakpointOnFailure helps determine if entrypoint execution needs to adapt debugging requirements
 	BreakpointOnFailure bool
 	// OnError defines exiting behavior of the entrypoint
-	// set it to "fail" to indicate the entrypoint to exit the taskRun if the container exits with non zero exit code
+	// set it to "stopAndFail" to indicate the entrypoint to exit the taskRun if the container exits with non zero exit code
 	// set it to "continue" to indicate the entrypoint to continue executing the rest of the steps irrespective of the container exit code
 	OnError string
 	// StepMetadataDir is the directory for a step where the step related metadata can be stored

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -295,13 +295,13 @@ func TestEntrypointer_OnError(t *testing.T) {
 		onError:       ContinueOnError,
 		expectedError: false,
 	}, {
-		desc:          "the step is exiting with 1, treat the step error as failure with onError set to fail",
+		desc:          "the step is exiting with 1, treat the step error as failure with onError set to stopAndFail",
 		runner:        &fakeExitErrorRunner{},
 		expectedError: true,
 		postFile:      "step-one",
 		onError:       FailOnError,
 	}, {
-		desc:          "the step is exiting with 0, treat the step error (but there is none) as failure with onError set to fail",
+		desc:          "the step is exiting with 0, treat the step error (but there is none) as failure with onError set to stopAndFail",
 		runner:        &fakeRunner{},
 		postFile:      "step-one",
 		onError:       FailOnError,

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -357,7 +357,7 @@ func TestEntryPointOnError(t *testing.T) {
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-passing-step",
 			"-step_metadata_dir_link", "/tekton/steps/1",
-			"-on_error", "fail",
+			"-on_error", "stopAndFail",
 			"-entrypoint", "cmd", "--",
 		},
 		VolumeMounts:           []corev1.VolumeMount{toolsMount},

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: publish-release
+  annotations:
+    chains.tekton.dev/transparency-upload: "true"
 spec:
   params:
     - name: package
@@ -52,6 +54,10 @@ spec:
         value: "$(params.imageRegistryRegions)"
       - name: OUTPUT_RELEASE_DIR
         value: "$(workspaces.output.path)/$(params.versionTag)"
+  results:
+  # IMAGES result is picked up by Tekton Chains to sign the release.
+  # See https://github.com/tektoncd/plumbing/blob/main/docs/signing.md for more info.
+  - name: IMAGES
   steps:
 
   - name: create-ko-yaml
@@ -177,6 +183,8 @@ spec:
         IMAGE_WITHOUT_SHA_AND_TAG=${IMAGE_WITHOUT_SHA%%:*}
         IMAGE_WITH_SHA=${IMAGE_WITHOUT_SHA_AND_TAG}@${IMAGE##*@}
 
+        echo $IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+
         if [[ "$(params.releaseAsLatest)" == "true" ]]
         then
           crane cp ${IMAGE_WITH_SHA} ${IMAGE_WITHOUT_SHA_AND_TAG}:latest
@@ -193,6 +201,7 @@ spec:
           else
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
+            echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
           fi
         done
       done


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR brings in two commits for the release of 0.27.1:

- [Change "fail" to "stopAndFail"](https://github.com/tektoncd/pipeline/pull/4151)
- [Add metadata to our publish task for Tekton Chains to observe and sign](https://github.com/tektoncd/pipeline/pull/4156)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```