### PR TITLE
Configure `user.name` in `git_test.go` `run` method.

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -295,6 +295,11 @@ func createTempGit(t *testing.T, logger *zap.SugaredLogger, gitDir string) {
 		t.Fatal(err)
 	}
 
+	// Not defining globally so we don't mess with the global gitconfig
+	if _, err := run(logger, "", "config", "user.name", "Tekton Test"); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := run(logger, "", "commit", "--allow-empty", "-m", "Hello Moto"); err != nil {
 		t.Fatal(err.Error())
 	}


### PR DESCRIPTION
In my work to add downstream testing to `knative.dev/pkg` this test is failing with:

```
        git_test.go:216: ["error" git]: Error running git [commit --allow-empty -m Hello Moto]: exit status 128
            Author identity unknown

            *** Please tell me who you are.

            Run

              git config --global user.email "you@example.com"
              git config --global user.name "Your Name"

            to set your account's default identity.
            Omit --global to set the identity only in this repository.

            fatal: empty ident name (for <tester@tekton.dev>) not allowed
```

Ref: https://github.com/knative/pkg/pull/2233/checks?check_run_id=3423565615#step:6:528

Tekton already configures `user.email`, but it seems to reject this on Actions without `user.name` as well.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
