### PR TITLE
Fix panic when pending pipelinerun is failed

### DIFF
--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -216,9 +216,12 @@ func (r *Recorder) DurationAndCount(pr *v1beta1.PipelineRun) error {
 		return fmt.Errorf("ignoring the metrics recording for %s , failed to initialize the metrics recorder", pr.Name)
 	}
 
-	duration := time.Since(pr.Status.StartTime.Time)
-	if pr.Status.CompletionTime != nil {
-		duration = pr.Status.CompletionTime.Sub(pr.Status.StartTime.Time)
+	duration := time.Duration(0)
+	if pr.Status.StartTime != nil {
+		duration = time.Since(pr.Status.StartTime.Time)
+		if pr.Status.CompletionTime != nil {
+			duration = pr.Status.CompletionTime.Sub(pr.Status.StartTime.Time)
+		}
 	}
 
 	status := "success"

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -210,6 +210,34 @@ func TestRecordPipelineRunDurationCount(t *testing.T) {
 		},
 		expectedDuration: 60,
 		expectedCount:    1,
+	}, {
+		name: "for pipeline without start or completion time",
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-1", Namespace: "ns"},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{Name: "pipeline-1"},
+				Status:      v1beta1.PipelineRunSpecStatusPending,
+			},
+			Status: v1beta1.PipelineRunStatus{
+				Status: duckv1beta1.Status{
+					Conditions: duckv1beta1.Conditions{{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionFalse,
+					}},
+				},
+			},
+		},
+		expectedTags: map[string]string{
+			"pipeline":    "pipeline-1",
+			"pipelinerun": "pipelinerun-1",
+			"namespace":   "ns",
+			"status":      "failed",
+		},
+		expectedCountTags: map[string]string{
+			"status": "failed",
+		},
+		expectedDuration: 0,
+		expectedCount:    1,
 	}} {
 		t.Run(test.name, func(t *testing.T) {
 			unregisterMetrics()


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cheery picking PR: https://github.com/tektoncd/pipeline/pull/4298 (All the credit goes to @sbwsg, thank you Scott 🙏 )

PipelineRuns that are created with status PipelineRunPending
can be placed into a failed state before their execution begins.
For example: a third-party controller may be watching for pending
PipelineRuns to perform some checks on them prior to execution
beginning. If those checks fail the controller might choose to
set the PipelineRun status to failed with a relevant error message
indicating which check failed and why.

Prior to this commit when a pending PR failed our metrics code
could panic because the PR's StartTime is nil.

This commit adds a guard to the metrics code to ensure that StartTime
is not nil before computing the PR's duration. If it is nil then
we assume the duration is 0. A unit test confirming this behaviour
has been added as well.

(cherry picked from commit 0299c6c2c35b809f903e2dbb287047977e60cbcc)

Co-authored-by: sbwsg sbws@google.com

/kind bug


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixed an issue where the PipelineRun reconciler could panic if a PipelineRun with spec.status set to PipelineRunPending was placed into a failed state before execution was able to begin.
```
