### PR TITLE
Mount entrypoint volume as read-only.

### DIFF
--- a/cmd/entrypoint/README.md
+++ b/cmd/entrypoint/README.md
@@ -29,14 +29,14 @@ Any extra positional arguments are passed to the original entrypoint command.
 ## Example
 
 The following example of usage for `entrypoint` waits for
-`/tekton/tools/3` file to exist and executes the command `bash` with args
-`echo` and `hello`, then writes the file `/tekton/tools/4`, or
-`/tekton/tools/4.err` in case the command fails.
+`/tekton/run/3` file to exist and executes the command `bash` with args
+`echo` and `hello`, then writes the file `/tekton/run/4`, or
+`/tekton/run/4.err` in case the command fails.
 
 ```shell
 entrypoint \
-  -wait_file /tekton/tools/3 \
-  -post_file /tekton/tools/4 \
+  -wait_file /tekton/run/3 \
+  -post_file /tekton/run/4 \
   -entrypoint bash -- \
   echo hello
 ```
@@ -64,14 +64,14 @@ to contain contents before proceeding.
 The following example of usage for `entrypoint` waits for
 `/tekton/downward/ready` file to exist and contain actual contents
 (`-wait_file_contents`), and executes the command `bash` with args
-`echo` and `hello`, then writes the file `/tekton/tools/1`, or
-`/tekton/tools/1.err` in case the command fails.
+`echo` and `hello`, then writes the file `/tekton/run/1`, or
+`/tekton/run/1.err` in case the command fails.
 
 ```shell
 entrypoint \
   -wait_file /tekton/downward/ready \
   -wait_file_contents \
-  -post_file /tekton/tools/1 \
+  -post_file /tekton/run/1 \
   -entrypoint bash -- \
   echo hello
 ```
@@ -79,7 +79,7 @@ entrypoint \
 ## `cp` Mode
 
 In order to make the `entrypoint` binary available to the user's steps, it gets
-copied to a Volume that's shared with all the steps' containers. This is done
+copied to a Volume that's shared with all the steps' containers as read-only. This is done
 in an `initContainer` pre-step, that runs before steps start.
 
 To reduce external dependencies, the `entrypoint` binary actually copies
@@ -95,22 +95,23 @@ initContainers:
   args:
   - cp
   - /ko-app/entrypoint  # <-- path to the entrypoint binary inside the image
-  - /tekton/tools/entrypoint
+  - /tekton/bin/entrypoint
   volumeMounts:
-  - name: tekton-internal-tools
-    mountPath: /tekton/tools
+  - name: tekton-internal-bin
+    mountPath: /tekton/bin
 
 containers:
 - image: user-image
   command:
-  - /tekton/tools/entrypoint
+  - /tekton/bin/entrypoint
   ... args to entrypoint ...
   volumeMounts:
-  - name: tekton-internal-tools
-    mountPath: /tekton/tools
+  - name: tekton-internal-bin
+    mountPath: /tekton/bin
+    readonly: true
 
 volumes:
