### PR TITLE
Verify failure of `PipelineRun` in `TestGitPipelineRunFail`

### DIFF
--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -278,6 +278,8 @@ func TestGitPipelineRunFail(t *testing.T) {
 						}
 					}
 				}
+			} else {
+				t.Fatal("PipelineRun succeeded when should have failed")
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

`TestGitPipelineRunFail` is test that is meant to verify that code extraction fails with invalid inputs to the `Git` `PipelineResource`.

However, the test does not fail if the `PipelineRun` does not succeed.

In this change, we ensure that the `PipelineRun` fails in these circumstances.

/kind bug

--

Pulled in commit from https://github.com/tektoncd/pipeline/pull/3870 by @savitaashture and made updates to it

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```