### PR TITLE
Turn on most of golangci-lint's `exclude-use-default` rules, address problems

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
   - gocritic
   - revive
   - misspell
+  - unconvert
 output:
   uniq-by-line: false
 issues:
@@ -22,6 +23,10 @@ issues:
     - gosec
   max-issues-per-linter: 0
   max-same-issues: 0
+  include:
+  # Enable off-by-default rules for revive requiring that all exported elements have a properly formatted comment.
+  - EXC0012
+  - EXC0014
 run:
   issues-exit-code: 1
   build-tags:

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -38,6 +38,7 @@ type realRunner struct {
 
 var _ entrypoint.Runner = (*realRunner)(nil)
 
+// Run executes the entrypoint.
 func (rr *realRunner) Run(ctx context.Context, args ...string) error {
 	if len(args) == 0 {
 		return nil

--- a/cmd/entrypoint/subcommands/cp.go
+++ b/cmd/entrypoint/subcommands/cp.go
@@ -21,6 +21,7 @@ import (
 	"os"
 )
 
+// CopyCommand is the name of the copy command.
 const CopyCommand = "cp"
 
 // Owner has permission to write and execute, and anybody has

--- a/cmd/entrypoint/subcommands/decode_script.go
+++ b/cmd/entrypoint/subcommands/decode_script.go
@@ -25,6 +25,7 @@ import (
 	"os"
 )
 
+// DecodeScriptCommand is the command name for decoding scripts.
 const DecodeScriptCommand = "decode-script"
 
 // decodeScript rewrites a script file from base64 back into its original content from

--- a/cmd/entrypoint/subcommands/subcommands.go
+++ b/cmd/entrypoint/subcommands/subcommands.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 )
 
+// SubcommandSuccessful is returned for successful subcommand executions.
 type SubcommandSuccessful struct {
 	message string
 }
@@ -28,6 +29,7 @@ func (err SubcommandSuccessful) Error() string {
 	return err.message
 }
 
+// SubcommandError is returned for failed subcommand executions.
 type SubcommandError struct {
 	subcommand string
 	message    string

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,6 @@ require (
 	k8s.io/code-generator v0.21.4
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
-	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
+	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect
 	knative.dev/pkg v0.0.0-20210827184538-2bd91f75571c
 )

--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -28,16 +28,22 @@ import (
 )
 
 const (
-	DefaultTimeoutMinutes          = 60
-	NoTimeoutDuration              = 0 * time.Minute
+	// DefaultTimeoutMinutes is used when no timeout is specified.
+	DefaultTimeoutMinutes = 60
+	// NoTimeoutDuration is used when a pipeline or task should never time out.
+	NoTimeoutDuration = 0 * time.Minute
+	// DefaultServiceAccountValue is the SA used when one is not specified.
+	DefaultServiceAccountValue = "default"
+	// DefaultManagedByLabelValue is the value for the managed-by label that is used by default.
+	DefaultManagedByLabelValue = "tekton-pipelines"
+	// DefaultCloudEventSinkValue is the default value for cloud event sinks.
+	DefaultCloudEventSinkValue = ""
+
 	defaultTimeoutMinutesKey       = "default-timeout-minutes"
 	defaultServiceAccountKey       = "default-service-account"
-	DefaultServiceAccountValue     = "default"
 	defaultManagedByLabelValueKey  = "default-managed-by-label-value"
-	DefaultManagedByLabelValue     = "tekton-pipelines"
 	defaultPodTemplateKey          = "default-pod-template"
 	defaultCloudEventsSinkKey      = "default-cloud-events-sink"
-	DefaultCloudEventSinkValue     = ""
 	defaultTaskRunWorkspaceBinding = "default-task-run-workspace-binding"
 )
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -26,28 +26,41 @@ import (
 )
 
 const (
-	StableAPIFields                         = "stable"
-	AlphaAPIFields                          = "alpha"
-	disableHomeEnvOverwriteKey              = "disable-home-env-overwrite"
-	disableWorkingDirOverwriteKey           = "disable-working-directory-overwrite"
-	disableAffinityAssistantKey             = "disable-affinity-assistant"
-	disableCredsInitKey                     = "disable-creds-init"
-	runningInEnvWithInjectedSidecarsKey     = "running-in-environment-with-injected-sidecars"
-	requireGitSSHSecretKnownHostsKey        = "require-git-ssh-secret-known-hosts" // nolint: gosec
-	enableTektonOCIBundles                  = "enable-tekton-oci-bundles"
-	enableCustomTasks                       = "enable-custom-tasks"
-	enableAPIFields                         = "enable-api-fields"
-	scopeWhenExpressionsToTask              = "scope-when-expressions-to-task"
-	DefaultDisableHomeEnvOverwrite          = true
-	DefaultDisableWorkingDirOverwrite       = true
-	DefaultDisableAffinityAssistant         = false
-	DefaultDisableCredsInit                 = false
+	// StableAPIFields is the value used for "enable-api-fields" when only stable APIs should be usable.
+	StableAPIFields = "stable"
+	// AlphaAPIFields is the value used for "enable-api-fields" when alpha APIs should be usable as well.
+	AlphaAPIFields = "alpha"
+	// DefaultDisableHomeEnvOverwrite is the default value for "disable-home-env-overwrite".
+	DefaultDisableHomeEnvOverwrite = true
+	// DefaultDisableWorkingDirOverwrite is the default value for "disable-working-directory-overwrite".
+	DefaultDisableWorkingDirOverwrite = true
+	// DefaultDisableAffinityAssistant is the default value for "disable-affinity-assistant".
+	DefaultDisableAffinityAssistant = false
+	// DefaultDisableCredsInit is the default value for "disable-creds-init".
+	DefaultDisableCredsInit = false
+	// DefaultRunningInEnvWithInjectedSidecars is the default value for "running-in-environment-with-injected-sidecars".
 	DefaultRunningInEnvWithInjectedSidecars = true
-	DefaultRequireGitSSHSecretKnownHosts    = false
-	DefaultEnableTektonOciBundles           = false
-	DefaultEnableCustomTasks                = false
-	DefaultScopeWhenExpressionsToTask       = false
-	DefaultEnableAPIFields                  = StableAPIFields
+	// DefaultRequireGitSSHSecretKnownHosts is the default value for "require-git-ssh-secret-known-hosts".
+	DefaultRequireGitSSHSecretKnownHosts = false
+	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
+	DefaultEnableTektonOciBundles = false
+	// DefaultEnableCustomTasks is the default value for "enable-custom-tasks".
+	DefaultEnableCustomTasks = false
+	// DefaultScopeWhenExpressionsToTask is the default value for "scope-when-expressions-to-task".
+	DefaultScopeWhenExpressionsToTask = false
+	// DefaultEnableAPIFields is the default value for "enable-api-fields".
+	DefaultEnableAPIFields = StableAPIFields
+
+	disableHomeEnvOverwriteKey          = "disable-home-env-overwrite"
+	disableWorkingDirOverwriteKey       = "disable-working-directory-overwrite"
+	disableAffinityAssistantKey         = "disable-affinity-assistant"
+	disableCredsInitKey                 = "disable-creds-init"
+	runningInEnvWithInjectedSidecarsKey = "running-in-environment-with-injected-sidecars"
+	requireGitSSHSecretKnownHostsKey    = "require-git-ssh-secret-known-hosts" // nolint: gosec
+	enableTektonOCIBundles              = "enable-tekton-oci-bundles"
+	enableCustomTasks                   = "enable-custom-tasks"
+	enableAPIFields                     = "enable-api-fields"
+	scopeWhenExpressionsToTask          = "scope-when-expressions-to-task"
 )
 
 // FeatureFlags holds the features configurations

--- a/pkg/apis/pipeline/pod/doc.go
+++ b/pkg/apis/pipeline/pod/doc.go
@@ -15,4 +15,6 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+
+// Package pod contains non-versioned pod configuration
 package pod

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -111,6 +111,7 @@ type Template struct {
 	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
+// Equals checks if this Template is identical to the given Template.
 func (tpl *Template) Equals(other *Template) bool {
 	if tpl == nil && other == nil {
 		return true

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1alpha1
 
 import (
@@ -28,23 +27,23 @@ import (
 var _ apis.Convertible = (*ClusterTask)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *ClusterTask) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+func (ct *ClusterTask) ConvertTo(ctx context.Context, obj apis.Convertible) error {
 	switch sink := obj.(type) {
 	case *v1beta1.ClusterTask:
-		sink.ObjectMeta = source.ObjectMeta
-		return source.Spec.ConvertTo(ctx, &sink.Spec)
+		sink.ObjectMeta = ct.ObjectMeta
+		return ct.Spec.ConvertTo(ctx, &sink.Spec)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *ClusterTask) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+func (ct *ClusterTask) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
 	switch source := obj.(type) {
 	case *v1beta1.ClusterTask:
-		sink.ObjectMeta = source.ObjectMeta
-		return sink.Spec.ConvertFrom(ctx, &source.Spec)
+		ct.ObjectMeta = source.ObjectMeta
+		return ct.Spec.ConvertFrom(ctx, &source.Spec)
 	default:
-		return fmt.Errorf("unknown version, got: %T", sink)
+		return fmt.Errorf("unknown version, got: %T", ct)
 	}
 }

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_defaults.go
@@ -24,6 +24,7 @@ import (
 
 var _ apis.Defaultable = (*ClusterTask)(nil)
 
+// SetDefaults sets the default values for the ClusterTask's Spec.
 func (t *ClusterTask) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
 }

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_types.go
@@ -40,7 +40,7 @@ type ClusterTask struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ClusterTaskList contains a list of ClusterTask
+// ClusterTaskList contains a list of ClusterTask.
 type ClusterTaskList struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
@@ -48,14 +48,17 @@ type ClusterTaskList struct {
 	Items           []ClusterTask `json:"items"`
 }
 
+// TaskSpec returns the ClusterTask's Spec.
 func (t *ClusterTask) TaskSpec() TaskSpec {
 	return t.Spec
 }
 
+// TaskMetadata returns the ObjectMeta for the ClusterTask.
 func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
+// Copy returns a DeepCopy of the ClusterTask.
 func (t *ClusterTask) Copy() TaskObject {
 	return t.DeepCopy()
 }

--- a/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/cluster_task_validation.go
@@ -25,6 +25,7 @@ import (
 
 var _ apis.Validatable = (*ClusterTask)(nil)
 
+// Validate performs validation of the metadata and spec of this ClusterTask.
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")

--- a/pkg/apis/pipeline/v1alpha1/condition_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_defaults.go
@@ -24,10 +24,12 @@ import (
 
 var _ apis.Defaultable = (*Condition)(nil)
 
+// SetDefaults sets the Condition's Spec's default values.
 func (c *Condition) SetDefaults(ctx context.Context) {
 	c.Spec.SetDefaults(ctx)
 }
 
+// SetDefaults sets defaults for all params on the ConditionSpec.
 func (cs *ConditionSpec) SetDefaults(ctx context.Context) {
 	for i := range cs.Params {
 		cs.Params[i].SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/condition_types.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_types.go
@@ -80,6 +80,7 @@ type ConditionList struct {
 	Items           []Condition `json:"items"`
 }
 
+// NewConditionCheck creates a new ConditionCheck from a given TaskRun.
 func NewConditionCheck(tr *TaskRun) *ConditionCheck {
 	if tr == nil {
 		return nil

--- a/pkg/apis/pipeline/v1alpha1/condition_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/condition_validation.go
@@ -28,6 +28,7 @@ import (
 
 var _ apis.Validatable = (*Condition)(nil)
 
+// Validate performs validation on the Condition's metadata and spec
 func (c Condition) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(c.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
@@ -38,6 +39,8 @@ func (c Condition) Validate(ctx context.Context) *apis.FieldError {
 	return c.Spec.Validate(ctx).ViaField("Spec")
 }
 
+// Validate makes sure the ConditionSpec is actually configured and that its name is a valid DNS label,
+// and finally validates its steps.
 func (cs *ConditionSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(cs, ConditionSpec{}) {
 		return apis.ErrMissingField(apis.CurrentField)

--- a/pkg/apis/pipeline/v1alpha1/container_replacements.go
+++ b/pkg/apis/pipeline/v1alpha1/container_replacements.go
@@ -21,6 +21,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// ApplyContainerReplacements replaces ${...} expressions in the container's name, image, args, env, command, workingDir,
+// and volumes.
 func ApplyContainerReplacements(step *corev1.Container, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	step.Name = substitution.ApplyReplacements(step.Name, stringReplacements)
 	step.Image = substitution.ApplyReplacements(step.Image, stringReplacements)

--- a/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_defaults.go
@@ -24,10 +24,12 @@ import (
 
 var _ apis.Defaultable = (*Pipeline)(nil)
 
+// SetDefaults sets default values on the Pipeline's Spec
 func (p *Pipeline) SetDefaults(ctx context.Context) {
 	p.Spec.SetDefaults(ctx)
 }
 
+// SetDefaults sets default values for the PipelineSpec's Params and Tasks
 func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for _, pt := range ps.Tasks {
 		if pt.TaskRef != nil {

--- a/pkg/apis/pipeline/v1alpha1/pipeline_resource_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_resource_types.go
@@ -25,10 +25,6 @@ import (
 // additional metatdata should be provided for it.
 type PipelineResourceType = resource.PipelineResourceType
 
-var (
-	AllowedOutputResources = resource.AllowedOutputResources
-)
-
 const (
 	// PipelineResourceTypeGit indicates that this source is a Git repo.
 	PipelineResourceTypeGit PipelineResourceType = resource.PipelineResourceTypeGit

--- a/pkg/apis/pipeline/v1alpha1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipeline_types.go
@@ -90,14 +90,17 @@ type Pipeline struct {
 type PipelineStatus struct {
 }
 
+// PipelineMetadata returns the Pipeline's ObjectMeta, implementing PipelineObject.
 func (p *Pipeline) PipelineMetadata() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
 
+// PipelineSpec returns the Pipeline's Spec, implementing PipelineObject.
 func (p *Pipeline) PipelineSpec() PipelineSpec {
 	return p.Spec
 }
 
+// Copy returns a deep copy of the Pipeline, implementing PipelineObject.
 func (p *Pipeline) Copy() PipelineObject {
 	return p.DeepCopy()
 }
@@ -151,10 +154,12 @@ type PipelineTask struct {
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }
 
+// HashKey is used as the key for this PipelineTask in the DAG
 func (pt PipelineTask) HashKey() string {
 	return pt.Name
 }
 
+// Deps returns all other PipelineTask dependencies of this PipelineTask, based on resource usage or ordering
 func (pt PipelineTask) Deps() []string {
 	deps := []string{}
 	deps = append(deps, pt.RunAfter...)
@@ -192,8 +197,10 @@ func (pt PipelineTask) Deps() []string {
 	return deps
 }
 
+// PipelineTaskList is a list of PipelineTasks
 type PipelineTaskList []PipelineTask
 
+// Items returns a slice of all tasks in the PipelineTaskList, converted to dag.Tasks
 func (l PipelineTaskList) Items() []dag.Task {
 	tasks := []dag.Task{}
 	for _, t := range l {
@@ -202,6 +209,7 @@ func (l PipelineTaskList) Items() []dag.Task {
 	return tasks
 }
 
+// Deps returns a map with key as name of a pipelineTask and value as a list of its dependencies
 func (l PipelineTaskList) Deps() map[string][]string {
 	deps := map[string][]string{}
 	for _, pt := range l {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1alpha1
 
 import (
@@ -28,14 +27,14 @@ import (
 var _ apis.Convertible = (*PipelineRun)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *PipelineRun) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+func (pr *PipelineRun) ConvertTo(ctx context.Context, obj apis.Convertible) error {
 	switch sink := obj.(type) {
 	case *v1beta1.PipelineRun:
-		sink.ObjectMeta = source.ObjectMeta
-		if err := source.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
+		sink.ObjectMeta = pr.ObjectMeta
+		if err := pr.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
 			return err
 		}
-		sink.Status = source.Status
+		sink.Status = pr.Status
 
 		spec := &v1beta1.PipelineSpec{}
 		if err := deserializeFinally(&sink.ObjectMeta, spec); err != nil {
@@ -54,62 +53,64 @@ func (source *PipelineRun) ConvertTo(ctx context.Context, obj apis.Convertible) 
 	}
 }
 
-func (source *PipelineRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.PipelineRunSpec) error {
-	sink.PipelineRef = source.PipelineRef
-	if source.PipelineSpec != nil {
+// ConvertTo implements api.Convertible
+func (prs *PipelineRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.PipelineRunSpec) error {
+	sink.PipelineRef = prs.PipelineRef
+	if prs.PipelineSpec != nil {
 		sink.PipelineSpec = &v1beta1.PipelineSpec{}
-		if err := source.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec); err != nil {
+		if err := prs.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec); err != nil {
 			return err
 		}
 	}
-	sink.Resources = source.Resources
-	sink.Params = source.Params
-	sink.ServiceAccountName = source.ServiceAccountName
-	sink.ServiceAccountNames = source.ServiceAccountNames
-	sink.Status = source.Status
-	sink.Timeout = source.Timeout
-	sink.PodTemplate = source.PodTemplate
-	sink.Workspaces = source.Workspaces
+	sink.Resources = prs.Resources
+	sink.Params = prs.Params
+	sink.ServiceAccountName = prs.ServiceAccountName
+	sink.ServiceAccountNames = prs.ServiceAccountNames
+	sink.Status = prs.Status
+	sink.Timeout = prs.Timeout
+	sink.PodTemplate = prs.PodTemplate
+	sink.Workspaces = prs.Workspaces
 	return nil
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *PipelineRun) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+func (pr *PipelineRun) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
 	switch source := obj.(type) {
 	case *v1beta1.PipelineRun:
-		sink.ObjectMeta = source.ObjectMeta
-		if err := sink.Spec.ConvertFrom(ctx, &source.Spec); err != nil {
+		pr.ObjectMeta = source.ObjectMeta
+		if err := pr.Spec.ConvertFrom(ctx, &source.Spec); err != nil {
 			return err
 		}
-		sink.Status = source.Status
+		pr.Status = source.Status
 
 		ps := source.Spec.PipelineSpec
 		if ps != nil && ps.Finally != nil {
-			if err := serializeFinally(&sink.ObjectMeta, ps.Finally); err != nil {
+			if err := serializeFinally(&pr.ObjectMeta, ps.Finally); err != nil {
 				return err
 			}
 		}
 		return nil
 	default:
-		return fmt.Errorf("unknown version, got: %T", sink)
+		return fmt.Errorf("unknown version, got: %T", pr)
 	}
 }
 
-func (sink *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1beta1.PipelineRunSpec) error {
-	sink.PipelineRef = source.PipelineRef
+// ConvertFrom implements api.Convertible
+func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1beta1.PipelineRunSpec) error {
+	prs.PipelineRef = source.PipelineRef
 	if source.PipelineSpec != nil {
-		sink.PipelineSpec = &PipelineSpec{}
-		if err := sink.PipelineSpec.ConvertFrom(ctx, *source.PipelineSpec); err != nil {
+		prs.PipelineSpec = &PipelineSpec{}
+		if err := prs.PipelineSpec.ConvertFrom(ctx, *source.PipelineSpec); err != nil {
 			return err
 		}
 	}
-	sink.Resources = source.Resources
-	sink.Params = source.Params
-	sink.ServiceAccountName = source.ServiceAccountName
-	sink.ServiceAccountNames = source.ServiceAccountNames
-	sink.Status = source.Status
-	sink.Timeout = source.Timeout
-	sink.PodTemplate = source.PodTemplate
-	sink.Workspaces = source.Workspaces
+	prs.Resources = source.Resources
+	prs.Params = source.Params
+	prs.ServiceAccountName = source.ServiceAccountName
+	prs.ServiceAccountNames = source.ServiceAccountNames
+	prs.Status = source.Status
+	prs.Timeout = source.Timeout
+	prs.PodTemplate = source.PodTemplate
+	prs.Workspaces = source.Workspaces
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_defaults.go
@@ -27,10 +27,12 @@ import (
 
 var _ apis.Defaultable = (*PipelineRun)(nil)
 
+// SetDefaults implements apis.Defaultable
 func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 	pr.Spec.SetDefaults(ctx)
 }
 
+// SetDefaults implements apis.Defaultable
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil {

--- a/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/pipelinerun_types.go
@@ -49,6 +49,7 @@ type PipelineRun struct {
 	Status PipelineRunStatus `json:"status,omitempty"`
 }
 
+// GetName returns the PipelineRun's name
 func (pr *PipelineRun) GetName() string {
 	return pr.ObjectMeta.GetName()
 }
@@ -113,8 +114,6 @@ type PipelineRunStatusFields = v1beta1.PipelineRunStatusFields
 
 // PipelineRunTaskRunStatus contains the name of the PipelineTask for this TaskRun and the TaskRun's Status
 type PipelineRunTaskRunStatus = v1beta1.PipelineRunTaskRunStatus
-
-type PipelineRunConditionCheckStatus = v1beta1.PipelineRunConditionCheckStatus
 
 // PipelineRunSpecServiceAccountName can be used to configure specific
 // ServiceAccountName for a concrete Task

--- a/pkg/apis/pipeline/v1alpha1/pod.go
+++ b/pkg/apis/pipeline/v1alpha1/pod.go
@@ -4,4 +4,5 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 )
 
+// PodTemplate holds pod specific configuration
 type PodTemplate = pod.Template

--- a/pkg/apis/pipeline/v1alpha1/run_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/run_defaults.go
@@ -25,11 +25,13 @@ import (
 
 var _ apis.Defaultable = (*Run)(nil)
 
+// SetDefaults implements apis.Defaultable
 func (r *Run) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, r.ObjectMeta)
 	r.Spec.SetDefaults(apis.WithinSpec(ctx))
 }
 
+// SetDefaults implements apis.Defaultable
 func (rs *RunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	defaultSA := cfg.Defaults.DefaultServiceAccount

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -218,6 +218,7 @@ func (r *Run) HasTimedOut() bool {
 	return runtime > timeout
 }
 
+// GetTimeout returns the timeout for this run, or the default if not configured
 func (r *Run) GetTimeout() time.Duration {
 	// Use the platform default if no timeout is set
 	if r.Spec.Timeout == nil {

--- a/pkg/apis/pipeline/v1alpha1/step_replacements.go
+++ b/pkg/apis/pipeline/v1alpha1/step_replacements.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/substitution"
 )
 
+// ApplyStepReplacements applies variable interpolation on a Step.
 func ApplyStepReplacements(step *Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	step.Script = substitution.ApplyReplacements(step.Script, stringReplacements)
 	ApplyContainerReplacements(&step.Container, stringReplacements, arrayReplacements)

--- a/pkg/apis/pipeline/v1alpha1/task_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/task_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1alpha1
 
 import (
@@ -28,47 +27,48 @@ import (
 var _ apis.Convertible = (*Task)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *Task) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+func (t *Task) ConvertTo(ctx context.Context, obj apis.Convertible) error {
 	switch sink := obj.(type) {
 	case *v1beta1.Task:
-		sink.ObjectMeta = source.ObjectMeta
-		return source.Spec.ConvertTo(ctx, &sink.Spec)
+		sink.ObjectMeta = t.ObjectMeta
+		return t.Spec.ConvertTo(ctx, &sink.Spec)
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 }
 
-func (source *TaskSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskSpec) error {
-	sink.Steps = source.Steps
-	sink.Volumes = source.Volumes
-	sink.StepTemplate = source.StepTemplate
-	sink.Sidecars = source.Sidecars
-	sink.Workspaces = source.Workspaces
-	sink.Results = source.Results
-	sink.Resources = source.Resources
-	sink.Params = source.Params
-	sink.Description = source.Description
-	if source.Inputs != nil {
-		if len(source.Inputs.Params) > 0 && len(source.Params) > 0 {
+// ConvertTo implements api.Convertible
+func (ts *TaskSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskSpec) error {
+	sink.Steps = ts.Steps
+	sink.Volumes = ts.Volumes
+	sink.StepTemplate = ts.StepTemplate
+	sink.Sidecars = ts.Sidecars
+	sink.Workspaces = ts.Workspaces
+	sink.Results = ts.Results
+	sink.Resources = ts.Resources
+	sink.Params = ts.Params
+	sink.Description = ts.Description
+	if ts.Inputs != nil {
+		if len(ts.Inputs.Params) > 0 && len(ts.Params) > 0 {
 			// This shouldn't happen as it shouldn't pass validation
 			return apis.ErrMultipleOneOf("inputs.params", "params")
 		}
-		if len(source.Inputs.Params) > 0 {
-			sink.Params = make([]v1beta1.ParamSpec, len(source.Inputs.Params))
-			for i, param := range source.Inputs.Params {
+		if len(ts.Inputs.Params) > 0 {
+			sink.Params = make([]v1beta1.ParamSpec, len(ts.Inputs.Params))
+			for i, param := range ts.Inputs.Params {
 				sink.Params[i] = *param.DeepCopy()
 			}
 		}
-		if len(source.Inputs.Resources) > 0 {
+		if len(ts.Inputs.Resources) > 0 {
 			if sink.Resources == nil {
 				sink.Resources = &v1beta1.TaskResources{}
 			}
-			if len(source.Inputs.Resources) > 0 && source.Resources != nil && len(source.Resources.Inputs) > 0 {
+			if len(ts.Inputs.Resources) > 0 && ts.Resources != nil && len(ts.Resources.Inputs) > 0 {
 				// This shouldn't happen as it shouldn't pass validation but just in case
 				return apis.ErrMultipleOneOf("inputs.resources", "resources.inputs")
 			}
-			sink.Resources.Inputs = make([]v1beta1.TaskResource, len(source.Inputs.Resources))
-			for i, resource := range source.Inputs.Resources {
+			sink.Resources.Inputs = make([]v1beta1.TaskResource, len(ts.Inputs.Resources))
+			for i, resource := range ts.Inputs.Resources {
 				sink.Resources.Inputs[i] = v1beta1.TaskResource{ResourceDeclaration: v1beta1.ResourceDeclaration{
 					Name:        resource.Name,
 					Type:        resource.Type,
@@ -79,16 +79,16 @@ func (source *TaskSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskSpec) e
 			}
 		}
 	}
-	if source.Outputs != nil && len(source.Outputs.Resources) > 0 {
+	if ts.Outputs != nil && len(ts.Outputs.Resources) > 0 {
 		if sink.Resources == nil {
 			sink.Resources = &v1beta1.TaskResources{}
 		}
-		if len(source.Outputs.Resources) > 0 && source.Resources != nil && len(source.Resources.Outputs) > 0 {
+		if len(ts.Outputs.Resources) > 0 && ts.Resources != nil && len(ts.Resources.Outputs) > 0 {
 			// This shouldn't happen as it shouldn't pass validation but just in case
 			return apis.ErrMultipleOneOf("outputs.resources", "resources.outputs")
 		}
-		sink.Resources.Outputs = make([]v1beta1.TaskResource, len(source.Outputs.Resources))
-		for i, resource := range source.Outputs.Resources {
+		sink.Resources.Outputs = make([]v1beta1.TaskResource, len(ts.Outputs.Resources))
+		for i, resource := range ts.Outputs.Resources {
 			sink.Resources.Outputs[i] = v1beta1.TaskResource{ResourceDeclaration: v1beta1.ResourceDeclaration{
 				Name:        resource.Name,
 				Type:        resource.Type,
@@ -102,25 +102,26 @@ func (source *TaskSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskSpec) e
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *Task) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+func (t *Task) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
 	switch source := obj.(type) {
 	case *v1beta1.Task:
-		sink.ObjectMeta = source.ObjectMeta
-		return sink.Spec.ConvertFrom(ctx, &source.Spec)
+		t.ObjectMeta = source.ObjectMeta
+		return t.Spec.ConvertFrom(ctx, &source.Spec)
 	default:
-		return fmt.Errorf("unknown version, got: %T", sink)
+		return fmt.Errorf("unknown version, got: %T", t)
 	}
 }
 
-func (sink *TaskSpec) ConvertFrom(ctx context.Context, source *v1beta1.TaskSpec) error {
-	sink.Steps = source.Steps
-	sink.Volumes = source.Volumes
-	sink.StepTemplate = source.StepTemplate
-	sink.Sidecars = source.Sidecars
-	sink.Workspaces = source.Workspaces
-	sink.Results = source.Results
-	sink.Params = source.Params
-	sink.Resources = source.Resources
-	sink.Description = source.Description
+// ConvertFrom implements api.Convertible
+func (ts *TaskSpec) ConvertFrom(ctx context.Context, source *v1beta1.TaskSpec) error {
+	ts.Steps = source.Steps
+	ts.Volumes = source.Volumes
+	ts.StepTemplate = source.StepTemplate
+	ts.Sidecars = source.Sidecars
+	ts.Workspaces = source.Workspaces
+	ts.Results = source.Results
+	ts.Params = source.Params
+	ts.Resources = source.Resources
+	ts.Description = source.Description
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/task_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/task_defaults.go
@@ -24,6 +24,7 @@ import (
 
 var _ apis.Defaultable = (*Task)(nil)
 
+// SetDefaults implements apis.Defaultable
 func (t *Task) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
 }
@@ -38,6 +39,7 @@ func (ts *TaskSpec) SetDefaults(ctx context.Context) {
 	}
 }
 
+// SetDefaults implements apis.Defaultable
 func (inputs *Inputs) SetDefaults(ctx context.Context) {
 	for i := range inputs.Params {
 		inputs.Params[i].SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1alpha1/task_types.go
+++ b/pkg/apis/pipeline/v1alpha1/task_types.go
@@ -31,14 +31,17 @@ const (
 	UnknownResultType ResultType = v1beta1.UnknownResultType
 )
 
+// TaskSpec returns the task's spec
 func (t *Task) TaskSpec() TaskSpec {
 	return t.Spec
 }
 
+// TaskMetadata returns the task's ObjectMeta
 func (t *Task) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
+// Copy returns a deep copy of the task
 func (t *Task) Copy() TaskObject {
 	return t.DeepCopy()
 }
@@ -64,6 +67,7 @@ type TaskResult = v1beta1.TaskResult
 // provided by Container.
 type Step = v1beta1.Step
 
+// Sidecar has nearly the same data structure as Step, consisting of a Container and an optional Script, but does not have the ability to timeout.
 type Sidecar = v1beta1.Sidecar
 
 // +genclient

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -33,6 +33,7 @@ import (
 
 var _ apis.Validatable = (*Task)(nil)
 
+// Validate implements apis.Validatable
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(t.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
@@ -43,6 +44,7 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	return t.Spec.Validate(ctx)
 }
 
+// Validate implements apis.Validatable
 func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 
 	if len(ts.Steps) == 0 {
@@ -182,6 +184,7 @@ func validateDeclaredWorkspaces(workspaces []WorkspaceDeclaration, steps []Step,
 	return nil
 }
 
+// ValidateVolumes validates a slice of volumes to make sure there are no duplicate names
 func ValidateVolumes(volumes []corev1.Volume) *apis.FieldError {
 	// Task must not have duplicate volume names.
 	vols := sets.NewString()
@@ -430,5 +433,5 @@ func validateResourceType(r TaskResource, path string) *apis.FieldError {
 			return nil
 		}
 	}
-	return apis.ErrInvalidValue(string(r.Type), path)
+	return apis.ErrInvalidValue(r.Type, path)
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1alpha1
 
 import (
@@ -28,57 +27,58 @@ import (
 var _ apis.Convertible = (*TaskRun)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *TaskRun) ConvertTo(ctx context.Context, obj apis.Convertible) error {
+func (tr *TaskRun) ConvertTo(ctx context.Context, obj apis.Convertible) error {
 	switch sink := obj.(type) {
 	case *v1beta1.TaskRun:
-		sink.ObjectMeta = source.ObjectMeta
-		if err := source.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
+		sink.ObjectMeta = tr.ObjectMeta
+		if err := tr.Spec.ConvertTo(ctx, &sink.Spec); err != nil {
 			return err
 		}
-		sink.Status = source.Status
+		sink.Status = tr.Status
 		return nil
 	default:
 		return fmt.Errorf("unknown version, got: %T", sink)
 	}
 }
 
-func (source *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskRunSpec) error {
-	sink.ServiceAccountName = source.ServiceAccountName
-	sink.TaskRef = source.TaskRef
-	if source.TaskSpec != nil {
+// ConvertTo implements api.Convertible
+func (trs *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskRunSpec) error {
+	sink.ServiceAccountName = trs.ServiceAccountName
+	sink.TaskRef = trs.TaskRef
+	if trs.TaskSpec != nil {
 		sink.TaskSpec = &v1beta1.TaskSpec{}
-		if err := source.TaskSpec.ConvertTo(ctx, sink.TaskSpec); err != nil {
+		if err := trs.TaskSpec.ConvertTo(ctx, sink.TaskSpec); err != nil {
 			return err
 		}
 	}
-	sink.Status = source.Status
-	sink.Timeout = source.Timeout
-	sink.PodTemplate = source.PodTemplate
-	sink.Workspaces = source.Workspaces
-	sink.Params = source.Params
-	sink.Resources = source.Resources
+	sink.Status = trs.Status
+	sink.Timeout = trs.Timeout
+	sink.PodTemplate = trs.PodTemplate
+	sink.Workspaces = trs.Workspaces
+	sink.Params = trs.Params
+	sink.Resources = trs.Resources
 	// Deprecated fields
-	if source.Inputs != nil {
-		if len(source.Inputs.Params) > 0 && len(source.Params) > 0 {
+	if trs.Inputs != nil {
+		if len(trs.Inputs.Params) > 0 && len(trs.Params) > 0 {
 			// This shouldn't happen as it shouldn't pass validation
 			return apis.ErrMultipleOneOf("inputs.params", "params")
 		}
-		if len(source.Inputs.Params) > 0 {
-			sink.Params = make([]v1beta1.Param, len(source.Inputs.Params))
-			for i, param := range source.Inputs.Params {
+		if len(trs.Inputs.Params) > 0 {
+			sink.Params = make([]v1beta1.Param, len(trs.Inputs.Params))
+			for i, param := range trs.Inputs.Params {
 				sink.Params[i] = *param.DeepCopy()
 			}
 		}
-		if len(source.Inputs.Resources) > 0 {
+		if len(trs.Inputs.Resources) > 0 {
 			if sink.Resources == nil {
 				sink.Resources = &v1beta1.TaskRunResources{}
 			}
-			if len(source.Inputs.Resources) > 0 && source.Resources != nil && len(source.Resources.Inputs) > 0 {
+			if len(trs.Inputs.Resources) > 0 && trs.Resources != nil && len(trs.Resources.Inputs) > 0 {
 				// This shouldn't happen as it shouldn't pass validation but just in case
 				return apis.ErrMultipleOneOf("inputs.resources", "resources.inputs")
 			}
-			sink.Resources.Inputs = make([]v1beta1.TaskResourceBinding, len(source.Inputs.Resources))
-			for i, resource := range source.Inputs.Resources {
+			sink.Resources.Inputs = make([]v1beta1.TaskResourceBinding, len(trs.Inputs.Resources))
+			for i, resource := range trs.Inputs.Resources {
 				sink.Resources.Inputs[i] = v1beta1.TaskResourceBinding{
 					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
 						Name:         resource.Name,
@@ -91,16 +91,16 @@ func (source *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskRunS
 		}
 	}
 
-	if source.Outputs != nil && len(source.Outputs.Resources) > 0 {
+	if trs.Outputs != nil && len(trs.Outputs.Resources) > 0 {
 		if sink.Resources == nil {
 			sink.Resources = &v1beta1.TaskRunResources{}
 		}
-		if len(source.Outputs.Resources) > 0 && source.Resources != nil && len(source.Resources.Outputs) > 0 {
+		if len(trs.Outputs.Resources) > 0 && trs.Resources != nil && len(trs.Resources.Outputs) > 0 {
 			// This shouldn't happen as it shouldn't pass validation but just in case
 			return apis.ErrMultipleOneOf("outputs.resources", "resources.outputs")
 		}
-		sink.Resources.Outputs = make([]v1beta1.TaskResourceBinding, len(source.Outputs.Resources))
-		for i, resource := range source.Outputs.Resources {
+		sink.Resources.Outputs = make([]v1beta1.TaskResourceBinding, len(trs.Outputs.Resources))
+		for i, resource := range trs.Outputs.Resources {
 			sink.Resources.Outputs[i] = v1beta1.TaskResourceBinding{
 				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
 					Name:         resource.Name,
@@ -115,34 +115,35 @@ func (source *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1beta1.TaskRunS
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *TaskRun) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
+func (tr *TaskRun) ConvertFrom(ctx context.Context, obj apis.Convertible) error {
 	switch source := obj.(type) {
 	case *v1beta1.TaskRun:
-		sink.ObjectMeta = source.ObjectMeta
-		if err := sink.Spec.ConvertFrom(ctx, &source.Spec); err != nil {
+		tr.ObjectMeta = source.ObjectMeta
+		if err := tr.Spec.ConvertFrom(ctx, &source.Spec); err != nil {
 			return err
 		}
-		sink.Status = source.Status
+		tr.Status = source.Status
 		return nil
 	default:
-		return fmt.Errorf("unknown version, got: %T", sink)
+		return fmt.Errorf("unknown version, got: %T", tr)
 	}
 }
 
-func (sink *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1beta1.TaskRunSpec) error {
-	sink.ServiceAccountName = source.ServiceAccountName
-	sink.TaskRef = source.TaskRef
+// ConvertFrom implements api.Convertible
+func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1beta1.TaskRunSpec) error {
+	trs.ServiceAccountName = source.ServiceAccountName
+	trs.TaskRef = source.TaskRef
 	if source.TaskSpec != nil {
-		sink.TaskSpec = &TaskSpec{}
-		if err := sink.TaskSpec.ConvertFrom(ctx, source.TaskSpec); err != nil {
+		trs.TaskSpec = &TaskSpec{}
+		if err := trs.TaskSpec.ConvertFrom(ctx, source.TaskSpec); err != nil {
 			return err
 		}
 	}
-	sink.Status = source.Status
-	sink.Timeout = source.Timeout
-	sink.PodTemplate = source.PodTemplate
-	sink.Workspaces = source.Workspaces
-	sink.Params = source.Params
-	sink.Resources = source.Resources
+	trs.Status = source.Status
+	trs.Timeout = source.Timeout
+	trs.PodTemplate = source.PodTemplate
+	trs.Workspaces = source.Workspaces
+	trs.Params = source.Params
+	trs.Resources = source.Resources
 	return nil
 }

--- a/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_defaults.go
@@ -27,8 +27,10 @@ import (
 
 var _ apis.Defaultable = (*TaskRun)(nil)
 
+// ManagedByLabelKey is the label key used to mark what is managing this resource
 const ManagedByLabelKey = "app.kubernetes.io/managed-by"
 
+// SetDefaults implements apis.Defaultable
 func (tr *TaskRun) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, tr.ObjectMeta)
 	tr.Spec.SetDefaults(apis.WithinSpec(ctx))
@@ -44,6 +46,7 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 	}
 }
 
+// SetDefaults implements apis.Defaultable
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if trs.TaskRef != nil && trs.TaskRef.Kind == "" {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_types.go
@@ -224,6 +224,7 @@ func (tr *TaskRun) HasTimedOut() bool {
 	return runtime > timeout
 }
 
+// GetTimeout returns the timeout for the TaskRun, or the default if not specified
 func (tr *TaskRun) GetTimeout() time.Duration {
 	// Use the platform default is no timeout is set
 	if tr.Spec.Timeout == nil {

--- a/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/taskrun_validation.go
@@ -101,6 +101,7 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) *apis.FieldError {
 	return nil
 }
 
+// Validate implements apis.Validatable
 func (i TaskRunInputs) Validate(ctx context.Context, path string) *apis.FieldError {
 	if err := validatePipelineResources(ctx, i.Resources, fmt.Sprintf("%s.Resources.Name", path)); err != nil {
 		return err
@@ -108,6 +109,7 @@ func (i TaskRunInputs) Validate(ctx context.Context, path string) *apis.FieldErr
 	return validateParameters("spec.inputs.params", i.Params)
 }
 
+// Validate implements apis.Validatable
 func (o TaskRunOutputs) Validate(ctx context.Context, path string) *apis.FieldError {
 	return validatePipelineResources(ctx, o.Resources, fmt.Sprintf("%s.Resources.Name", path))
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1beta1
 
 import (
@@ -27,11 +26,11 @@ import (
 var _ apis.Convertible = (*ClusterTask)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *ClusterTask) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+func (ct *ClusterTask) ConvertTo(ctx context.Context, sink apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *ClusterTask) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+func (ct *ClusterTask) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_defaults.go
@@ -24,6 +24,7 @@ import (
 
 var _ apis.Defaultable = (*ClusterTask)(nil)
 
+// SetDefaults sets the default values for the ClusterTask's Spec.
 func (t *ClusterTask) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_types.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_types.go
@@ -54,14 +54,17 @@ type ClusterTaskList struct {
 	Items           []ClusterTask `json:"items"`
 }
 
+// TaskSpec returns the ClusterTask's Spec
 func (t *ClusterTask) TaskSpec() TaskSpec {
 	return t.Spec
 }
 
+// TaskMetadata returns the ObjectMeta for the ClusterTask
 func (t *ClusterTask) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
+// Copy returns a DeepCopy of the ClusterTask
 func (t *ClusterTask) Copy() TaskObject {
 	return t.DeepCopy()
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -25,6 +25,7 @@ import (
 
 var _ apis.Validatable = (*ClusterTask)(nil)
 
+// Validate performs validation of the metadata and spec of this ClusterTask.
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {

--- a/pkg/apis/pipeline/v1beta1/condition_types.go
+++ b/pkg/apis/pipeline/v1beta1/condition_types.go
@@ -26,6 +26,7 @@ import (
 // ConditionCheck represents a single evaluation of a Condition step.
 type ConditionCheck TaskRun
 
+// NewConditionCheck creates a new ConditionCheck from a given TaskRun
 func NewConditionCheck(tr *TaskRun) *ConditionCheck {
 	if tr == nil {
 		return nil

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -658,7 +658,8 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
@@ -2187,7 +2188,8 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskMetadata(ref common.ReferenceC
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"labels": {
 						SchemaProps: spec.SchemaProps{
@@ -4204,7 +4206,8 @@ func schema_pkg_apis_pipeline_v1beta1_TimeoutFields(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "TimeoutFields allows granular specification of pipeline, task, and finally timeouts",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"pipeline": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// ParamsPrefix is the prefix used in $(...) expressions referring to parameters
 const ParamsPrefix = "params"
 
 // ParamSpec defines arbitrary parameters needed beyond typed inputs (such as

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1beta1
 
 import (
@@ -26,11 +25,12 @@ import (
 
 var _ apis.Convertible = (*Pipeline)(nil)
 
-func (source *Pipeline) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+// ConvertTo implements api.Convertible
+func (p *Pipeline) ConvertTo(ctx context.Context, sink apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *Pipeline) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+func (p *Pipeline) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -25,10 +25,12 @@ import (
 
 var _ apis.Defaultable = (*Pipeline)(nil)
 
+// SetDefaults sets default values on the Pipeline's Spec
 func (p *Pipeline) SetDefaults(ctx context.Context) {
 	p.Spec.SetDefaults(ctx)
 }
 
+// SetDefaults sets default values for the PipelineSpec's Params, Tasks, and Finally
 func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -64,14 +64,17 @@ type Pipeline struct {
 
 var _ kmeta.OwnerRefable = (*Pipeline)(nil)
 
+// PipelineMetadata returns the Pipeline's ObjectMeta, implementing PipelineObject
 func (p *Pipeline) PipelineMetadata() metav1.ObjectMeta {
 	return p.ObjectMeta
 }
 
+// PipelineSpec returns the Pipeline's Spec, implementing PipelineObject
 func (p *Pipeline) PipelineSpec() PipelineSpec {
 	return p.Spec
 }
 
+// Copy returns a deep copy of the Pipeline, implementing PipelineObject
 func (p *Pipeline) Copy() PipelineObject {
 	return p.DeepCopy()
 }
@@ -121,6 +124,7 @@ type PipelineResult struct {
 	Value string `json:"value"`
 }
 
+// PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask
 type PipelineTaskMetadata struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
@@ -129,6 +133,7 @@ type PipelineTaskMetadata struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.
 type EmbeddedTask struct {
 	// +optional
 	runtime.TypeMeta `json:",inline,omitempty"`
@@ -280,14 +285,17 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 	return errs
 }
 
+// TaskSpecMetadata returns the metadata of the PipelineTask's EmbeddedTask spec.
 func (pt *PipelineTask) TaskSpecMetadata() PipelineTaskMetadata {
 	return pt.TaskSpec.Metadata
 }
 
+// HashKey is the name of the PipelineTask, and is used as the key for this PipelineTask in the DAG
 func (pt PipelineTask) HashKey() string {
 	return pt.Name
 }
 
+// ValidateName checks whether the PipelineTask's name is a valid DNS label
 func (pt PipelineTask) ValidateName() *apis.FieldError {
 	if err := validation.IsDNS1123Label(pt.Name); len(err) > 0 {
 		return &apis.FieldError{
@@ -321,6 +329,7 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return
 }
 
+// Deps returns all other PipelineTask dependencies of this PipelineTask, based on resource usage or ordering
 func (pt PipelineTask) Deps() []string {
 	deps := []string{}
 
@@ -369,6 +378,7 @@ func (pt PipelineTask) orderingDeps() []string {
 	return orderingDeps
 }
 
+// PipelineTaskList is a list of PipelineTasks
 type PipelineTaskList []PipelineTask
 
 // Deps returns a map with key as name of a pipelineTask and value as a list of its dependencies
@@ -385,6 +395,7 @@ func (l PipelineTaskList) Deps() map[string][]string {
 	return deps
 }
 
+// Items returns a slice of all tasks in the PipelineTaskList, converted to dag.Tasks
 func (l PipelineTaskList) Items() []dag.Task {
 	tasks := []dag.Task{}
 	for _, t := range l {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1beta1
 
 import (
@@ -27,11 +26,11 @@ import (
 var _ apis.Convertible = (*PipelineRun)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *PipelineRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+func (pr *PipelineRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *PipelineRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+func (pr *PipelineRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -27,10 +27,12 @@ import (
 
 var _ apis.Defaultable = (*PipelineRun)(nil)
 
+// SetDefaults implements apis.Defaultable
 func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 	pr.Spec.SetDefaults(ctx)
 }
 
+// SetDefaults implements apis.Defaultable
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil && prs.Timeouts == nil {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -52,6 +52,7 @@ type PipelineRun struct {
 	Status PipelineRunStatus `json:"status,omitempty"`
 }
 
+// GetName Returns the name of the PipelineRun
 func (pr *PipelineRun) GetName() string {
 	return pr.ObjectMeta.GetName()
 }
@@ -91,6 +92,7 @@ func (pr *PipelineRun) IsGracefullyStopped() bool {
 	return pr.Spec.Status == PipelineRunSpecStatusStoppedRunFinally
 }
 
+// GetTimeout returns the the applicable timeout for the PipelineRun
 func (pr *PipelineRun) GetTimeout(ctx context.Context) time.Duration {
 	// Use the platform default if no timeout is set
 	if pr.Spec.Timeout == nil && pr.Spec.Timeouts == nil {
@@ -206,6 +208,7 @@ type PipelineRunSpec struct {
 	TaskRunSpecs []PipelineTaskRunSpec `json:"taskRunSpecs,omitempty"`
 }
 
+// TimeoutFields allows granular specification of pipeline, task, and finally timeouts
 type TimeoutFields struct {
 	// Pipeline sets the maximum allowed duration for execution of the entire pipeline. The sum of individual timeouts for tasks and finally must not exceed this value.
 	Pipeline *metav1.Duration `json:"pipeline,omitempty"`
@@ -219,7 +222,7 @@ type TimeoutFields struct {
 type PipelineRunSpecStatus string
 
 const (
-	// Deprecated: "PipelineRunCancelled" indicates that the user wants to cancel the task,
+	// PipelineRunSpecStatusCancelledDeprecated Deprecated: indicates that the user wants to cancel the task,
 	// if not already cancelled or terminated (replaced by "Cancelled")
 	PipelineRunSpecStatusCancelledDeprecated = "PipelineRunCancelled"
 

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -32,6 +32,7 @@ import (
 type PipelineResourceType = resource.PipelineResourceType
 
 var (
+	// AllowedOutputResources are the resource types that can be used as outputs
 	AllowedOutputResources = resource.AllowedOutputResources
 )
 

--- a/pkg/apis/pipeline/v1beta1/resource_types_validation.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_validation.go
@@ -25,6 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// Validate implements apis.Validatable
 func (tr *TaskResources) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if tr != nil {
 		errs = errs.Also(validateTaskResources(tr.Inputs).ViaField("inputs"))
@@ -57,9 +58,10 @@ func validateResourceType(r TaskResource, path string) *apis.FieldError {
 			return nil
 		}
 	}
-	return apis.ErrInvalidValue(string(r.Type), path)
+	return apis.ErrInvalidValue(r.Type, path)
 }
 
+// Validate implements apis.Validatable
 func (tr *TaskRunResources) Validate(ctx context.Context) *apis.FieldError {
 	if tr == nil {
 		return nil

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -485,6 +485,7 @@
       }
     },
     "v1beta1.EmbeddedTask": {
+      "description": "EmbeddedTask is used to define a Task inline within a Pipeline's PipelineTasks.",
       "type": "object",
       "properties": {
         "apiVersion": {
@@ -1345,6 +1346,7 @@
       }
     },
     "v1beta1.PipelineTaskMetadata": {
+      "description": "PipelineTaskMetadata contains the labels or annotations for an EmbeddedTask",
       "type": "object",
       "properties": {
         "annotations": {
@@ -2477,6 +2479,7 @@
       }
     },
     "v1beta1.TimeoutFields": {
+      "description": "TimeoutFields allows granular specification of pipeline, task, and finally timeouts",
       "type": "object",
       "properties": {
         "finally": {

--- a/pkg/apis/pipeline/v1beta1/task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1beta1
 
 import (
@@ -27,11 +26,11 @@ import (
 var _ apis.Convertible = (*Task)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *Task) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+func (t *Task) ConvertTo(ctx context.Context, sink apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *Task) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+func (t *Task) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/task_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/task_defaults.go
@@ -25,6 +25,7 @@ import (
 
 var _ apis.Defaultable = (*Task)(nil)
 
+// SetDefaults implements apis.Defaultable
 func (t *Task) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
 }

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -58,14 +58,17 @@ type Task struct {
 
 var _ kmeta.OwnerRefable = (*Task)(nil)
 
+// TaskSpec returns the task's spec
 func (t *Task) TaskSpec() TaskSpec {
 	return t.Spec
 }
 
+// TaskMetadata returns the task's ObjectMeta
 func (t *Task) TaskMetadata() metav1.ObjectMeta {
 	return t.ObjectMeta
 }
 
+// Copy returns a deep copy of the task
 func (t *Task) Copy() TaskObject {
 	return t.DeepCopy()
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -34,6 +34,7 @@ import (
 
 var _ apis.Validatable = (*Task)(nil)
 
+// Validate implements apis.Validatable
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
@@ -42,6 +43,7 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 
+// Validate implements apis.Validatable
 func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if len(ts.Steps) == 0 {
 		errs = errs.Also(apis.ErrMissingField("steps"))
@@ -75,6 +77,7 @@ func validateResults(ctx context.Context, results []TaskResult) (errs *apis.Fiel
 	return errs
 }
 
+// Validate implements apis.Validatable
 func (tr TaskResult) Validate(_ context.Context) *apis.FieldError {
 	if !resultNameFormatRegex.MatchString(tr.Name) {
 		return apis.ErrInvalidKeyName(tr.Name, "name", fmt.Sprintf("Name must consist of alphanumeric characters, '-', '_', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my-name',  or 'my_name', regex used for validation is '%s')", ResultNameFormat))
@@ -155,6 +158,7 @@ func validateWorkspaceUsages(ctx context.Context, ts *TaskSpec) (errs *apis.Fiel
 	return errs
 }
 
+// ValidateVolumes validates a slice of volumes to make sure there are no dupilcate names
 func ValidateVolumes(volumes []corev1.Volume) (errs *apis.FieldError) {
 	// Task must not have duplicate volume names.
 	vols := sets.NewString()
@@ -240,6 +244,7 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	return errs
 }
 
+// ValidateParameterTypes validates all the types within a slice of ParamSpecs
 func ValidateParameterTypes(params []ParamSpec) (errs *apis.FieldError) {
 	for _, p := range params {
 		errs = errs.Also(p.ValidateType())
@@ -247,6 +252,7 @@ func ValidateParameterTypes(params []ParamSpec) (errs *apis.FieldError) {
 	return errs
 }
 
+// ValidateType checks that the type of a ParamSpec is allowed and its default value matches that type
 func (p ParamSpec) ValidateType() *apis.FieldError {
 	// Ensure param has a valid type.
 	validType := false
@@ -273,6 +279,7 @@ func (p ParamSpec) ValidateType() *apis.FieldError {
 	return nil
 }
 
+// ValidateParameterVariables validates all variables within a slice of ParamSpecs against a slice of Steps
 func ValidateParameterVariables(steps []Step, params []ParamSpec) *apis.FieldError {
 	parameterNames := sets.NewString()
 	arrayParameterNames := sets.NewString()
@@ -302,6 +309,7 @@ func validateTaskContextVariables(steps []Step) *apis.FieldError {
 	return errs.Also(validateVariables(steps, "context\\.task", taskContextNames))
 }
 
+// ValidateResourcesVariables validates all variables within a TaskResources against a slice of Steps
 func ValidateResourcesVariables(steps []Step, resources *TaskResources) *apis.FieldError {
 	if resources == nil {
 		return nil

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint: revive
 package v1beta1
 
 import (
@@ -27,11 +26,11 @@ import (
 var _ apis.Convertible = (*TaskRun)(nil)
 
 // ConvertTo implements api.Convertible
-func (source *TaskRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+func (tr *TaskRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
-func (sink *TaskRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+func (tr *TaskRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -27,8 +27,10 @@ import (
 
 var _ apis.Defaultable = (*TaskRun)(nil)
 
+// ManagedByLabelKey is the label key used to mark what is managing this resource
 const ManagedByLabelKey = "app.kubernetes.io/managed-by"
 
+// SetDefaults implements apis.Defaultable
 func (tr *TaskRun) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, tr.ObjectMeta)
 	tr.Spec.SetDefaults(ctx)
@@ -44,6 +46,7 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 	}
 }
 
+// SetDefaults implements apis.Defaultable
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 	cfg := config.FromContextOrDefaults(ctx)
 	if trs.TaskRef != nil && trs.TaskRef.Kind == "" {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -397,6 +397,7 @@ func (tr *TaskRun) HasTimedOut(ctx context.Context) bool {
 	return runtime > timeout
 }
 
+// GetTimeout returns the timeout for the TaskRun, or the default if not specified
 func (tr *TaskRun) GetTimeout(ctx context.Context) time.Duration {
 	// Use the platform default is no timeout is set
 	if tr.Spec.Timeout == nil {

--- a/pkg/apis/resource/v1alpha1/cloudevent/cloud_event_resource.go
+++ b/pkg/apis/resource/v1alpha1/cloudevent/cloud_event_resource.go
@@ -75,7 +75,7 @@ func (s Resource) GetType() resource.PipelineResourceType {
 func (s *Resource) Replacements() map[string]string {
 	return map[string]string{
 		"name":       s.Name,
-		"type":       string(s.Type),
+		"type":       s.Type,
 		"target-uri": s.TargetURI,
 	}
 }

--- a/pkg/apis/resource/v1alpha1/git/git_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/git/git_resource_test.go
@@ -521,7 +521,7 @@ func TestGitResource_Replacements(t *testing.T) {
 
 	want := map[string]string{
 		"name":       "git-resource",
-		"type":       string(resourcev1alpha1.PipelineResourceTypeGit),
+		"type":       resourcev1alpha1.PipelineResourceTypeGit,
 		"url":        "git@github.com:test/test.git",
 		"revision":   "master",
 		"refspec":    "",

--- a/pkg/apis/resource/v1alpha1/image/image_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/image/image_resource_test.go
@@ -91,7 +91,7 @@ func TestImageResource_Replacements(t *testing.T) {
 
 	want := map[string]string{
 		"name":   "image-resource",
-		"type":   string(v1alpha1.PipelineResourceTypeImage),
+		"type":   v1alpha1.PipelineResourceTypeImage,
 		"url":    "https://test.com/test/test",
 		"digest": "test",
 	}

--- a/pkg/apis/resource/v1alpha1/pipeline_resource_defaults.go
+++ b/pkg/apis/resource/v1alpha1/pipeline_resource_defaults.go
@@ -24,9 +24,11 @@ import (
 
 var _ apis.Defaultable = (*PipelineResource)(nil)
 
+// SetDefaults implements api.Defaultable
 func (t *PipelineResource) SetDefaults(ctx context.Context) {
 	t.Spec.SetDefaults(ctx)
 }
 
+// SetDefaults implements api.Defaultable
 func (ts *PipelineResourceSpec) SetDefaults(ctx context.Context) {
 }

--- a/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
+++ b/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
@@ -26,6 +26,7 @@ import (
 type PipelineResourceType = string
 
 var (
+	// AllowedOutputResources are the resource types that can be used as outputs
 	AllowedOutputResources = map[PipelineResourceType]bool{
 		PipelineResourceTypeStorage: true,
 		PipelineResourceTypeGit:     true,

--- a/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
+++ b/pkg/apis/resource/v1alpha1/pipelineresource_validation.go
@@ -30,6 +30,7 @@ import (
 
 var _ apis.Validatable = (*PipelineResource)(nil)
 
+// Validate validates the PipelineResource's ObjectMeta and Spec
 func (r *PipelineResource) Validate(ctx context.Context) *apis.FieldError {
 	if err := validate.ObjectMetadata(r.GetObjectMeta()); err != nil {
 		return err.ViaField("metadata")
@@ -40,6 +41,7 @@ func (r *PipelineResource) Validate(ctx context.Context) *apis.FieldError {
 	return r.Spec.Validate(ctx)
 }
 
+// Validate validates the PipelineResourceSpec based on its type
 func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(rs, &PipelineResourceSpec{}) {
 		return apis.ErrMissingField("spec.type")
@@ -126,9 +128,10 @@ func (rs *PipelineResourceSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	return apis.ErrInvalidValue("spec.type", string(rs.Type))
+	return apis.ErrInvalidValue("spec.type", rs.Type)
 }
 
+// AllowedStorageType returns true if the provided string can be used as a storage type, and false otherwise
 func AllowedStorageType(gotType string) bool {
 	return gotType == PipelineResourceTypeGCS
 }

--- a/pkg/apis/validate/metadata.go
+++ b/pkg/apis/validate/metadata.go
@@ -24,8 +24,10 @@ import (
 	"knative.dev/pkg/apis"
 )
 
+// MaxLength is the maximum length that an object's name can be
 const MaxLength = validation.DNS1123LabelMaxLength
 
+// ObjectMetadata validates that the given object's name is a valid DNS name and isn't longer than the max length
 func ObjectMetadata(meta metav1.Object) *apis.FieldError {
 	name := meta.GetName()
 

--- a/pkg/credentials/dockercreds/creds.go
+++ b/pkg/credentials/dockercreds/creds.go
@@ -69,6 +69,7 @@ func (dc *basicDocker) String() string {
 	return strings.Join(urls, ",")
 }
 
+// Set sets a secret for a URL from a value in the format of "secret=url"
 func (dc *basicDocker) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {
@@ -93,6 +94,7 @@ type arrayArg struct {
 	Values []string
 }
 
+// Set adds a value to the arrayArg's value slice
 func (aa *arrayArg) Set(value string) error {
 	aa.Values = append(aa.Values, value)
 	return nil

--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -49,6 +49,7 @@ func (dc *basicGitConfig) String() string {
 	return strings.Join(urls, ",")
 }
 
+// Set sets a secret for a given URL from a "secret=url" value.
 func (dc *basicGitConfig) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {

--- a/pkg/credentials/gitcreds/ssh.go
+++ b/pkg/credentials/gitcreds/ssh.go
@@ -52,6 +52,7 @@ func (dc *sshGitConfig) String() string {
 	return strings.Join(urls, ",")
 }
 
+// Set sets a secret for a given URL from a "secret=url" value.
 func (dc *sshGitConfig) Set(value string) error {
 	parts := strings.Split(value, "=")
 	if len(parts) != 2 {

--- a/pkg/entrypoint/entrypointer.go
+++ b/pkg/entrypoint/entrypointer.go
@@ -235,6 +235,7 @@ func (e Entrypointer) readResultsFromDisk() error {
 	return nil
 }
 
+// BreakpointExitCode reads the post file and returns the exit code it contains
 func (e Entrypointer) BreakpointExitCode(breakpointExitPostFile string) (int, error) {
 	exitCode, err := ioutil.ReadFile(breakpointExitPostFile)
 	if os.IsNotExist(err) {

--- a/pkg/entrypoint/entrypointer_test.go
+++ b/pkg/entrypoint/entrypointer_test.go
@@ -231,7 +231,7 @@ func TestEntrypointer(t *testing.T) {
 			fileContents, err := ioutil.ReadFile(terminationPath)
 			if err == nil {
 				var entries []v1alpha1.PipelineResourceResult
-				if err := json.Unmarshal([]byte(fileContents), &entries); err == nil {
+				if err := json.Unmarshal(fileContents, &entries); err == nil {
 					var found = false
 					for _, result := range entries {
 						if result.Key == "StartedAt" {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -176,6 +176,7 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 	return nil
 }
 
+// ShowCommit calls "git show ..." to get the commit SHA for the given revision
 func ShowCommit(logger *zap.SugaredLogger, revision, path string) (string, error) {
 	output, err := run(logger, path, "show", "-q", "--pretty=format:%H", revision)
 	if err != nil {
@@ -262,7 +263,7 @@ func userHasKnownHostsFile(logger *zap.SugaredLogger) (bool, error) {
 		}
 		return false, err
 	}
-	f.Close()
+	defer f.Close()
 	return true, nil
 }
 
@@ -307,7 +308,7 @@ func configSparseCheckout(logger *zap.SugaredLogger, spec FetchSpec) error {
 		}
 		for _, pattern := range dirPatterns {
 			if _, err := file.WriteString(pattern + "\n"); err != nil {
-				file.Close()
+				defer file.Close()
 				logger.Errorf("failed to write to sparse-checkout file: %v", err)
 				return err
 			}

--- a/pkg/internal/affinityassistant/transformer.go
+++ b/pkg/internal/affinityassistant/transformer.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// NewTransformer returns a pod.Transformer that will pod affinity if needed
 func NewTransformer(_ context.Context, annotations map[string]string) pod.Transformer {
 	return func(p *corev1.Pod) (*corev1.Pod, error) {
 		// Using node affinity on taskRuns sharing PVC workspace, with an Affinity Assistant

--- a/pkg/internal/deprecated/override.go
+++ b/pkg/internal/deprecated/override.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// NewOverrideWorkingDirTransformer returns a pod.Transformer that will override the workingDir on pods if needed.
 func NewOverrideWorkingDirTransformer(ctx context.Context) pod.Transformer {
 	return func(p *corev1.Pod) (*corev1.Pod, error) {
 		if shouldOverrideWorkingDir(ctx) {
@@ -50,6 +51,7 @@ func shouldOverrideWorkingDir(ctx context.Context) bool {
 	return !cfg.FeatureFlags.DisableWorkingDirOverwrite
 }
 
+// NewOverrideHomeTransformer returns a pod.Transformer that will override HOME if needed
 func NewOverrideHomeTransformer(ctx context.Context) pod.Transformer {
 	return func(p *corev1.Pod) (*corev1.Pod, error) {
 		if shouldOverrideHomeEnv(ctx) {

--- a/pkg/internal/limitrange/transformer.go
+++ b/pkg/internal/limitrange/transformer.go
@@ -31,6 +31,7 @@ func isZero(q resource.Quantity) bool {
 	return (&q).IsZero()
 }
 
+// NewTransformer returns a pod.Transformer that will modify limits if needed
 func NewTransformer(ctx context.Context, namespace string, lister corev1listers.LimitRangeLister) pod.Transformer {
 	return func(p *corev1.Pod) (*corev1.Pod, error) {
 		limitRange, err := getVirtualLimitRange(ctx, namespace, lister)

--- a/pkg/names/generate.go
+++ b/pkg/names/generate.go
@@ -51,6 +51,8 @@ const (
 	maxGeneratedNameLength = maxNameLength - randomLength - 1
 )
 
+// RestrictLengthWithRandomSuffix takes a base name and returns a potentially shortened version of that name with
+// a random suffix, with the whole string no longer than 63 characters.
 func (simpleNameGenerator) RestrictLengthWithRandomSuffix(base string) string {
 	if len(base) > maxGeneratedNameLength {
 		base = base[:maxGeneratedNameLength]
@@ -60,6 +62,7 @@ func (simpleNameGenerator) RestrictLengthWithRandomSuffix(base string) string {
 
 var alphaNumericRE = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 
+// RestrictLength takes a base name and returns a potentially shortened version of that name, no longer than 63 characters.
 func (simpleNameGenerator) RestrictLength(base string) string {
 	if len(base) > maxNameLength {
 		base = base[:maxNameLength]

--- a/pkg/pipelinerunmetrics/injection.go
+++ b/pkg/pipelinerunmetrics/injection.go
@@ -41,6 +41,7 @@ func init() {
 // RecorderKey is used for associating the Recorder inside the context.Context.
 type RecorderKey struct{}
 
+// WithClient adds a metrics recorder to the given context
 func WithClient(ctx context.Context) context.Context {
 	rec, err := NewRecorder(ctx)
 	if err != nil {
@@ -61,6 +62,7 @@ func Get(ctx context.Context) *Recorder {
 // InformerKey is used for associating the Informer inside the context.Context.
 type InformerKey struct{}
 
+// WithInformer returns the given context, and a configured informer
 func WithInformer(ctx context.Context) (context.Context, controller.Informer) {
 	return ctx, &recorderInformer{
 		ctx:     ctx,
@@ -77,6 +79,7 @@ type recorderInformer struct {
 
 var _ controller.Informer = (*recorderInformer)(nil)
 
+// Run starts the recorder informer in a goroutine
 func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
 	// Turn the stopCh into a context for reporting metrics.
 	ctx, cancel := context.WithCancel(ri.ctx)
@@ -88,6 +91,7 @@ func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
 	go ri.metrics.ReportRunningPipelineRuns(ctx, ri.lister)
 }
 
+// HasSynced returns whether the informer has synced, which in this case will always be true.
 func (ri *recorderInformer) HasSynced() bool {
 	return true
 }

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -63,7 +63,7 @@ var (
 const (
 	// ReasonCancelled indicates that a PipelineRun was cancelled.
 	ReasonCancelled = "Cancelled"
-	// Deprecated: "PipelineRunCancelled" indicates that a PipelineRun was cancelled.
+	// ReasonCancelledDeprecated Deprecated: "PipelineRunCancelled" indicates that a PipelineRun was cancelled.
 	ReasonCancelledDeprecated = "PipelineRunCancelled"
 )
 
@@ -173,6 +173,7 @@ func viewUnregister() {
 	view.Unregister(prDurationView, prCountView, runningPRsCountView)
 }
 
+// MetricsOnStore returns a function that checks if metrics are configured for a config.Store, and registers it if so
 func MetricsOnStore(logger *zap.SugaredLogger) func(name string,
 	value interface{}) {
 	return func(name string, value interface{}) {

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -54,7 +54,7 @@ const (
 	stepPrefix    = "step-"
 	sidecarPrefix = "sidecar-"
 
-	BreakpointOnFailure = "onFailure"
+	breakpointOnFailure = "onFailure"
 )
 
 var (
@@ -160,7 +160,7 @@ func orderContainers(commonExtraEntrypointArgs []string, steps []corev1.Containe
 			breakpoints := breakpointConfig.Breakpoint
 			for _, b := range breakpoints {
 				// TODO(TEP #0042): Add other breakpoints
-				if b == BreakpointOnFailure {
+				if b == breakpointOnFailure {
 					argsForEntrypoint = append(argsForEntrypoint, "-breakpoint_on_failure")
 				}
 			}

--- a/pkg/pod/entrypoint_lookup_impl.go
+++ b/pkg/pod/entrypoint_lookup_impl.go
@@ -50,6 +50,7 @@ func NewEntrypointCache(kubeclient kubernetes.Interface) (EntrypointCache, error
 	}, nil
 }
 
+// Get gets the image from the cache for the given ref, namespace, and SA
 func (e *entrypointCache) Get(ctx context.Context, ref name.Reference, namespace, serviceAccountName string) (v1.Image, error) {
 	// If image is specified by digest, check the local cache.
 	if digest, ok := ref.(name.Digest); ok {
@@ -96,4 +97,5 @@ func (e *entrypointCache) Get(ctx context.Context, ref name.Reference, namespace
 	return img, nil
 }
 
+// Set puts the image in the cache with the digest as the key.
 func (e *entrypointCache) Set(d name.Digest, img v1.Image) { e.lru.Add(d.String(), img) }

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -151,7 +151,7 @@ func TestPodBuild(t *testing.T) {
 		desc: "simple with breakpoint onFailure enabled, alpha api fields disabled",
 		trs: v1beta1.TaskRunSpec{
 			Debug: &v1beta1.TaskRunDebug{
-				Breakpoint: []string{BreakpointOnFailure},
+				Breakpoint: []string{breakpointOnFailure},
 			},
 		},
 		ts: v1beta1.TaskSpec{
@@ -1526,7 +1526,7 @@ func TestPodBuildwithAlphaAPIEnabled(t *testing.T) {
 		desc: "simple with debug breakpoint onFailure",
 		trs: v1beta1.TaskRunSpec{
 			Debug: &v1beta1.TaskRunDebug{
-				Breakpoint: []string{BreakpointOnFailure},
+				Breakpoint: []string{breakpointOnFailure},
 			},
 		},
 		ts: v1beta1.TaskSpec{

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -247,7 +247,7 @@ script-3`,
 			Args:         []string{"my", "args"},
 		},
 	}}, []v1beta1.Sidecar{}, &v1beta1.TaskRunDebug{
-		Breakpoint: []string{BreakpointOnFailure},
+		Breakpoint: []string{breakpointOnFailure},
 	})
 	wantInit := &corev1.Container{
 		Name:    "place-scripts",

--- a/pkg/pullrequest/disk.go
+++ b/pkg/pullrequest/disk.go
@@ -235,7 +235,6 @@ func manifestFromDisk(path string) (Manifest, error) {
 		return nil, err
 	}
 	defer f.Close()
-
 	m := Manifest{}
 	dec := gob.NewDecoder(f)
 	if err := dec.Decode(&m); err != nil {

--- a/pkg/pullrequest/scm.go
+++ b/pkg/pullrequest/scm.go
@@ -32,6 +32,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// NewSCMHandler returns a new Handler  for the given URL, provider and token
 func NewSCMHandler(logger *zap.SugaredLogger, raw, provider, token string, skipTLSVerify bool) (*Handler, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -180,6 +181,7 @@ type gitlabClient struct {
 	transport http.RoundTripper
 }
 
+// RoundTrip handles authentication for the gitlabClient
 func (g *gitlabClient) RoundTrip(r *http.Request) (*http.Response, error) {
 	r.Header.Add("Private-Token", g.token)
 	return g.transport.RoundTrip(r)

--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -25,11 +25,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// Task is an interface for all types that could be in a DAG
 type Task interface {
 	HashKey() string
 	Deps() []string
 }
 
+// Tasks is an interface for lists of types that could be in a DAG
 type Tasks interface {
 	Items() []Task
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -98,7 +98,7 @@ const (
 	ReasonInvalidGraph = "PipelineInvalidGraph"
 	// ReasonCancelled indicates that a PipelineRun was cancelled.
 	ReasonCancelled = pipelinerunmetrics.ReasonCancelled
-	// Deprecated: "PipelineRunCancelled" indicates that a PipelineRun was cancelled.
+	// ReasonCancelledDeprecated Deprecated: "PipelineRunCancelled" indicates that a PipelineRun was cancelled.
 	ReasonCancelledDeprecated = pipelinerunmetrics.ReasonCancelledDeprecated
 	// ReasonPending indicates that a PipelineRun is pending.
 	ReasonPending = "PipelineRunPending"

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -38,19 +38,29 @@ const (
 	ReasonConditionCheckFailed = "ConditionCheckFailed"
 )
 
+// SkippingReason explains why a task was skipped
 type SkippingReason string
 
 const (
-	WhenExpressionsSkip       SkippingReason = "WhenExpressionsSkip"
-	ConditionsSkip            SkippingReason = "ConditionsSkip"
-	ParentTasksSkip           SkippingReason = "ParentTasksSkip"
-	IsStoppingSkip            SkippingReason = "IsStoppingSkip"
+	// WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false
+	WhenExpressionsSkip SkippingReason = "WhenExpressionsSkip"
+	// ConditionsSkip means the task was skipped due to at least one of its conditions failing
+	ConditionsSkip SkippingReason = "ConditionsSkip"
+	// ParentTasksSkip means the task was skipped because its parent was skipped
+	ParentTasksSkip SkippingReason = "ParentTasksSkip"
+	// IsStoppingSkip means the task was skipped because the pipeline run is stopping
+	IsStoppingSkip SkippingReason = "IsStoppingSkip"
+	// IsGracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled
 	IsGracefullyCancelledSkip SkippingReason = "IsGracefullyCancelledSkip"
-	IsGracefullyStoppedSkip   SkippingReason = "IsGracefullyStoppedSkip"
-	MissingResultsSkip        SkippingReason = "MissingResultsSkip"
-	None                      SkippingReason = "None"
+	// IsGracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped
+	IsGracefullyStoppedSkip SkippingReason = "IsGracefullyStoppedSkip"
+	// MissingResultsSkip means the task was skipped because it's missing necessary results
+	MissingResultsSkip SkippingReason = "MissingResultsSkip"
+	// None means the task was not skipped
+	None SkippingReason = "None"
 )
 
+// TaskSkipStatus stores whether a task was skipped and why
 type TaskSkipStatus struct {
 	IsSkipped      bool
 	SkippingReason SkippingReason

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -26,6 +26,8 @@ import (
 
 // GetTask is a function used to retrieve Tasks.
 type GetTask func(context.Context, string) (v1beta1.TaskObject, error)
+
+// GetTaskRun is a function used to retrieve TaskRuns
 type GetTaskRun func(string) (*v1beta1.TaskRun, error)
 
 // GetClusterTask is a function that will retrieve the Task from name and namespace.

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -720,8 +720,6 @@ func (c *Reconciler) createPod(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	return pod, err
 }
 
-type DeletePod func(podName string, options *metav1.DeleteOptions) error
-
 func isExceededResourceQuotaError(err error) bool {
 	return err != nil && k8serrors.IsForbidden(err) && strings.Contains(err.Error(), "exceeded quota")
 }

--- a/pkg/reconciler/volumeclaim/pvchandler.go
+++ b/pkg/reconciler/volumeclaim/pvchandler.go
@@ -36,6 +36,7 @@ const (
 	ReasonCouldntCreateWorkspacePVC = "CouldntCreateWorkspacePVC"
 )
 
+// PvcHandler is used to create PVCs for workspaces
 type PvcHandler interface {
 	CreatePersistentVolumeClaimsForWorkspaces(ctx context.Context, wb []v1beta1.WorkspaceBinding, ownerReference metav1.OwnerReference, namespace string) error
 }
@@ -45,6 +46,7 @@ type defaultPVCHandler struct {
 	logger    *zap.SugaredLogger
 }
 
+// NewPVCHandler returns a new defaultPVCHandler
 func NewPVCHandler(clientset clientset.Interface, logger *zap.SugaredLogger) PvcHandler {
 	return &defaultPVCHandler{clientset, logger}
 }

--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -35,9 +35,13 @@ import (
 )
 
 const (
-	KindAnnotation       = "dev.tekton.image.kind"
+	// KindAnnotation is an OCI annotation for the bundle kind
+	KindAnnotation = "dev.tekton.image.kind"
+	// APIVersionAnnotation is an OCI annotation for the bundle version
 	APIVersionAnnotation = "dev.tekton.image.apiVersion"
-	TitleAnnotation      = "dev.tekton.image.name"
+	// TitleAnnotation is an OCI annotation for the bundle title
+	TitleAnnotation = "dev.tekton.image.name"
+	// MaximumBundleObjects defines the maximum number of objects in a bundle
 	MaximumBundleObjects = 10
 )
 
@@ -54,6 +58,7 @@ func NewResolver(ref string, keychain authn.Keychain) remote.Resolver {
 	return &Resolver{imageReference: ref, keychain: keychain, timeout: time.Second * 60}
 }
 
+// List retrieves a flat set of Tekton objects
 func (o *Resolver) List() ([]remote.ResolvedObject, error) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), o.timeout)
 	defer cancel()
@@ -83,6 +88,7 @@ func (o *Resolver) List() ([]remote.ResolvedObject, error) {
 	return contents, nil
 }
 
+// Get retrieves a specific object with the given Kind and name
 func (o *Resolver) Get(kind, name string) (runtime.Object, error) {
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), o.timeout)
 	defer cancel()

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -29,6 +29,7 @@ const parameterSubstitution = `[_a-zA-Z][_a-zA-Z0-9.-]*(\[\*\])?`
 
 const braceMatchingRegex = "(\\$(\\(%s\\.(?P<var>%s)\\)))"
 
+// ValidateVariable makes sure all variables in the provided string are known
 func ValidateVariable(name, value, prefix, locationName, path string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
@@ -44,6 +45,7 @@ func ValidateVariable(name, value, prefix, locationName, path string, vars sets.
 	return nil
 }
 
+// ValidateVariableP makes sure all variables for a parameter in the provided string are known
 func ValidateVariableP(value, prefix string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
@@ -76,6 +78,7 @@ func ValidateVariableProhibited(name, value, prefix, locationName, path string, 
 	return nil
 }
 
+// ValidateVariableProhibitedP verifies that variables for a parameter matching the relevant string expressions do not reference any of the names present in vars.
 func ValidateVariableProhibitedP(value, prefix string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		for _, v := range vs {
@@ -111,6 +114,7 @@ func ValidateVariableIsolated(name, value, prefix, locationName, path string, va
 	return nil
 }
 
+// ValidateVariableIsolatedP verifies that variables matching the relevant string expressions are completely isolated if present.
 func ValidateVariableIsolatedP(value, prefix string, vars sets.String) *apis.FieldError {
 	if vs, present := extractVariablesFromString(value, prefix); present {
 		firstMatch, _ := extractExpressionFromString(value, prefix)
@@ -168,6 +172,7 @@ func matchGroups(matches []string, pattern *regexp.Regexp) map[string]string {
 	return groups
 }
 
+// ApplyReplacements applies string replacements
 func ApplyReplacements(in string, replacements map[string]string) string {
 	replacementsList := []string{}
 	for k, v := range replacements {

--- a/pkg/taskrunmetrics/injection.go
+++ b/pkg/taskrunmetrics/injection.go
@@ -41,6 +41,7 @@ func init() {
 // RecorderKey is used for associating the Recorder inside the context.Context.
 type RecorderKey struct{}
 
+// WithClient adds a metrics recorder to the given context
 func WithClient(ctx context.Context) context.Context {
 	rec, err := NewRecorder(ctx)
 	if err != nil {
@@ -61,6 +62,7 @@ func Get(ctx context.Context) *Recorder {
 // InformerKey is used for associating the Informer inside the context.Context.
 type InformerKey struct{}
 
+// WithInformer returns the given context, and a configured informer
 func WithInformer(ctx context.Context) (context.Context, controller.Informer) {
 	return ctx, &recorderInformer{
 		ctx:     ctx,
@@ -77,6 +79,7 @@ type recorderInformer struct {
 
 var _ controller.Informer = (*recorderInformer)(nil)
 
+// Run starts the recorder informer in a goroutine
 func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
 	// Turn the stopCh into a context for reporting metrics.
 	ctx, cancel := context.WithCancel(ri.ctx)
@@ -88,6 +91,7 @@ func (ri *recorderInformer) Run(stopCh <-chan struct{}) {
 	go ri.metrics.ReportRunningTaskRuns(ctx, ri.lister)
 }
 
+// HasSynced returns whether the informer has synced, which in this case will always be true.
 func (ri *recorderInformer) HasSynced() bool {
 	return true
 }

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -81,6 +81,7 @@ var (
 		stats.UnitDimensionless)
 )
 
+// Recorder is used to actually record TaskRun metrics
 type Recorder struct {
 	mutex       sync.Mutex
 	initialized bool
@@ -232,6 +233,7 @@ func viewUnregister() {
 	)
 }
 
+// MetricsOnStore returns a function that checks if metrics are configured for a config.Store, and registers it if so
 func MetricsOnStore(logger *zap.SugaredLogger) func(name string,
 	value interface{}) {
 	return func(name string, value interface{}) {

--- a/pkg/termination/write.go
+++ b/pkg/termination/write.go
@@ -37,7 +37,7 @@ func WriteMessage(path string, pro []v1beta1.PipelineResourceResult) error {
 	fileContents, err := ioutil.ReadFile(path)
 	if err == nil {
 		var existingEntries []v1beta1.PipelineResourceResult
-		if err := json.Unmarshal([]byte(fileContents), &existingEntries); err == nil {
+		if err := json.Unmarshal(fileContents, &existingEntries); err == nil {
 			// append new entries to existing entries
 			pro = append(existingEntries, pro...)
 		}

--- a/pkg/workspace/affinity_assistant_names.go
+++ b/pkg/workspace/affinity_assistant_names.go
@@ -21,7 +21,8 @@ const (
 	LabelInstance = "app.kubernetes.io/instance"
 
 	// LabelComponent is used to configure PodAntiAffinity to other Affinity Assistants
-	LabelComponent                 = "app.kubernetes.io/component"
+	LabelComponent = "app.kubernetes.io/component"
+	// ComponentNameAffinityAssistant is the component name for an Affinity Assistant
 	ComponentNameAffinityAssistant = "affinity-assistant"
 
 	// AnnotationAffinityAssistantName is used to pass the instance name of an Affinity Assistant to TaskRun pods

--- a/test/controller.go
+++ b/test/controller.go
@@ -112,6 +112,7 @@ type Assets struct {
 	Ctx        context.Context
 }
 
+// AddToInformer returns a function to add ktesting.Actions to the cache store
 func AddToInformer(t *testing.T, store cache.Store) func(ktesting.Action) (bool, runtime.Object, error) {
 	return func(action ktesting.Action) (bool, runtime.Object, error) {
 		switch a := action.(type) {
@@ -274,10 +275,12 @@ func SeedTestData(t *testing.T, ctx context.Context, d Data) (Clients, Informers
 	return c, i
 }
 
+// ResourceVersionReactor is an implementation of Reactor for our tests
 type ResourceVersionReactor struct {
 	count int64
 }
 
+// Handles returns whether our test reactor can handle a given ktesting.Action
 func (r *ResourceVersionReactor) Handles(action ktesting.Action) bool {
 	body := func(o runtime.Object) bool {
 		objMeta, err := meta.Accessor(o)


### PR DESCRIPTION
# Changes

This started with me wanting to make sure every exported element had a proper comment, but then I just decided to set `exclude-use-defaults` to `false`, which enables a bunch of rules (see https://golangci-lint.run/usage/configuration/) that are nice-to-haves that often result in a giant pile of failures in existing code. So I "fixed" all those failures as well.

I then decided that some of the `exclude-use-defaults` checks weren't actually relevant, and switched to explicitly including the relevant excluded rules (you can find the full list via `golangci-lint run --help`) that actually made sense, skipping the ones around things like not checking returns of `f.Close()`, using variables in opening files etc, and using permissions other than `0x00` ones.

Finally, I added the `unconvert` linter to check for cases where we do things like `string(alreadyAStringVar)`, just 'cos why not.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
