### PR TITLE
Improve the logging in pkg/git testing

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -211,6 +211,11 @@ func TestFetch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			observer, log := observer.New(zap.InfoLevel)
+			defer func() {
+				for _, line := range log.TakeAll() {
+					t.Logf("[%q git]: %s", line.Level, line.Message)
+				}
+			}()
 			logger := zap.New(observer).Sugar()
 
 			gitDir, cleanup := createTempDir(t)
@@ -248,11 +253,11 @@ func TestFetch(t *testing.T) {
 			}
 
 			if tt.logMessage != "" {
-				takeAll := log.TakeAll()
-				if len(takeAll) == 0 {
+				allLogLines := log.All()
+				if len(allLogLines) == 0 {
 					t.Fatal("We didn't receive any logging")
 				}
-				gotmsg := takeAll[0].Message
+				gotmsg := allLogLines[0].Message
 				if !strings.Contains(gotmsg, tt.logMessage) {
 					t.Errorf("log message: '%s'\n should contains: '%s'", tt.logMessage, gotmsg)
 				}


### PR DESCRIPTION
Currently the "fetch" testing nicely captures logs (to examine output), but doesn't actually surface them on failures.

This change adds a `defer`red function that stream the output to `t.Log` so that `git` failures can be debugged.

For example, when I introduce a typo into the "commit" command, it now prints:

```
=== RUN   TestFetch/test-clone-with-sparse-checkout
    git_test.go:299: exit status 1
    git_test.go:216: ["error" git]: Error running git [codmmit --allow-empty -m Hello Moto]: exit status 1
        git: 'codmmit' is not a git command. See 'git --help'.

        The most similar command is
                commit
```

Previously, this would only print the exit status, which isn't particularly useful.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
