### PR TITLE
Adjust the way `{pipeline,task}run` metrics are surfaced.

### DIFF
--- a/pkg/pipelinerunmetrics/fake/fake.go
+++ b/pkg/pipelinerunmetrics/fake/fake.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	_ "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun/fake" // Make sure the fake pipelinerun informer is setup
+	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/injection"
+)
+
+func init() {
+	injection.Fake.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return pipelinerunmetrics.WithClient(ctx) })
+	injection.Fake.RegisterInformer(pipelinerunmetrics.WithInformer)
+}

--- a/pkg/pipelinerunmetrics/injection.go
+++ b/pkg/pipelinerunmetrics/injection.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerunmetrics
+
+import (
+	"context"
+
+	pipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return WithClient(ctx) })
+	injection.Default.RegisterInformer(WithInformer)
+
+	injection.Dynamic.RegisterDynamicClient(WithClient)
+	injection.Dynamic.RegisterDynamicInformer(func(ctx context.Context) context.Context {
+		ctx, _ = WithInformer(ctx)
+		return ctx
+	})
+}
+
+// RecorderKey is used for associating the Recorder inside the context.Context.
+type RecorderKey struct{}
+
+func WithClient(ctx context.Context) context.Context {
+	rec, err := NewRecorder()
+	if err != nil {
+		logging.FromContext(ctx).Errorf("Failed to create pipelinerun metrics recorder %v", err)
+	}
+	return context.WithValue(ctx, RecorderKey{}, rec)
+}
+
+// Get extracts the pipelinerunmetrics.Recorder from the context.
+func Get(ctx context.Context) *Recorder {
+	untyped := ctx.Value(RecorderKey{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panic("Unable to fetch *pipelinerunmetrics.Recorder from context.")
+	}
+	return untyped.(*Recorder)
+}
+
+// InformerKey is used for associating the Informer inside the context.Context.
+type InformerKey struct{}
+
+func WithInformer(ctx context.Context) (context.Context, controller.Informer) {
+	return ctx, &recorderInformer{
+		ctx:     ctx,
+		metrics: Get(ctx),
+		lister:  pipelineruninformer.Get(ctx).Lister(),
+	}
+}
+
+type recorderInformer struct {
+	ctx     context.Context
+	metrics *Recorder
+	lister  listers.PipelineRunLister
+}
+
+var _ controller.Informer = (*recorderInformer)(nil)
+
+func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
+	// Turn the stopCh into a context for reporting metrics.
+	ctx, cancel := context.WithCancel(ri.ctx)
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	go ri.metrics.ReportRunningPipelineRuns(ctx, ri.lister)
+}
+
+func (ri *recorderInformer) HasSynced() bool {
+	return true
+}

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pipelinerun
+package pipelinerunmetrics
 
 import (
 	"context"
@@ -47,6 +47,13 @@ var (
 	runningPRsCount = stats.Float64("running_pipelineruns_count",
 		"Number of pipelineruns executing currently",
 		stats.UnitDimensionless)
+)
+
+const (
+	// ReasonCancelled indicates that a PipelineRun was cancelled.
+	ReasonCancelled = "Cancelled"
+	// Deprecated: "PipelineRunCancelled" indicates that a PipelineRun was cancelled.
+	ReasonCancelledDeprecated = "PipelineRunCancelled"
 )
 
 // Recorder holds keys for Tekton metrics

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package pipelinerun
+package pipelinerunmetrics
 
 import (
 	"testing"

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -39,6 +39,7 @@ import (
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	resourcelisters "github.com/tektoncd/pipeline/pkg/client/resource/listers/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/contexts"
+	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
@@ -97,9 +98,9 @@ const (
 	// associated Pipeline is an invalid graph (a.k.a wrong order, cycle, …)
 	ReasonInvalidGraph = "PipelineInvalidGraph"
 	// ReasonCancelled indicates that a PipelineRun was cancelled.
-	ReasonCancelled = "Cancelled"
+	ReasonCancelled = pipelinerunmetrics.ReasonCancelled
 	// Deprecated: "PipelineRunCancelled" indicates that a PipelineRun was cancelled.
-	ReasonCancelledDeprecated = "PipelineRunCancelled"
+	ReasonCancelledDeprecated = pipelinerunmetrics.ReasonCancelledDeprecated
 	// ReasonPending indicates that a PipelineRun is pending.
 	ReasonPending = "PipelineRunPending"
 	// ReasonCouldntCancel indicates that a PipelineRun was cancelled but attempting to update
@@ -129,7 +130,7 @@ type Reconciler struct {
 	resourceLister    resourcelisters.PipelineResourceLister
 	conditionLister   listersv1alpha1.ConditionLister
 	cloudEventClient  cloudevent.CEClient
-	metrics           *Recorder
+	metrics           *pipelinerunmetrics.Recorder
 	pvcHandler        volumeclaim.PvcHandler
 }
 
@@ -197,7 +198,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, pr *v1beta1.PipelineRun)
 			logger.Errorf("Failed to update Run status for PipelineRun %s: %v", pr.Name, err)
 			return c.finishReconcileUpdateEmitEvents(ctx, pr, before, err)
 		}
-		go func(metrics *Recorder) {
+		go func(metrics *pipelinerunmetrics.Recorder) {
 			err := metrics.DurationAndCount(pr)
 			if err != nil {
 				logger.Warnf("Failed to log the metrics : %v", err)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -45,6 +45,8 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
+	"github.com/tektoncd/pipeline/pkg/taskrunmetrics"
+	_ "github.com/tektoncd/pipeline/pkg/taskrunmetrics/fake" // Make sure the taskrunmetrics are setup
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,7 +72,7 @@ type Reconciler struct {
 	resourceLister    resourcelisters.PipelineResourceLister
 	cloudEventClient  cloudevent.CEClient
 	entrypointCache   podconvert.EntrypointCache
-	metrics           *Recorder
+	metrics           *taskrunmetrics.Recorder
 	pvcHandler        volumeclaim.PvcHandler
 }
 
@@ -128,7 +130,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1beta1.TaskRun) pkg
 			return err
 		}
 
-		go func(metrics *Recorder) {
+		go func(metrics *taskrunmetrics.Recorder) {
 			err := metrics.DurationAndCount(tr)
 			if err != nil {
 				logger.Warnf("Failed to log the metrics : %v", err)

--- a/pkg/taskrunmetrics/fake/fake.go
+++ b/pkg/taskrunmetrics/fake/fake.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+
+	_ "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun/fake" // Make sure the fake taskrun informer is setup
+	"github.com/tektoncd/pipeline/pkg/taskrunmetrics"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/injection"
+)
+
+func init() {
+	injection.Fake.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return taskrunmetrics.WithClient(ctx) })
+	injection.Fake.RegisterInformer(taskrunmetrics.WithInformer)
+}

--- a/pkg/taskrunmetrics/injection.go
+++ b/pkg/taskrunmetrics/injection.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package taskrunmetrics
+
+import (
+	"context"
+
+	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
+	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/logging"
+)
+
+func init() {
+	injection.Default.RegisterClient(func(ctx context.Context, _ *rest.Config) context.Context { return WithClient(ctx) })
+	injection.Default.RegisterInformer(WithInformer)
+
+	injection.Dynamic.RegisterDynamicClient(WithClient)
+	injection.Dynamic.RegisterDynamicInformer(func(ctx context.Context) context.Context {
+		ctx, _ = WithInformer(ctx)
+		return ctx
+	})
+}
+
+// RecorderKey is used for associating the Recorder inside the context.Context.
+type RecorderKey struct{}
+
+func WithClient(ctx context.Context) context.Context {
+	rec, err := NewRecorder()
+	if err != nil {
+		logging.FromContext(ctx).Errorf("Failed to create taskrun metrics recorder %v", err)
+	}
+	return context.WithValue(ctx, RecorderKey{}, rec)
+}
+
+// Get extracts the taskrunmetrics.Recorder from the context.
+func Get(ctx context.Context) *Recorder {
+	untyped := ctx.Value(RecorderKey{})
+	if untyped == nil {
+		logging.FromContext(ctx).Panic("Unable to fetch *taskrunmetrics.Recorder from context.")
+	}
+	return untyped.(*Recorder)
+}
+
+// InformerKey is used for associating the Informer inside the context.Context.
+type InformerKey struct{}
+
+func WithInformer(ctx context.Context) (context.Context, controller.Informer) {
+	return ctx, &recorderInformer{
+		ctx:     ctx,
+		metrics: Get(ctx),
+		lister:  taskruninformer.Get(ctx).Lister(),
+	}
+}
+
+type recorderInformer struct {
+	ctx     context.Context
+	metrics *Recorder
+	lister  listers.TaskRunLister
+}
+
+var _ controller.Informer = (*recorderInformer)(nil)
+
+func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
+	// Turn the stopCh into a context for reporting metrics.
+	ctx, cancel := context.WithCancel(ri.ctx)
+	go func() {
+		<-stopCh
+		cancel()
+	}()
+
+	go ri.metrics.ReportRunningTaskRuns(ctx, ri.lister)
+}
+
+func (ri *recorderInformer) HasSynced() bool {
+	return true
+}

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package taskrun
+package taskrunmetrics
 
 import (
 	"context"

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package taskrun
+package taskrunmetrics
 
 import (
 	"testing"


### PR DESCRIPTION
It's been bugging me that `NewController` methods for the `TaskRun` and `PipelineRun` controllers launch a go routine to harvest metrics, and it occurred to me that there might be a better way.

Borrowing from the CloudEvent client's use of hand-crafted injection logic: https://github.com/tektoncd/pipeline/blob/7297c48d26da98552be4ee3c50d94a130bd8e79d/pkg/reconciler/events/cloudevent/cloudeventclient.go#L29

This change takes a similar approach, creating `pkg/{task,pipeline}runmetrics` packages, which surface their `*Recorder` via `.Get(ctx)` methods.  Rather than the controller spinning off go routine, this piggybacks on informer injection to "Start()" that process after the dependent informers have been started.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

