### PR TITLE
Update comment for `dag.GetSchedulable`

### DIFF
--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -88,11 +88,11 @@ func Build(tasks Tasks, deps map[string][]string) (*Graph, error) {
 	return d, nil
 }
 
-// GetSchedulable returns a map of PipelineTask that can be scheduled (keyed
-// by the name of the PipelineTask) given a list of successfully finished doneTasks.
-// It returns tasks which have all dependencies marked as done, and thus can be scheduled. If the
-// specified doneTasks are invalid (i.e. if it is indicated that a Task is
-// done, but the previous Tasks are not done), an error is returned.
+// GetSchedulable returns a set of PipelineTask names that can be scheduled,
+// given a list of successfully finished doneTasks. It returns tasks which have
+// all dependencies marked as done, and thus can be scheduled. If the specified
+// doneTasks are invalid (i.e. if it is indicated that a Task is done, but the
+// previous Tasks are not done), an error is returned.
 func GetSchedulable(g *Graph, doneTasks ...string) (sets.String, error) {
 	roots := getRoots(g)
 	tm := sets.NewString(doneTasks...)


### PR DESCRIPTION
# Changes

The comment still described its return as a map, but in #2909, that was changed
to a `sets.String`. When I happened to stumble across this while looking into
something else, I thought "hey, this should probably be updated to be accurate!"

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
