### PR TITLE
Switch from -Z to -w

### DIFF
--- a/test/pullrequest/e2e_test.go
+++ b/test/pullrequest/e2e_test.go
@@ -103,7 +103,7 @@ func TestPullRequest(t *testing.T) {
 			runPRBinary(t, "download", dir, tc.url)
 			// Diff downloaded contents with golden copies.
 			golden := filepath.Join("testdata", "golden")
-			if diff, err := exec.Command("diff", "-ruZ", golden, dir).CombinedOutput(); err != nil {
+			if diff, err := exec.Command("diff", "-ruw", golden, dir).CombinedOutput(); err != nil {
 				t.Error(string(diff))
 			}
 


### PR DESCRIPTION
The flag `-Z` (trailing space) is not available in all versions of `diff`, but `-w` (all space) is available.

When I run things on my macbook I hit:
```
e2e_test.go:107: diff: invalid option -- Z
diff: Try `diff --help' for more information.
```

Fixes: https://github.com/tektoncd/pipeline/issues/4177

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

/assign @vdemeester 
