### PR TITLE
Retry pod creation if serviceaccount is missing

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -549,6 +549,8 @@ func (c *Reconciler) handlePodCreationError(ctx context.Context, tr *v1beta1.Tas
 		})
 	case isTaskRunValidationFailed(err):
 		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
+	case k8serrors.IsNotFound(err): // serviceaccount or a secret is missing
+		tr.Status.MarkResourceOngoing(podconvert.ReasonPending, err.Error())
 	default:
 		// The pod creation failed with unknown reason. The most likely
 		// reason is that something is wrong with the spec of the Task, that we could

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -57,6 +57,7 @@ spec:
 metadata:
   name: apple
 spec:
+  timeout: 2s
   taskRef:
     name: banana
   serviceAccountName: inexistent`)
@@ -75,6 +76,7 @@ metadata:
 spec:
   tasks:
   - name: foo
+    timeout: 2s
     taskRef:
       name: banana`)
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {

--- a/test/v1alpha1/status_test.go
+++ b/test/v1alpha1/status_test.go
@@ -56,6 +56,7 @@ spec:
 metadata:
   name: apple
 spec:
+  timeout: 2s
   taskRef:
     name: banana
   serviceAccountName: inexistent`)
@@ -74,6 +75,7 @@ metadata:
 spec:
   tasks:
   - name: foo
+    timeout: 2s
     taskRef:
       name: banana`)
 	pipelineRun := parse.MustParseAlphaPipelineRun(t, `


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A missing serviceaccount error can be recovered if the user creates the
serviceaccount few seconds after.

This situation can happen in an environment where a non-default SA is
used: if the user creates a namespace and right after creates a task
run, the system responsible for creating the custom SA might not have
the time to do it quickly enough. The task run is then mark as failed.
With this change, the task run will be requeued and mark as pending
until the timeout.

/kind bug

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->


```release-note
taskrun: when serviceaccount or a secret is missing, retry pod creation instead of failing
```
