### PR TITLE
Rewrite flakey workspace-in-sidecar example

### DIFF
--- a/examples/v1beta1/taskruns/alpha/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/alpha/workspace-in-sidecar.yaml
@@ -12,28 +12,41 @@ spec:
   timeout: 60s
   workspaces:
   - name: signals
-    emptyDir: {}
+    emptyDir:
+      sizeLimit: 1M
   taskSpec:
     workspaces:
     - name: signals
     steps:
     - image: alpine:3.12.0
+      resources:
+        requests:
+          memory: "16Mi"
+          cpu: "100m"
       script: |
         #!/usr/bin/env ash
-        echo "foo" > "$(workspaces.signals.path)"/bar
-        echo "Wrote bar file"
-        while [ ! -f "$(workspaces.signals.path)"/ready ] ; do
-          echo "Waiting for $(workspaces.signals.path)/ready"
-          sleep 1
-        done
-        echo "Saw ready file"
+        mkfifo "$(workspaces.signals.path)/channel"
+        echo "Greeting sidecar..."
+        echo "hello there" > "$(workspaces.signals.path)/channel"
+        echo "Awaiting response..."
+        read response < "$(workspaces.signals.path)/channel"
+        echo "Sidecar responded: ${response}"
+        echo "Step Done."
     sidecars:
     - image: alpine:3.12.0
+      resources:
+        requests:
+          memory: "16Mi"
+          cpu: "100m"
       script: |
         #!/usr/bin/env ash
-        while [ ! -f "$(workspaces.signals.path)"/bar ] ; do
-          echo "Waiting for $(workspaces.signals.path)/bar"
-          sleep 1
+        while [[ ! -p "$(workspaces.signals.path)/channel" ]] ; do
+          sleep 4
+          echo "Polling channel..."
         done
-        touch "$(workspaces.signals.path)"/ready
-        echo "Wrote ready file"
+        echo "Awaiting greeting..."
+        read message < "$(workspaces.signals.path)"/channel
+        echo "Step sent message: ${message}"
+        echo "Responding..."
+        echo "good day" > "$(workspaces.signals.path)"/channel
+        echo "Sidecar Done."

--- a/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
@@ -13,7 +13,8 @@ spec:
   timeout: 60s
   workspaces:
   - name: signals
-    emptyDir: {}
+    emptyDir:
+      sizeLimit: 1M
   taskSpec:
     workspaces:
     - name: signals
@@ -21,32 +22,36 @@ spec:
     - image: alpine:3.12.0
       resources:
         requests:
-          memory: "64Mi"
-          cpu: "250m"
+          memory: "16Mi"
+          cpu: "100m"
       script: |
         #!/usr/bin/env ash
-        echo "foo" > "$(workspaces.signals.path)"/bar
-        echo "Wrote bar file"
-        while [ ! -f "$(workspaces.signals.path)"/ready ] ; do
-          echo "Waiting for $(workspaces.signals.path)/ready"
-          sleep 1
-        done
-        echo "Saw ready file"
+        mkfifo "$(workspaces.signals.path)/channel"
+        echo "Greeting sidecar..."
+        echo "hello there" > "$(workspaces.signals.path)/channel"
+        echo "Awaiting response..."
+        read response < "$(workspaces.signals.path)/channel"
+        echo "Sidecar responded: ${response}"
+        echo "Step Done."
     sidecars:
     - image: alpine:3.12.0
       resources:
         requests:
-          memory: "64Mi"
-          cpu: "250m"
+          memory: "16Mi"
+          cpu: "100m"
       # Note: must explicitly add volumeMount to gain access to Workspace in sidecar
       volumeMounts:
       - name: $(workspaces.signals.volume)
         mountPath: $(workspaces.signals.path)
       script: |
         #!/usr/bin/env ash
-        while [ ! -f "$(workspaces.signals.path)"/bar ] ; do
-          echo "Waiting for $(workspaces.signals.path)/bar"
-          sleep 1
+        while [[ ! -p "$(workspaces.signals.path)/channel" ]] ; do
+          sleep 4
+          echo "Polling channel..."
         done
-        touch "$(workspaces.signals.path)"/ready
-        echo "Wrote ready file"
+        echo "Awaiting greeting..."
+        read message < "$(workspaces.signals.path)"/channel
+        echo "Step sent message: ${message}"
+        echo "Responding..."
+        echo "good day" > "$(workspaces.signals.path)"/channel
+        echo "Sidecar Done."


### PR DESCRIPTION
# Changes

Issue: https://github.com/tektoncd/pipeline/issues/4169

The `workspace-in-sidecar` example taskruns are the source of regular
flakes in Pipelines' CI. The examples work by using files in a shared
emptyDir volume to synchronize the behaviour of two containers.

This commit introduces a named pipe for synchronizing behaviour between
the two containers, removing one of the file polling loops. The size of the
shared volume has been set extremely low (just in case the problem is related
to disk pressure on the kubelet) and extra log lines are also included to help
narrow down where a freeze might be occurring.

Adding a hold to see if we can get the CI to fail on workspace-in-sidecar
examples for debugging.

/hold

/kind flake

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```