### PR TITLE
Remove last lingering unnecessarily exported functions

### DIFF
--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -117,8 +117,8 @@ func (cfg *Metrics) Equals(other *Metrics) bool {
 		other.DurationPipelinerunType == cfg.DurationPipelinerunType
 }
 
-// NewMetricsFromMap returns a Config given a map corresponding to a ConfigMap
-func NewMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
+// newMetricsFromMap returns a Config given a map corresponding to a ConfigMap
+func newMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 	tc := Metrics{
 		TaskrunLevel:            DefaultTaskrunLevel,
 		PipelinerunLevel:        DefaultPipelinerunLevel,
@@ -144,5 +144,5 @@ func NewMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 
 // NewArtifactBucketFromConfigMap returns a Config for the given configmap
 func NewMetricsFromConfigMap(config *corev1.ConfigMap) (*Metrics, error) {
-	return NewMetricsFromMap(config.Data)
+	return newMetricsFromMap(config.Data)
 }

--- a/pkg/apis/config/store.go
+++ b/pkg/apis/config/store.go
@@ -53,7 +53,7 @@ func FromContextOrDefaults(ctx context.Context) *Config {
 	featureFlags, _ := NewFeatureFlagsFromMap(map[string]string{})
 	artifactBucket, _ := NewArtifactBucketFromMap(map[string]string{})
 	artifactPVC, _ := NewArtifactPVCFromMap(map[string]string{})
-	metrics, _ := NewMetricsFromMap(map[string]string{})
+	metrics, _ := newMetricsFromMap(map[string]string{})
 	return &Config{
 		Defaults:       defaults,
 		FeatureFlags:   featureFlags,
@@ -121,7 +121,7 @@ func (s *Store) Load() *Config {
 
 	metrics := s.UntypedLoad(GetMetricsConfigName())
 	if metrics == nil {
-		metrics, _ = NewMetricsFromMap(map[string]string{})
+		metrics, _ = newMetricsFromMap(map[string]string{})
 	}
 	return &Config{
 		Defaults:       defaults.(*Defaults).DeepCopy(),

--- a/pkg/apis/pipeline/v1beta1/param_context.go
+++ b/pkg/apis/pipeline/v1beta1/param_context.go
@@ -30,9 +30,9 @@ var paramCtxKey struct{}
 // This maps param names -> ParamSpec.
 type paramCtxVal map[string]ParamSpec
 
-// AddContextParams adds the given Params to the param context. This only
+// addContextParams adds the given Params to the param context. This only
 // preserves the fields included in ParamSpec - Name and Type.
-func AddContextParams(ctx context.Context, in []Param) context.Context {
+func addContextParams(ctx context.Context, in []Param) context.Context {
 	if in == nil {
 		return ctx
 	}
@@ -67,8 +67,8 @@ func AddContextParams(ctx context.Context, in []Param) context.Context {
 	return context.WithValue(ctx, paramCtxKey, out)
 }
 
-// AddContextParamSpec adds the given ParamSpecs to the param context.
-func AddContextParamSpec(ctx context.Context, in []ParamSpec) context.Context {
+// addContextParamSpec adds the given ParamSpecs to the param context.
+func addContextParamSpec(ctx context.Context, in []ParamSpec) context.Context {
 	if in == nil {
 		return ctx
 	}
@@ -97,12 +97,12 @@ func AddContextParamSpec(ctx context.Context, in []ParamSpec) context.Context {
 	return context.WithValue(ctx, paramCtxKey, out)
 }
 
-// GetContextParams returns the current context parameters overlayed with a
+// getContextParams returns the current context parameters overlayed with a
 // given set of params. Overrides should generally be the current layer you
 // are trying to evaluate. Any context params not in the overrides will default
 // to a generic pass-through param of the given type (i.e. $(params.name) or
 // $(params.name[*])).
-func GetContextParams(ctx context.Context, overlays ...Param) []Param {
+func getContextParams(ctx context.Context, overlays ...Param) []Param {
 	pv := paramCtxVal{}
 	v := ctx.Value(paramCtxKey)
 	if v == nil && len(overlays) == 0 {
@@ -151,8 +151,8 @@ func GetContextParams(ctx context.Context, overlays ...Param) []Param {
 	return out
 }
 
-// GetContextParamSpecs returns the current context ParamSpecs.
-func GetContextParamSpecs(ctx context.Context) []ParamSpec {
+// getContextParamSpecs returns the current context ParamSpecs.
+func getContextParamSpecs(ctx context.Context) []ParamSpec {
 	v := ctx.Value(paramCtxKey)
 	if v == nil {
 		return nil

--- a/pkg/apis/pipeline/v1beta1/param_context_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_context_test.go
@@ -27,7 +27,7 @@ func TestAddContextParams(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("no-alpha", func(t *testing.T) {
-		ctx := AddContextParams(ctx, []Param{{Name: "a"}})
+		ctx := addContextParams(ctx, []Param{{Name: "a"}})
 		if v := ctx.Value(paramCtxKey); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
 		}
@@ -108,7 +108,7 @@ func TestAddContextParams(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx = AddContextParams(ctx, tc.params)
+			ctx = addContextParams(ctx, tc.params)
 			got := ctx.Value(paramCtxKey)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("-want,+got: %s", diff)
@@ -121,7 +121,7 @@ func TestAddContextParamSpec(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("no-alpha", func(t *testing.T) {
-		ctx := AddContextParamSpec(ctx, []ParamSpec{{Name: "a"}})
+		ctx := addContextParamSpec(ctx, []ParamSpec{{Name: "a"}})
 		if v := ctx.Value(paramCtxKey); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
 		}
@@ -188,7 +188,7 @@ func TestAddContextParamSpec(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx = AddContextParamSpec(ctx, tc.params)
+			ctx = addContextParamSpec(ctx, tc.params)
 			got := ctx.Value(paramCtxKey)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("-want,+got: %s", diff)
@@ -214,8 +214,8 @@ func TestGetContextParams(t *testing.T) {
 		},
 	}
 	t.Run("no-alpha", func(t *testing.T) {
-		ctx := AddContextParamSpec(ctx, want)
-		if v := GetContextParamSpecs(ctx); v != nil {
+		ctx := addContextParamSpec(ctx, want)
+		if v := getContextParamSpecs(ctx); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
 		}
 	})
@@ -225,7 +225,7 @@ func TestGetContextParams(t *testing.T) {
 	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
 	ctx = config.ToContext(ctx, cfg)
 
-	ctx = AddContextParamSpec(ctx, want)
+	ctx = addContextParamSpec(ctx, want)
 
 	for _, tc := range []struct {
 		name    string
@@ -270,7 +270,7 @@ func TestGetContextParams(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := GetContextParams(ctx, tc.overlay...)
+			got := getContextParams(ctx, tc.overlay...)
 			if diff := cmp.Diff(tc.want, got, cmpopts.SortSlices(func(x, y Param) bool { return x.Name < y.Name })); diff != "" {
 				t.Errorf("-want,+got: %s", diff)
 			}
@@ -295,8 +295,8 @@ func TestGetContextParamSpecs(t *testing.T) {
 		},
 	}
 	t.Run("no-alpha", func(t *testing.T) {
-		ctx := AddContextParamSpec(ctx, want)
-		if v := GetContextParamSpecs(ctx); v != nil {
+		ctx := addContextParamSpec(ctx, want)
+		if v := getContextParamSpecs(ctx); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
 		}
 	})
@@ -306,8 +306,8 @@ func TestGetContextParamSpecs(t *testing.T) {
 	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
 	ctx = config.ToContext(ctx, cfg)
 
-	ctx = AddContextParamSpec(ctx, want)
-	got := GetContextParamSpecs(ctx)
+	ctx = addContextParamSpec(ctx, want)
+	got := getContextParamSpecs(ctx)
 	if diff := cmp.Diff(want, got, cmpopts.SortSlices(func(x, y ParamSpec) bool { return x.Name < y.Name })); diff != "" {
 		t.Errorf("-want,+got: %s", diff)
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -34,14 +34,14 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 		ps.Params[i].SetDefaults(ctx)
 	}
 	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-		ctx = AddContextParamSpec(ctx, ps.Params)
-		ps.Params = GetContextParamSpecs(ctx)
+		ctx = addContextParamSpec(ctx, ps.Params)
+		ps.Params = getContextParamSpecs(ctx)
 	}
 	for i, pt := range ps.Tasks {
 		ctx := ctx // Ensure local scoping per Task
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = AddContextParams(ctx, pt.Params)
-			ps.Tasks[i].Params = GetContextParams(ctx, pt.Params...)
+			ctx = addContextParams(ctx, pt.Params)
+			ps.Tasks[i].Params = getContextParams(ctx, pt.Params...)
 		}
 		if pt.TaskRef != nil {
 			if pt.TaskRef.Kind == "" {
@@ -56,8 +56,8 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for i, ft := range ps.Finally {
 		ctx := ctx // Ensure local scoping per Task
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = AddContextParams(ctx, ft.Params)
-			ps.Finally[i].Params = GetContextParams(ctx, ft.Params...)
+			ctx = addContextParams(ctx, ft.Params)
+			ps.Finally[i].Params = getContextParams(ctx, ft.Params...)
 		}
 		if ft.TaskRef != nil {
 			if ft.TaskRef.Kind == "" {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -51,7 +51,7 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 
 	if prs.PipelineSpec != nil {
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = AddContextParams(ctx, prs.Params)
+			ctx = addContextParams(ctx, prs.Params)
 		}
 		prs.PipelineSpec.SetDefaults(ctx)
 	}

--- a/pkg/apis/pipeline/v1beta1/task_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/task_defaults.go
@@ -35,7 +35,7 @@ func (ts *TaskSpec) SetDefaults(ctx context.Context) {
 		ts.Params[i].SetDefaults(ctx)
 	}
 	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-		ctx = AddContextParamSpec(ctx, ts.Params)
-		ts.Params = GetContextParamSpecs(ctx)
+		ctx = addContextParamSpec(ctx, ts.Params)
+		ts.Params = getContextParamSpecs(ctx)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -65,7 +65,7 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	// If this taskrun has an embedded task, apply the usual task defaults
 	if trs.TaskSpec != nil {
 		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = AddContextParams(ctx, trs.Params)
+			ctx = addContextParams(ctx, trs.Params)
 		}
 		trs.TaskSpec.SetDefaults(ctx)
 	}


### PR DESCRIPTION
# Changes

fixes #3262

There are a few things left, either by design or uncertainty:
* `pkg/apis/pipeline/v1beta1/conversion_error.go`'s `ConvertErrorf` - I'm not entirely clear on whether this should be around or not. `CannotConvertError` is still used in tests in `pkg/apis/pipeline/v1alpha1`, and the whole thing is just messy enough that I'm not sure what to do.
* `pkg/apis/pipeline/v1beta1/version_validation.go`'s `ValidateEnabledAPIFields` - it's referenced in `docs/developers/README.md` and I can't tell if that's something that could be intended to eb used in something depending on Tekton, not just in Tekton itself.
* `pkg/pipelinerunmetrics/injection.go` and `pkg/taskrunmetrics/injection.go`'s `WithInformer` - these are both used as function references in their respective `.../fake/fake.go`s.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