-- name: tekton-internal-tools
+- name: tekton-internal-bin
   volumeSource:
     emptyDir: {}
 ```

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -47,7 +47,7 @@ and error. The subsequent steps are skipped in this case as well, marking the Ta
 
 #### Halting a Step on failure
 
-The failed step writes `<step-no>.err` to `/tekton/tools` and stops running completely. To be able to debug a step we would
+The failed step writes `<step-no>.err` to `/tekton/run` and stops running completely. To be able to debug a step we would
 need it to continue running (not exit), not skip the next steps and signal health of the step. By disabling step skipping, 
 stopping write of the `<step-no>.err` file and waiting on a signal by the user to disable the halt, we would be simulating a 
 "breakpoint".
@@ -58,7 +58,7 @@ environment using a CLI or an IDE.
 #### Exiting breakpoint
 
 To exit a step which has been paused upon failure, the step would wait on a file similar to `<step-no>.breakpointexit` which 
-would unpause and exit the step container. eg: Step 0 fails and is paused. Writing `0.breakpointexit` in `/tekton/tools`
+would unpause and exit the step container. eg: Step 0 fails and is paused. Writing `0.breakpointexit` in `/tekton/run`
 would unpause and exit the step container.
 
 ## Debug Environment 
@@ -75,8 +75,8 @@ to reflect step number. eg: Step 0 will have `/tekton/debug/info/0`, Step 1 will
 
 ### Debug Scripts
 
-`/tekton/debug/scripts/debug-continue` : Mark the step as completed with success by writing to `/tekton/tools`. eg: User wants to exit
-breakpoint for failed step 0. Running this script would create `/tekton/tools/0` and `/tekton/tools/0.breakpointexit`.
+`/tekton/debug/scripts/debug-continue` : Mark the step as completed with success by writing to `/tekton/run`. eg: User wants to exit
+breakpoint for failed step 0. Running this script would create `/tekton/run/0` and `/tekton/run/0.breakpointexit`.
 
-`/tekton/debug/scripts/debug-fail-continue` : Mark the step as completed with failure by writing to `/tekton/tools`. eg: User wants to exit
-breakpoint for failed step 0. Running this script would create `/tekton/tools/0.err` and `/tekton/tools/0.breakpointexit`.
+`/tekton/debug/scripts/debug-fail-continue` : Mark the step as completed with failure by writing to `/tekton/run`. eg: User wants to exit
+breakpoint for failed step 0. Running this script would create `/tekton/run/0.err` and `/tekton/run/0.breakpointexit`.

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -137,6 +137,8 @@ with the binary and file(s) is mounted.
 If the image is a private registry, the service account should include an
 [ImagePullSecret](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
 
+For more details, see [entrypoint/README.md](../../cmd/entrypoint/README.md).
+
 ## Reserved directories
 
 ### /workspace
@@ -152,6 +154,8 @@ Here is an example of a directory layout for a simple Task with 2 script steps:
 
 ```
 /tekton
+|-- bin
+    `-- entrypoint
 |-- creds
 |-- downward
 |   |-- ..2021_09_16_18_31_06.270542700
@@ -160,6 +164,8 @@ Here is an example of a directory layout for a simple Task with 2 script steps:
 |   `-- ready -> ..data/ready
 |-- home
 |-- results
+|-- run
+    `-- 0
 |-- scripts
 |   |-- script-0-t4jd8
 |   `-- script-1-4pjwp
@@ -169,23 +175,21 @@ Here is an example of a directory layout for a simple Task with 2 script steps:
 |   |-- step-foo
 |   `-- step-unnamed-0
 |       `-- exitCode
-|-- termination
-`-- tools
-    |-- 0
-    `-- entrypoint
+`-- termination
 ```
 
 | Path                | Description                                                                                                                                                                                                                                                          |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | /tekton             | Directory used for Tekton specific functionality                                                                                                                                                                                                                     |
