### PR TITLE
V0.28 Cherry-Pick: disable resolution flag, onError with workspaces, enforce step timeout, and refactor controllers

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -40,42 +40,27 @@ const (
 	ControllerLogKey = "tekton-pipelines-controller"
 )
 
-var (
-	entrypointImage          = flag.String("entrypoint-image", "", "The container image containing our entrypoint binary.")
-	nopImage                 = flag.String("nop-image", "", "The container image used to stop sidecars")
-	gitImage                 = flag.String("git-image", "", "The container image containing our Git binary.")
-	kubeconfigWriterImage    = flag.String("kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
-	shellImage               = flag.String("shell-image", "", "The container image containing a shell")
-	shellImageWin            = flag.String("shell-image-win", "", "The container image containing a windows shell")
-	gsutilImage              = flag.String("gsutil-image", "", "The container image containing gsutil")
-	prImage                  = flag.String("pr-image", "", "The container image containing our PR binary.")
-	imageDigestExporterImage = flag.String("imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
-	namespace                = flag.String("namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
-	threadsPerController     = flag.Int("threads-per-controller", controller.DefaultThreadsPerController, "Threads (goroutines) to create per controller")
-	disableHighAvailability  = flag.Bool("disable-ha", false, "Whether to disable high-availability functionality for this component.  This flag will be deprecated "+
-		"and removed when we have promoted this feature to stable, so do not pass it without filing an "+
+func main() {
+	flag.IntVar(&controller.DefaultThreadsPerController, "threads-per-controller", controller.DefaultThreadsPerController, "Threads (goroutines) to create per controller")
+	namespace := flag.String("namespace", corev1.NamespaceAll, "Namespace to restrict informer to. Optional, defaults to all namespaces.")
+	disableHighAvailability := flag.Bool("disable-ha", false, "Whether to disable high-availability functionality for this component.  This flag will be deprecated "+"and removed when we have promoted this feature to stable, so do not pass it without filing an "+
 		"issue upstream!")
-	experimentalDisableInTreeResolution = flag.Bool(disableInTreeResolutionFlag, false,
+
+	opts := &pipeline.Options{}
+	flag.StringVar(&opts.Images.EntrypointImage, "entrypoint-image", "", "The container image containing our entrypoint binary.")
+	flag.StringVar(&opts.Images.NopImage, "nop-image", "", "The container image used to stop sidecars")
+	flag.StringVar(&opts.Images.GitImage, "git-image", "", "The container image containing our Git binary.")
+	flag.StringVar(&opts.Images.KubeconfigWriterImage, "kubeconfig-writer-image", "", "The container image containing our kubeconfig writer binary.")
+	flag.StringVar(&opts.Images.ShellImage, "shell-image", "", "The container image containing a shell")
+	flag.StringVar(&opts.Images.ShellImageWin, "shell-image-win", "", "The container image containing a windows shell")
+	flag.StringVar(&opts.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
+	flag.StringVar(&opts.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
+	flag.StringVar(&opts.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
+	flag.BoolVar(&opts.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
 		"Disable resolution of taskrun and pipelinerun refs by the taskrun and pipelinerun reconcilers.")
 
-	disableInTreeResolutionFlag = "experimental-disable-in-tree-resolution"
-)
-
-func main() {
 	cfg := injection.ParseAndGetRESTConfigOrDie()
-	controller.DefaultThreadsPerController = *threadsPerController
-	images := pipeline.Images{
-		EntrypointImage:          *entrypointImage,
-		NopImage:                 *nopImage,
-		GitImage:                 *gitImage,
-		KubeconfigWriterImage:    *kubeconfigWriterImage,
-		ShellImage:               *shellImage,
-		ShellImageWin:            *shellImageWin,
-		GsutilImage:              *gsutilImage,
-		PRImage:                  *prImage,
-		ImageDigestExporterImage: *imageDigestExporterImage,
-	}
-	if err := images.Validate(); err != nil {
+	if err := opts.Images.Validate(); err != nil {
 		log.Fatal(err)
 	}
 	if cfg.QPS == 0 {
@@ -112,20 +97,10 @@ func main() {
 		log.Fatal(http.ListenAndServe(":"+port, mux))
 	}()
 
-	taskrunControllerConfig := taskrun.ControllerConfiguration{
-		Images:                   images,
-		DisableTaskRefResolution: *experimentalDisableInTreeResolution,
-	}
-
-	pipelinerunControllerConfig := pipelinerun.ControllerConfiguration{
-		Images:                       images,
-		DisablePipelineRefResolution: *experimentalDisableInTreeResolution,
-	}
-
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)
 	sharedmain.MainWithConfig(ctx, ControllerLogKey, cfg,
-		taskrun.NewController(*namespace, taskrunControllerConfig),
-		pipelinerun.NewController(*namespace, pipelinerunControllerConfig),
+		taskrun.NewController(opts),
+		pipelinerun.NewController(opts),
 	)
 }
 

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -59,7 +59,9 @@ func main() {
 	flag.BoolVar(&opts.ExperimentalDisableResolution, "experimental-disable-in-tree-resolution", false,
 		"Disable resolution of taskrun and pipelinerun refs by the taskrun and pipelinerun reconcilers.")
 
+	// This parses flags.
 	cfg := injection.ParseAndGetRESTConfigOrDie()
+
 	if err := opts.Images.Validate(); err != nil {
 		log.Fatal(err)
 	}

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -631,7 +631,6 @@ first step in a task.
 
 ## TaskRun Use of Pod Termination Messages
 
-<<<<<<< HEAD
 Tekton Pipelines uses a `Pod's` [termination
 message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/)
 to pass data from a Step's container to the Pipelines controller.
@@ -645,19 +644,6 @@ the data from the message is internal to Tekton Pipelines, used for
 book-keeping, and some is distributed across a number of fields of the
 `TaskRun's` `status`. For example, a `TaskRun's` `status.taskResults` is
 populated from the termination message.
-=======
-Tekton Pipelines uses a `Pod's`
-[termination message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/)
-to pass data from a Step's container to the Pipelines controller. Examples of
-this data include: the time that execution of the user's step began, contents of
-task results, contents of pipeline resource results.
-
-The contents and format of the termination message can change. At time of
-writing the message takes the form of a serialized JSON blob. Some of the data
-from the message is internal to Tekton Pipelines, used for book-keeping, and
-some is distributed across a number of fields of the `TaskRun's` `status`. For
-example, a `TaskRun's` `status.taskResults` is populated from the termination
-message.
 
 ## Experimentally Disabling PipelineRef and TaskRef Resolution
 
@@ -675,4 +661,3 @@ reconcilers. To do so add `-experimental-disable-in-tree-resolution` as
 an additional `arg` passed to the `tekton-pipelines-controller` in its
 [Deployment YAML](../../config/controller.yaml). Once this is done
 you're free to experiment with non-Pipelines resolution mechanisms.
->>>>>>> 5681ce992... Test and Document Disable Resolution Flag

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -631,6 +631,7 @@ first step in a task.
 
 ## TaskRun Use of Pod Termination Messages
 
+<<<<<<< HEAD
 Tekton Pipelines uses a `Pod's` [termination
 message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/)
 to pass data from a Step's container to the Pipelines controller.
@@ -644,3 +645,34 @@ the data from the message is internal to Tekton Pipelines, used for
 book-keeping, and some is distributed across a number of fields of the
 `TaskRun's` `status`. For example, a `TaskRun's` `status.taskResults` is
 populated from the termination message.
+=======
+Tekton Pipelines uses a `Pod's`
+[termination message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/)
+to pass data from a Step's container to the Pipelines controller. Examples of
+this data include: the time that execution of the user's step began, contents of
+task results, contents of pipeline resource results.
+
+The contents and format of the termination message can change. At time of
+writing the message takes the form of a serialized JSON blob. Some of the data
+from the message is internal to Tekton Pipelines, used for book-keeping, and
+some is distributed across a number of fields of the `TaskRun's` `status`. For
+example, a `TaskRun's` `status.taskResults` is populated from the termination
+message.
+
+## Experimentally Disabling PipelineRef and TaskRef Resolution
+
+In
+[TEP-0060](https://github.com/tektoncd/community/blob/main/teps/0060-remote-resource-resolution.md)
+we are exploring ways for the Tekton Pipelines controller to offload
+resolution of `taskRefs` and `pipelineRefs` to external systems. The
+idea is to allow for resolution of these resources from locations that
+aren't supported directly by Pipelines, for example pulling in `Tasks`
+and `Pipelines` from `git` repos.
+
+To support this functionality Pipelines has an experimental flag to
+allow a developer to disable resolution in the TaskRun and PipelineRun
+reconcilers. To do so add `-experimental-disable-in-tree-resolution` as
+an additional `arg` passed to the `tekton-pipelines-controller` in its
+[Deployment YAML](../../config/controller.yaml). Once this is done
+you're free to experiment with non-Pipelines resolution mechanisms.
+>>>>>>> 5681ce992... Test and Document Disable Resolution Flag

--- a/examples/v1beta1/pipelineruns/alpha/ignore-step-error.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/ignore-step-error.yaml
@@ -57,3 +57,54 @@ spec:
               onError: continue
               script: |
                 exit 20
+---
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-with-failing-step-and-ws-
+spec:
+  workspaces:
+    - name: ws
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 16Mi
+  pipelineSpec:
+    tasks:
+      - name: writer
+        taskSpec:
+          steps:
+            - name: write
+              image: alpine
+              onError: continue
+              script: |
+                ls -1 /tekton/run/
+                echo bar > $(workspaces.task-ws.path)/foo
+                exit 1
+          workspaces:
+            - name: task-ws
+        workspaces:
+          - name: task-ws
+            workspace: ws
+      - name: reader
+        runAfter:
+          - writer
+        taskSpec:
+          steps:
+            - name: read
+              image: alpine
+              onError: continue
+              script: |
+                cat $(workspaces.myws.path)/foo | grep bar
+                exit 1
+          workspaces:
+            - name: myws
+        workspaces:
+          - name: myws
+            workspace: ws
+    workspaces:
+      - name: ws

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -52,15 +52,15 @@ func (i Images) Validate() error {
 	for _, f := range []struct {
 		v, name string
 	}{
-		{i.EntrypointImage, "entrypoint"},
-		{i.NopImage, "nop"},
-		{i.GitImage, "git"},
-		{i.KubeconfigWriterImage, "kubeconfig-writer"},
-		{i.ShellImage, "shell"},
-		{i.ShellImageWin, "windows-shell"},
-		{i.GsutilImage, "gsutil"},
-		{i.PRImage, "pr"},
-		{i.ImageDigestExporterImage, "imagedigest-exporter"},
+		{i.EntrypointImage, "entrypoint-image"},
+		{i.NopImage, "nop-image"},
+		{i.GitImage, "git-image"},
+		{i.KubeconfigWriterImage, "kubeconfig-writer-image"},
+		{i.ShellImage, "shell-image"},
+		{i.ShellImageWin, "shell-image-win"},
+		{i.GsutilImage, "gsutil-image"},
+		{i.PRImage, "pr-image"},
+		{i.ImageDigestExporterImage, "imagedigest-exporter-image"},
 	} {
 		if f.v == "" {
 			unset = append(unset, f.name)

--- a/pkg/apis/pipeline/images_test.go
+++ b/pkg/apis/pipeline/images_test.go
@@ -33,7 +33,7 @@ func TestValidate(t *testing.T) {
 		PRImage:                  "", // unset!
 		ImageDigestExporterImage: "set",
 	}
-	wantErr := "found unset image flags: [git pr shell]"
+	wantErr := "found unset image flags: [git-image pr-image shell-image]"
 	if err := invalid.Validate(); err == nil {
 		t.Error("invalid Images expected error, got nil")
 	} else if err.Error() != wantErr {

--- a/pkg/apis/pipeline/options.go
+++ b/pkg/apis/pipeline/options.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipeline
+
+// Options holds options passed to the Tekton Pipeline controllers
+// typically via command-line flags.
+type Options struct {
+	Images                        Images
+	ExperimentalDisableResolution bool
+}

--- a/pkg/apis/pipeline/v1beta1/merge.go
+++ b/pkg/apis/pipeline/v1beta1/merge.go
@@ -85,7 +85,7 @@ func MergeStepsWithStepTemplate(template *v1.Container, steps []Step) ([]Step, e
 		}
 
 		// Pass through original step Script, for later conversion.
-		steps[i] = Step{Container: *merged, Script: s.Script}
+		steps[i] = Step{Container: *merged, Script: s.Script, OnError: s.OnError}
 	}
 	return steps, nil
 }

--- a/pkg/apis/pipeline/v1beta1/merge.go
+++ b/pkg/apis/pipeline/v1beta1/merge.go
@@ -85,7 +85,7 @@ func MergeStepsWithStepTemplate(template *v1.Container, steps []Step) ([]Step, e
 		}
 
 		// Pass through original step Script, for later conversion.
-		steps[i] = Step{Container: *merged, Script: s.Script, OnError: s.OnError}
+		steps[i] = Step{Container: *merged, Script: s.Script, OnError: s.OnError, Timeout: s.Timeout}
 	}
 	return steps, nil
 }

--- a/pkg/apis/pipeline/v1beta1/merge_test.go
+++ b/pkg/apis/pipeline/v1beta1/merge_test.go
@@ -38,24 +38,27 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 	}{{
 		name:     "nil-template",
 		template: nil,
-		steps: []Step{{Container: corev1.Container{
-			Image: "some-image",
-		}}},
-		expected: []Step{{Container: corev1.Container{
-			Image: "some-image",
-		}}},
+		steps: []Step{{
+			Container: corev1.Container{Image: "some-image"},
+			OnError:   "foo",
+		}},
+		expected: []Step{{
+			Container: corev1.Container{Image: "some-image"},
+			OnError:   "foo",
+		}},
 	}, {
 		name: "not-overlapping",
 		template: &corev1.Container{
 			Command: []string{"/somecmd"},
 		},
-		steps: []Step{{Container: corev1.Container{
-			Image: "some-image",
-		}}},
-		expected: []Step{{Container: corev1.Container{
-			Command: []string{"/somecmd"},
-			Image:   "some-image",
-		}}},
+		steps: []Step{{
+			Container: corev1.Container{Image: "some-image"},
+			OnError:   "foo",
+		}},
+		expected: []Step{{
+			Container: corev1.Container{Command: []string{"/somecmd"}, Image: "some-image"},
+			OnError:   "foo",
+		}},
 	}, {
 		name: "overwriting-one-field",
 		template: &corev1.Container{

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -170,13 +170,7 @@ func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipel
 	ensureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
-<<<<<<< HEAD
-
-	ctl := NewController(namespace, ControllerConfiguration{Images: images})(ctx, configMapWatcher)
-
-=======
 	ctl := NewController(&opts)(ctx, configMapWatcher)
->>>>>>> 5681ce992... Test and Document Disable Resolution Flag
 	if la, ok := ctl.Reconciler.(reconciler.LeaderAware); ok {
 		la.Promote(reconciler.UniversalBucket(), func(reconciler.Bucket, types.NamespacedName) {})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -70,7 +70,6 @@ import (
 )
 
 var (
-	namespace                = ""
 	ignoreLastTransitionTime = cmpopts.IgnoreTypes(apis.Condition{}.LastTransitionTime.Inner.Time)
 	images                   = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -41,18 +41,8 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-// ControllerConfiguration holds fields used to configure the
-// TaskRun controller.
-type ControllerConfiguration struct {
-	// Images are the image references used across Tekton Pipelines.
-	Images pipeline.Images
-	// DisableTaskRefResolution tells the controller not to perform
-	// resolution of task refs from the cluster or bundles.
-	DisableTaskRefResolution bool
-}
-
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(namespace string, conf ControllerConfiguration) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(opts *pipeline.Options) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -74,7 +64,7 @@ func NewController(namespace string, conf ControllerConfiguration) func(context.
 		c := &Reconciler{
 			KubeClientSet:     kubeclientset,
 			PipelineClientSet: pipelineclientset,
-			Images:            conf.Images,
+			Images:            opts.Images,
 			taskRunLister:     taskRunInformer.Lister(),
 			taskLister:        taskInformer.Lister(),
 			clusterTaskLister: clusterTaskInformer.Lister(),
@@ -84,7 +74,7 @@ func NewController(namespace string, conf ControllerConfiguration) func(context.
 			metrics:           taskrunmetrics.Get(ctx),
 			entrypointCache:   entrypointCache,
 			pvcHandler:        volumeclaim.NewPVCHandler(kubeclientset, logger),
-			disableResolution: conf.DisableTaskRefResolution,
+			disableResolution: opts.ExperimentalDisableResolution,
 		}
 		impl := taskrunreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 			return controller.Options{

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -322,14 +322,25 @@ func ensureConfigurationConfigMapsExist(d *test.Data) {
 // getTaskRunController returns an instance of the TaskRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
-	// unregisterMetrics()
+	return initializeTaskRunControllerAssets(t, d, pipeline.Options{Images: images})
+}
+
+func getTaskRunControllerWithResolutionDisabled(t *testing.T, d test.Data) (test.Assets, func()) {
+	return initializeTaskRunControllerAssets(t, d, pipeline.Options{Images: images, ExperimentalDisableResolution: true})
+}
+
+func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	ensureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
+<<<<<<< HEAD
 
 	ctl := NewController(namespace, ControllerConfiguration{Images: images})(ctx, configMapWatcher)
+=======
+	ctl := NewController(&opts)(ctx, configMapWatcher)
+>>>>>>> 5681ce992... Test and Document Disable Resolution Flag
 	if err := configMapWatcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("error starting configmap watcher: %v", err)
 	}
@@ -3851,4 +3862,114 @@ func TestPodAdoption(t *testing.T) {
 		t.Fatalf("First reconcile created pod %s but TaskRun now has another pod name %s", podName, reconciledRun.Status.PodName)
 	}
 
+}
+
+func TestDisableResolutionFlag_PreventsResolution(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		tr          *v1beta1.TaskRun
+	}{{
+		description: "inline taskspec is not resolved",
+		tr: tb.TaskRun("test-taskrun",
+			tb.TaskRunNamespace("foo"),
+			tb.TaskRunLabel("mylabel", "myvalue"),
+			tb.TaskRunSpec(tb.TaskRunTaskSpec(
+				tb.Step("myimage", tb.StepName("mycontainer"), tb.StepCommand("/mycmd")),
+			)),
+		),
+	}, {
+		description: "taskref is not resolved",
+		tr: tb.TaskRun("test-taskrun",
+			tb.TaskRunNamespace("foo"),
+			tb.TaskRunLabel("mylabel", "myvalue"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef("foo")),
+		),
+	}, {
+		description: "bundle is not resolved",
+		tr: tb.TaskRun("test-taskrun",
+			tb.TaskRunNamespace("foo"),
+			tb.TaskRunLabel("mylabel", "myvalue"),
+			tb.TaskRunSpec(tb.TaskRunTaskRef(simpleTypedTask.Name, tb.TaskRefBundle("foobar.bundle.url"))),
+		),
+	}} {
+		tr := tc.tr
+
+		names.TestingSeed()
+		testAssets, cancel := getTaskRunControllerWithResolutionDisabled(t, test.Data{
+			TaskRuns: []*v1beta1.TaskRun{tr},
+		})
+		defer cancel()
+		c := testAssets.Controller
+		clients := testAssets.Clients
+
+		if _, err := clients.Kube.CoreV1().ServiceAccounts(tr.Namespace).Create(testAssets.Ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		}, metav1.CreateOptions{}); err != nil {
+			t.Fatal(err)
+		}
+
+		err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr))
+		isRequeue, _ := controller.IsRequeueKey(err)
+		if err != nil && !isRequeue {
+			t.Errorf("Error reconciling TaskRun. Got error %v", err)
+		}
+
+		reconciledRun, err := clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Error getting updated TaskRun: %v", err)
+		}
+
+		if reconciledRun.Status.TaskSpec != nil {
+			t.Fatal("status.taskspec should not have been resolved during reconciliation")
+		}
+
+		if reconciledRun.Status.PodName != "" {
+			t.Fatal("Pod should not have been created")
+		}
+	}
+}
+
+func TestDisableResolutionFlag_ProceedsWithStatusTaskSpec(t *testing.T) {
+	tr := tb.TaskRun("test-taskrun",
+		tb.TaskRunNamespace("foo"),
+		tb.TaskRunLabel("mylabel", "myvalue"),
+		tb.TaskRunSpec(tb.TaskRunTaskSpec(
+			tb.Step("myimage", tb.StepName("mycontainer"), tb.StepCommand("/mycmd")),
+		)),
+	)
+
+	tr.Status.TaskSpec = tr.Spec.TaskSpec
+
+	names.TestingSeed()
+	testAssets, cancel := getTaskRunControllerWithResolutionDisabled(t, test.Data{
+		TaskRuns: []*v1beta1.TaskRun{tr},
+	})
+	defer cancel()
+	c := testAssets.Controller
+	clients := testAssets.Clients
+
+	if _, err := clients.Kube.CoreV1().ServiceAccounts(tr.Namespace).Create(testAssets.Ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := c.Reconciler.Reconcile(testAssets.Ctx, getRunName(tr))
+	isRequeue, _ := controller.IsRequeueKey(err)
+	if err != nil && !isRequeue {
+		t.Errorf("Error reconciling TaskRun. Got error %v", err)
+	}
+
+	reconciledRun, err := clients.Pipeline.TektonV1beta1().TaskRuns(tr.Namespace).Get(testAssets.Ctx, tr.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Error getting updated TaskRun: %v", err)
+	}
+
+	if reconciledRun.Status.PodName == "" {
+		t.Fatal("Expected pod to have been created")
+	}
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -76,7 +76,6 @@ const (
 )
 
 var (
-	namespace                    = "" // all namespaces
 	defaultActiveDeadlineSeconds = int64(config.DefaultTimeoutMinutes * 60 * 1.5)
 	images                       = pipeline.Images{
 		EntrypointImage:          "override-with-entrypoint:latest",

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -335,12 +335,7 @@ func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.
 	ensureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
-<<<<<<< HEAD
-
-	ctl := NewController(namespace, ControllerConfiguration{Images: images})(ctx, configMapWatcher)
-=======
 	ctl := NewController(&opts)(ctx, configMapWatcher)
->>>>>>> 5681ce992... Test and Document Disable Resolution Flag
 	if err := configMapWatcher.Start(ctx.Done()); err != nil {
 		t.Fatalf("error starting configmap watcher: %v", err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cheery-pick three commits:

* https://github.com/tektoncd/pipeline/pull/4231 - commit [5681ce99232cffebc42b4a097514bc0a3e14a6e5](https://github.com/tektoncd/pipeline/commit/5681ce99232cffebc42b4a097514bc0a3e14a6e5)
* https://github.com/tektoncd/pipeline/pull/4254 - commit [c5477eb6ba296ca00fcc55b22661b059474c1779](https://github.com/tektoncd/pipeline/commit/c5477eb6ba296ca00fcc55b22661b059474c1779)
* https://github.com/tektoncd/pipeline/pull/4255 - commit [6d5217a956de56353ece80a5f6732caa86bfb0ee](https://github.com/tektoncd/pipeline/commit/6d5217a956de56353ece80a5f6732caa86bfb0ee)
* https://github.com/tektoncd/pipeline/pull/4228: 
   * 48437f3f0903c38ee858d2ef766df081f91462d9 Split options into new file, rename params
   * 7fa7539005f7a28441c494d7eda53673a82c12e6 Drop flags from pkg/api, rename options struct.
   * d0a10534c90fd6a8a4950abe271d7314a5602bee Refactor the way the Pipelines controllers receive flags.

All six commits will be part of v0.28.1

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
* Fixing a bug where the specified step timeout was lost and not propagated to the entrypoint. This fix enforces the step timeout. 

* Fixing a bug where `onError` was not honored in presence of a workspace. Now, `onError` can be set to `continue` to ignore a step error in a task with a workspace.

* Documented a controller flag that disables ref resolution in pipelineruns and taskruns.

* (New in v0.28.1, will be part of v0.29.0) Downstream consumers of `taskrun.NewController` and `pipelinerun.NewController` will have to fix a breaking signature change; however, they can now take advantage of `pipeline.NewFlagOptions(flag.CommandLine)` to reduce churn due to flag changes.
```