### PR TITLE
cherry-pick to 0.27.x: Propagate Pipeline name label to PipelineRun

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -943,9 +943,9 @@ func propagatePipelineNameLabelToPipelineRun(pr *v1beta1.PipelineRun) error {
 	}
 	switch {
 	case pr.Spec.PipelineRef != nil && pr.Spec.PipelineRef.Name != "":
-		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Spec.PipelineRef.Name
+		pr.ObjectMeta.Labels[pipeline.GroupName+pipeline.PipelineLabelKey] = pr.Spec.PipelineRef.Name
 	case pr.Spec.PipelineSpec != nil:
-		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Name
+		pr.ObjectMeta.Labels[pipeline.GroupName+pipeline.PipelineLabelKey] = pr.Name
 	default:
 		return fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pr.Name)
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -208,6 +208,11 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, nil)
 	}
 
+	if err := propagatePipelineNameLabelToPipelineRun(pr); err != nil {
+		logger.Errorf("Failed to propagate pipeline name label to pipelinerun %s: %v", pr.Name, err)
+		return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
+	}
+
 	// If the pipelinerun is cancelled, cancel tasks and update status
 	if pr.IsCancelled() {
 		err := cancelPipelineRun(ctx, logger, pr, c.PipelineClientSet)
@@ -930,6 +935,21 @@ func getTaskrunAnnotations(pr *v1beta1.PipelineRun) map[string]string {
 		annotations[key] = val
 	}
 	return annotations
+}
+
+func propagatePipelineNameLabelToPipelineRun(pr *v1beta1.PipelineRun) error {
+	if pr.ObjectMeta.Labels == nil {
+		pr.ObjectMeta.Labels = make(map[string]string)
+	}
+	switch {
+	case pr.Spec.PipelineRef != nil && pr.Spec.PipelineRef.Name != "":
+		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Spec.PipelineRef.Name
+	case pr.Spec.PipelineSpec != nil:
+		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pr.Name
+	default:
+		return fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pr.Name)
+	}
+	return nil
 }
 
 func getTaskrunLabels(pr *v1beta1.PipelineRun, pipelineTaskName string, includePipelineLabels bool) map[string]string {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2555,9 +2555,14 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 			tb.PipelineRunStartTime(time.Now()),
 		),
 	)}
+	ps := []*v1beta1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
+		tb.PipelineTask("hello-world-1", "hello-world"),
+		tb.PipelineTask("hello-world-2", "hello-world"),
+	))}
 
 	d := test.Data{
 		PipelineRuns: prs,
+		Pipelines:    ps,
 	}
 
 	testAssets, cancel := getPipelineRunController(t, d)
@@ -2579,6 +2584,13 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 	reconciledRun, err := clients.Pipeline.TektonV1beta1().PipelineRuns("foo").Get(testAssets.Ctx, "test-pipeline-fails-to-cancel", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
+	}
+
+	if val, ok := reconciledRun.GetLabels()[pipeline.PipelineLabelKey]; !ok {
+		t.Fatalf("expected pipeline label")
+		if d := cmp.Diff("test-pipelines", val); d != "" {
+			t.Errorf("expected to see pipeline label. Diff %s", diff.PrintWantGot(d))
+		}
 	}
 
 	// The PipelineRun should not be cancelled b/c we couldn't cancel the TaskRun
@@ -2696,6 +2708,82 @@ func TestReconcilePropagateLabels(t *testing.T) {
 	actual := getTaskRunCreations(t, actions)[0]
 	if d := cmp.Diff(actual, expected); d != "" {
 		t.Errorf("expected to see TaskRun %v created. Diff %s", expected, diff.PrintWantGot(d))
+	}
+}
+
+func TestReconcilePropagateLabelsPending(t *testing.T) {
+	names.TestingSeed()
+	taskName := "hello-world-1"
+
+	ps := []*v1beta1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
+		tb.PipelineTask(taskName, "hello-world"),
+	))}
+	prs := []*v1beta1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-labels", tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunLabel("PipelineRunLabel", "PipelineRunValue"),
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccountName("test-sa"),
+			tb.PipelineRunPending,
+		),
+	)}
+	ts := []*v1beta1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+	}
+	prt := newPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	_, clients := prt.reconcileRun("foo", "test-pipeline-run-with-labels", []string{}, false)
+
+	reconciledRun, err := clients.Pipeline.TektonV1beta1().PipelineRuns("foo").Get(prt.TestAssets.Ctx, "test-pipeline-run-with-labels", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error when updating status: %v", err)
+	}
+
+	want := "test-pipeline"
+	got := reconciledRun.ObjectMeta.Labels["tekton.dev/pipeline"]
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("expected to see label %v created. Diff %s", want, diff.PrintWantGot(d))
+	}
+}
+
+func TestReconcilePropagateLabelsCancelled(t *testing.T) {
+	names.TestingSeed()
+	taskName := "hello-world-1"
+
+	ps := []*v1beta1.Pipeline{tb.Pipeline("test-pipeline", tb.PipelineNamespace("foo"), tb.PipelineSpec(
+		tb.PipelineTask(taskName, "hello-world"),
+	))}
+	prs := []*v1beta1.PipelineRun{tb.PipelineRun("test-pipeline-run-with-labels", tb.PipelineRunNamespace("foo"),
+		tb.PipelineRunLabel("PipelineRunLabel", "PipelineRunValue"),
+		tb.PipelineRunSpec("test-pipeline",
+			tb.PipelineRunServiceAccountName("test-sa"),
+			tb.PipelineRunCancelled,
+		),
+	)}
+	ts := []*v1beta1.Task{tb.Task("hello-world", tb.TaskNamespace("foo"))}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+	}
+	prt := newPipelineRunTest(d, t)
+	defer prt.Cancel()
+
+	_, clients := prt.reconcileRun("foo", "test-pipeline-run-with-labels", []string{}, false)
+
+	reconciledRun, err := clients.Pipeline.TektonV1beta1().PipelineRuns("foo").Get(prt.TestAssets.Ctx, "test-pipeline-run-with-labels", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error when updating status: %v", err)
+	}
+
+	want := "test-pipeline"
+	got := reconciledRun.ObjectMeta.Labels["tekton.dev/pipeline"]
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("expected to see label %v created. Diff %s", want, diff.PrintWantGot(d))
 	}
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2586,7 +2586,7 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 		t.Fatalf("Somehow had error getting reconciled run out of fake client: %s", err)
 	}
 
-	if val, ok := reconciledRun.GetLabels()[pipeline.PipelineLabelKey]; !ok {
+	if val, ok := reconciledRun.GetLabels()[pipeline.GroupName+pipeline.PipelineLabelKey]; !ok {
 		t.Fatalf("expected pipeline label")
 		if d := cmp.Diff("test-pipelines", val); d != "" {
 			t.Errorf("expected to see pipeline label. Diff %s", diff.PrintWantGot(d))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cherry-pick https://github.com/tektoncd/pipeline/pull/4163 into v0.27.x branch in preparation for a v0.27.2 release on Monday.

The above fixes a bug where Pipelines created in Pending or Cancelled state wouldn't receive a `tekton.dev/pipeline = <pipelineName>` label, limiting the ability to filter for them.

Another commit was added to resolve a small skew in some publicly exported constants that have changed on `main` after the v0.27 branch was cut. Bringing the updated label constants over to 0.27 would be, I think, technically a breaking change - if someone were importing pipelines @ 0.27 into their codebase they'd need to update usage of these constants in their own code from one patch release to the next.  🤷 I don't know how likely this really is but I figure it doesn't hurt.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
