### PR TITLE
Fix Concurrency issue in the metrics

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -281,9 +281,6 @@ func (r *Recorder) RunningPipelineRuns(lister listers.PipelineRunLister) error {
 // ReportRunningPipelineRuns invokes RunningPipelineRuns on our configured PeriodSeconds
 // until the context is cancelled.
 func (r *Recorder) ReportRunningPipelineRuns(ctx context.Context, lister listers.PipelineRunLister) {
-	r.mutex.Lock()
-	r.mutex.Unlock()
-
 	logger := logging.FromContext(ctx)
 
 	for {

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -367,9 +367,6 @@ func (r *Recorder) RunningTaskRuns(lister listers.TaskRunLister) error {
 // ReportRunningTaskRuns invokes RunningTaskRuns on our configured PeriodSeconds
 // until the context is cancelled.
 func (r *Recorder) ReportRunningTaskRuns(ctx context.Context, lister listers.TaskRunLister) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-
 	logger := logging.FromContext(ctx)
 	for {
 		select {


### PR DESCRIPTION
A double locking was happening in recorder mutex which was creating
unexpected behavior. Lock needs to be done only in the function that
calls opencensus stats recorder.  ReportRunningPipelineRuns and 
ReportRunningTaskRuns calls RunningPipelineRuns and RunningTaskRuns 
respectively which in turns lock the recorder.
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
