### PR TITLE
Only add gcr.io images to publish results

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -202,6 +202,8 @@ spec:
             TAG="$(params.versionTag)"
             crane cp ${IMAGE_WITH_SHA} ${REGION}.${IMAGE_WITHOUT_SHA_AND_TAG}:$TAG
           fi
-          echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
+          # Until we are able to store larger results, we cannot include the
+          # regional copies of the images in the result - see https://github.com/tektoncd/pipeline/issues/4282
+          # echo ${REGION}.$IMAGE_WITH_SHA, >> $(results.IMAGES.path)
         done
       done


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The release process generates and number of container images and
publishes them to gcr.io as well as three regional versions of the
registry. Today all those images are added to the IMAGES result,
for signing by chains, however that causes the nightly build to
fail as we hit the termination message size limit.

Until we have a way to store larger results, we shall only sign
images on gcr.io as a workaround.

Workaround to #4282

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Due to a technical limitation, only images published to `gcr.io`, which are included in the `release.yaml`, are signed.
Images on `eu.gcr.io`, `us.gcr.io` and `asia.gcr.io` are not signed yet.
```