### PR TITLE
updating release cheat sheet

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -31,7 +31,7 @@ consumers of a project. In that case we'll make a patch release. To make one:
    [`needs-cherry-pick`](https://github.com/tektoncd/pipeline/pulls?q=label%3Aneeds-cherry-pick).
 1. Create a branch for the release named `release-<version number>x`, e.g. [`release-v0.13.0x`](https://github.com/tektoncd/pipeline/tree/release-v0.13.0x)
    and push it to the repo https://github.com/tektoncd/pipeline (you may need help from
-   [an OWNER](../OWNERS_ALIASES) with permission to push).
+   [an OWNER](../OWNERS_ALIASES) with permission to push) if that release branch does not exist.
 1. Use [git cherry-pick](https://git-scm.com/docs/git-cherry-pick) to cherry pick the
    fixes from master into the release branch you have created (use `-x` to include
    the original commit information).

--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -138,6 +138,10 @@ the pipelines repo, a terminal window and a text editor.
 
     1. Publish the GitHub release once all notes are correct and in order.
 
+1. Create a branch for the release named `release-<version number>x`, e.g. [`release-v0.28.x`](https://github.com/tektoncd/pipeline/tree/release-v0.28.x)
+   and push it to the repo https://github.com/tektoncd/pipeline.
+   Make sure to fetch the commit specified in `TEKTON_RELEASE_GIT_SHA` to create the released branch.
+
 1. Edit `README.md` on `main` branch, add entry to docs table with latest release links.
 
 1. Push & make PR for updated `README.md`
@@ -174,7 +178,7 @@ Congratulations, you're done!
    a short memorable name such as `dogfooding`:
 
    ```bash
-   kubectl config rename-context gke_tekton-releases_us-central1-a_dogfooding dogfoodin
+   kubectl config rename-context gke_tekton-releases_us-central1-a_dogfooding dogfooding
    ```
 
 1. **Important: Switch `kubectl` back to your own cluster by default.**


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Add a new item as part of the release creation process, creating a branch in the GitHub repo for the release that was just created.

This branch can be useful to the website https://tekton.dev/docs/ to point to the latest release. Also, the released branch is needed for creating a patch. Instead of creating such branch just before creating a patch, make it part of the release process.

Closes #3875 

/kind documentation


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
Updated the release cheat sheet to include creating a GitHub release branch such as release-v0.28.x as part of the release creation process.
```
