### PR TITLE
Don't pass the pipeline's default platforms value to the publish-image task

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -134,10 +134,11 @@ spec:
           value: $(params.imageRegistryPath)
         - name: releaseAsLatest
           value: $(params.releaseAsLatest)
-        - name: platforms
-          value: $(params.platforms)
         - name: serviceAccountPath
           value: $(params.serviceAccountPath)
+        # NOTE: We're purposefully *not* passing the pipeline's platforms to
+        # this task. We want to use the task's default platforms, which include
+        # windows.
       workspaces:
         - name: source
           workspace: workarea


### PR DESCRIPTION
We want to use the publish-image task's default platforms parameter
value which includes windows. build-base-image doesn't need to build for
windows, and fails if it's asked to.

/kind bug

#1826 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```