### PR TITLE
Make sure images stored in registry mirrors are signed

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -201,7 +201,7 @@ spec:
           else
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
-            echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
           fi
+          echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
         done
       done


### PR DESCRIPTION



# Changes

We were't previously signing these images because we weren't storing them in the `IMAGES` result when releaseAsLatest=true.

Since releaseAsLatest=true by default for releases, these images were never getting signed.

This change includes mirror images in the result, so they should be picked up by Chains and signed from now on.

Ref https://github.com/tektoncd/chains/issues/241

/kind misc

cc @pritidesai 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
