### PR TITLE
Remove sbwsg from OWNERS_ALIAS file

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,7 +5,6 @@ aliases:
   - dibyom
   - dlorenc
   - ImJasonH
-  - sbwsg
   - vdemeester
   - pritidesai
   - jerop
@@ -16,7 +15,6 @@ aliases:
   - dibyom
   - dlorenc
   - ImJasonH
-  - sbwsg
   - vdemeester
   - pritidesai
   - jerop
@@ -29,7 +27,6 @@ aliases:
   - dibyom
   - dlorenc
   - ImJasonH
-  - sbwsg
 
 # Alumni ❤️
 # tejal29
@@ -37,3 +34,4 @@ aliases:
 # shashwathi
 # aaron-prindle
 # abayer
+# sbwsg


### PR DESCRIPTION
# Changes

I can't remember what OWNERS_ALIAS is used for.

Removing self from approvers lists here just in case
it has bearing on the mechanics of that.

A bit more context: I'm trying to reduce my footprint in open source so that I can focus a bit more on delivering features. I'm still planning to be around to review, lgtm, etc.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```