### PR TITLE
TEP-69, Implementation. Support retry for custom tasks.

### DIFF
--- a/docs/runs.md
+++ b/docs/runs.md
@@ -196,6 +196,41 @@ Supporting timeouts is optional but recommended.
    `conditions` on the `Run`'s `status` of `Succeeded/False` with a `Reason`
    of `RunTimedOut`.
 
+### Specifying `Retries`
+
+A custom task specification can be created with `Retries` as follows:
+
+```yaml
+apiVersion: tekton.dev/v1alpha1
+kind: Run
+metadata:
+  generateName: simpleexample
+spec:
+  retries: 3 # set retries
+  params:
+    - name: searching
+      value: the purpose of my existence
+  ref:
+    apiVersion: custom.tekton.dev/v1alpha1
+    kind: Example
+    name: exampleName
+```
+
+Supporting retries is optional but recommended.
+
+#### Developer guide for custom controllers supporting `retries`
+
+1. Tekton controllers will use the entire `timeout` duration for exhausting
+    all the retries the custom task is configured to run with. In other words,
+    tekton does not discriminate, if the failure was due to a stuck up process or
+    exhausting all the retries. Custom task developers are recommended to use the
+    same strategy for implementing their timeout for the custom task.
+2. Those custom task who do not wish to support retry, can simply ignore it.
+3. It is recommended, that custom task should update the field `RetriesStatus`
+   of a `Run` on each retry performed by the custom task.
+4. Tekton controller does not validate that number of entries in `RetriesStatus`
+    is same as specified value of retries count.
+
 ### Specifying `Parameters`
 
 If a custom task supports [`parameters`](tasks.md#parameters), you can use the

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -59,6 +59,10 @@ type RunSpec struct {
 	// +optional
 	Status RunSpecStatus `json:"status,omitempty"`
 
+	// Used for propagating retries count to custom tasks
+	// +optional
+	Retries int `json:"retries,omitempty"`
+
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -178,6 +178,7 @@ kind: Run
 metadata:
   name: run
 spec:
+  retries: 3
   ref:
     apiVersion: example.dev/v0
     kind: Example
@@ -207,6 +208,7 @@ status:
 			Name: "run",
 		},
 		Spec: v1alpha1.RunSpec{
+			Retries: 3,
 			Ref: &v1alpha1.TaskRef{
 				APIVersion: "example.dev/v0",
 				Kind:       "Example",

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -238,9 +238,6 @@ func (pt PipelineTask) validateCustomTask() (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support conditions - use when expressions instead", "conditions"))
 	}
 	// TODO(#3133): Support these features if possible.
-	if pt.Retries > 0 {
-		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support retries", "retries"))
-	}
 	if pt.Resources != nil {
 		errs = errs.Also(apis.ErrInvalidValue("custom tasks do not support PipelineResources", "resources"))
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -183,17 +183,6 @@ func TestPipelineTask_ValidateCustomTask(t *testing.T) {
 			Paths:   []string{"conditions"},
 		},
 	}, {
-		name: "custom task doesn't support retries",
-		task: PipelineTask{
-			Name:    "foo",
-			Retries: 3,
-			TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example"},
-		},
-		expectedError: apis.FieldError{
-			Message: `invalid value: custom tasks do not support retries`,
-			Paths:   []string{"retries"},
-		},
-	}, {
 		name: "custom task doesn't support pipeline resources",
 		task: PipelineTask{
 			Name:      "foo",

--- a/pkg/apis/run/v1alpha1/runstatus_types.go
+++ b/pkg/apis/run/v1alpha1/runstatus_types.go
@@ -58,6 +58,10 @@ type RunStatusFields struct {
 	// +optional
 	Results []RunResult `json:"results,omitempty"`
 
+	// RetriesStatus contains the history of RunStatus, in case of a retry.
+	// +optional
+	RetriesStatus []RunStatus `json:"retriesStatus,omitempty"`
+
 	// ExtraFields holds arbitrary fields provided by the custom task
 	// controller.
 	ExtraFields runtime.RawExtension `json:"extraFields,omitempty"`

--- a/pkg/apis/run/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/run/v1alpha1/zz_generated.deepcopy.go
@@ -54,6 +54,13 @@ func (in *RunStatusFields) DeepCopyInto(out *RunStatusFields) {
 		*out = make([]RunResult, len(*in))
 		copy(*out, *in)
 	}
+	if in.RetriesStatus != nil {
+		in, out := &in.RetriesStatus, &out.RetriesStatus
+		*out = make([]RunStatus, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.ExtraFields.DeepCopyInto(&out.ExtraFields)
 	return
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -830,6 +830,7 @@ func (c *Reconciler) createRun(ctx context.Context, rprt *resources.ResolvedPipe
 			Annotations:     getTaskrunAnnotations(pr),
 		},
 		Spec: v1alpha1.RunSpec{
+			Retries:            rprt.PipelineTask.Retries,
 			Ref:                rprt.PipelineTask.TaskRef,
 			Params:             rprt.PipelineTask.Params,
 			ServiceAccountName: taskRunSpec.TaskServiceAccountName,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -767,7 +767,8 @@ func TestReconcile_CustomTask(t *testing.T) {
 			Spec: v1beta1.PipelineRunSpec{
 				PipelineSpec: &v1beta1.PipelineSpec{
 					Tasks: []v1beta1.PipelineTask{{
-						Name: pipelineTaskName,
+						Name:    pipelineTaskName,
+						Retries: 3,
 						Params: []v1beta1.Param{{
 							Name:  "param1",
 							Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "value1"},
@@ -800,6 +801,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 				Annotations: map[string]string{},
 			},
 			Spec: v1alpha1.RunSpec{
+				Retries: 3,
 				Params: []v1beta1.Param{{
 					Name:  "param1",
 					Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "value1"},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
1. Add field Retries to RunSpec.
2. Add field RetriesStatus to RunStatusFields
3. Now pipeline task support retries for custom task by copying it to `Retries` of `RunsSpec`.
4. Removed validation that forbade user from configuring retries for a custom task inside a `pipelineSpec`.

5. Tests included.
6. Documentation,  added a developer guide for custom task developer.
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

/kind tep

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:


-->

```release-note
A custom task specification can be created with `Retries` as follows:

            
             apiVersion: tekton.dev/v1alpha1
             kind: Run
             metadata:
               generateName: simpleexample
             spec:
               retries: 3 # set retries
               params:
                 - name: searching
                   value: the purpose of my existence
               ref:
                 apiVersion: custom.tekton.dev/v1alpha1
                 kind: Example
                 name: exampleName


```