### PR TITLE
Switch the linter from golint to revive, and fix warnings.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,7 @@ linters:
   - goimports
   - gosec
   - gocritic
-  - golint
+  - revive
   - misspell
 output:
   uniq-by-line: false

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -133,7 +133,7 @@ func newConfigValidationController(ctx context.Context, cmw configmap.Watcher) *
 }
 
 func newConversionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	// nolint: golint
+	// nolint: revive
 	var (
 		v1alpha1GroupVersion = v1alpha1.SchemeGroupVersion.Version
 		v1beta1GroupVersion  = v1beta1.SchemeGroupVersion.Version

--- a/pkg/apis/pipeline/controller.go
+++ b/pkg/apis/pipeline/controller.go
@@ -18,7 +18,7 @@ package pipeline
 
 const (
 	// PipelineRunControllerName holds the name of the PipelineRun controller
-	// nolint: golint
+	// nolint: revive
 	PipelineRunControllerName = "PipelineRun"
 
 	// TaskRunControllerName holds the name of the TaskRun controller

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1alpha1
 
 import (

--- a/pkg/apis/pipeline/v1alpha1/condition_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation.go
@@ -52,8 +52,5 @@ func (cs *ConditionSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	if err := validateSteps([]Step{cs.Check}).ViaField("Check"); err != nil {
-		return err
-	}
-	return nil
+	return validateSteps([]Step{cs.Check}).ViaField("Check")
 }

--- a/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1alpha1
 
 import (

--- a/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_validation.go
@@ -175,11 +175,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	// Validate the pipeline's workspaces.
-	if err := validatePipelineWorkspaces(ps.Workspaces, ps.Tasks); err != nil {
-		return err
-	}
-
-	return nil
+	return validatePipelineWorkspaces(ps.Workspaces, ps.Tasks)
 }
 
 func validatePipelineTasks(ctx context.Context, tasks []PipelineTask) *apis.FieldError {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1alpha1
 
 import (

--- a/pkg/apis/pipeline/v1alpha1/run_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation.go
@@ -70,9 +70,5 @@ func (rs *RunSpec) Validate(ctx context.Context) *apis.FieldError {
 		return err
 	}
 
-	if err := validateWorkspaceBindings(ctx, rs.Workspaces); err != nil {
-		return err
-	}
-
-	return nil
+	return validateWorkspaceBindings(ctx, rs.Workspaces)
 }

--- a/pkg/apis/pipeline/v1alpha1/task_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/task_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1alpha1
 
 import (

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -140,10 +140,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 		return err
 	}
 	// Deprecated
-	if err := validateResourceVariables(ts.Steps, ts.Inputs, ts.Outputs, ts.Resources); err != nil {
-		return err
-	}
-	return nil
+	return validateResourceVariables(ts.Steps, ts.Inputs, ts.Outputs, ts.Resources)
 }
 
 // validateDeclaredWorkspaces will make sure that the declared workspaces do not try to use

--- a/pkg/apis/pipeline/v1alpha1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1alpha1
 
 import (

--- a/pkg/apis/pipeline/v1beta1/cluster_task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1beta1
 
 import (

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1beta1
 
 import (

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1beta1
 
 import (

--- a/pkg/apis/pipeline/v1beta1/resource_types_validation.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_validation.go
@@ -67,10 +67,7 @@ func (tr *TaskRunResources) Validate(ctx context.Context) *apis.FieldError {
 	if err := validateTaskRunResources(ctx, tr.Inputs, "spec.resources.inputs.name"); err != nil {
 		return err
 	}
-	if err := validateTaskRunResources(ctx, tr.Outputs, "spec.resources.outputs.name"); err != nil {
-		return err
-	}
-	return nil
+	return validateTaskRunResources(ctx, tr.Outputs, "spec.resources.outputs.name")
 }
 
 // validateTaskRunResources validates that

--- a/pkg/apis/pipeline/v1beta1/task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1beta1
 
 import (

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: golint
+// nolint: revive
 package v1beta1
 
 import (

--- a/pkg/pullrequest/disk.go
+++ b/pkg/pullrequest/disk.go
@@ -96,11 +96,7 @@ func ToDisk(r *Resource, path string) error {
 	if err := refToDisk("head", path, r.PR.Head); err != nil {
 		return err
 	}
-	if err := refToDisk("base", path, r.PR.Base); err != nil {
-		return err
-	}
-
-	return nil
+	return refToDisk("base", path, r.PR.Base)
 }
 
 func commentsToDisk(path string, comments []*scm.Comment) error {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -174,7 +174,7 @@ func ApplyTaskResultsToPipelineResults(
 		customTaskStatuses[runStatus.PipelineTaskName] = runStatus
 	}
 
-	var runResults []v1beta1.PipelineRunResult = nil
+	var runResults []v1beta1.PipelineRunResult
 	stringReplacements := map[string]string{}
 	for _, pipelineResult := range results {
 		variablesInPipelineResult, _ := v1beta1.GetVarSubstitutionExpressionsForPipelineResult(pipelineResult)

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -61,10 +61,7 @@ func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
 	if _, err = f.Write(jsonOutput); err != nil {
 		return err
 	}
-	if err := f.Sync(); err != nil {
-		return err
-	}
-	return nil
+	return f.Sync()
 }
 
 // MessageLengthError indicate the length of termination message of container is beyond 4096 which is the max length read by kubenates

--- a/test/controller.go
+++ b/test/controller.go
@@ -154,7 +154,7 @@ func AddToInformer(t *testing.T, store cache.Store) func(ktesting.Action) (bool,
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-// nolint: golint
+// nolint: revive
 func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
 	c := Clients{
 		Kube:        fakekubeclient.Get(ctx),

--- a/test/v1alpha1/controller.go
+++ b/test/v1alpha1/controller.go
@@ -85,7 +85,7 @@ type Assets struct {
 
 // SeedTestData returns Clients and Informers populated with the
 // given Data.
-// nolint: golint
+// nolint: revive
 func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers) {
 	c := Clients{
 		Kube:     fakekubeclient.Get(ctx),


### PR DESCRIPTION
# Changes

This finishes up the switch from the deprecated golint to
revive, which is the replacement. This was started in #4206.

This consisted of one new lint warning, and switching some
suppressions to revive from golint.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
