### PR TITLE
Bump Alpine base images from 3.11 to 3.14 (current latest)

### DIFF
--- a/images/git-init/Dockerfile
+++ b/images/git-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.14
 
 RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
 

--- a/images/pullrequest-init/Dockerfile
+++ b/images/pullrequest-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as source
+FROM alpine:3.14 as source
 RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
 
 FROM gcr.io/distroless/static:latest


### PR DESCRIPTION
/kind cleanup

https://hub.docker.com/_/alpine shows `alpine:3.14` as `latest`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Bump base image for git-init and pullrequest-init from alpine:3.11 to alpine:3.14
```