### PR TITLE
Refactor the way the Pipelines controllers receive flags.

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -46,7 +46,19 @@ func main() {
 	disableHighAvailability := flag.Bool("disable-ha", false, "Whether to disable high-availability functionality for this component.  This flag will be deprecated "+
 		"and removed when we have promoted this feature to stable, so do not pass it without filing an "+
 		"issue upstream!")
-	fo := pipeline.NewFlagOptions(flag.CommandLine)
+
+	fo := &pipeline.Options{}
+	flag.StringVar(&fo.Images.EntrypointImage, "entrypoint-image", "", "The container image containing our entrypoint binary.")
+	flag.StringVar(&fo.Images.NopImage, "nop-image", "", "The container image used to stop sidecars")
+	flag.StringVar(&fo.Images.GitImage, "git-image", "", "The container image containing our Git binary.")
+	flag.StringVar(&fo.Images.KubeconfigWriterImage, "kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
+	flag.StringVar(&fo.Images.ShellImage, "shell-image", "", "The container image containing a shell")
+	flag.StringVar(&fo.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
+	flag.StringVar(&fo.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
+	flag.StringVar(&fo.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
+	flag.StringVar(&fo.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
+	flag.BoolVar(&fo.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
+		"Disable resolution of taskrun and pipelinerun refs by the taskrun and pipelinerun reconcilers.")
 
 	// This parses flags.
 	cfg := injection.ParseAndGetRESTConfigOrDie()

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -47,23 +47,23 @@ func main() {
 		"and removed when we have promoted this feature to stable, so do not pass it without filing an "+
 		"issue upstream!")
 
-	fo := &pipeline.Options{}
-	flag.StringVar(&fo.Images.EntrypointImage, "entrypoint-image", "", "The container image containing our entrypoint binary.")
-	flag.StringVar(&fo.Images.NopImage, "nop-image", "", "The container image used to stop sidecars")
-	flag.StringVar(&fo.Images.GitImage, "git-image", "", "The container image containing our Git binary.")
-	flag.StringVar(&fo.Images.KubeconfigWriterImage, "kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
-	flag.StringVar(&fo.Images.ShellImage, "shell-image", "", "The container image containing a shell")
-	flag.StringVar(&fo.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
-	flag.StringVar(&fo.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
-	flag.StringVar(&fo.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
-	flag.StringVar(&fo.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
-	flag.BoolVar(&fo.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
+	opts := &pipeline.Options{}
+	flag.StringVar(&opts.Images.EntrypointImage, "entrypoint-image", "", "The container image containing our entrypoint binary.")
+	flag.StringVar(&opts.Images.NopImage, "nop-image", "", "The container image used to stop sidecars")
+	flag.StringVar(&opts.Images.GitImage, "git-image", "", "The container image containing our Git binary.")
+	flag.StringVar(&opts.Images.KubeconfigWriterImage, "kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
+	flag.StringVar(&opts.Images.ShellImage, "shell-image", "", "The container image containing a shell")
+	flag.StringVar(&opts.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
+	flag.StringVar(&opts.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
+	flag.StringVar(&opts.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
+	flag.StringVar(&opts.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
+	flag.BoolVar(&opts.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
 		"Disable resolution of taskrun and pipelinerun refs by the taskrun and pipelinerun reconcilers.")
 
 	// This parses flags.
 	cfg := injection.ParseAndGetRESTConfigOrDie()
 
-	if err := fo.Images.Validate(); err != nil {
+	if err := opts.Images.Validate(); err != nil {
 		log.Fatal(err)
 	}
 	if cfg.QPS == 0 {
@@ -102,8 +102,8 @@ func main() {
 
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)
 	sharedmain.MainWithConfig(ctx, ControllerLogKey, cfg,
-		taskrun.NewController(fo),
-		pipelinerun.NewController(fo),
+		taskrun.NewController(opts),
+		pipelinerun.NewController(opts),
 	)
 }
 

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -17,9 +17,33 @@ limitations under the License.
 package pipeline
 
 import (
+	"flag"
 	"fmt"
 	"sort"
 )
+
+// FlagOptions holds options passed to the Tekton Pipeline controllers via command-line flags.
+type FlagOptions struct {
+	Images                        Images
+	ExperimentalDisableResolution bool
+}
+
+func NewFlagOptions(fs *flag.FlagSet) *FlagOptions {
+	fo := &FlagOptions{}
+	fs.StringVar(&fo.Images.EntrypointImage, "entrypoint-image", "", "The container image containing our entrypoint binary.")
+	fs.StringVar(&fo.Images.NopImage, "nop-image", "", "The container image used to stop sidecars")
+	fs.StringVar(&fo.Images.GitImage, "git-image", "", "The container image containing our Git binary.")
+	fs.StringVar(&fo.Images.KubeconfigWriterImage, "kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
+	fs.StringVar(&fo.Images.ShellImage, "shell-image", "", "The container image containing a shell")
+	fs.StringVar(&fo.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
+	fs.StringVar(&fo.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
+	fs.StringVar(&fo.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
+	fs.StringVar(&fo.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
+	fs.BoolVar(&fo.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
+		"Disable resolution of taskrun and pipelinerun refs by the taskrun and pipelinerun reconcilers.")
+
+	return fo
+}
 
 // Images holds the images reference for a number of container images used
 // across tektoncd pipelines.
@@ -52,15 +76,15 @@ func (i Images) Validate() error {
 	for _, f := range []struct {
 		v, name string
 	}{
-		{i.EntrypointImage, "entrypoint"},
-		{i.NopImage, "nop"},
-		{i.GitImage, "git"},
-		{i.KubeconfigWriterImage, "kubeconfig-writer"},
-		{i.ShellImage, "shell"},
-		{i.ShellImageWin, "windows-shell"},
-		{i.GsutilImage, "gsutil"},
-		{i.PRImage, "pr"},
-		{i.ImageDigestExporterImage, "imagedigest-exporter"},
+		{i.EntrypointImage, "entrypoint-image"},
+		{i.NopImage, "nop-image"},
+		{i.GitImage, "git-image"},
+		{i.KubeconfigWriterImage, "kubeconfig-writer-image"},
+		{i.ShellImage, "shell-image"},
+		{i.ShellImageWin, "shell-image-win"},
+		{i.GsutilImage, "gsutil-image"},
+		{i.PRImage, "pr-image"},
+		{i.ImageDigestExporterImage, "imagedigest-exporter-image"},
 	} {
 		if f.v == "" {
 			unset = append(unset, f.name)

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -21,13 +21,6 @@ import (
 	"sort"
 )
 
-// Options holds options passed to the Tekton Pipeline controllers
-// typically via command-line flags.
-type Options struct {
-	Images                        Images
-	ExperimentalDisableResolution bool
-}
-
 // Images holds the images reference for a number of container images used
 // across tektoncd pipelines.
 type Images struct {

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -17,32 +17,15 @@ limitations under the License.
 package pipeline
 
 import (
-	"flag"
 	"fmt"
 	"sort"
 )
 
-// FlagOptions holds options passed to the Tekton Pipeline controllers via command-line flags.
-type FlagOptions struct {
+// Options holds options passed to the Tekton Pipeline controllers
+// typically via command-line flags.
+type Options struct {
 	Images                        Images
 	ExperimentalDisableResolution bool
-}
-
-func NewFlagOptions(fs *flag.FlagSet) *FlagOptions {
-	fo := &FlagOptions{}
-	fs.StringVar(&fo.Images.EntrypointImage, "entrypoint-image", "", "The container image containing our entrypoint binary.")
-	fs.StringVar(&fo.Images.NopImage, "nop-image", "", "The container image used to stop sidecars")
-	fs.StringVar(&fo.Images.GitImage, "git-image", "", "The container image containing our Git binary.")
-	fs.StringVar(&fo.Images.KubeconfigWriterImage, "kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
-	fs.StringVar(&fo.Images.ShellImage, "shell-image", "", "The container image containing a shell")
-	fs.StringVar(&fo.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
-	fs.StringVar(&fo.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
-	fs.StringVar(&fo.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
-	fs.StringVar(&fo.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
-	fs.BoolVar(&fo.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
-		"Disable resolution of taskrun and pipelinerun refs by the taskrun and pipelinerun reconcilers.")
-
-	return fo
 }
 
 // Images holds the images reference for a number of container images used

--- a/pkg/apis/pipeline/images_test.go
+++ b/pkg/apis/pipeline/images_test.go
@@ -1,40 +1,45 @@
 package pipeline_test
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 )
 
 func TestValidate(t *testing.T) {
-	valid := pipeline.Images{
-		EntrypointImage:          "set",
-		NopImage:                 "set",
-		GitImage:                 "set",
-		KubeconfigWriterImage:    "set",
-		ShellImage:               "set",
-		ShellImageWin:            "set",
-		GsutilImage:              "set",
-		PRImage:                  "set",
-		ImageDigestExporterImage: "set",
-	}
-	if err := valid.Validate(); err != nil {
+	fs := flag.FlagSet{}
+	valid := pipeline.NewFlagOptions(&fs)
+	fs.Parse([]string{
+		"-entrypoint-image", "set",
+		"-nop-image", "set",
+		"-git-image", "set",
+		"-kubeconfig-writer-image", "set",
+		"-shell-image", "set",
+		"-shell-image-win", "set",
+		"-gsutil-image", "set",
+		"-pr-image", "set",
+		"-imagedigest-exporter-image", "set",
+	})
+	if err := valid.Images.Validate(); err != nil {
 		t.Errorf("valid Images returned error: %v", err)
 	}
 
-	invalid := pipeline.Images{
-		EntrypointImage:          "set",
-		NopImage:                 "set",
-		GitImage:                 "", // unset!
-		KubeconfigWriterImage:    "set",
-		ShellImage:               "", // unset!
-		ShellImageWin:            "set",
-		GsutilImage:              "set",
-		PRImage:                  "", // unset!
-		ImageDigestExporterImage: "set",
-	}
-	wantErr := "found unset image flags: [git pr shell]"
-	if err := invalid.Validate(); err == nil {
+	fs = flag.FlagSet{}
+	invalid := pipeline.NewFlagOptions(&fs)
+	fs.Parse([]string{
+		"-entrypoint-image", "set",
+		"-nop-image", "set",
+		// "-git-image", "unset",
+		"-kubeconfig-writer-image", "set",
+		// "-shell-image", "unset",
+		"-shell-image-win", "set",
+		"-gsutil-image", "set",
+		// "-pr-image", "unset",
+		"-imagedigest-exporter-image", "set",
+	})
+	wantErr := "found unset image flags: [git-image pr-image shell-image]"
+	if err := invalid.Images.Validate(); err == nil {
 		t.Error("invalid Images expected error, got nil")
 	} else if err.Error() != wantErr {
 		t.Errorf("Unexpected error message: got %q, want %q", err.Error(), wantErr)

--- a/pkg/apis/pipeline/images_test.go
+++ b/pkg/apis/pipeline/images_test.go
@@ -1,45 +1,40 @@
 package pipeline_test
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 )
 
 func TestValidate(t *testing.T) {
-	fs := flag.FlagSet{}
-	valid := pipeline.NewFlagOptions(&fs)
-	fs.Parse([]string{
-		"-entrypoint-image", "set",
-		"-nop-image", "set",
-		"-git-image", "set",
-		"-kubeconfig-writer-image", "set",
-		"-shell-image", "set",
-		"-shell-image-win", "set",
-		"-gsutil-image", "set",
-		"-pr-image", "set",
-		"-imagedigest-exporter-image", "set",
-	})
-	if err := valid.Images.Validate(); err != nil {
+	valid := pipeline.Images{
+		EntrypointImage:          "set",
+		NopImage:                 "set",
+		GitImage:                 "set",
+		KubeconfigWriterImage:    "set",
+		ShellImage:               "set",
+		ShellImageWin:            "set",
+		GsutilImage:              "set",
+		PRImage:                  "set",
+		ImageDigestExporterImage: "set",
+	}
+	if err := valid.Validate(); err != nil {
 		t.Errorf("valid Images returned error: %v", err)
 	}
 
-	fs = flag.FlagSet{}
-	invalid := pipeline.NewFlagOptions(&fs)
-	fs.Parse([]string{
-		"-entrypoint-image", "set",
-		"-nop-image", "set",
-		// "-git-image", "unset",
-		"-kubeconfig-writer-image", "set",
-		// "-shell-image", "unset",
-		"-shell-image-win", "set",
-		"-gsutil-image", "set",
-		// "-pr-image", "unset",
-		"-imagedigest-exporter-image", "set",
-	})
+	invalid := pipeline.Images{
+		EntrypointImage:          "set",
+		NopImage:                 "set",
+		GitImage:                 "", // unset!
+		KubeconfigWriterImage:    "set",
+		ShellImage:               "", // unset!
+		ShellImageWin:            "set",
+		GsutilImage:              "set",
+		PRImage:                  "", // unset!
+		ImageDigestExporterImage: "set",
+	}
 	wantErr := "found unset image flags: [git-image pr-image shell-image]"
-	if err := invalid.Images.Validate(); err == nil {
+	if err := invalid.Validate(); err == nil {
 		t.Error("invalid Images expected error, got nil")
 	} else if err.Error() != wantErr {
 		t.Errorf("Unexpected error message: got %q, want %q", err.Error(), wantErr)

--- a/pkg/apis/pipeline/options.go
+++ b/pkg/apis/pipeline/options.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+// Options holds options passed to the Tekton Pipeline controllers
+// typically via command-line flags.
+type Options struct {
+	Images                        Images
+	ExperimentalDisableResolution bool
+}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -43,7 +43,7 @@ import (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(fo *pipeline.FlagOptions) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -43,7 +43,7 @@ import (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(opts *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -62,7 +62,7 @@ func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher
 		c := &Reconciler{
 			KubeClientSet:     kubeclientset,
 			PipelineClientSet: pipelineclientset,
-			Images:            fo.Images,
+			Images:            opts.Images,
 			pipelineRunLister: pipelineRunInformer.Lister(),
 			pipelineLister:    pipelineInformer.Lister(),
 			taskLister:        taskInformer.Lister(),
@@ -74,7 +74,7 @@ func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher
 			cloudEventClient:  cloudeventclient.Get(ctx),
 			metrics:           pipelinerunmetrics.Get(ctx),
 			pvcHandler:        volumeclaim.NewPVCHandler(kubeclientset, logger),
-			disableResolution: fo.ExperimentalDisableResolution,
+			disableResolution: opts.ExperimentalDisableResolution,
 		}
 		impl := pipelinerunreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 			return controller.Options{

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -42,18 +42,8 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// ControllerConfiguration holds fields used to configure the
-// PipelineRun controller.
-type ControllerConfiguration struct {
-	// Images are the image references used across Tekton Pipelines.
-	Images pipeline.Images
-	// DisablePipelineRefResolution tells the controller not to perform
-	// resolution of pipeline refs from the cluster or bundles.
-	DisablePipelineRefResolution bool
-}
-
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(namespace string, conf ControllerConfiguration) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(fo *pipeline.FlagOptions) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -72,7 +62,7 @@ func NewController(namespace string, conf ControllerConfiguration) func(context.
 		c := &Reconciler{
 			KubeClientSet:     kubeclientset,
 			PipelineClientSet: pipelineclientset,
-			Images:            conf.Images,
+			Images:            fo.Images,
 			pipelineRunLister: pipelineRunInformer.Lister(),
 			pipelineLister:    pipelineInformer.Lister(),
 			taskLister:        taskInformer.Lister(),
@@ -84,7 +74,7 @@ func NewController(namespace string, conf ControllerConfiguration) func(context.
 			cloudEventClient:  cloudeventclient.Get(ctx),
 			metrics:           pipelinerunmetrics.Get(ctx),
 			pvcHandler:        volumeclaim.NewPVCHandler(kubeclientset, logger),
-			disableResolution: conf.DisablePipelineRefResolution,
+			disableResolution: fo.ExperimentalDisableResolution,
 		}
 		impl := pipelinerunreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 			return controller.Options{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -70,7 +70,6 @@ import (
 )
 
 var (
-	namespace                = ""
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
 	images                   = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",
@@ -159,7 +158,7 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 
-	ctl := NewController(namespace, ControllerConfiguration{Images: images})(ctx, configMapWatcher)
+	ctl := NewController(&pipeline.FlagOptions{Images: images})(ctx, configMapWatcher)
 
 	if la, ok := ctl.Reconciler.(reconciler.LeaderAware); ok {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -158,7 +158,7 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 
-	ctl := NewController(&pipeline.FlagOptions{Images: images})(ctx, configMapWatcher)
+	ctl := NewController(&pipeline.Options{Images: images})(ctx, configMapWatcher)
 
 	if la, ok := ctl.Reconciler.(reconciler.LeaderAware); ok {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(fo *pipeline.FlagOptions) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(opts *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -64,7 +64,7 @@ func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher
 		c := &Reconciler{
 			KubeClientSet:     kubeclientset,
 			PipelineClientSet: pipelineclientset,
-			Images:            fo.Images,
+			Images:            opts.Images,
 			taskRunLister:     taskRunInformer.Lister(),
 			taskLister:        taskInformer.Lister(),
 			clusterTaskLister: clusterTaskInformer.Lister(),
@@ -74,7 +74,7 @@ func NewController(fo *pipeline.Options) func(context.Context, configmap.Watcher
 			metrics:           taskrunmetrics.Get(ctx),
 			entrypointCache:   entrypointCache,
 			pvcHandler:        volumeclaim.NewPVCHandler(kubeclientset, logger),
-			disableResolution: fo.ExperimentalDisableResolution,
+			disableResolution: opts.ExperimentalDisableResolution,
 		}
 		impl := taskrunreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 			return controller.Options{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -334,7 +334,7 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 
-	ctl := NewController(&pipeline.FlagOptions{Images: images})(ctx, configMapWatcher)
+	ctl := NewController(&pipeline.Options{Images: images})(ctx, configMapWatcher)
 	if err := configMapWatcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("error starting configmap watcher: %v", err)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -76,7 +76,6 @@ const (
 )
 
 var (
-	namespace                    = "" // all namespaces
 	defaultActiveDeadlineSeconds = int64(config.DefaultTimeoutMinutes * 60 * 1.5)
 	images                       = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",
@@ -335,7 +334,7 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 
-	ctl := NewController(namespace, ControllerConfiguration{Images: images})(ctx, configMapWatcher)
+	ctl := NewController(&pipeline.FlagOptions{Images: images})(ctx, configMapWatcher)
 	if err := configMapWatcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("error starting configmap watcher: %v", err)
 	}


### PR DESCRIPTION
This change has a few parts, but the overarching goal is to make it easier for downstreams to repackage Tekton Pipelines across updates to the flags that are parsed and passed into the controllers.
1. Instead of defining `var`s for the flags, and then extracting the flags into the `pipeline.Images` struct, this change takes advantage of `flag.NewFooVar` to pass in the address of the variable to update.  This lets us have flag parsing process things directly into its final variable.
2. Wrap `Images` in `FlagOptions`, which is passed to controllers.  I'm sort of ambivalent about the nested struct vs. renaming Images, but opted for the former because so many files reference `pipeline.Images` and I wanted to reduce the scope of the change.
3. For flags only used in `main()` use a local flag definition (vs. `FlagOptions`).  It turns out the `*namespace` we were passing to the `NewController` methods was unused!
4. For globals we've turned into flags, use the `flag.NewFooVar` form to update the global directly.
5. Colocate the `flag` setup with the validation setup.  This allows us to get coverage of the flag processing code, and it turns out there were some bugs in the names of flags emitted from validation!

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Downstream consumers of `taskrun.NewController` and `pipelinerun.NewController` will have to fix a breaking signature change; however, they can now take advantage of `pipeline.NewFlagOptions(flag.CommandLine)` to reduce churn due to flag changes.
```
