### PR TITLE
Stop using milli-quantities for memory and ephemeral storage

### DIFF
--- a/pkg/internal/limitrange/transformer.go
+++ b/pkg/internal/limitrange/transformer.go
@@ -115,7 +115,11 @@ func getDefaultRequest(limitRange *corev1.LimitRange, nbContainers int) corev1.R
 				if item.Min != nil {
 					min = item.Min[name]
 				}
-				r[name] = takeTheMax(request, *resource.NewMilliQuantity(defaultRequest.MilliValue()/int64(nbContainers), defaultRequest.Format), min)
+				if name == corev1.ResourceMemory || name == corev1.ResourceEphemeralStorage {
+					r[name] = takeTheMax(request, *resource.NewQuantity(defaultRequest.Value()/int64(nbContainers), defaultRequest.Format), min)
+				} else {
+					r[name] = takeTheMax(request, *resource.NewMilliQuantity(defaultRequest.MilliValue()/int64(nbContainers), defaultRequest.Format), min)
+				}
 			}
 		}
 	}

--- a/pkg/internal/limitrange/transformer_test.go
+++ b/pkg/internal/limitrange/transformer_test.go
@@ -153,7 +153,7 @@ func TestTransformerOneContainer(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(536870912000, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}},
@@ -162,7 +162,7 @@ func TestTransformerOneContainer(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(536870912000, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}},
@@ -203,7 +203,7 @@ func TestTransformerOneContainer(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(536870912000, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}},
@@ -217,7 +217,7 @@ func TestTransformerOneContainer(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(536870912000, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}},
@@ -573,8 +573,8 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewMilliQuantity(34952533333, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(357913941333, resource.BinarySI),
+						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
 					},
 				},
 			}},
@@ -582,16 +582,16 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewMilliQuantity(34952533333, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(357913941333, resource.BinarySI),
+						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
 					},
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewMilliQuantity(34952533333, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(357913941333, resource.BinarySI),
+						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
 					},
 				},
 			}},
@@ -634,8 +634,8 @@ func TestTransformerMultipleContainer(t *testing.T) {
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewMilliQuantity(34952533333, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(357913941333, resource.BinarySI),
+						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
 					},
 				},
 			}},
@@ -648,8 +648,8 @@ func TestTransformerMultipleContainer(t *testing.T) {
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewMilliQuantity(34952533333, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(357913941333, resource.BinarySI),
+						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
 					},
 				},
 			}, {
@@ -661,8 +661,8 @@ func TestTransformerMultipleContainer(t *testing.T) {
 					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewMilliQuantity(34952533333, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewMilliQuantity(357913941333, resource.BinarySI),
+						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
 					},
 				},
 			}},


### PR DESCRIPTION
Adjusting the pod transformation code based on limit ranges to only use milli-quantities for CPU, but not for memory and ephemeral store because fractions of a byte do not exist in this context.

# Changes

We recently updated from Tekton 0.23 to 0.28, and now noticed that the place-tools init container has a new resource calculation. While we are okay with the values in general, they are somewhere between non-sense and incorrect for memory and ephemeral storage. The reason is that the code used milli quantities causing requests like:

```yaml
spec:
  initContainers:
  - command:
    name: place-tools
    resources:
      limits:
        cpu: "1"
        ephemeral-storage: 400M
        memory: 4G
      requests:
        cpu: 333m
        ephemeral-storage: 133333333333m
        memory: 1333333333333m
```

But there is not a third of a byte that can be requested. The [Kubernetes documentation on resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory) therefore states:

> You can express memory as a plain integer or as a fixed-point number using one of these suffixes: E, P, T, G, M, k. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.

We have some code that analyzes pods which is struggling with milli quantities for memory. While this is an easy fix, we think it makes sense if Tekton stops requesting it like this.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Adjusting the pod transformation code based on limit ranges to only use milli-quantities for CPU, but not for memory and ephemeral store and half bytes do not exist.
```
