### PR TITLE
Fix link to API compatibility policy

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -193,7 +193,7 @@ Here is an example of a directory layout for a simple Task with 2 script steps:
 | /tekton/termination | where the eventual [termination log message](https://kubernetes.io/docs/tasks/debug-application-cluster/determine-reason-pod-failure/#writing-and-reading-a-termination-message) is written to [Sequencing step containers](#entrypoint-rewriting-and-step-ordering) |
 
 The following directories are covered by the
-[Tekton API Compatibility policy](../api_compatibility_policy.md), and can be
+[Tekton API Compatibility policy](../../api_compatibility_policy.md), and can be
 relied on for stability:
 
 - `/tekton/results`


### PR DESCRIPTION
/kind docs 
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```