### PR TITLE
Adding note regarding whitespace sensitivity of `when` expressions

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -871,6 +871,20 @@ when:
 
 For an end-to-end example, see [`Task` `Results` in a `PipelineRun`](../examples/v1beta1/pipelineruns/task_results_example.yaml).
 
+Note that `when` expressions are whitespace-sensitive.  In particular, when producing results intended for inputs to `when` 
+expressions that may include newlines at their close (e.g. `cat`, `jq`), you may wish to truncate them.
+
+```yaml
+taskSpec:
+  params:
+  - name: jsonQuery-check
+  steps:
+  - image: ubuntu
+    name: store-name-in-results
+    script: |
+      curl -s https://my-json-server.typicode.com/typicode/demo/profile | jq -r .name | tr -d '\n' | tee $(results.name.path)
+```
+
 ### Emitting `Results` from a `Pipeline`
 
 A `Pipeline` can emit `Results` of its own for a variety of reasons - an external


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind documentation

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

After encountering a surprising interaction between task result persistence and `when` expressions, and verifying it would be a welcome documentation change, I prepared this example to demonstrate an approach that generated a working result for me.

This is my first submission so feel free to correct any (unintentional!) mistakes.  Thanks for all your work on tekton.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ X ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- ~[ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [ X ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ X ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ X ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
