### PR TITLE
Document Pipeline's use of Pod termination messages

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -628,3 +628,19 @@ cat /tekton/steps/step-unnamed-<step-index>/exitCode
 
 Or, you can access the step metadata directory via symlink, for example, use `cat /tekton/steps/0/exitCode` for the
 first step in a task.
+
+## TaskRun Use of Pod Termination Messages
+
+Tekton Pipelines uses a `Pod's` [termination
+message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/)
+to pass data from a Step's container to the Pipelines controller.
+Examples of this data include: the time that execution of the user's
+step began, contents of task results, contents of pipeline resource
+results.
+
+The contents and format of the termination message can change. At time
+of writing the message takes the form of a serialized JSON blob. Some of
+the data from the message is internal to Tekton Pipelines, used for
+book-keeping, and some is distributed across a number of fields of the
+`TaskRun's` `status`. For example, a `TaskRun's` `status.taskResults` is
+populated from the termination message.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit we primarily documented use of termination messages
through a lens of Task Results, but the mechanism is used more broadly
than this.

This commit adds notes to our developer docs explaining use of pod termination
messages, giving examples of the data included, how the data is distributed to
other parts of the Pipelines machinery and describing the lack of guarantees
around the message's content.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Our developer docs now include more details on how Tekton Pipelines uses Pod termination messages to communicate information between Task pods and the Tekton Pipelines controller.
```