### PR TITLE
Test and Document Disable Resolution Flag

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -722,3 +722,20 @@ from the message is internal to Tekton Pipelines, used for book-keeping, and
 some is distributed across a number of fields of the `TaskRun's` `status`. For
 example, a `TaskRun's` `status.taskResults` is populated from the termination
 message.
+
+## Experimentally Disabling PipelineRef and TaskRef Resolution
+
+In
+[TEP-0060](https://github.com/tektoncd/community/blob/main/teps/0060-remote-resource-resolution.md)
+we are exploring ways for the Tekton Pipelines controller to offload
+resolution of `taskRefs` and `pipelineRefs` to external systems. The
+idea is to allow for resolution of these resources from locations that
+aren't supported directly by Pipelines, for example pulling in `Tasks`
+and `Pipelines` from `git` repos.
+
+To support this functionality Pipelines has an experimental flag to
+allow a developer to disable resolution in the TaskRun and PipelineRun
+reconcilers. To do so add `-experimental-disable-in-tree-resolution` as
+an additional `arg` passed to the `tekton-pipelines-controller` in its
+[Deployment YAML](../../config/controller.yaml). Once this is done
+you're free to experiment with non-Pipelines resolution mechanisms.

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -151,26 +151,35 @@ func ensureConfigurationConfigMapsExist(d *test.Data) {
 // getPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
-	// unregisterMetrics()
+	return initializePipelineRunControllerAssets(t, d, pipeline.Options{Images: images})
+}
+
+// getPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
+// d, where d represents the state of the system (existing resources) needed for the test. The returned controller
+// has pipeline ref resolution switched off.
+func getPipelineRunControllerWithResolutionDisabled(t *testing.T, d test.Data) (test.Assets, func()) {
+	return initializePipelineRunControllerAssets(t, d, pipeline.Options{Images: images, ExperimentalDisableResolution: true})
+}
+
+// initiailizePipelinerunControllerAssets is a shared helper for
+// controller initialization.
+func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	ensureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
-
-	ctl := NewController(&pipeline.Options{Images: images})(ctx, configMapWatcher)
-
+	ctl := NewController(&opts)(ctx, configMapWatcher)
 	if la, ok := ctl.Reconciler.(reconciler.LeaderAware); ok {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}
 	if err := configMapWatcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("error starting configmap watcher: %v", err)
 	}
-
 	return test.Assets{
 		Logger:     logging.FromContext(ctx),
-		Controller: ctl,
 		Clients:    c,
+		Controller: ctl,
 		Informers:  informers,
 		Recorder:   controller.GetEventRecorder(ctx).(*record.FakeRecorder),
 		Ctx:        ctx,
@@ -6873,6 +6882,147 @@ func TestReconcile_DependencyValidationsImmediatelyFailPipelineRun(t *testing.T)
 
 	if cond3.Reason != ReasonRequiredWorkspaceMarkedOptional {
 		t.Errorf("expected optional workspace not supported condition but saw: %v", cond3)
+	}
+}
+
+func TestDisableResolutionFlag_PreventsResolution(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		pr          *v1beta1.PipelineRun
+	}{{
+		description: "inline pipelinespec is not resolved",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pr",
+				Namespace: "foo",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				ServiceAccountName: "test-sa",
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Tasks: []v1beta1.PipelineTask{{
+						Name: "pt0",
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{
+								Container: corev1.Container{
+									Image: "foo:latest",
+								},
+							}},
+						}},
+					}},
+				},
+			},
+		},
+	}, {
+		description: "pipelineref from cluster is not resolved",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pr",
+				Namespace: "foo",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				ServiceAccountName: "test-sa",
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "test-pipeline",
+				},
+			},
+		},
+	}, {
+		description: "bundle is not resolved",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pr",
+				Namespace: "foo",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				ServiceAccountName: "test-sa",
+				PipelineRef: &v1beta1.PipelineRef{
+					Name:   "test-pipeline",
+					Bundle: "http://bundle.url",
+				},
+			},
+		},
+	}} {
+		t.Run(tc.description, func(t *testing.T) {
+			d := test.Data{
+				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
+				ServiceAccounts: []*corev1.ServiceAccount{{
+					ObjectMeta: metav1.ObjectMeta{Name: tc.pr.Spec.ServiceAccountName, Namespace: tc.pr.Namespace},
+				}},
+			}
+
+			testAssets, cancel := getPipelineRunControllerWithResolutionDisabled(t, d)
+			defer cancel()
+
+			err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, tc.pr.Namespace+"/"+tc.pr.Name)
+			isRequeue, _ := controller.IsRequeueKey(err)
+			if err != nil && !isRequeue {
+				t.Fatalf("unexpected error reconciling: %v", err)
+			}
+
+			reconciledRun, err := testAssets.Clients.Pipeline.TektonV1beta1().PipelineRuns(tc.pr.Namespace).Get(testAssets.Ctx, tc.pr.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("unexpected pipelinerun get error: %s", err)
+			}
+
+			if reconciledRun.Status.PipelineSpec != nil {
+				t.Fatal("status.pipelinespec should not have been resolved during reconciliation")
+			}
+		})
+	}
+}
+
+func TestDisableResolutionFlag_ProceedsWithStatusPipelineSpec(t *testing.T) {
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pr",
+			Namespace: "foo",
+		},
+		Spec: v1beta1.PipelineRunSpec{
+			ServiceAccountName: "test-sa",
+			PipelineSpec: &v1beta1.PipelineSpec{
+				Tasks: []v1beta1.PipelineTask{{
+					Name: "pt0",
+					TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+						Steps: []v1beta1.Step{{
+							Container: corev1.Container{
+								Image: "foo:latest",
+							},
+						}},
+					}},
+				}},
+			},
+		},
+	}
+
+	pr.Status.PipelineSpec = pr.Spec.PipelineSpec
+
+	d := test.Data{
+		PipelineRuns: []*v1beta1.PipelineRun{pr},
+		ServiceAccounts: []*corev1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{Name: pr.Spec.ServiceAccountName, Namespace: pr.Namespace},
+		}},
+	}
+
+	testAssets, cancel := getPipelineRunControllerWithResolutionDisabled(t, d)
+	defer cancel()
+
+	err := testAssets.Controller.Reconciler.Reconcile(testAssets.Ctx, pr.Namespace+"/"+pr.Name)
+	isRequeue, _ := controller.IsRequeueKey(err)
+	if err != nil && !isRequeue {
+		t.Fatalf("unexpected error reconciling: %v", err)
+	}
+
+	labelSelector := fmt.Sprintf("tekton.dev/pipelineTask=%s,tekton.dev/pipelineRun=%s", pr.Spec.PipelineSpec.Tasks[0].Name, pr.Name)
+	tr, err := testAssets.Clients.Pipeline.TektonV1beta1().TaskRuns("foo").List(testAssets.Ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+		Limit:         1,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error fetching pipelinerun's taskrun: %v", err)
+	}
+	if tr == nil || len(tr.Items) == 0 {
+		t.Fatal("expected pipelinerun to have spawned a taskrun")
 	}
 }
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In commit 5fa4348b I added a flag to switch off ref resolution in pipelineruns
and taskruns. As part of that I should've included tests and docs but they got
dropped during a rushed cull of some of the functionality originally intended
for that commit.

This commit re-introduces the tests to make sure that the
disable resolution flag operates as expected, and the bit of developer
docs that explains the flag's usage.


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Documented a controller flag that disables ref resolution in pipelineruns and taskruns.
```