### PR TITLE
Fix nightly release process

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -66,6 +66,8 @@ spec:
       #!/bin/sh
       set -ex
 
+      cd ${PROJECT_ROOT}
+
       # Combine Distroless with a Windows base image, used for the entrypoint image.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
         gcr.io/distroless/base:debug-nonroot \


### PR DESCRIPTION
Previously, create-ko-yaml didn't need to be run in `${PROJECT_ROOT}`, but
after #4260 it tries to `go run` something assuming it's in
`${PROJECT_ROOT}`, which fails unless we `cd` into that directory.

#1826 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```