### PR TITLE
Remove confusing comment (◎_◎;)

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -232,7 +232,7 @@ func (t *ResolvedPipelineRunTask) Skip(facts *PipelineRunFacts) TaskSkipStatus {
 		facts.SkipCache = make(map[string]TaskSkipStatus)
 	}
 	if _, cached := facts.SkipCache[t.PipelineTask.Name]; !cached {
-		facts.SkipCache[t.PipelineTask.Name] = t.skip(facts) // t.skip() is same as our existing t.Skip()
+		facts.SkipCache[t.PipelineTask.Name] = t.skip(facts)
 	}
 	return facts.SkipCache[t.PipelineTask.Name]
 }


### PR DESCRIPTION
# Changes

@jerop was walking through this code in a meeting and I noticed this
comment for a few reasons:
- it's at the end of the line v.s. above the line which is kind of abnormal
- it's referring to some specific code shape at some point in time which
  seems like something that will fall out of sync quickly
- in fact im not sure what the `t.Skip` is that it is referring to - it
  seems to be the function that `t.skip` is being called from??

After trying to understand it more it not only doesn't seem to be adding
anything useful, I'm actually not sure what it means (maybe it was
included from some WIP refactoring to help the author?)

Anyway if anyone knows more or feels like this should stay maybe we can
update it :D

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
