### PR TITLE
Escape git usernames with backslashes in .gitconfig

### DIFF
--- a/pkg/credentials/gitcreds/basic.go
+++ b/pkg/credentials/gitcreds/basic.go
@@ -111,7 +111,14 @@ type basicEntry struct {
 }
 
 func (be *basicEntry) configBlurb(u string) string {
-	return fmt.Sprintf("[credential %q]\n	username = %s\n", u, be.username)
+	return fmt.Sprintf("[credential %q]\n	username = %s\n", u, be.escapedUsername())
+}
+
+func (be *basicEntry) escapedUsername() string {
+	if strings.Contains(be.username, "\\") {
+		return strings.ReplaceAll(be.username, "\\", "\\\\")
+	}
+	return be.username
 }
 
 func newBasicEntry(u, secret string) (*basicEntry, error) {


### PR DESCRIPTION
# Changes

Fixes #3887

The proper format for a username like `foo\bar` in `.gitconfig` is `username = foo\\bar` - i.e., the `\` needs to be escaped.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Git credential usernames containing a backslash will have that backslash escaped with an additional backslash in .gitconfig.
```
