### PR TITLE
Have `[Cluster]Task` and `Pipeline` implement `kmeta.OwnerRefable`.

### DIFF
--- a/pkg/apis/pipeline/controller.go
+++ b/pkg/apis/pipeline/controller.go
@@ -21,8 +21,18 @@ const (
 	// nolint: revive
 	PipelineRunControllerName = "PipelineRun"
 
+	// PipelineControllerName holds the name of the Pipeline controller
+	// nolint: revive
+	PipelineControllerName = "Pipeline"
+
 	// TaskRunControllerName holds the name of the TaskRun controller
 	TaskRunControllerName = "TaskRun"
+
+	// TaskControllerName holds the name of the Task controller
+	TaskControllerName = "Task"
+
+	// ClusterTaskControllerName holds the name of the Task controller
+	ClusterTaskControllerName = "ClusterTask"
 
 	// RuncControllerName holds the name of the Custom Task controller
 	RunControllerName = "Run"

--- a/pkg/apis/pipeline/v1beta1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_types.go
@@ -17,7 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/kmeta"
 )
 
 // +genclient
@@ -37,6 +40,8 @@ type ClusterTask struct {
 	// +optional
 	Spec TaskSpec `json:"spec,omitempty"`
 }
+
+var _ kmeta.OwnerRefable = (*ClusterTask)(nil)
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -58,4 +63,9 @@ func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
 
 func (t *ClusterTask) Copy() TaskObject {
 	return t.DeepCopy()
+}
+
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*ClusterTask) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.ClusterTaskControllerName)
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -23,13 +23,16 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 )
 
 const (
@@ -58,6 +61,8 @@ type Pipeline struct {
 	Spec PipelineSpec `json:"spec"`
 }
 
+var _ kmeta.OwnerRefable = (*Pipeline)(nil)
+
 func (p *Pipeline) PipelineMetadata() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
@@ -68,6 +73,11 @@ func (p *Pipeline) PipelineSpec() PipelineSpec {
 
 func (p *Pipeline) Copy() PipelineObject {
 	return p.DeepCopy()
+}
+
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*Pipeline) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.PipelineControllerName)
 }
 
 // PipelineSpec defines the desired state of Pipeline.

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -17,8 +17,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/kmeta"
 )
 
 const (
@@ -52,6 +55,8 @@ type Task struct {
 	Spec TaskSpec `json:"spec"`
 }
 
+var _ kmeta.OwnerRefable = (*Task)(nil)
+
 func (t *Task) TaskSpec() TaskSpec {
 	return t.Spec
 }
@@ -62,6 +67,11 @@ func (t *Task) TaskMetadata() metav1.ObjectMeta {
 
 func (t *Task) Copy() TaskObject {
 	return t.DeepCopy()
+}
+
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*Task) GetGroupVersionKind() schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(pipeline.TaskControllerName)
 }
 
 // TaskSpec defines the desired state of Task.


### PR DESCRIPTION
This is somewhat related to https://github.com/tektoncd/pipeline/pull/4293,
in that a common thing to do one reconciling a certain primary resource is
to hang child resources off of it.

A simple example of this might be if you wanted to create Knative `Image`
resources for the images in a `TaskRun` to direct a caching system to warm
those images on builder nodes.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- N/A [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
