### PR TITLE
Set the scripts dir to readonly after init

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -652,7 +652,7 @@ func TestPodBuild(t *testing.T) {
 					Name:         "place-scripts",
 					Image:        "busybox",
 					Command:      []string{"sh"},
-					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
+					VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
 					Args: []string{"-c", `scriptfile="/tekton/scripts/sidecar-script-0-9l9zj"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
@@ -910,7 +910,7 @@ IyEvdXNyL2Jpbi9lbnYgcHl0aG9uCnByaW50KCJIZWxsbyBmcm9tIFB5dGhvbiIp
 _EOF_
 /tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
-					VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
+					VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
 				},
 			},
 			Containers: []corev1.Container{{
@@ -1035,7 +1035,7 @@ IyEvYmluL3NoCiQk
 _EOF_
 /tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
-				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
+				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
 			}},
 			Containers: []corev1.Container{{
 				Name:    "step-one",

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -48,6 +48,12 @@ var (
 	scriptsVolumeMount = corev1.VolumeMount{
 		Name:      scriptsVolumeName,
 		MountPath: scriptsDir,
+		ReadOnly:  true,
+	}
+	writeScriptsVolumeMount = corev1.VolumeMount{
+		Name:      scriptsVolumeName,
+		MountPath: scriptsDir,
+		ReadOnly:  false,
 	}
 	debugScriptsVolume = corev1.Volume{
 		Name:         debugScriptsVolumeName,
@@ -78,7 +84,7 @@ func convertScripts(shellImage string, steps []v1beta1.Step, sidecars []v1beta1.
 		Image:        shellImage,
 		Command:      []string{"sh"},
 		Args:         []string{"-c", ""},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
 	}
 
 	breakpoints := []string{}

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -177,7 +177,7 @@ IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
 _EOF_
 /tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -316,7 +316,7 @@ else
 fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount, debugScriptsVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount, debugScriptsVolumeMount},
 	}
 	want := []corev1.Container{{
 		Image:   "step-1",
@@ -408,7 +408,7 @@ IyEvYmluL3NoCnNpZGVjYXItMQ==
 _EOF_
 /tekton/tools/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Make the script volume mount read-only for all mounts excluding the init container that creates the scripts

This resolves issue #4160 and prevents overwriting the scripts from subsequent steps leading to anomalous, obscure, or dangerous results.

I made these changes a while ago before the debug scripts volume was added. I added an extra commit to deal with debug scripts too. I've ran the unit tests and I've deployed with `ko` and done some normal runs (using the tests from catalog) in a k3d cluster but I'm not very familiar with this debug scripts feature so some deeper testing might be necessary.
*Edit:* the debug scripts need to be written to each step like `/tekton/tools` with it's post/wait files

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

**Note:** I can modify the release-note to "action required" if we think someone might actually be overwriting the scripts in their use of tekton
Their resolution action would be to either an alternative mentioned at the bottom of #4160 or to mount their own volume to write other scripts to

```release-note
Mount script workspace as readonly
```