### PR TITLE
Support for single-quote bracket notation for params

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -796,8 +796,10 @@ variable values as follows:
 
 - To reference a parameter in a `Task`, use the following syntax, where `<name>` is the name of the parameter:
   ```shell
+  # dot notation
   $(params.<name>)
-  # or subscript form:
+  # or bracket notation (wrapping <name> with either single or double quotes):
+  $(params['<name>'])
   $(params["<name>"])
   ```
 - To access parameter values from resources, see [variable substitution](resources.md#variable-substitution)

--- a/docs/variables.md
+++ b/docs/variables.md
@@ -17,8 +17,10 @@ For instructions on using variable substitutions see the relevant section of [th
 | Variable | Description |
 | -------- | ----------- |
 | `params.<param name>` | The value of the parameter at runtime. |
+| `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
+| `tasks.<taskName>.results['<resultName>']` | (see above)) |
 | `tasks.<taskName>.results["<resultName>"]` | (see above)) |
 | `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
@@ -34,10 +36,12 @@ For instructions on using variable substitutions see the relevant section of [th
 | Variable | Description |
 | -------- | ----------- |
 | `params.<param name>` | The value of the parameter at runtime. |
+| `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
 | `resources.inputs.<resourceName>.path` | The path to the input resource's directory. |
 | `resources.outputs.<resourceName>.path` | The path to the output resource's directory. |
 | `results.<resultName>.path` | The path to the file where the `Task` writes its results data. |
+| `results['<resultName>'].path` | (see above) |
 | `results["<resultName>"].path` | (see above) |
 | `workspaces.<workspaceName>.path` | The path to the mounted `Workspace`. Empty string if an optional `Workspace` has not been provided by the TaskRun. |
 | `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if an optional`Workspace` has not been provided by the TaskRun. |

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -38,6 +38,7 @@ func ApplyParameters(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) *v1beta1.
 	patterns := []string{
 		"params.%s",
 		"params[%q]",
+		"params['%s']",
 	}
 
 	// Set all the default stringReplacements

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -272,31 +272,42 @@ func TestApplyParameters(t *testing.T) {
 			}},
 		},
 	}, {
-		name: "parameter references with subscript notation and special characters",
+		name: "parameter references with bracket notation and special characters",
 		original: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first.param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewArrayOrString("default-value")},
 				{Name: "second/param", Type: v1beta1.ParamTypeString},
+				{Name: "third.param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewArrayOrString("default-value")},
+				{Name: "fourth/param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
 				Params: []v1beta1.Param{
 					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString(`$(params["first.param"])`)},
 					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString(`$(params["second/param"])`)},
-					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString("static value")},
+					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString(`$(params['third.param'])`)},
+					{Name: "first-task-fourth-param", Value: *v1beta1.NewArrayOrString(`$(params['fourth/param'])`)},
+					{Name: "first-task-fifth-param", Value: *v1beta1.NewArrayOrString("static value")},
 				},
 			}},
 		},
