### PR TITLE
Adjust several log lines

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -85,7 +85,6 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 			}
 		})
 
-		logger.Info("Setting up event handlers")
 		pipelineRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		taskRunInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -757,6 +757,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 			Type:   apis.ConditionSucceeded,
 			Status: corev1.ConditionUnknown,
 		})
+		logger.Infof("Updating taskrun %s with cleared status and retry history (length: %d).", tr.GetName(), len(tr.Status.RetriesStatus))
 		return c.PipelineClientSet.TektonV1beta1().TaskRuns(pr.Namespace).UpdateStatus(ctx, tr, metav1.UpdateOptions{})
 	}
 

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -83,7 +83,6 @@ func NewController(namespace string, images pipeline.Images) func(context.Contex
 			}
 		})
 
-		logger.Info("Setting up event handlers")
 		taskRunInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 		podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -367,7 +367,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	// and they have not been initialized yet.
 	// FIXME(afrittoli) This resource specific logic will have to be replaced
 	// once we have a custom PipelineResource framework in place.
-	logger.Infof("Cloud Events: %s", tr.Status.CloudEvents)
+	logger.Debugf("Cloud Events: %s", tr.Status.CloudEvents)
 	cloudevent.InitializeCloudEvents(tr, rtr.Outputs)
 
 	return taskSpec, rtr, nil


### PR DESCRIPTION
Drop two that provide nearly no value that have been copy/pasted around since the early days of Knative controllers.

Reduce the CloudEvents log statement to debug level.

Add a log statement to the path where PipelineRun updates the TaskRun status.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

cc @afrittoli (IIRC you care most about things touching CE)
