### PR TITLE
include `onError` while merging step specifications with a template

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/ignore-step-error.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/ignore-step-error.yaml
@@ -57,3 +57,54 @@ spec:
               onError: continue
               script: |
                 exit 20
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-with-failing-step-and-ws-
+spec:
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 16Mi
+  pipelineSpec:
+    tasks:
+      - name: writer
+        taskSpec:
+          steps:
+            - name: write
+              image: alpine
+              onError: continue
+              script: |
+                ls -1 /tekton/run/
+                echo bar > $(workspaces.task-ws.path)/foo
+                exit 1
+          workspaces:
+            - name: task-ws
+        workspaces:
+          - name: task-ws
+            workspace: ws
+      - name: reader
+        runAfter:
+          - writer
+        taskSpec:
+          steps:
+            - name: read
+              image: alpine
+              onError: continue
+              script: |
+                cat $(workspaces.myws.path)/foo | grep bar
+                exit 1
+          workspaces:
+            - name: myws
+        workspaces:
+          - name: myws
+            workspace: ws
+    workspaces:
+      - name: ws

--- a/pkg/apis/pipeline/v1beta1/merge.go
+++ b/pkg/apis/pipeline/v1beta1/merge.go
@@ -85,7 +85,7 @@ func MergeStepsWithStepTemplate(template *v1.Container, steps []Step) ([]Step, e
 		}
 
 		// Pass through original step Script, for later conversion.
-		steps[i] = Step{Container: *merged, Script: s.Script}
+		steps[i] = Step{Container: *merged, Script: s.Script, OnError: s.OnError}
 	}
 	return steps, nil
 }

--- a/pkg/apis/pipeline/v1beta1/merge_test.go
+++ b/pkg/apis/pipeline/v1beta1/merge_test.go
@@ -38,24 +38,27 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 	}{{
 		name:     "nil-template",
 		template: nil,
-		steps: []Step{{Container: corev1.Container{
-			Image: "some-image",
-		}}},
-		expected: []Step{{Container: corev1.Container{
-			Image: "some-image",
-		}}},
+		steps: []Step{{
+			Container: corev1.Container{Image: "some-image"},
+			OnError:   "foo",
+		}},
+		expected: []Step{{
+			Container: corev1.Container{Image: "some-image"},
+			OnError:   "foo",
+		}},
 	}, {
 		name: "not-overlapping",
 		template: &corev1.Container{
 			Command: []string{"/somecmd"},
 		},
-		steps: []Step{{Container: corev1.Container{
-			Image: "some-image",
-		}}},
-		expected: []Step{{Container: corev1.Container{
-			Command: []string{"/somecmd"},
-			Image:   "some-image",
-		}}},
+		steps: []Step{{
+			Container: corev1.Container{Image: "some-image"},
+			OnError:   "foo",
+		}},
+		expected: []Step{{
+			Container: corev1.Container{Command: []string{"/somecmd"}, Image: "some-image"},
+			OnError:   "foo",
+		}},
 	}, {
 		name: "overwriting-one-field",
 		template: &corev1.Container{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`onError` is a part of step specification and should be included in the specification such that it can be propagated to the `entrypoint`.

Before this commit, the step was merged with the template only including the merged container and script. `onError` was missing from the merge which was resulting in the dropping this value before it can be added to the `entrypoint` args.

Added `onError` in `MergeStepsWithStepTemplate` along with the `script`.

Closes #4253 
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixing a bug where `onError` was not honored in presence of a workspace. Now, `onError` can be set to `continue` to ignore a step error in a task with a workspace.
```
