### PR TITLE
Convert test/cluster_resource_test.go's Tekton structs to YAML

### DIFF
--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -20,11 +20,12 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
+
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	resources "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
@@ -58,17 +59,17 @@ func TestClusterResource(t *testing.T) {
 	}
 
 	t.Logf("Creating cluster PipelineResource %s", resourceName)
-	if _, err := c.PipelineResourceClient.Create(ctx, getClusterResource(resourceName, secretName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.PipelineResourceClient.Create(ctx, getClusterResource(t, resourceName, secretName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create cluster Pipeline Resource `%s`: %s", resourceName, err)
 	}
 
 	t.Logf("Creating Task %s", taskName)
-	if _, err := c.TaskClient.Create(ctx, getClusterResourceTask(namespace, taskName, configName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.TaskClient.Create(ctx, getClusterResourceTask(t, namespace, taskName, configName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task `%s`: %s", taskName, err)
 	}
 
 	t.Logf("Creating TaskRun %s", taskRunName)
-	if _, err := c.TaskRunClient.Create(ctx, getClusterResourceTaskRun(namespace, taskRunName, taskName, resourceName), metav1.CreateOptions{}); err != nil {
+	if _, err := c.TaskRunClient.Create(ctx, getClusterResourceTaskRun(t, namespace, taskRunName, taskName, resourceName), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Taskrun `%s`: %s", taskRunName, err)
 	}
 
@@ -78,45 +79,30 @@ func TestClusterResource(t *testing.T) {
 	}
 }
 
-func getClusterResource(name, sname string) *v1alpha1.PipelineResource {
-	return &v1alpha1.PipelineResource{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1alpha1.PipelineResourceSpec{
-			Type: v1alpha1.PipelineResourceTypeCluster,
-			Params: []v1alpha1.ResourceParam{
-				{
-					Name:  "Name",
-					Value: "helloworld-cluster",
-				},
-				{
-					Name:  "Url",
-					Value: "https://1.1.1.1",
-				},
-				{
-					Name:  "username",
-					Value: "test-user",
-				},
-				{
-					Name:  "password",
-					Value: "test-password",
-				},
-			},
-			SecretParams: []v1alpha1.SecretParam{
-				{
-					FieldName:  "cadata",
-					SecretKey:  "cadatakey",
-					SecretName: sname,
-				},
-				{
-					FieldName:  "token",
-					SecretKey:  "tokenkey",
-					SecretName: sname,
-				},
-			},
-		},
-	}
+func getClusterResource(t *testing.T, name, sname string) *resourcev1alpha1.PipelineResource {
+	return mustParsePipelineResource(t, fmt.Sprintf(`
+metadata:
+  name: %s
+spec:
+  type: cluster
+  params:
+  - name: Name
+    value: helloworld-cluster
+  - name: Url
+    value: https://1.1.1.1
+  - name: username
+    value: test-user
+  - name: password
+    value: test-password
+  secrets:
+  - fieldName: cadata
+    secretKey: cadatakey
+    secretName: %s
+  - fieldName: token
+    secretKey: tokenkey
+    secretName: %s
+`, name, sname, sname))
+
 }
 
 func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
@@ -132,70 +118,56 @@ func getClusterResourceTaskSecret(namespace, name string) *corev1.Secret {
 	}
 }
 
-func getClusterResourceTask(namespace, name, configName string) *v1beta1.Task {
-	return &v1beta1.Task{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: v1beta1.TaskSpec{
-			Resources: &v1beta1.TaskResources{
-				Inputs: []v1beta1.TaskResource{{ResourceDeclaration: v1beta1.ResourceDeclaration{
-					Name: "target-cluster",
-					Type: resources.PipelineResourceTypeCluster,
-				}}},
-			},
-			Volumes: []corev1.Volume{{
-				Name: "config-vol",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: configName,
-						},
-					},
-				},
-			}},
-			Steps: []v1beta1.Step{{Container: corev1.Container{
-				Name:    "check-file-existence",
-				Image:   "ubuntu",
-				Command: []string{"cat"},
-				Args:    []string{"$(resources.inputs.target-cluster.path)/kubeconfig"},
-			}}, {Container: corev1.Container{
-				Name:    "check-config-data",
-				Image:   "ubuntu",
-				Command: []string{"cat"},
-				Args:    []string{"/config/test.data"},
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "config-vol",
-					MountPath: "/config",
-				}},
-			}}, {Container: corev1.Container{
-				Name:    "check-contents",
-				Image:   "ubuntu",
-				Command: []string{"bash"},
-				Args:    []string{"-c", "cmp -b $(resources.inputs.target-cluster.path)/kubeconfig /config/test.data"},
-				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "config-vol",
-					MountPath: "/config",
-				}},
-			}},
-			},
-		},
-	}
+func getClusterResourceTask(t *testing.T, namespace, name, configName string) *v1beta1.Task {
+	return mustParseTask(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  resources:
+    inputs:
+    - name: target-cluster
+      type: cluster
+  volumes:
+  - name: config-vol
+    configMap:
+      name: %s
+  steps:
+  - name: check-file-existence
+    image: ubuntu
+    command: ['cat']
+    args: ['$(resources.inputs.target-cluster.path)/kubeconfig']
+  - name: check-config-data
+    image: ubuntu
+    command: ['cat']
+    args: ['/config/test.data']
+    volumeMounts:
+    - name: config-vol
+      mountPath: /config
+  - name: check-contents
+    image: ubuntu
+    command: ['bash']
+    args: ['-c', 'cmp -b $(resources.inputs.target-cluster.path)/kubeconfig /config/test.data']
+    volumeMounts:
+    - name: config-vol
+      mountPath: /config
+`, name, namespace, configName))
 }
 
-func getClusterResourceTaskRun(namespace, name, taskName, resName string) *v1beta1.TaskRun {
-	return &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: taskName},
-			Resources: &v1beta1.TaskRunResources{
-				Inputs: []v1beta1.TaskResourceBinding{{
-					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-						Name:        "target-cluster",
-						ResourceRef: &v1beta1.PipelineResourceRef{Name: resName},
-					},
-				}},
-			},
-		},
-	}
+func getClusterResourceTaskRun(t *testing.T, namespace, name, taskName, resName string) *v1beta1.TaskRun {
+	return mustParseTaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  taskRef:
+    name: %s
+  resources:
+    inputs:
+    - name: target-cluster
+      resourceRef:
+        name: %s
+`, name, namespace, taskName, resName))
 }
 
 func getClusterConfigMap(namespace, name string) *corev1.ConfigMap {

--- a/test/yaml.go
+++ b/test/yaml.go
@@ -19,6 +19,9 @@ package test
 import (
 	"testing"
 
+	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
+
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned/scheme"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,4 +67,13 @@ kind: Pipeline
 ` + yaml
 	mustParseYAML(t, yaml, &pipeline)
 	return &pipeline
+}
+
+func mustParsePipelineResource(t *testing.T, yaml string) *resourcev1alpha1.PipelineResource {
+	var resource v1alpha1.PipelineResource
+	yaml = `apiVersion: tekton.dev/v1alpha1
+kind: PipelineResource
+` + yaml
+	mustParseYAML(t, yaml, &resource)
+	return &resource
 }


### PR DESCRIPTION
# Changes

Part of #4276

This is just one file from `test/...`, but it seemed like a good "let's start here" case to make sure the approaches I've gone with are acceptable:
* To deal with cases where we're parameterizing the struct currently, this keeps the parameterizing, using `fmt.Sprintf(...)`, since I decided that the raw multiline string literal was the way to go even if we need to do some `%s` replacement in it.
* For the moment, at least, I'm only worrying about Tekton structs - so the `Secret` and `ConfigMap` used in this test I just leave as is, rather than changing them to YAML. If y'all feel we should move those too, well, I'll do that. =)

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
