### PR TITLE
Bump golangci-lint to v1.42.0 from v1.30.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TESTPKGS = $(shell env GO111MODULE=on $(GO) list -f \
 			$(PKGS))
 BIN      = $(CURDIR)/.bin
 
-GOLANGCI_VERSION = v1.30.0
+GOLANGCI_VERSION = v1.42.0
 GOSEC_VERSION    = v2.4.0
 
 GO           = go

--- a/pkg/apis/pipeline/v1beta1/version_validation.go
+++ b/pkg/apis/pipeline/v1beta1/version_validation.go
@@ -34,6 +34,5 @@ func ValidateEnabledAPIFields(ctx context.Context, featureName, wantVersion stri
 		message := fmt.Sprintf(`%s requires "enable-api-fields" feature gate to be %q but it is %q`, featureName, wantVersion, currentVersion)
 		return errs.Also(apis.ErrGeneric(message))
 	}
-	var errs *apis.FieldError = nil
-	return errs
+	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation.go
@@ -25,7 +25,7 @@ import (
 
 // allVolumeSourceFields is a list of all the volume source field paths that a
 // WorkspaceBinding may include.
-var allVolumeSourceFields []string = []string{
+var allVolumeSourceFields = []string{
 	"persistentvolumeclaim",
 	"volumeclaimtemplate",
 	"emptydir",

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -189,7 +189,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	// themselves their value takes precedence.
 	if len(implicitEnvVars) > 0 {
 		for i, s := range stepContainers {
-			env := append(implicitEnvVars, s.Env...)
+			env := append(implicitEnvVars, s.Env...) //nolint
 			stepContainers[i].Env = env
 		}
 	}
@@ -198,7 +198,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	if taskRun.Annotations[ExecutionModeAnnotation] == ExecutionModeHermetic && alphaAPIEnabled {
 		for i, s := range stepContainers {
 			// Add it at the end so it overrides
-			env := append(s.Env, corev1.EnvVar{Name: TektonHermeticEnvVar, Value: "1"})
+			env := append(s.Env, corev1.EnvVar{Name: TektonHermeticEnvVar, Value: "1"}) //nolint
 			stepContainers[i].Env = env
 		}
 	}
@@ -227,7 +227,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 				toAdd = append(toAdd, imp)
 			}
 		}
-		vms := append(s.VolumeMounts, toAdd...)
+		vms := append(s.VolumeMounts, toAdd...) //nolint
 		stepContainers[i].VolumeMounts = vms
 	}
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -1604,7 +1604,7 @@ _EOF_
 
 			overrideHomeEnv := false
 			if s, ok := c.featureFlags[featureFlagDisableHomeEnvKey]; ok {
-				var err error = nil
+				var err error
 				if overrideHomeEnv, err = strconv.ParseBool(s); err != nil {
 					t.Fatalf("error parsing bool from %s feature flag: %v", featureFlagDisableHomeEnvKey, err)
 				}
@@ -1762,7 +1762,7 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 
 			overrideHomeEnv := false
 			if s, ok := c.featureFlags[featureFlagDisableHomeEnvKey]; ok {
-				var err error = nil
+				var err error
 				if overrideHomeEnv, err = strconv.ParseBool(s); err != nil {
 					t.Fatalf("error parsing bool from %s feature flag: %v", featureFlagDisableHomeEnvKey, err)
 				}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1003,7 +1003,7 @@ func TestReconcile_InvalidPipelineRuns(t *testing.T) {
 			prt := newPipelineRunTest(d, t)
 			defer prt.Cancel()
 
-			wantEvents := append(tc.wantEvents, "Warning InternalError 1 error occurred")
+			wantEvents := append(tc.wantEvents, "Warning InternalError 1 error occurred") //nolint
 			reconciledRun, _ := prt.reconcileRun("foo", tc.pipelineRun.Name, wantEvents, tc.permanentError)
 
 			if reconciledRun.Status.CompletionTime == nil {


### PR DESCRIPTION
# Changes

Also fix the resulting lint errors, and a few of the resulting lint warnings.
One of the main linters we use (golint) is now deprecated. The replacement is known
as revive, and golangci-lint displays a warning about this now.

Unfortunately quite a few lint warnings appear during that update, so I'm doing it in a few pieces.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind cleanup

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
