### PR TITLE
Build images for linux/arm (arm32v7)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -419,6 +419,25 @@ to better fit specific usecases.
 
 Out-of-the-box, Tekton Pipelines Controller is configured for relatively small-scale deployments but there have several options for configuring Pipelines' performance are available. See the [Performance Configuration](tekton-controller-performance-configuration.md) document which describes how to change the default ThreadsPerController, QPS and Burst settings to meet your requirements.
 
+## Platform Support
+
+The Tekton project provides support for running on x86 Linux Kubernetes nodes.
+
+The project produces images capable of running on other architectures and operating systems, but may not be able to help debug issues specific to those platforms as readily as those that affect Linux on x86.
+
+The controller and webhook components are currently built for:
+
+- linux/amd64
+- linux/arm64
+- linux/arm (Arm v7)
+- linux/ppc64le (PowerPC)
+- linux/s390x (IBM Z)
+
+The entrypoint component is also built for Windows, which enables TaskRun workloads to execute on Windows nodes.
+See [Windows documentation](windows.md) for more information.
+
+Additional components to support PipelineResources may be available for other architectures as well.
+
 ## Creating a custom release of Tekton Pipelines
 
 You can create a custom release of Tekton Pipelines by following and customizing the steps in [Creating an official release](https://github.com/tektoncd/pipeline/blob/main/tekton/README.md#create-an-official-release). For example, you might want to customize the container images built and used by Tekton Pipelines.

--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -13,7 +13,7 @@ spec:
     description: The path (project) in the container registry
   - name: platforms
     description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+    default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le
   - name: serviceAccountPath
     description: The name of the service account path within the release-secret workspace
   workspaces:

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -27,7 +27,7 @@ spec:
       default: "true"
     - name: platforms
       description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-      default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
+      default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
     - name: serviceAccountPath
       description: The name of the service account path within the release-secret workspace
   workspaces:

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -26,7 +26,7 @@ spec:
     default: "true"
   - name: platforms
     description: Platforms to publish for the images (e.g. linux/amd64,linux/arm64)
-    default: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+    default: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le
   - name: serviceAccountPath
     description: The path to the service account file within the release-secret workspace
   workspaces:


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/4059

We seemingly stopped building these images because of some issue with `git-init`, but IMO that's no reason not to build other core components for this platform. It's only supported on a best-effort basis but it seems like there's demand.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Images are built for linux/arm (arm32v7)
```