### PR TITLE
Fix ignore annotation for gosec

### DIFF
--- a/pkg/pullrequest/scm.go
+++ b/pkg/pullrequest/scm.go
@@ -102,7 +102,8 @@ func githubHandlerFromURL(u *url.URL, token string, skipTLSVerify bool, logger *
 	// gosec complains that we're setting the InsecureSkipVerify option to bypass
 	// security checks. As long as this is generally set to false (which is the
 	// case by default), this should be fine.
-	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipTLSVerify} // nolint: gosec
+	// #nosec G402
+	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipTLSVerify}
 
 	if token != "" {
 		ts := oauth2.StaticTokenSource(
@@ -157,7 +158,8 @@ func gitlabHandlerFromURL(u *url.URL, token string, skipTLSVerify bool, logger *
 	}
 
 	t := http.DefaultTransport.(*http.Transport).Clone()
-	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipTLSVerify} // nolint: gosec
+	// #nosec G402
+	t.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipTLSVerify}
 
 	if token != "" {
 		client.Client = &http.Client{


### PR DESCRIPTION
Running gosec yielded two G403 high sev problems in `pkg/pullrequest/scm.go` although they are supposed to be ignored. This commit replaces the ignore annotation for gosec to the most current annotation as presented [here](https://github.com/securego/gosec#annotating-code).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit replaces the ignore annotation for gosec to the most current annotation as presented [here](https://github.com/securego/gosec#annotating-code).

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing 
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

```release-note
NONE
```