### PR TITLE
Reduce integration test run times

### DIFF
--- a/test/duplicate_test.go
+++ b/test/duplicate_test.go
@@ -32,7 +32,7 @@ import (
 	"knative.dev/pkg/test/helpers"
 )
 
-// TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
+// TestDuplicatePodTaskRun creates multiple builds and checks that each of them has only one build pod.
 func TestDuplicatePodTaskRun(t *testing.T) {
 	t.Parallel()
 
@@ -44,7 +44,10 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 25; i++ {
+	// The number of builds generated has a direct impact on test
+	// runtime and is traded off against proving the taskrun
+	// reconciler's efficacy at not duplicating pods.
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		taskrunName := helpers.ObjectNameForTest(t)
 		t.Logf("Creating taskrun %q.", taskrunName)

--- a/test/v1alpha1/duplicate_test.go
+++ b/test/v1alpha1/duplicate_test.go
@@ -32,7 +32,7 @@ import (
 	"knative.dev/pkg/test/helpers"
 )
 
-// TestDuplicatePodTaskRun creates 10 builds and checks that each of them has only one build pod.
+// TestDuplicatePodTaskRun creates multiple builds and checks that each of them has only one build pod.
 func TestDuplicatePodTaskRun(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -44,7 +44,10 @@ func TestDuplicatePodTaskRun(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	var wg sync.WaitGroup
-	for i := 0; i < 25; i++ {
+	// The number of builds generated has a direct impact on test
+	// runtime and is traded off against proving the taskrun
+	// reconciler's efficacy at not duplicating pods.
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
 		taskrunName := helpers.ObjectNameForTest(t)
 		t.Logf("Creating taskrun %q.", taskrunName)

--- a/test/v1alpha1/sidecar_test.go
+++ b/test/v1alpha1/sidecar_test.go
@@ -46,9 +46,11 @@ func TestSidecarTaskSupport(t *testing.T) {
 		stepCommand    []string
 		sidecarCommand []string
 	}{{
-		desc:           "A sidecar that runs forever is terminated when Steps complete",
-		stepCommand:    []string{"echo", "\"hello world\""},
-		sidecarCommand: []string{"sh", "-c", "while [[ true ]] ; do echo \"hello from sidecar\" ; done"},
+		desc:        "A sidecar that runs forever is terminated when Steps complete",
+		stepCommand: []string{"echo", "\"hello world\""},
+		// trapping the exit signals lets us stop the sidecar more
+		// rapidly than waiting for a force stop.
+		sidecarCommand: []string{"sh", "-c", "trap exit SIGTERM SIGINT; while [[ true ]] ; do echo \"hello from sidecar\" ; sleep 3 ; done"},
 	}, {
 		desc:           "A sidecar that terminates early does not cause problems running Steps",
 		stepCommand:    []string{"echo", "\"hello world\""},
@@ -56,16 +58,19 @@ func TestSidecarTaskSupport(t *testing.T) {
 	}}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	clients, namespace := setup(ctx, t)
 	t.Parallel()
 
-	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, clients, namespace) }, t.Logf)
-	defer tearDown(ctx, t, clients, namespace)
-
 	for i, test := range tests {
+		i := i
+		test := test
 		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			clients, namespace := setup(ctx, t)
+			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, clients, namespace) }, t.Logf)
+			defer tearDown(ctx, t, clients, namespace)
 			sidecarTaskName := fmt.Sprintf("%s-%d", sidecarTaskName, i)
 			sidecarTaskRunName := fmt.Sprintf("%s-%d", sidecarTaskRunName, i)
 			task := parse.MustParseAlphaTask(t, fmt.Sprintf(`

--- a/test/v1alpha1/start_time_test.go
+++ b/test/v1alpha1/start_time_test.go
@@ -28,10 +28,15 @@ import (
 
 // TestStartTime tests that step start times are reported accurately.
 //
-// It runs a TaskRun with 5 steps that each sleep 10 seconds, then checks that
-// the reported step start times are 10+ seconds apart from each other.
-// Scheduling and reporting specifics can result in start times being reported
-// more than 10s apart, but they shouldn't be less than 10s apart.
+// It runs a TaskRun with multiple steps that each sleep for several
+// seconds, then checks that the reported step start times are several
+// seconds apart from each other.  Scheduling and reporting specifics
+// can result in start times being later than expected, but they
+// shouldn't be earlier.
+//
+// The number of seconds between each step has a big impact on the total
+// duration of the test so smaller is better (while still supporting the
+// test's intended purpose).
 func TestStartTime(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -49,16 +54,16 @@ metadata:
 spec:
   taskSpec:
     steps:
-    - image: ubuntu
-      script: sleep 10
-    - image: ubuntu
-      script: sleep 10
-    - image: ubuntu
-      script: sleep 10
-    - image: ubuntu
-      script: sleep 10
-    - image: ubuntu
-      script: sleep 10
+    - image: busybox
+      script: sleep 2
+    - image: busybox
+      script: sleep 2
+    - image: busybox
+      script: sleep 2
+    - image: busybox
+      script: sleep 2
+    - image: busybox
+      script: sleep 2
 `, namespace)), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating TaskRun: %v", err)
@@ -75,6 +80,7 @@ spec:
 	if got, want := len(tr.Status.Steps), len(tr.Spec.TaskSpec.Steps); got != want {
 		t.Errorf("Got unexpected number of step states: got %d, want %d", got, want)
 	}
+	minimumDiff := 2 * time.Second
 	var lastStart metav1.Time
 	for idx, s := range tr.Status.Steps {
 		if s.Terminated == nil {
@@ -82,8 +88,8 @@ spec:
 			continue
 		}
 		diff := s.Terminated.StartedAt.Time.Sub(lastStart.Time)
-		if diff < 10*time.Second {
-			t.Errorf("Step %d start time was %s since last start, wanted >10s", idx, diff)
+		if diff < minimumDiff {
+			t.Errorf("Step %d start time was %s since last start, wanted > %s", idx, diff, minimumDiff)
 		}
 		lastStart = s.Terminated.StartedAt
 	}

--- a/test/v1alpha1/timeout_test.go
+++ b/test/v1alpha1/timeout_test.go
@@ -174,7 +174,9 @@ spec:
 // TestTaskRunTimeout is an integration test that will verify a TaskRun can be timed out.
 func TestTaskRunTimeout(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout+2*time.Minute)
+	taskTimeout := 1 * time.Second
+	testTimeout := taskTimeout + (2 * time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
@@ -203,7 +205,7 @@ spec:
   taskRef:
     name: %s
   timeout: %s
-`, helpers.ObjectNameForTest(t), namespace, task.Name, 30*time.Second))
+`, helpers.ObjectNameForTest(t), namespace, task.Name, taskTimeout))
 	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun `%s`: %s", taskRun.Name, err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The `TestDuplicatePodTaskRun` test creates 50 pods every integration run (25 for v1beta1, 25 for v1alpha1).
On a successful test run in Pipelines' CI cluster this takes around 49 seconds. Locally
in a kind cluster a successful run takes 40 seconds. This commit reduces the number of pods created to 10 per integration run (5 for v1beta1, 5 for v1alpha1). This drops the run time to anything from 10 seconds locally to 21 seconds for the first run in our CI (v1alpha1) and 36 seconds for the second run (v1beta1).

`TestStartTime` takes 73 seconds in our CI and includes multiple 10 second `sleep`s. Reducing these to 2 seconds drops the test run time to 21 seconds.

`TestSidecarTaskSupport` is sped up by trapping the exit signals sent to the container when a sidecar is stopped and by running the sidecar subtests in parallel. This looks to drop the test time from about 60 seconds to around 15 seconds. Log spam from this test is also reduced by sleeping inside an otherwise tight while loop.

~~Total time for an integration run drops from ~ 25 minutes to ~ 22 minutes.~~ Correction: The total runtime of the integration tests is too variable to assign a specific improvement.

Using this integration log for my "before" numbers: https://storage.googleapis.com/tekton-prow/pr-logs/pull/tektoncd_pipeline/4351/pull-tekton-pipeline-integration-tests/1455940433015214081/build-log.txt

Using this integration log for my "after" numbers: https://storage.googleapis.com/tekton-prow/pr-logs/pull/tektoncd_pipeline/4353/pull-tekton-pipeline-integration-tests/1456052547604189184/build-log.txt

And this one for the sidecar tests "after" numbers: https://prow.tekton.dev/log?job=pull-tekton-pipeline-integration-tests&id=1456370392624009217

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```