### PR TITLE
enforce step timeout

### DIFF
--- a/pkg/apis/pipeline/v1beta1/merge.go
+++ b/pkg/apis/pipeline/v1beta1/merge.go
@@ -85,7 +85,7 @@ func MergeStepsWithStepTemplate(template *v1.Container, steps []Step) ([]Step, e
 		}
 
 		// Pass through original step Script, for later conversion.
-		steps[i] = Step{Container: *merged, Script: s.Script, OnError: s.OnError}
+		steps[i] = Step{Container: *merged, Script: s.Script, OnError: s.OnError, Timeout: s.Timeout}
 	}
 	return steps, nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add timeout while merging step specification with a template.

A step can specify `timeout` which should limit the duration of that step and must result in failure if goes beyond the specified timeout. 

This specified `timeout` was being lost while merging step specification with the step template.

Fixing a bug where the timeout can be propagated to the entrypoint.

https://github.com/tektoncd/pipeline/blob/main/docs/tasks.md#specifying-a-timeout

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixing a bug where the specified step timeout was lost and not propagated to the entrypoint. This fix enforces the step timeout. 
```