### PR TITLE
Support activeDeadlineSeconds for Tekton pods 🦌

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -59,6 +59,8 @@ var (
 	featureFlagDisableWorkingDirKey          = "disable-working-directory-overwrite"
 	featureFlagSetReadyAnnotationOnPodCreate = "enable-ready-annotation-on-pod-create"
 
+	defaultActiveDeadlineSeconds = int64(config.DefaultTimeoutMinutes * 60 * deadlineFactor)
+
 	fakeVersion string
 )
 
@@ -141,6 +143,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "simple with breakpoint onFailure enabled, alpha api fields disabled",
@@ -190,6 +193,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "simple with running-in-environment-with-injected-sidecar set to false",
@@ -237,6 +241,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 		wantAnnotations: map[string]string{
 			readyAnnotation: readyAnnotationValue,
@@ -293,6 +298,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "with service account",
@@ -348,6 +354,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "with-pod-template",
@@ -423,8 +430,9 @@ func TestPodBuild(t *testing.T) {
 				Nameservers: []string{"8.8.8.8"},
 				Searches:    []string{"tekton.local"},
 			},
-			EnableServiceLinks: &enableServiceLinks,
-			PriorityClassName:  priorityClassName,
+			EnableServiceLinks:    &enableServiceLinks,
+			PriorityClassName:     priorityClassName,
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "very long step name",
@@ -469,6 +477,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "step name ends with non alphanumeric",
@@ -513,6 +522,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "workingDir in workspace",
@@ -569,6 +579,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "sidecar container",
@@ -626,6 +637,7 @@ func TestPodBuild(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "sidecar container with script",
@@ -701,6 +713,7 @@ _EOF_
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "sidecar container with enable-ready-annotation-on-pod-create",
@@ -761,6 +774,7 @@ _EOF_
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "resource request",
@@ -859,6 +873,7 @@ _EOF_
 				Name:         "tekton-creds-init-home-1",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "step with script and stepTemplate",
@@ -1010,6 +1025,7 @@ _EOF_
 				Name:         "tekton-creds-init-home-2",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "step with script that uses two dollar signs",
@@ -1068,6 +1084,7 @@ _EOF_
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "using another scheduler",
@@ -1122,6 +1139,7 @@ _EOF_
 				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 				TerminationMessagePath: "/tekton/termination",
 			}},
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}, {
 		desc: "setting image pull secret",
@@ -1175,7 +1193,8 @@ _EOF_
 				Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			ImagePullSecrets: []corev1.LocalObjectReference{{Name: "imageSecret"}},
+			ImagePullSecrets:      []corev1.LocalObjectReference{{Name: "imageSecret"}},
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		}},
 		{
 			desc: "setting host aliases",
@@ -1230,7 +1249,8 @@ _EOF_
 					Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 					TerminationMessagePath: "/tekton/termination",
 				}},
