### PR TITLE
Fix unreachable code in `TestReconcileCancelledFailsTaskRunCancellation`

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -3230,9 +3230,8 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 
 	if val, ok := reconciledRun.GetLabels()[pipeline.PipelineLabelKey]; !ok {
 		t.Fatalf("expected pipeline label")
-		if d := cmp.Diff("test-pipelines", val); d != "" {
-			t.Errorf("expected to see pipeline label. Diff %s", diff.PrintWantGot(d))
-		}
+	} else if d := cmp.Diff("test-pipeline", val); d != "" {
+		t.Errorf("expected to see pipeline label. Diff %s", diff.PrintWantGot(d))
 	}
 
 	// The PipelineRun should not be cancelled b/c we couldn't cancel the TaskRun


### PR DESCRIPTION
# Changes

Code in `TestReconcileCancelledFailsTaskRunCancellation` was never going to be reached - it was getting a value from a map and fataling if the key wasn't present, and then the actual test logic for that value was in the same block as the `t.Fatalf`. I rearranged that, and also made the test logic for the value be valid - it was expecting `test-pipelines` as the value, but the value was actually always `test-pipeline` (singular!).

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
