### PR TITLE
Clean up a bunch of exported comments to actually match the element

### DIFF
--- a/pkg/apis/config/artifact_bucket.go
+++ b/pkg/apis/config/artifact_bucket.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	// bucketLocationKey is the name of the configmap entry that specifies
+	// BucketLocationKey is the name of the configmap entry that specifies
 	// loction of the bucket.
 	BucketLocationKey = "location"
 
@@ -38,16 +38,16 @@ const (
 	// to the bucket
 	BucketServiceAccountSecretKeyKey = "bucket.service.account.secret.key"
 
-	// DefaultBucketServiceAccountSecretKey defaults to a gcs bucket
+	// DefaultBucketServiceFieldName defaults to a gcs bucket
 	DefaultBucketServiceFieldName = "GOOGLE_APPLICATION_CREDENTIALS"
 
-	// bucketServiceAccountFieldName is the name of the configmap entry that specifies
+	// BucketServiceAccountFieldNameKey is the name of the configmap entry that specifies
 	// the field name that should be used for the service account.
 	// Valid values: GOOGLE_APPLICATION_CREDENTIALS, BOTO_CONFIG.
 	BucketServiceAccountFieldNameKey = "bucket.service.account.field.name"
 )
 
-// ArtifactPVC holds the configurations for the artifacts PVC
+// ArtifactBucket holds the configurations for the artifacts PVC
 // +k8s:deepcopy-gen=true
 type ArtifactBucket struct {
 	Location                 string

--- a/pkg/apis/config/artifact_pvc.go
+++ b/pkg/apis/config/artifact_pvc.go
@@ -63,7 +63,7 @@ func (cfg *ArtifactPVC) Equals(other *ArtifactPVC) bool {
 		other.StorageClassName == cfg.StorageClassName
 }
 
-// NewDefaultsFromMap returns a Config given a map corresponding to a ConfigMap
+// NewArtifactPVCFromMap returns a Config given a map corresponding to a ConfigMap
 func NewArtifactPVCFromMap(cfgMap map[string]string) (*ArtifactPVC, error) {
 	tc := ArtifactPVC{
 		Size: DefaultPVCSize,
@@ -80,7 +80,7 @@ func NewArtifactPVCFromMap(cfgMap map[string]string) (*ArtifactPVC, error) {
 	return &tc, nil
 }
 
-// NewDefaultsFromConfigMap returns a Config for the given configmap
+// NewArtifactPVCFromConfigMap returns a Config for the given configmap
 func NewArtifactPVCFromConfigMap(config *corev1.ConfigMap) (*ArtifactPVC, error) {
 	return NewArtifactPVCFromMap(config.Data)
 }

--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -70,7 +70,7 @@ const (
 	// DurationTaskrunTypeHistogram specify that histogram
 	// type metrics need to be use for Duration of Taskrun
 	DurationTaskrunTypeHistogram = "histogram"
-	// DurationTaskrunTypeHistogram specify that lastValue or
+	// DurationTaskrunTypeLastValue specify that lastValue or
 	// gauge type metrics need to be use for Duration of Taskrun
 	DurationTaskrunTypeLastValue = "lastvalue"
 
@@ -81,7 +81,7 @@ const (
 	// DurationPipelinerunTypeHistogram specify that histogram
 	// type metrics need to be use for Duration of Pipelinerun
 	DurationPipelinerunTypeHistogram = "histogram"
-	// DurationPipelinerunTypeHistogram specify that lastValue or
+	// DurationPipelinerunTypeLastValue specify that lastValue or
 	// gauge type metrics need to be use for Duration of Pipelinerun
 	DurationPipelinerunTypeLastValue = "lastvalue"
 )
@@ -95,7 +95,7 @@ type Metrics struct {
 	DurationPipelinerunType string
 }
 
-// GetArtifactBucketConfigName returns the name of the configmap containing all
+// GetMetricsConfigName returns the name of the configmap containing all
 // customizations for the storage bucket.
 func GetMetricsConfigName() string {
 	return metrics.ConfigMapName()
@@ -142,7 +142,7 @@ func newMetricsFromMap(cfgMap map[string]string) (*Metrics, error) {
 	return &tc, nil
 }
 
-// NewArtifactBucketFromConfigMap returns a Config for the given configmap
+// NewMetricsFromConfigMap returns a Config for the given configmap
 func NewMetricsFromConfigMap(config *corev1.ConfigMap) (*Metrics, error) {
 	return newMetricsFromMap(config.Data)
 }

--- a/pkg/apis/pipeline/controller.go
+++ b/pkg/apis/pipeline/controller.go
@@ -34,6 +34,6 @@ const (
 	// ClusterTaskControllerName holds the name of the Task controller
 	ClusterTaskControllerName = "ClusterTask"
 
-	// RuncControllerName holds the name of the Custom Task controller
+	// RunControllerName holds the name of the Custom Task controller
 	RunControllerName = "Run"
 )

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// PodTemplate holds pod specific configuration
+// Template holds pod specific configuration
 // +k8s:deepcopy-gen=true
 // +k8s:openapi-gen=true
 type Template struct {

--- a/pkg/apis/pipeline/v1alpha1/conversion_error.go
+++ b/pkg/apis/pipeline/v1alpha1/conversion_error.go
@@ -26,6 +26,6 @@ const (
 	// resources when they cannot be converted to warn of a forthcoming
 	// breakage.
 	ConditionTypeConvertible apis.ConditionType = v1beta1.ConditionTypeConvertible
-	// Conversion Error message for a field not available in v1alpha1
+	// ConversionErrorFieldNotAvailableMsg Conversion Error message for a field not available in v1alpha1
 	ConversionErrorFieldNotAvailableMsg = "the specified field/section is not available in v1alpha1"
 )

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -49,6 +49,7 @@ type PipelineSpec struct {
 type PipelineResult = v1beta1.PipelineResult
 
 // Check that Pipeline may be validated and defaulted.
+
 // TaskKind defines the type of Task used by the pipeline.
 type TaskKind = v1beta1.TaskKind
 

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -89,6 +89,7 @@ const (
 	RunSpecStatusCancelled RunSpecStatus = "RunCancelled"
 )
 
+// GetParam gets the Param from the RunSpec with the given name
 // TODO(jasonhall): Move this to a Params type so other code can use it?
 func (rs RunSpec) GetParam(name string) *v1beta1.Param {
 	for _, p := range rs.Params {

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -181,8 +181,8 @@ type Sidecar struct {
 	Workspaces []WorkspaceUsage `json:"workspaces,omitempty"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // TaskList contains a list of Task
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type TaskList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -206,6 +206,7 @@ type TaskRef struct {
 }
 
 // Check that Pipeline may be validated and defaulted.
+
 // TaskKind defines the type of Task used by the pipeline.
 type TaskKind string
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package git
 
 import (

--- a/pkg/internal/affinityassistant/transformer.go
+++ b/pkg/internal/affinityassistant/transformer.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package affinityassistant
 
 import (

--- a/pkg/internal/deprecated/override.go
+++ b/pkg/internal/deprecated/override.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package deprecated
 
 import (

--- a/pkg/internal/limitrange/doc.go
+++ b/pkg/internal/limitrange/doc.go
@@ -13,5 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 // Package limitrange defines logic for supporting Kubernetes LimitRange for the specific Tekton use cases
 package limitrange

--- a/pkg/internal/limitrange/limitrange.go
+++ b/pkg/internal/limitrange/limitrange.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package limitrange
 
 import (

--- a/pkg/internal/limitrange/transformer.go
+++ b/pkg/internal/limitrange/transformer.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package limitrange
 
 import (

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -267,7 +267,7 @@ func IsSidecarStatusRunning(tr *v1beta1.TaskRun) bool {
 	return false
 }
 
-// isContainerStep returns true if the container name indicates that it
+// IsContainerStep returns true if the container name indicates that it
 // represents a step.
 func IsContainerStep(name string) bool { return strings.HasPrefix(name, stepPrefix) }
 

--- a/pkg/pod/entrypoint_lookup.go
+++ b/pkg/pod/entrypoint_lookup.go
@@ -32,7 +32,7 @@ type EntrypointCache interface {
 	// not found in the cache, it will be fetched from the image registry,
 	// possibly using K8s service account imagePullSecrets.
 	Get(ctx context.Context, ref name.Reference, namespace, serviceAccountName string) (v1.Image, error)
-	// Update the cache with a new digest->Image mapping. This will avoid a
+	// Set updates the cache with a new digest->Image mapping. This will avoid a
 	// remote registry lookup next time Get is called.
 	Set(digest name.Digest, img v1.Image)
 }

--- a/pkg/reconciler/events/event.go
+++ b/pkg/reconciler/events/event.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package events
 
 import (

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	// ReasonUnknown indicates that the execution status of a pipelineTask is unknown
+	// PipelineTaskStateNone indicates that the execution status of a pipelineTask is unknown
 	PipelineTaskStateNone = "None"
 	// PipelineTaskStatusPrefix is a prefix of the param representing execution state of pipelineTask
 	PipelineTaskStatusPrefix = "tasks."

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
@@ -86,7 +86,7 @@ func validateResultRef(ref *v1beta1.ResultRef, ptMap map[string]*ResolvedPipelin
 	return nil
 }
 
-// validateOptionalWorkspaces validates that any workspaces in the Pipeline that are
+// ValidateOptionalWorkspaces validates that any workspaces in the Pipeline that are
 // marked as optional are also marked optional in the Tasks that receive them. This
 // prevents a situation where a Task requires a workspace but a Pipeline does not offer
 // the same guarantee the workspace will be provided at runtime.

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -60,7 +60,7 @@ func ValidateVariableP(value, prefix string, vars sets.String) *apis.FieldError 
 	return nil
 }
 
-// Verifies that variables matching the relevant string expressions do not reference any of the names present in vars.
+// ValidateVariableProhibited verifies that variables matching the relevant string expressions do not reference any of the names present in vars.
 func ValidateVariableProhibited(name, value, prefix, locationName, path string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
@@ -92,7 +92,7 @@ func ValidateVariableProhibitedP(value, prefix string, vars sets.String) *apis.F
 	return nil
 }
 
-// Verifies that variables matching the relevant string expressions are completely isolated if present.
+// ValidateVariableIsolated verifies that variables matching the relevant string expressions are completely isolated if present.
 func ValidateVariableIsolated(name, value, prefix, locationName, path string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		firstMatch, _ := extractExpressionFromString(value, prefix)
@@ -179,7 +179,7 @@ func ApplyReplacements(in string, replacements map[string]string) string {
 	return replacer.Replace(in)
 }
 
-// Take an input string, and output an array of strings related to possible arrayReplacements. If there aren't any
+// ApplyArrayReplacements takes an input string, and output an array of strings related to possible arrayReplacements. If there aren't any
 // areas where the input can be split up via arrayReplacements, then just return an array with a single element,
 // which is ApplyReplacements(in, replacements).
 func ApplyArrayReplacements(in string, stringReplacements map[string]string, arrayReplacements map[string][]string) []string {

--- a/pkg/termination/parse.go
+++ b/pkg/termination/parse.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package termination
 
 import (

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package termination
 
 import (

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package workspace
 
 import (

--- a/test/clients.go
+++ b/test/clients.go
@@ -36,6 +36,7 @@ And you can use the client to clean up resources created by your test
 	}
 
 */
+
 package test
 
 import (

--- a/test/v1alpha1/clients.go
+++ b/test/v1alpha1/clients.go
@@ -36,6 +36,7 @@ And you can use the client to clean up resources created by your test
 	}
 
 */
+
 package test
 
 import (

--- a/test/v1alpha1/wait.go
+++ b/test/v1alpha1/wait.go
@@ -41,6 +41,7 @@ For example, you can poll a TaskRun object to wait for it to have a Status.Condi
 	}, "TaskRunHasCondition")
 
 */
+
 package test
 
 import (

--- a/test/wait.go
+++ b/test/wait.go
@@ -41,6 +41,7 @@ For example, you can poll a TaskRun object to wait for it to have a Status.Condi
 	}, "TaskRunHasCondition")
 
 */
+
 package test
 
 import (


### PR DESCRIPTION
# Changes

Also separates license/misc comments from `package ...` lines.

These kept annoying me in my IDE, so hey, might as well fix them.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
