### PR TITLE
Deduplicate timeout constants.

### DIFF
--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -86,7 +86,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				}
 
 				t.Logf("Waiting for Pipelinerun %s in namespace %s to be started", pipelineRun.Name, namespace)
-				if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
+				if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, Running(pipelineRun.Name), "PipelineRunRunning"); err != nil {
 					t.Fatalf("Error waiting for PipelineRun %s to be running: %s", pipelineRun.Name, err)
 				}
 
@@ -133,7 +133,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 				}
 				expectedCondition := FailedWithReason(expectedReason, pipelineRun.Name)
 				t.Logf("Waiting for PipelineRun %s in namespace %s to be cancelled", pipelineRun.Name, namespace)
-				if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, expectedCondition, expectedReason); err != nil {
+				if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, expectedCondition, expectedReason); err != nil {
 					t.Errorf("Error waiting for PipelineRun %q to finished: %s", pipelineRun.Name, err)
 				}
 

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -199,7 +199,7 @@ func TestDAGPipelineRun(t *testing.T) {
 		t.Fatalf("Failed to create dag-pipeline-run PipelineRun: %s", err)
 	}
 	t.Logf("Waiting for DAG pipeline to complete")
-	if err := WaitForPipelineRunState(ctx, c, "dag-pipeline-run", pipelineRunTimeout, PipelineRunSucceed("dag-pipeline-run"), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, "dag-pipeline-run", timeout, PipelineRunSucceed("dag-pipeline-run"), "PipelineRunSuccess"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish: %s", err)
 	}
 

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -29,13 +29,10 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
 )
-
-const pipelineRunTimeout = 10 * time.Minute
 
 var (
 	defaultKoDockerRepoRE = regexp.MustCompile("gcr.io/christiewilson-catfactory")
@@ -54,7 +51,7 @@ func getCreatedTektonCRD(input []byte, kind string) (string, error) {
 }
 
 func waitValidatePipelineRunDone(ctx context.Context, t *testing.T, c *clients, pipelineRunName string) {
-	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, pipelineRunTimeout, Succeed(pipelineRunName), pipelineRunName); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRunName, timeout, Succeed(pipelineRunName), pipelineRunName); err != nil {
 		t.Fatalf("Failed waiting for pipeline run done: %v", err)
 	}
 }

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -72,7 +72,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, FailedWithReason(pipelinerun.ReasonInvalidTaskResultReference, pipelineRun.Name), "InvalidTaskResultReference"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, FailedWithReason(pipelinerun.ReasonInvalidTaskResultReference, pipelineRun.Name), "InvalidTaskResultReference"); err != nil {
 		t.Errorf("Error waiting for PipelineRun to fail: %s", err)
 	}
 

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -44,14 +44,13 @@ import (
 )
 
 var (
-	pipelineName       = "pipeline"
-	pipelineRunName    = "pipelinerun"
-	secretName         = "secret"
-	saName             = "service-account"
-	taskName           = "task"
-	task1Name          = "task1"
-	cond1Name          = "cond-1"
-	pipelineRunTimeout = 10 * time.Minute
+	pipelineName    = "pipeline"
+	pipelineRunName = "pipelinerun"
+	secretName      = "secret"
+	saName          = "service-account"
+	taskName        = "task"
+	task1Name       = "task1"
+	cond1Name       = "cond-1"
 )
 
 func TestPipelineRun(t *testing.T) {
@@ -230,7 +229,7 @@ func TestPipelineRun(t *testing.T) {
 			}
 
 			t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-			if err := WaitForPipelineRunState(ctx, c, prName, pipelineRunTimeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+			if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
 				t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 			}
 
@@ -381,7 +380,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, pipelineRunTimeout, Running(prName), "PipelineRunRunning"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, Running(prName), "PipelineRunRunning"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
@@ -390,7 +389,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, pipelineRunTimeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 
@@ -450,7 +449,7 @@ func TestPipelineRunPending(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be marked pending", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, pipelineRunTimeout, PipelineRunPending(prName), "PipelineRunPending"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunPending(prName), "PipelineRunPending"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to be marked pending: %s", prName, err)
 	}
 
@@ -472,7 +471,7 @@ func TestPipelineRunPending(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", prName, namespace)
-	if err := WaitForPipelineRunState(ctx, c, prName, pipelineRunTimeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, prName, timeout, PipelineRunSucceed(prName), "PipelineRunSuccess"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", prName, err)
 	}
 }

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -174,7 +174,7 @@ func TestPipelineRunWithServiceAccounts(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 
@@ -284,7 +284,7 @@ func TestPipelineRunWithServiceAccountNameAndTaskRunSpec(t *testing.T) {
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to complete", pipelineRun.Name, namespace)
-	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun %s to finish: %s", pipelineRun.Name, err)
 	}
 

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -90,7 +90,7 @@ spec:
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, "pear", pipelineRunTimeout, PipelineRunFailed("pear"), "BuildValidationFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, "pear", timeout, PipelineRunFailed("pear"), "BuildValidationFailed"); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 }


### PR DESCRIPTION
Trying to set up a "downstream test" for Tekton (to detect when knative.dev/pkg changed break Tekton), I noticed that Tekton had a duplicate constant `pipelineRunTimeout`, which is a problem when a build is run with both Go tags).

When I went to combine/move this into `wait.go` (no build tag) I noticed there was already a `timeout` constant with an identical value.  So I simply removed both constants and changed the uses of the old constant to `timeout`.

With this change, and another to our downstream-test action, I will hopefully be able to add the check I want on knative.dev/pkg.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
