### PR TITLE
Add CE Client to dynamic injection

### DIFF
--- a/pkg/reconciler/events/cloudevent/cloudeventclient.go
+++ b/pkg/reconciler/events/cloudevent/cloudeventclient.go
@@ -27,13 +27,16 @@ import (
 )
 
 func init() {
-	injection.Default.RegisterClient(withCloudEventClient)
+	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context {
+		return withCloudEventClient(ctx)
+	})
+	injection.Dynamic.RegisterDynamicClient(withCloudEventClient)
 }
 
 // CECKey is used to associate the CloudEventClient inside the context.Context
 type CECKey struct{}
 
-func withCloudEventClient(ctx context.Context, cfg *rest.Config) context.Context {
+func withCloudEventClient(ctx context.Context) context.Context {
 	logger := logging.FromContext(ctx)
 
 	// When KeepAlive is enabled the connections are not reused - see


### PR DESCRIPTION
I noticed log statements experimenting with using the dynamic injection logic with Tekton.  Since it seems like the CE stuff is just piggybacking on injection (and not actually using the `rest.Config`) this should be a pretty trivial/benign change.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

/assign @afrittoli 