+| /tekton/bin         | Tekton provided binaries / tools                                                                                                                                                                                                                                     |
 | /tekton/creds       | Location of Tekton mounted secrets. See [Authentication at Run Time](../auth.md) for more details.                                                                                                                                                                   |
 | /tekton/downward    | Location of data mounted via the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api).                                                                                              |
 | /tekton/home        | (deprecated - see https://github.com/tektoncd/pipeline/issues/2013) Default home directory for user containers.                                                                                                                                                      |
 | /tekton/results     | Where [results](#results) are written to (path available to `Task` authors via [`$(results.name.path)`](../variables.md))                                                                                                                                            |
+| /tekton/run         | Runtime variable data. [Used for coordinating step ordering](#entrypoint-rewriting-and-step-ordering).                                                                                                                                                               |
 | /tekton/scripts     | Contains user provided scripts specified in the TaskSpec.                                                                                                                                                                                                            |
 | /tekton/steps       | Where the `step` exitCodes are written to (path available to `Task` authors via [`$(steps.<stepName>.exitCode.path)`](../variables.md#variables-available-in-a-task))                                                                                                |
 | /tekton/termination | where the eventual [termination log message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#writing-and-reading-a-termination-message) is written to [Sequencing step containers](#entrypoint-rewriting-and-step-ordering) |
-| /tekton/tools       | Contains tools like the [entrypoint binary](#entrypoint-rewriting-and-step-ordering), post_files for coordinating step starts                                                                                                                                        |
 
 The following directories are covered by the
 [Tekton API Compatibility policy](../api_compatibility_policy.md), and can be

--- a/internal/builder/v1beta1/container.go
+++ b/internal/builder/v1beta1/container.go
@@ -78,6 +78,8 @@ func VolumeMount(name, mountPath string, ops ...VolumeMountOp) ContainerOp {
 	}
 }
 
+var VolumeMountRO = func(vm *corev1.VolumeMount) { vm.ReadOnly = true }
+
 // Resources adds ResourceRequirements to the Container (step).
 func Resources(ops ...ResourceRequirementsOp) ContainerOp {
 	return func(c *corev1.Container) {

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -56,21 +56,21 @@ func TestOrderContainers(t *testing.T) {
 		Args: []string{
 			"-wait_file", "/tekton/downward/ready",
 			"-wait_file_content",
-			"-post_file", "/tekton/tools/0",
+			"-post_file", "/tekton/run/0",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-0",
 			"-step_metadata_dir_link", "/tekton/steps/0",
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}, {
 		Image:   "step-2",
 		Command: []string{entrypointBinary},
 		Args: []string{
-			"-wait_file", "/tekton/tools/0",
-			"-post_file", "/tekton/tools/1",
+			"-wait_file", "/tekton/run/0",
+			"-post_file", "/tekton/run/1",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-1",
 			"-step_metadata_dir_link", "/tekton/steps/1",
@@ -78,21 +78,21 @@ func TestOrderContainers(t *testing.T) {
 			"cmd2", "cmd3",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{volumeMount, toolsMount},
+		VolumeMounts:           []corev1.VolumeMount{volumeMount, binROMount, runMount},
 		TerminationMessagePath: "/tekton/termination",
 	}, {
 		Image:   "step-3",
 		Command: []string{entrypointBinary},
 		Args: []string{
-			"-wait_file", "/tekton/tools/1",
-			"-post_file", "/tekton/tools/2",
+			"-wait_file", "/tekton/run/1",
+			"-post_file", "/tekton/run/2",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-2",
 			"-step_metadata_dir_link", "/tekton/steps/2",
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	gotInit, got, err := orderContainers(images.EntrypointImage, []string{}, steps, nil, nil)
@@ -108,7 +108,7 @@ func TestOrderContainers(t *testing.T) {
 		Image:        images.EntrypointImage,
 		WorkingDir:   "/",
 		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", entrypointBinary},
-		VolumeMounts: []corev1.VolumeMount{toolsMount},
+		VolumeMounts: []corev1.VolumeMount{binMount},
 	}
 	if d := cmp.Diff(wantInit, gotInit); d != "" {
 		t.Errorf("Init Container Diff %s", diff.PrintWantGot(d))
@@ -127,7 +127,7 @@ func TestOrderContainersWithDebugOnFailure(t *testing.T) {
 		Args: []string{
 			"-wait_file", "/tekton/downward/ready",
 			"-wait_file_content",
-			"-post_file", "/tekton/tools/0",
+			"-post_file", "/tekton/run/0",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-0",
 			"-step_metadata_dir_link", "/tekton/steps/0",
@@ -135,7 +135,7 @@ func TestOrderContainersWithDebugOnFailure(t *testing.T) {
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	taskRunDebugConfig := &v1beta1.TaskRunDebug{
@@ -181,7 +181,7 @@ func TestEntryPointResults(t *testing.T) {
 		Args: []string{
 			"-wait_file", "/tekton/downward/ready",
 			"-wait_file_content",
-			"-post_file", "/tekton/tools/0",
+			"-post_file", "/tekton/run/0",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-0",
 			"-step_metadata_dir_link", "/tekton/steps/0",
@@ -189,14 +189,14 @@ func TestEntryPointResults(t *testing.T) {
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}, {
 		Image:   "step-2",
 		Command: []string{entrypointBinary},
 		Args: []string{
-			"-wait_file", "/tekton/tools/0",
-			"-post_file", "/tekton/tools/1",
+			"-wait_file", "/tekton/run/0",
+			"-post_file", "/tekton/run/1",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-1",
 			"-step_metadata_dir_link", "/tekton/steps/1",
@@ -205,14 +205,14 @@ func TestEntryPointResults(t *testing.T) {
 			"cmd2", "cmd3",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{volumeMount, toolsMount},
+		VolumeMounts:           []corev1.VolumeMount{volumeMount, binROMount, runMount},
 		TerminationMessagePath: "/tekton/termination",
 	}, {
 		Image:   "step-3",
 		Command: []string{entrypointBinary},
 		Args: []string{
-			"-wait_file", "/tekton/tools/1",
-			"-post_file", "/tekton/tools/2",
+			"-wait_file", "/tekton/run/1",
+			"-post_file", "/tekton/run/2",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-2",
 			"-step_metadata_dir_link", "/tekton/steps/2",
@@ -220,7 +220,7 @@ func TestEntryPointResults(t *testing.T) {
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec, nil)
@@ -254,7 +254,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 		Args: []string{
 			"-wait_file", "/tekton/downward/ready",
 			"-wait_file_content",
-			"-post_file", "/tekton/tools/0",
+			"-post_file", "/tekton/run/0",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-0",
 			"-step_metadata_dir_link", "/tekton/steps/0",
@@ -262,7 +262,7 @@ func TestEntryPointResultsSingleStep(t *testing.T) {
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec, nil)
@@ -292,7 +292,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 		Args: []string{
 			"-wait_file", "/tekton/downward/ready",
 			"-wait_file_content",
-			"-post_file", "/tekton/tools/0",
+			"-post_file", "/tekton/run/0",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-unnamed-0",
 			"-step_metadata_dir_link", "/tekton/steps/0",
@@ -300,7 +300,7 @@ func TestEntryPointSingleResultsSingleStep(t *testing.T) {
 			"-entrypoint", "cmd", "--",
 			"arg1", "arg2",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec, nil)
@@ -338,29 +338,29 @@ func TestEntryPointOnError(t *testing.T) {
 		Args: []string{
 			"-wait_file", "/tekton/downward/ready",
 			"-wait_file_content",
-			"-post_file", "/tekton/tools/0",
+			"-post_file", "/tekton/run/0",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-failing-step",
 			"-step_metadata_dir_link", "/tekton/steps/0",
 			"-on_error", "continue",
 			"-entrypoint", "cmd", "--",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount, downwardMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount, downwardMount},
 		TerminationMessagePath: "/tekton/termination",
 	}, {
 		Name:    "passing-step",
 		Image:   "step-2",
 		Command: []string{entrypointBinary},
 		Args: []string{
-			"-wait_file", "/tekton/tools/0",
-			"-post_file", "/tekton/tools/1",
+			"-wait_file", "/tekton/run/0",
+			"-post_file", "/tekton/run/1",
 			"-termination_path", "/tekton/termination",
 			"-step_metadata_dir", "/tekton/steps/step-passing-step",
 			"-step_metadata_dir_link", "/tekton/steps/1",
 			"-on_error", "stopAndFail",
 			"-entrypoint", "cmd", "--",
 		},
-		VolumeMounts:           []corev1.VolumeMount{toolsMount},
+		VolumeMounts:           []corev1.VolumeMount{binROMount, runMount},
 		TerminationMessagePath: "/tekton/termination",
 	}}
 	_, got, err := orderContainers(images.EntrypointImage, []string{}, steps, &taskSpec, nil)

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -182,7 +182,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	// place the entrypoint first in case other init containers rely on its
 	// features (e.g. decode-script).
 	initContainers = append([]corev1.Container{entrypointInit}, initContainers...)
-	volumes = append(volumes, toolsVolume, downwardVolume)
+	volumes = append(volumes, binVolume, runVolume, downwardVolume)
 
 	// Add implicit env vars.
 	// They're prepended to the list, so that if the user specified any

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -86,8 +86,8 @@ func TestPodBuild(t *testing.T) {
 		Name:         "place-tools",
 		Image:        images.EntrypointImage,
 		WorkingDir:   "/",
-		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
-		VolumeMounts: []corev1.VolumeMount{toolsMount},
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/bin/entrypoint"},
+		VolumeMounts: []corev1.VolumeMount{binMount},
 	}
 	runtimeClassName := "gvisor"
 	automountServiceAccountToken := false
@@ -119,13 +119,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -136,13 +136,13 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -168,13 +168,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -185,13 +185,13 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -215,13 +215,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -232,13 +232,13 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -267,13 +267,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -288,13 +288,13 @@ func TestPodBuild(t *testing.T) {
 					Name:  "HOME",
 					Value: "/tekton/home",
 				}},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -319,13 +319,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -340,7 +340,7 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, append(append([]corev1.VolumeMount{}, implicitVolumeMounts...), corev1.VolumeMount{
@@ -349,7 +349,7 @@ func TestPodBuild(t *testing.T) {
 				})...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, secretsVolume, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, secretsVolume, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -388,13 +388,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -406,13 +406,13 @@ func TestPodBuild(t *testing.T) {
 					"--",
 				},
 				VolumeMounts: append([]corev1.VolumeMount{
-					toolsMount,
+					binROMount, runMount,
 					downwardMount,
 					{Name: "tekton-creds-init-home-0", MountPath: "/tekton/creds"},
 				}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -447,13 +447,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-a-very-very-long-character-step-name-to-trigger-max-len", // step name trimmed.
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -464,13 +464,13 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -491,13 +491,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-ends-with-invalid", // invalid suffix removed.
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -508,13 +508,13 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -546,13 +546,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -563,14 +563,14 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				WorkingDir:             filepath.Join(pipeline.WorkspaceDir, "test"),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -598,13 +598,13 @@ func TestPodBuild(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-primary-name",
 				Image:   "primary-image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -615,7 +615,7 @@ func TestPodBuild(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -627,7 +627,7 @@ func TestPodBuild(t *testing.T) {
 					Requests: nil,
 				},
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -658,26 +658,26 @@ func TestPodBuild(t *testing.T) {
 					Name:         "place-scripts",
 					Image:        "busybox",
 					Command:      []string{"sh"},
-					VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+					VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 					Args: []string{"-c", `scriptfile="/tekton/scripts/sidecar-script-0-9l9zj"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCmVjaG8gaGVsbG8gZnJvbSBzaWRlY2Fy
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 				},
 			},
 			Containers: []corev1.Container{{
 				Name:    "step-primary-name",
 				Image:   "primary-image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -688,7 +688,7 @@ _EOF_
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -699,7 +699,7 @@ _EOF_
 				Command:      []string{"/tekton/scripts/sidecar-script-0-9l9zj"},
 				VolumeMounts: []corev1.VolumeMount{scriptsVolumeMount},
 			}},
-			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, scriptsVolume, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -730,13 +730,13 @@ _EOF_
 			Containers: []corev1.Container{{
 				Name:    "step-primary-name",
 				Image:   "primary-image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -747,7 +747,7 @@ _EOF_
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -756,7 +756,7 @@ _EOF_
 				Name:  "sidecar-sc-name",
 				Image: "sidecar-image",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -791,13 +791,13 @@ _EOF_
 			Containers: []corev1.Container{{
 				Name:    "step-unnamed-0",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -808,7 +808,7 @@ _EOF_
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -822,12 +822,12 @@ _EOF_
 			}, {
 				Name:    "step-unnamed-1",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-post_file",
-					"/tekton/tools/1",
+					"/tekton/run/1",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -838,7 +838,7 @@ _EOF_
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, {
 					Name:      "tekton-creds-init-home-1",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -850,7 +850,7 @@ _EOF_
 				},
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}, corev1.Volume{
@@ -901,27 +901,27 @@ touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCmVjaG8gaGVsbG8gZnJvbSBzdGVwIG9uZQ==
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/script-1-mz4c7"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvdXNyL2Jpbi9lbnYgcHl0aG9uCnByaW50KCJIZWxsbyBmcm9tIFB5dGhvbiIp
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-					VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+					VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 				},
 			},
 			Containers: []corev1.Container{{
 				Name:    "step-one",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -935,7 +935,7 @@ _EOF_
 					"args",
 				},
 				Env: []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
-				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -943,12 +943,12 @@ _EOF_
 			}, {
 				Name:    "step-two",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-post_file",
-					"/tekton/tools/1",
+					"/tekton/run/1",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -962,7 +962,7 @@ _EOF_
 					"args",
 				},
 				Env: []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
-				VolumeMounts: append([]corev1.VolumeMount{{Name: "i-have-a-volume-mount"}, scriptsVolumeMount, toolsMount, {
+				VolumeMounts: append([]corev1.VolumeMount{{Name: "i-have-a-volume-mount"}, scriptsVolumeMount, binROMount, runMount, {
 					Name:      "tekton-creds-init-home-1",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -970,12 +970,12 @@ _EOF_
 			}, {
 				Name:    "step-regular-step",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
-					"/tekton/tools/1",
+					"/tekton/run/1",
 					"-post_file",
-					"/tekton/tools/2",
+					"/tekton/run/2",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -990,13 +990,13 @@ _EOF_
 					"args",
 				},
 				Env: []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, {
 					Name:      "tekton-creds-init-home-2",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, scriptsVolume, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}, corev1.Volume{
@@ -1030,20 +1030,20 @@ touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCiQk
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+				VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 			}},
 			Containers: []corev1.Container{{
 				Name:    "step-one",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -1054,13 +1054,13 @@ _EOF_
 					"/tekton/scripts/script-0-9l9zj",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{scriptsVolumeMount, binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, scriptsVolume, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, scriptsVolume, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
@@ -1088,20 +1088,20 @@ _EOF_
 			RestartPolicy:  corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{placeToolsInit},
 			SchedulerName:  "there-scheduler",
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 			Containers: []corev1.Container{{
 				Name:    "step-schedule-me",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -1112,7 +1112,7 @@ _EOF_
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -1142,20 +1142,20 @@ _EOF_
 		want: &corev1.PodSpec{
 			RestartPolicy:  corev1.RestartPolicyNever,
 			InitContainers: []corev1.Container{placeToolsInit},
-			Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),
 			Containers: []corev1.Container{{
 				Name:    "step-image-pull",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -1166,7 +1166,7 @@ _EOF_
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
@@ -1197,20 +1197,20 @@ _EOF_
 			want: &corev1.PodSpec{
 				RestartPolicy:  corev1.RestartPolicyNever,
 				InitContainers: []corev1.Container{placeToolsInit},
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				Containers: []corev1.Container{{
 					Name:    "step-host-aliases",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1221,7 +1221,7 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
@@ -1251,20 +1251,20 @@ _EOF_
 				RestartPolicy:  corev1.RestartPolicyNever,
 				InitContainers: []corev1.Container{placeToolsInit},
 				HostNetwork:    true,
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				Containers: []corev1.Container{{
 					Name:    "step-use-my-hostNetwork",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1275,7 +1275,7 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
@@ -1319,20 +1319,20 @@ _EOF_
 				RestartPolicy:  corev1.RestartPolicyNever,
 				InitContainers: []corev1.Container{placeToolsInit},
 				HostNetwork:    false,
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
 				Containers: []corev1.Container{{
 					Name:    "step-name",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1343,7 +1343,7 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
@@ -1368,13 +1368,13 @@ _EOF_
 				Containers: []corev1.Container{{
 					Name:    "step-name",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1387,13 +1387,13 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
 					TerminationMessagePath: "/tekton/termination",
 				}},
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
@@ -1417,13 +1417,13 @@ _EOF_
 				Containers: []corev1.Container{{
 					Name:    "step-name",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1434,10 +1434,10 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts:           append([]corev1.VolumeMount{toolsMount, downwardMount}, implicitVolumeMounts...),
+					VolumeMounts:           append([]corev1.VolumeMount{binROMount, runMount, downwardMount}, implicitVolumeMounts...),
 					TerminationMessagePath: "/tekton/termination",
 				}},
-				Volumes:               append(implicitVolumes, toolsVolume, downwardVolume),
+				Volumes:               append(implicitVolumes, binVolume, runVolume, downwardVolume),
 				ActiveDeadlineSeconds: &defaultActiveDeadlineSeconds,
 			},
 		}, {
@@ -1459,13 +1459,13 @@ _EOF_
 				Containers: []corev1.Container{{
 					Name:    "step-name",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1476,7 +1476,7 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
@@ -1485,7 +1485,7 @@ _EOF_
 						{Name: "TEKTON_HERMETIC", Value: "1"},
 					},
 				}},
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
@@ -1511,13 +1511,13 @@ _EOF_
 				Containers: []corev1.Container{{
 					Name:    "step-name",
 					Image:   "image",
-					Command: []string{"/tekton/tools/entrypoint"},
+					Command: []string{"/tekton/bin/entrypoint"},
 					Args: []string{
 						"-wait_file",
 						"/tekton/downward/ready",
 						"-wait_file_content",
 						"-post_file",
-						"/tekton/tools/0",
+						"/tekton/run/0",
 						"-termination_path",
 						"/tekton/termination",
 						"-step_metadata_dir",
@@ -1528,7 +1528,7 @@ _EOF_
 						"cmd",
 						"--",
 					},
-					VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+					VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 						Name:      "tekton-creds-init-home-0",
 						MountPath: "/tekton/creds",
 					}}, implicitVolumeMounts...),
@@ -1539,7 +1539,7 @@ _EOF_
 						{Name: "TEKTON_HERMETIC", Value: "1"},
 					},
 				}},
-				Volumes: append(implicitVolumes, toolsVolume, downwardVolume, corev1.Volume{
+				Volumes: append(implicitVolumes, binVolume, runVolume, downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 				}),
@@ -1640,8 +1640,8 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		Name:         "place-tools",
 		Image:        images.EntrypointImage,
 		WorkingDir:   "/",
-		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/tools/entrypoint"},
-		VolumeMounts: []corev1.VolumeMount{toolsMount},
+		Command:      []string{"/ko-app/entrypoint", "cp", "/ko-app/entrypoint", "/tekton/bin/entrypoint"},
+		VolumeMounts: []corev1.VolumeMount{binMount},
 	}
 
 	for _, c := range []struct {
@@ -1672,13 +1672,13 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 			Containers: []corev1.Container{{
 				Name:    "step-name",
 				Image:   "image",
-				Command: []string{"/tekton/tools/entrypoint"},
+				Command: []string{"/tekton/bin/entrypoint"},
 				Args: []string{
 					"-wait_file",
 					"/tekton/downward/ready",
 					"-wait_file_content",
 					"-post_file",
-					"/tekton/tools/0",
+					"/tekton/run/0",
 					"-termination_path",
 					"/tekton/termination",
 					"-step_metadata_dir",
@@ -1690,13 +1690,13 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 					"cmd",
 					"--",
 				},
-				VolumeMounts: append([]corev1.VolumeMount{toolsMount, downwardMount, {
+				VolumeMounts: append([]corev1.VolumeMount{binROMount, runMount, downwardMount, {
 					Name:      "tekton-creds-init-home-0",
 					MountPath: "/tekton/creds",
 				}}, implicitVolumeMounts...),
 				TerminationMessagePath: "/tekton/termination",
 			}},
-			Volumes: append(implicitVolumes, debugScriptsVolume, debugInfoVolume, toolsVolume, downwardVolume, corev1.Volume{
+			Volumes: append(implicitVolumes, debugScriptsVolume, debugInfoVolume, binVolume, runVolume, downwardVolume, corev1.Volume{
 				Name:         "tekton-creds-init-home-0",
 				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}},
 			}),

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -92,7 +92,7 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1beta
 		Image:        shellImage,
 		Command:      []string{shellCommand},
 		Args:         []string{shellArg, ""},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 	}
 
 	breakpoints := []string{}
@@ -174,7 +174,7 @@ touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '%s'
 %s
 %s
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 `, scriptFile, heredoc, script, heredoc)
 
 			// Set the command to execute the correct script in the mounted
@@ -205,10 +205,10 @@ cat > ${scriptfile} << '%s'
 		}
 		debugScripts := []script{{
 			name:    "continue",
-			content: defaultScriptPreamble + fmt.Sprintf(debugContinueScriptTemplate, len(steps), debugInfoDir, mountPoint),
+			content: defaultScriptPreamble + fmt.Sprintf(debugContinueScriptTemplate, len(steps), debugInfoDir, runDir),
 		}, {
 			name:    "fail-continue",
-			content: defaultScriptPreamble + fmt.Sprintf(debugFailScriptTemplate, len(steps), debugInfoDir, mountPoint),
+			content: defaultScriptPreamble + fmt.Sprintf(debugFailScriptTemplate, len(steps), debugInfoDir, runDir),
 		}}
 
 		// Add debug or breakpoint related scripts to /tekton/debug/scripts

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -163,21 +163,21 @@ touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0x
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/script-2-mz4c7"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 CiMhL2Jpbi9zaApzY3JpcHQtMw==
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/script-3-mssqb"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -258,19 +258,19 @@ touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0x
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/script-2-mz4c7"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 CiMhL2Jpbi9zaApzY3JpcHQtMw==
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/script-3-mssqb"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 tmpfile="/tekton/debug/scripts/debug-continue"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'debug-continue-heredoc-randomly-generated-78c5n'
@@ -279,7 +279,7 @@ set -xe
 
 numberOfSteps=4
 debugInfo=/tekton/debug/info
-tektonTools=/tekton/tools
+tektonTools=/tekton/run
 
 postFile="$(ls ${debugInfo} | grep -E '[0-9]+' | tail -1)"
 stepNumber="$(echo ${postFile} | sed 's/[^0-9]*//g')"
@@ -301,7 +301,7 @@ set -xe
 
 numberOfSteps=4
 debugInfo=/tekton/debug/info
-tektonTools=/tekton/tools
+tektonTools=/tekton/run
 
 postFile="$(ls ${debugInfo} | grep -E '[0-9]+' | tail -1)"
 stepNumber="$(echo ${postFile} | sed 's/[^0-9]*//g')"
@@ -316,7 +316,7 @@ else
 fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount, debugScriptsVolumeMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
 	}
 	want := []corev1.Container{{
 		Image:   "step-1",
@@ -394,21 +394,21 @@ touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0x
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/script-2-mz4c7"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNjcmlwdC0z
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 scriptfile="/tekton/scripts/sidecar-script-0-mssqb"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
 IyEvYmluL3NoCnNpZGVjYXItMQ==
 _EOF_
-/tekton/tools/entrypoint decode-script "${scriptfile}"
+/tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -499,7 +499,7 @@ script-3
 no-shebang
 "@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -583,7 +583,7 @@ script-3
 sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -645,7 +645,7 @@ sidecar-1`,
 sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
-		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, toolsMount},
+		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
 	}
 	want := []corev1.Container{{
 		Image: "step-1",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change makes the entrypoint binary volume read-only by separating the
/tekton/tools directory:

- `/tekton/bin` - Mounted as RW by the place-tools init container, and RO
for all user steps. This directory will hold Tekton provided binaries (i.e.
entrypoint).

- `/tekton/run` - Named after Linux's /run directory
(https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard). This
directory will hold Tekton runtime data (i.e. step post/wait files).

This is being done as an extra layer of security to prevent any tampering
of Tekton provided tools. This is similar in spirit to
89a623317e57a10ff83ad6a2b823e4f617ac644e (making the scripts directory
read-only).

/tekton/tools was considered an internal directory, so this change is not bound to
API compatibility/deprecation policies. This change should have no
affect on the user API surface.

This change does not try to address any issues with the shared post/wait
file volume - this will be handled in another change.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

/release-note-none

This is an internal-only change.

Part of #4227 
