### PR TITLE
Don't rely on condition ordering.

### DIFF
--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 )
@@ -195,7 +196,7 @@ func (r *Recorder) DurationAndCount(tr *v1beta1.TaskRun) error {
 	}
 
 	status := "success"
-	if tr.Status.Conditions[0].Status == corev1.ConditionFalse {
+	if cond := tr.Status.GetCondition(apis.ConditionSucceeded); cond.Status == corev1.ConditionFalse {
 		status = "failed"
 	}
 
@@ -332,7 +333,7 @@ func (r *Recorder) CloudEvents(tr *v1beta1.TaskRun) error {
 	}
 
 	status := "success"
-	if tr.Status.Conditions[0].Status == corev1.ConditionFalse {
+	if cond := tr.Status.GetCondition(apis.ConditionSucceeded); cond.Status == corev1.ConditionFalse {
 		status = "failed"
 	}
 


### PR DESCRIPTION
I noticed a few places in the metrics code that was relying on `Conditions[0]` to access the `Succeeded` condition.  Generally we try to sort the conditions to ensure determinism across reconciles, and our sorting generally puts the summary condition (Ready, Succeeded) first, but this is mostly for UX and not something the consuming code should rely upon.

While I think it's extremely unlikely that this behavior will change, I believe that the code is much more readable this way because it no longer assumes the reader knows about the sorting or has the expectation that the `Succeeded` condition is always first.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```