-		params: []v1beta1.Param{{Name: "second/param", Value: *v1beta1.NewArrayOrString("second-value")}},
+		params: []v1beta1.Param{
+			{Name: "second/param", Value: *v1beta1.NewArrayOrString("second-value")},
+			{Name: "fourth/param", Value: *v1beta1.NewArrayOrString("fourth-value")},
+		},
 		expected: v1beta1.PipelineSpec{
 			Params: []v1beta1.ParamSpec{
 				{Name: "first.param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewArrayOrString("default-value")},
 				{Name: "second/param", Type: v1beta1.ParamTypeString},
+				{Name: "third.param", Type: v1beta1.ParamTypeString, Default: v1beta1.NewArrayOrString("default-value")},
+				{Name: "fourth/param", Type: v1beta1.ParamTypeString},
 			},
 			Tasks: []v1beta1.PipelineTask{{
 				Params: []v1beta1.Param{
 					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("default-value")},
 					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("second-value")},
-					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString("static value")},
+					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString("default-value")},
+					{Name: "first-task-fourth-param", Value: *v1beta1.NewArrayOrString("fourth-value")},
+					{Name: "first-task-fifth-param", Value: *v1beta1.NewArrayOrString("static value")},
 				},
 			}},
 		},

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -196,5 +196,6 @@ func (r *ResolvedResultRef) getReplaceTarget() []string {
 	return []string{
 		fmt.Sprintf("%s.%s.%s.%s", v1beta1.ResultTaskPart, r.ResultReference.PipelineTask, v1beta1.ResultResultPart, r.ResultReference.Result),
 		fmt.Sprintf("%s.%s.%s[%q]", v1beta1.ResultTaskPart, r.ResultReference.PipelineTask, v1beta1.ResultResultPart, r.ResultReference.Result),
+		fmt.Sprintf("%s.%s.%s['%s']", v1beta1.ResultTaskPart, r.ResultReference.PipelineTask, v1beta1.ResultResultPart, r.ResultReference.Result),
 	}
 }

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -44,6 +44,7 @@ func ApplyParameters(spec *v1beta1.TaskSpec, tr *v1beta1.TaskRun, defaults ...v1
 	patterns := []string{
 		"params.%s",
 		"params[%q]",
+		"params['%s']",
 		// FIXME(vdemeester) Remove that with deprecating v1beta1
 		"inputs.params.%s",
 	}
@@ -203,6 +204,7 @@ func ApplyTaskResults(spec *v1beta1.TaskSpec) *v1beta1.TaskSpec {
 	patterns := []string{
 		"results.%s.path",
 		"results[%q].path",
+		"results['%s'].path",
 	}
 
 	for _, result := range spec.Results {

--- a/test/pipelinerun_test.go
+++ b/test/pipelinerun_test.go
@@ -106,14 +106,14 @@ func TestPipelineRun(t *testing.T) {
 					Params: []v1beta1.ParamSpec{{
 						Name: "the.path", Type: v1beta1.ParamTypeString,
 					}, {
-						Name: "dest", Type: v1beta1.ParamTypeString,
+						Name: "the.dest", Type: v1beta1.ParamTypeString,
 					}},
 					Steps: []v1beta1.Step{{
 						Container: corev1.Container{
 							Name:    "config-docker",
 							Image:   "gcr.io/tekton-releases/dogfooding/skopeo:latest",
 							Command: []string{"skopeo"},
-							Args:    []string{"copy", `$(params["the.path"])`, "$(params.dest)"},
+							Args:    []string{"copy", `$(params["the.path"])`, "$(params['the.dest'])"},
 						}},
 					},
 				},
@@ -190,7 +190,7 @@ func TestPipelineRun(t *testing.T) {
 							Name:    "config-docker",
 							Image:   "gcr.io/tekton-releases/dogfooding/skopeo:latest",
 							Command: []string{"skopeo"},
-							Args:    []string{"copy", `$(params["the.path"])`, `$(params["dest"])`},
+							Args:    []string{"copy", `$(params["the.path"])`, `$(params['dest'])`},
 						}},
 					},
 				},


### PR DESCRIPTION
This change adds single-quote bracket notation to the work done in #4215. This is consistent with how referencing is done elsewhere in K8s in the downwards api.

The original patch used the name subscript notation to describe this however the standard name for this approach is bracket notation and updates the doc accordingly.

This is based on TEP: tektoncd/community#503 -- which also needs to be aligned with the two bracket notation approaches in the implementation. See https://github.com/tektoncd/community/pull/527

# Changes

This change adds single-quote bracket param matching to the params and param results analagous with the double-quote bracket param matching. It also adds similar test cases and updates the doc with the single-quote syntax. 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Params and result can now be referenced with bracket notation using both single and double quotes in addition to dot notation. For example, the following are equivalent:  $(param.myparam), $(param['myparam']), and $(param["myparam"]). Bracket notation has the additional benefit of allowing users to work with parameter names containing conflicting characters like "." (e.g. $(param['my.param']) or $(param["my.param"]).
```