-				HostAliases: []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"foo.bar"}}},
+				HostAliases:           []corev1.HostAlias{{IP: "127.0.0.1", Hostnames: []string{"foo.bar"}}},
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			}}, {
 			desc: "using hostNetwork",
 			ts: v1beta1.TaskSpec{
@@ -1284,6 +1304,7 @@ _EOF_
 					Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 					TerminationMessagePath: "/tekton/termination",
 				}},
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}, {
 			desc: "with a propagated Affinity Assistant name - expect proper affinity",
@@ -1352,6 +1373,7 @@ _EOF_
 					Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 					TerminationMessagePath: "/tekton/termination",
 				}},
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}, {
 			desc: "step-with-timeout",
@@ -1400,6 +1422,7 @@ _EOF_
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}, {
 			desc: "task-with-creds-init-disabled",
@@ -1440,7 +1463,8 @@ _EOF_
 					Resources:              corev1.ResourceRequirements{Requests: allZeroQty()},
 					TerminationMessagePath: "/tekton/termination",
 				}},
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume),
+				Volumes:               append(implicitVolumes, toolsVolume, downwardVolume),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}, {
 			desc:         "hermetic env var",
@@ -1492,6 +1516,7 @@ _EOF_
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}, {
 			desc:         "override hermetic env var",
@@ -1546,6 +1571,7 @@ _EOF_
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
+				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}} {
 		t.Run(c.desc, func(t *testing.T) {
@@ -1651,7 +1677,6 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		trs             v1beta1.TaskRunSpec
 		trAnnotation    map[string]string
 		ts              v1beta1.TaskSpec
-		featureFlags    map[string]string
 		overrideHomeEnv *bool
 		want            *corev1.PodSpec
 		wantAnnotations map[string]string
@@ -1704,15 +1729,19 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
+			ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
+			featureFlags := map[string]string{
+				"enable-api-fields": "alpha",
+			}
 			names.TestingSeed()
 			store := config.NewStore(logtesting.TestLogger(t))
 			store.OnConfigChanged(
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-					Data:       c.featureFlags,
+					Data:       featureFlags,
 				},
 			)
 			kubeclient := fakek8s.NewSimpleClientset(
@@ -1759,29 +1788,13 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 
 			// No entrypoints should be looked up.
 			entrypointCache := fakeCache{}
-
-			overrideHomeEnv := false
-			if s, ok := c.featureFlags[featureFlagDisableHomeEnvKey]; ok {
-				var err error
-				if overrideHomeEnv, err = strconv.ParseBool(s); err != nil {
-					t.Fatalf("error parsing bool from %s feature flag: %v", featureFlagDisableHomeEnvKey, err)
-				}
-			}
 			builder := Builder{
 				Images:          images,
 				KubeClient:      kubeclient,
 				EntrypointCache: entrypointCache,
-				OverrideHomeEnv: overrideHomeEnv,
 			}
 
-			featureFlags, _ := config.NewFeatureFlagsFromMap(map[string]string{
-				"enable-api-fields": "alpha",
-			})
-			cfg := &config.Config{
-				FeatureFlags: featureFlags,
-			}
-			ctx := config.ToContext(context.Background(), cfg)
-			got, err := builder.Build(ctx, tr, c.ts)
+			got, err := builder.Build(store.ToContext(context.Background()), tr, c.ts)
 			if err != nil {
 				t.Fatalf("builder.Build: %v", err)
 			}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -76,8 +76,9 @@ const (
 )
 
 var (
-	namespace = "" // all namespaces
-	images    = pipeline.Images{
+	namespace                    = "" // all namespaces
+	defaultActiveDeadlineSeconds = int64(config.DefaultTimeoutMinutes * 60 * 1.5)
+	images                       = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",
 		NopImage:                 "override-with-nop:latest",
 		GitImage:                 "override-with-git:latest",
@@ -428,6 +429,10 @@ func eventFromChannelUnordered(c chan string, wantEvents []string) error {
 	return fmt.Errorf("too many events received")
 }
 
+func withActiveDeadlineSeconds(spec *corev1.PodSpec) {
+	spec.ActiveDeadlineSeconds = &defaultActiveDeadlineSeconds
+}
+
 func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 	taskRunSuccess := tb.TaskRun("test-taskrun-run-success", tb.TaskRunNamespace("foo"), tb.TaskRunSpec(
 		tb.TaskRunTaskRef(simpleTask.Name, tb.TaskRefAPIVersion("a1")),
@@ -468,6 +473,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(defaultSAName),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -501,6 +507,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 					tb.VolumeMount("tekton-internal-steps", "/tekton/steps"),
 					tb.TerminationMessagePath("/tekton/termination"),
 				),
+				withActiveDeadlineSeconds,
 			),
 		),
 	}, {
@@ -515,6 +522,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-sa-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName("test-sa"),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -652,6 +660,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-home-env",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -686,6 +695,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 					tb.VolumeMount("tekton-internal-steps", "/tekton/steps"),
 					tb.TerminationMessagePath("/tekton/termination"),
 				),
+				withActiveDeadlineSeconds,
 			),
 		),
 	}, {
@@ -701,6 +711,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-working-dir",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -734,6 +745,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 					tb.VolumeMount("tekton-internal-steps", "/tekton/steps"),
 					tb.TerminationMessagePath("/tekton/termination"),
 				),
+				withActiveDeadlineSeconds,
 			),
 		),
 	}} {
@@ -1054,6 +1066,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1105,6 +1118,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-sa-run-success",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName("test-sa"),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1156,6 +1170,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-substitution",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(
 					workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
@@ -1339,6 +1354,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-taskspec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1423,6 +1439,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-cluster-task",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1473,6 +1490,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-resource-spec",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1557,6 +1575,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-pod",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1606,6 +1625,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-with-credentials-variable",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -1657,6 +1677,7 @@ func TestReconcile(t *testing.T) {
 			tb.PodOwnerReference("TaskRun", "test-taskrun-bundle",
 				tb.OwnerReferenceAPIVersion(currentAPIVersion)),
 			tb.PodSpec(
+				withActiveDeadlineSeconds,
 				tb.PodServiceAccountName(config.DefaultServiceAccountValue),
 				tb.PodVolumes(workspaceVolume, homeVolume, resultsVolume, stepsVolume, toolsVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Kubernetes (and OpenShift) mark `Pod` as either Terminating — has a
"relatively" short life and will terminate at some point — and
NonTerminating — is supposed to run for ever. Kubernetes does the
difference between the two using the `ActiveDeadlineSeconds` field. A
`Pod` with `activeDeadlineSeconds` set will be considered as
Terminating. For example, `Job`'s `Pod` have this field set and are
considered as Terminated.

Currently the pods created by tekton fall under the NonTerminating
quota limits of Kubernetes and OpenShift. This can create issues as
generally builds should fall under the separate terminating quota
limits.

This sets the `activeDeadlineSeconds` field or TaskRun's `Pod` so that
they are considered Terminating. It also sets the value of this field
to a higher value than the specified (or default) Timeout set on the
TaskRun so that Kubernetes won't try to terminate the `Pod` before
Pipeline does.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature
/cc @sbwsg @bobcatfish @mattmoor @pritidesai @jerop 

Tentatively adding the 0.28 milestone 🙃 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Set `activeDeadlineSeconds` on Tekton's Pod so that they are considered Terminating for Kubernetes. 
This helps supporting ResourceQuota a bit better as now Tekton Pipeline's pod are considered terminating and thus can be using a specific scoped ResourceQuota for those.
```
