### PR TITLE
Add doc links for 0.27.2 and 0.27.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ a cluster with **Kubernetes version 1.19 or later***.
 | Version | Docs | Examples |
 | ------- | ---- | -------- |
 | [HEAD](DEVELOPMENT.md#install-pipeline) | [Docs @ HEAD](/docs/README.md) | [Examples @ HEAD](/examples) |
+| [v0.27.3](https://github.com/tektoncd/pipeline/releases/tag/v0.27.3) | [Docs @ v0.27.3](https://github.com/tektoncd/pipeline/tree/v0.27.3/docs#tekton-pipelines) | [Examples @ v0.27.3](https://github.com/tektoncd/pipeline/tree/v0.27.3/examples#examples) |
+| [v0.27.2](https://github.com/tektoncd/pipeline/releases/tag/v0.27.2) | [Docs @ v0.27.2](https://github.com/tektoncd/pipeline/tree/v0.27.2/docs#tekton-pipelines) | [Examples @ v0.27.2](https://github.com/tektoncd/pipeline/tree/v0.27.2/examples#examples) |
 | [v0.27.1](https://github.com/tektoncd/pipeline/releases/tag/v0.27.1) | [Docs @ v0.27.1](https://github.com/tektoncd/pipeline/tree/v0.27.1/docs#tekton-pipelines) | [Examples @ v0.27.1](https://github.com/tektoncd/pipeline/tree/v0.27.1/examples#examples) |
 | [v0.27.0](https://github.com/tektoncd/pipeline/releases/tag/v0.27.0) | [Docs @ v0.27.0](https://github.com/tektoncd/pipeline/tree/v0.27.0/docs#tekton-pipelines) | [Examples @ v0.27.0](https://github.com/tektoncd/pipeline/tree/v0.27.0/examples#examples) |
 | [v0.26.0](https://github.com/tektoncd/pipeline/releases/tag/v0.26.0) | [Docs @ v0.26.0](https://github.com/tektoncd/pipeline/tree/v0.26.0/docs#tekton-pipelines) | [Examples @ v0.26.0](https://github.com/tektoncd/pipeline/tree/v0.26.0/examples#examples) |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

We released 0.27.3 today, so we need the doc links added to the README.md doc.

I forgot to make this equivalent PR for 0.27.2 so I'm adding links for both
.2 and .3 as part of this commit.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

/kind documentation