### PR TITLE
Use kmeta.ChildName for child resources

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -143,7 +143,7 @@ of the event. Inside the root key, the whole `spec` and `status` of the resource
           "type": "Succeeded"
         }
       ],
-      "podName": "curl-run-6gplk-pod-rsgn2",
+      "podName": "curl-run-6gplk-pod",
       "startTime": "2021-01-29T14:47:57Z",
       "steps": [
         {

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -547,7 +547,7 @@ conditions:
     type: Succeeded
 startTime: "2020-05-04T02:00:11Z"
 taskRuns:
-  triggers-release-nightly-frwmw-build-ng2qk:
+  triggers-release-nightly-frwmw-build:
     pipelineTaskName: build
     status:
       completionTime: "2020-05-04T02:10:49Z"
@@ -557,7 +557,7 @@ taskRuns:
           reason: Succeeded
           status: "True"
           type: Succeeded
-      podName: triggers-release-nightly-frwmw-build-ng2qk-pod-8vj99
+      podName: triggers-release-nightly-frwmw-build-pod
       resourcesResult:
         - key: commit
           resourceRef:
@@ -616,7 +616,7 @@ Skipped Tasks:
     Values:
       foo
 Task Runs:
-  pipelinerun-to-skip-task-run-this-task-r2djj:
+  pipelinerun-to-skip-task-run-this-task:
     Pipeline Task Name:  run-this-task
     Status:
       ...
@@ -626,6 +626,20 @@ Task Runs:
       Values:
         foo
 ```
+
+The name of the `TaskRuns` and `Runs` owned by a `PipelineRun`  are univocally associated to the owning resource.
+If a `PipelineRun` resource is deleted and created with the same name, the child `TaskRuns` will be created with the
+same name as before. The base format of the name is `<pipelinerun-name>-<pipelinetask-name>`. The name may vary
+according the logic of [`kmeta.ChildName`](https://pkg.go.dev/github.com/knative/pkg/kmeta#ChildName).
+
+Some examples:
+
+| `PipelineRun` Name       | `PipelineTask` Name          | `TaskRun` Name     |
+|--------------------------|------------------------------|--------------------|
+| pipeline-run             | task1                        | pipeline-run-task1 |
+| pipeline-run             | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-runee4a397d6eab67777d4e6f9991cd19e6-task2-0123456789-0 |
+| pipeline-run-0123456789-0123456789-0123456789-0123456789 | task3 | pipeline-run-0123456789-0123456789-0123456789-0123456789-task3 |
+| pipeline-run-0123456789-0123456789-0123456789-0123456789 | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b5c |
 
 ## Cancelling a `PipelineRun`
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -428,7 +428,7 @@ conditions:
     reason: Succeeded
     status: "True"
     type: Succeeded
-podName: status-taskrun-pod-6488ef
+podName: status-taskrun-pod
 startTime: "2019-08-12T18:22:51Z"
 steps:
   - container: step-hello
@@ -458,6 +458,21 @@ False|TaskRunCancelled|Yes|The TaskRun was cancelled successfully.
 False|TaskRunTimeout|Yes|The TaskRun timed out.
 
 When a `TaskRun` changes status, [events](events.md#taskruns) are triggered accordingly.
+
+The name of the `Pod` owned by a `TaskRun`  is univocally associated to the owning resource. 
+If a `TaskRun` resource is deleted and created with the same name, the child `Pod` will be created with the same name
+as before. The base format of the name is `<taskrun-name>-pod`. The name may vary according to the logic of
+[`kmeta.ChildName`](https://pkg.go.dev/github.com/knative/pkg/kmeta#ChildName). In case of retries of a `TaskRun`
+triggered by the `PipelineRun` controller, the base format of the name is `<taskrun-name>-pod-retry<N>` starting from
+the first retry.
+
+Some examples:
+
+| `TaskRun` Name       | `Pod` Name    |
+|----------------------|---------------|
+| task-run             | task-run-pod  |
+| task-run-0123456789-0123456789-0123456789-0123456789-0123456789-0123456789 | task-run-0123456789-01234560d38957287bb0283c59440df14069f59-pod |
+
 
 ### Monitoring `Steps`
 
@@ -535,7 +550,7 @@ change done by the user (running the debug-continue or debug-fail-continue scrip
 During this time, the user/client can get remote shell access to the step container with a command such as the following.
 
 ```bash
-kubectl exec -it print-date-d7tj5-pod-w5qrn -c step-print-date-human-readable
+kubectl exec -it print-date-d7tj5-pod -c step-print-date-human-readable
 ```
 
 ### Debug Environment

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -546,9 +546,9 @@ Params
 No params
 
 Taskruns
-NAME                                               TASK NAME            STARTED       DURATION     STATUS
-tutorial-pipeline-run-1-deploy-web-jjf2l           deploy-web           4 hours ago   14 seconds   Succeeded
-tutorial-pipeline-run-1-build-skaffold-web-7jgjh   build-skaffold-web   4 hours ago   1 minute     Succeeded
+NAME                                         TASK NAME            STARTED       DURATION     STATUS
+tutorial-pipeline-run-1-deploy-web           deploy-web           4 hours ago   14 seconds   Succeeded
+tutorial-pipeline-run-1-build-skaffold-web   build-skaffold-web   4 hours ago   1 minute     Succeeded
 ```
 
 The `Succeeded` status indicates that your `PipelineRun` completed without errors.

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -643,7 +642,7 @@ func TestReconcile(t *testing.T) {
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, actions)[0]
 	expectedTaskRun := &v1beta1.TaskRun{
-		ObjectMeta: taskRunObjectMeta("test-pipeline-run-success-unit-test-1-mz4c7", "foo", "test-pipeline-run-success", "test-pipeline", "unit-test-1", false),
+		ObjectMeta: taskRunObjectMeta("test-pipeline-run-success-unit-test-1", "foo", "test-pipeline-run-success", "test-pipeline", "unit-test-1", false),
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
 				Name: "unit-test-task",
@@ -734,10 +733,10 @@ func TestReconcile(t *testing.T) {
 	if len(reconciledRun.Status.TaskRuns) != 2 {
 		t.Errorf("Expected PipelineRun status to include both TaskRun status items that can run immediately: %v", reconciledRun.Status.TaskRuns)
 	}
-	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1-mz4c7"]; !exists {
+	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1"]; !exists {
 		t.Errorf("Expected PipelineRun status to include TaskRun status but was %v", reconciledRun.Status.TaskRuns)
 	}
-	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-cluster-task-78c5n"]; !exists {
+	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-cluster-task"]; !exists {
 		t.Errorf("Expected PipelineRun status to include TaskRun status but was %v", reconciledRun.Status.TaskRuns)
 	}
 
@@ -782,7 +781,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 		},
 		wantRun: &v1alpha1.Run{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pipelinerun-custom-task-9l9zj",
+				Name:      "test-pipelinerun-custom-task",
 				Namespace: namespace,
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "tekton.dev/v1beta1",
@@ -843,7 +842,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 		},
 		wantRun: &v1alpha1.Run{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pipelinerun-custom-task-mz4c7",
+				Name:      "test-pipelinerun-custom-task",
 				Namespace: namespace,
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "tekton.dev/v1beta1",
@@ -914,7 +913,7 @@ func TestReconcile_CustomTask(t *testing.T) {
 		},
 		wantRun: &v1alpha1.Run{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pipelinerun-custom-task-mssqb",
+				Name:      "test-pipelinerun-custom-task",
 				Namespace: namespace,
 				OwnerReferences: []metav1.OwnerReference{{
 					APIVersion:         "tekton.dev/v1beta1",
@@ -1057,7 +1056,7 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, actions)[0]
 	expectedTaskRun := &v1beta1.TaskRun{
-		ObjectMeta: taskRunObjectMeta("test-pipeline-run-success-unit-test-task-spec-9l9zj", "foo", "test-pipeline-run-success", "test-pipeline", "unit-test-task-spec", false),
+		ObjectMeta: taskRunObjectMeta("test-pipeline-run-success-unit-test-task-spec", "foo", "test-pipeline-run-success", "test-pipeline", "unit-test-task-spec", false),
 		Spec: v1beta1.TaskRunSpec{
 			TaskSpec: &v1beta1.TaskSpec{
 				Steps: []v1beta1.Step{{
@@ -1087,7 +1086,7 @@ func TestReconcile_PipelineSpecTaskSpec(t *testing.T) {
 		t.Errorf("Expected PipelineRun status to include both TaskRun status items that can run immediately: %v", reconciledRun.Status.TaskRuns)
 	}
 
-	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-task-spec-9l9zj"]; !exists {
+	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-task-spec"]; !exists {
 		t.Errorf("Expected PipelineRun status to include TaskRun status but was %v", reconciledRun.Status.TaskRuns)
 	}
 }
@@ -2251,7 +2250,7 @@ func TestReconcileForCustomTaskWithPipelineRunTimedOut(t *testing.T) {
 	wantEvents := []string{
 		fmt.Sprintf("Warning Failed PipelineRun \"%s\" failed to finish within \"12h0m0s\"", prName),
 	}
-	runName := "test-pipeline-run-custom-task-hello-world-1-9l9zj"
+	runName := "test-pipeline-run-custom-task-hello-world-1"
 
 	reconciledRun, clients := prt.reconcileRun("test", prName, wantEvents, false)
 
@@ -3333,7 +3332,7 @@ func TestReconcilePropagateLabels(t *testing.T) {
 	}}
 	ts := []*v1beta1.Task{simpleHelloWorldTask}
 
-	expectedObjectMeta := taskRunObjectMeta("test-pipeline-run-with-labels-hello-world-1-9l9zj", "foo", "test-pipeline-run-with-labels", "test-pipeline", "hello-world-1", false)
+	expectedObjectMeta := taskRunObjectMeta("test-pipeline-run-with-labels-hello-world-1", "foo", "test-pipeline-run-with-labels", "test-pipeline", "hello-world-1", false)
 	expectedObjectMeta.Labels["PipelineRunLabel"] = "PipelineRunValue"
 	expected := &v1beta1.TaskRun{
 		ObjectMeta: expectedObjectMeta,
@@ -3501,7 +3500,7 @@ func TestReconcileWithDifferentServiceAccounts(t *testing.T) {
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
 
-	taskRunNames := []string{"test-pipeline-run-different-service-accs-hello-world-0-9l9zj", "test-pipeline-run-different-service-accs-hello-world-1-mz4c7"}
+	taskRunNames := []string{"test-pipeline-run-different-service-accs-hello-world-0", "test-pipeline-run-different-service-accs-hello-world-1"}
 
 	expectedTaskRuns := []*v1beta1.TaskRun{
 		{
@@ -3590,7 +3589,7 @@ func TestReconcileCustomTasksWithDifferentServiceAccounts(t *testing.T) {
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
 
-	runNames := []string{"test-pipeline-run-different-service-accs-hello-world-0-9l9zj", "test-pipeline-run-different-service-accs-hello-world-1-mz4c7"}
+	runNames := []string{"test-pipeline-run-different-service-accs-hello-world-0", "test-pipeline-run-different-service-accs-hello-world-1"}
 	expectedSANames := []string{"test-sa-0", "test-sa-1"}
 
 	for i := range ps[0].Spec.Tasks {
@@ -3748,7 +3747,7 @@ func TestReconcilePropagateAnnotations(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, actions)[0]
-	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-with-annotations-hello-world-1-9l9zj", "foo", "test-pipeline-run-with-annotations", "test-pipeline", "hello-world-1", false)
+	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-with-annotations-hello-world-1", "foo", "test-pipeline-run-with-annotations", "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: expectedTaskRunObjectMeta,
@@ -4139,7 +4138,7 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, actions)[0]
-	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-hello-world-1-9l9zj", "foo", "test-pipeline-run", "test-pipeline", "hello-world-1", false)
+	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-hello-world-1", "foo", "test-pipeline-run", "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: expectedTaskRunObjectMeta,
@@ -4214,7 +4213,7 @@ func TestReconcileCustomTasksWithTaskRunSpec(t *testing.T) {
 
 	_, clients := prt.reconcileRun("foo", prName, []string{}, false)
 
-	runName := "test-pipeline-run-hello-world-1-9l9zj"
+	runName := "test-pipeline-run-hello-world-1"
 
 	actual, err := clients.Pipeline.TektonV1alpha1().Runs("foo").Get(prt.TestAssets.Ctx, runName, metav1.GetOptions{})
 	if err != nil {
@@ -4323,10 +4322,10 @@ func TestReconcileWithConditionChecks(t *testing.T) {
 	}
 	_, clients := prt.reconcileRun("foo", prName, wantEvents, false)
 
-	ccNameBase := prName + "-hello-world-1-9l9zj"
+	ccNameBase := prName + "-hello-world-1"
 	ccNames := map[string]string{
-		"cond-1": ccNameBase + "-cond-1-0-mz4c7",
-		"cond-2": ccNameBase + "-cond-2-1-mssqb",
+		"cond-1": ccNameBase + "-cond-1-0",
+		"cond-2": ccNameBase + "-cond-2-1",
 	}
 	expectedConditionChecks := make([]*v1beta1.TaskRun, len(conditions))
 	for index, condition := range conditions {
@@ -4367,7 +4366,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 	pipelineRunName := "test-pipeline-run-with-conditions"
 	prccs := make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
 
-	conditionCheckName := pipelineRunName + "task-2-always-false-xxxyyy"
+	conditionCheckName := pipelineRunName + "task-2-always-false"
 	prccs[conditionCheckName] = &v1beta1.PipelineRunConditionCheckStatus{
 		ConditionName: "always-false-0",
 		Status:        &v1beta1.ConditionCheckStatus{},
@@ -4523,7 +4522,7 @@ func TestReconcileWithFailingConditionChecks(t *testing.T) {
 
 	// Check that the expected TaskRun was created
 	actual := getTaskRunCreations(t, actions)[0]
-	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-with-conditions-task-3-9l9zj", "foo", "test-pipeline-run-with-conditions", "test-pipeline", "task-3", false)
+	expectedTaskRunObjectMeta := taskRunObjectMeta("test-pipeline-run-with-conditions-task-3", "foo", "test-pipeline-run-with-conditions", "test-pipeline", "task-3", false)
 	expectedTaskRunObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: expectedTaskRunObjectMeta,
@@ -4677,7 +4676,7 @@ func TestReconcileWithWhenExpressionsWithParameters(t *testing.T) {
 	if len(actual.Items) != 1 {
 		t.Fatalf("Expected 1 TaskRun got %d", len(actual.Items))
 	}
-	expectedTaskRunName := "test-pipeline-run-hello-world-1-9l9zj"
+	expectedTaskRunName := "test-pipeline-run-hello-world-1"
 	expectedTaskRunObjectMeta := taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run", "test-pipeline", "hello-world-1", false)
 	expectedTaskRunObjectMeta.Annotations["PipelineRunAnnotation"] = "PipelineRunValue"
 	expectedTaskRun := &v1beta1.TaskRun{
@@ -4836,7 +4835,7 @@ func TestReconcileWithWhenExpressionsWithTaskResults(t *testing.T) {
 	}
 	pipelineRun, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", wantEvents, false)
 
-	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task-9l9zj"
+	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task"
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs", "test-pipeline", "b-task", false),
 		Spec: v1beta1.TaskRunSpec{
@@ -5061,8 +5060,8 @@ func TestReconcileWithWhenExpressionsScopedToTask(t *testing.T) {
 		}
 	}
 
-	taskRunExists("b-task", "test-pipeline-run-different-service-accs-b-task-mz4c7")
-	taskRunExists("d-task", "test-pipeline-run-different-service-accs-d-task-78c5n")
+	taskRunExists("b-task", "test-pipeline-run-different-service-accs-b-task")
+	taskRunExists("d-task", "test-pipeline-run-different-service-accs-d-task")
 
 	actualSkippedTasks := pipelineRun.Status.SkippedTasks
 	expectedSkippedTasks := []v1beta1.SkippedTask{{
@@ -5791,7 +5790,7 @@ func TestReconcileWithTaskResults(t *testing.T) {
 
 	_, clients := prt.reconcileRun("foo", "test-pipeline-run-different-service-accs", []string{}, false)
 
-	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task-9l9zj"
+	expectedTaskRunName := "test-pipeline-run-different-service-accs-b-task"
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs",
 			"test-pipeline", "b-task", false),
@@ -5890,7 +5889,7 @@ func TestReconcileWithTaskResultsEmbeddedNoneStarted(t *testing.T) {
 	}
 
 	// Since b-task is dependent on a-task, via the results, only a-task should run
-	expectedTaskRunName := "test-pipeline-run-different-service-accs-a-task-9l9zj"
+	expectedTaskRunName := "test-pipeline-run-different-service-accs-a-task"
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: taskRunObjectMeta(expectedTaskRunName, "foo", "test-pipeline-run-different-service-accs",
 			"test-pipeline-run-different-service-accs", "a-task", false),
@@ -5949,7 +5948,7 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 		},
 	}}
 	trs := []*v1beta1.TaskRun{{
-		ObjectMeta: taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task-9l9zj", "foo",
+		ObjectMeta: taskRunObjectMeta("test-pipeline-run-different-service-accs-a-task", "foo",
 			"test-pipeline-run-different-service-accs", "test-pipeline", "a-task",
 			true),
 		Spec: v1beta1.TaskRunSpec{
@@ -6073,7 +6072,7 @@ func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 
 	// Condition checks for the third task
 	prccs3 := make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
-	conditionCheckName3 := prOutOfSyncName + "-hello-world-3-always-true-xxxyyy"
+	conditionCheckName3 := prOutOfSyncName + "-hello-world-3-always-true"
 	prccs3[conditionCheckName3] = &v1beta1.PipelineRunConditionCheckStatus{
 		ConditionName: "always-true-0",
 		Status: &v1beta1.ConditionCheckStatus{
@@ -6089,7 +6088,7 @@ func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 	}
 	// Condition checks for the fourth task
 	prccs4 := make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
-	conditionCheckName4 := prOutOfSyncName + "-hello-world-4-always-true-xxxyyy"
+	conditionCheckName4 := prOutOfSyncName + "-hello-world-4-always-true"
 	prccs4[conditionCheckName4] = &v1beta1.PipelineRunConditionCheckStatus{
 		ConditionName: "always-true-0",
 		Status: &v1beta1.ConditionCheckStatus{
@@ -6466,15 +6465,6 @@ func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 		},
 	}
 
-	// We cannot just diff status directly because the taskrun name for the orphaned condition
-	// is dynamically generated, but we can change the name to allow us to then diff.
-	for taskRunName, taskRunStatus := range reconciledRun.Status.TaskRuns {
-		if strings.HasPrefix(taskRunName, taskRunWithOrphanedConditionName) {
-			reconciledRun.Status.TaskRuns[taskRunWithOrphanedConditionName] = taskRunStatus
-			delete(reconciledRun.Status.TaskRuns, taskRunName)
-			break
-		}
-	}
 	if d := cmp.Diff(reconciledRun.Status.TaskRuns, expectedTaskRunsStatus); d != "" {
 		t.Fatalf("Expected PipelineRun status to match TaskRun(s) status, but got a mismatch: %s", d)
 	}
@@ -7517,8 +7507,8 @@ func TestReconcilePipeline_TaskSpecMetadata(t *testing.T) {
 	}
 
 	expectedTaskRun := make(map[string]*v1beta1.TaskRun)
-	expectedTaskRun["test-pipeline-run-success-task-with-metadata-mz4c7"] = getTaskRunWithTaskSpec(
-		"test-pipeline-run-success-task-with-metadata-mz4c7",
+	expectedTaskRun["test-pipeline-run-success-task-with-metadata"] = getTaskRunWithTaskSpec(
+		"test-pipeline-run-success-task-with-metadata",
 		"test-pipeline-run-success",
 		"test-pipeline",
 		"task-with-metadata",
@@ -7526,8 +7516,8 @@ func TestReconcilePipeline_TaskSpecMetadata(t *testing.T) {
 		annotations,
 	)
 
-	expectedTaskRun["test-pipeline-run-success-task-without-metadata-9l9zj"] = getTaskRunWithTaskSpec(
-		"test-pipeline-run-success-task-without-metadata-9l9zj",
+	expectedTaskRun["test-pipeline-run-success-task-without-metadata"] = getTaskRunWithTaskSpec(
+		"test-pipeline-run-success-task-without-metadata",
 		"test-pipeline-run-success",
 		"test-pipeline",
 		"task-without-metadata",
@@ -7627,7 +7617,7 @@ func TestReconciler_ReconcileKind_PipelineTaskContext(t *testing.T) {
 
 	_, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
 
-	expectedTaskRunName := pipelineRunName + "-finaltask-9l9zj"
+	expectedTaskRunName := pipelineRunName + "-finaltask"
 	expectedTaskRunObjectMeta := taskRunObjectMeta(expectedTaskRunName, "foo", pipelineRunName, pipelineName, "finaltask", false)
 	expectedTaskRunObjectMeta.Labels[pipeline.MemberOfLabelKey] = v1beta1.PipelineFinallyTasks
 	expectedTaskRun := &v1beta1.TaskRun{
@@ -7856,7 +7846,7 @@ func TestReconcileWithTaskResultsInFinalTasks(t *testing.T) {
 
 	reconciledRun, clients := prt.reconcileRun("foo", "test-pipeline-run-final-task-results", []string{}, false)
 
-	expectedTaskRunName := "test-pipeline-run-final-task-results-final-task-1-9l9zj"
+	expectedTaskRunName := "test-pipeline-run-final-task-results-final-task-1"
 	expectedTaskRun := v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      expectedTaskRunName,
@@ -8061,7 +8051,7 @@ func TestReconcile_RemotePipelineRef(t *testing.T) {
 	actual := getTaskRunCreations(t, clients.Pipeline.Actions())[0]
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-pipeline-run-success-unit-test-1-9l9zj",
+			Name:        "test-pipeline-run-success-unit-test-1",
 			Namespace:   "foo",
 			Annotations: map[string]string{},
 			Labels: map[string]string{
@@ -8106,7 +8096,7 @@ func TestReconcile_RemotePipelineRef(t *testing.T) {
 	if len(reconciledRun.Status.TaskRuns) != 1 {
 		t.Errorf("Expected PipelineRun status to include the TaskRun status item that ran immediately: %v", reconciledRun.Status.TaskRuns)
 	}
-	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1-9l9zj"]; !exists {
+	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1"]; !exists {
 		t.Errorf("Expected PipelineRun status to include TaskRun status but was %v", reconciledRun.Status.TaskRuns)
 	}
 }
@@ -8169,7 +8159,7 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 	actual := getTaskRunCreations(t, clients.Pipeline.Actions())[0]
 	expectedTaskRun := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-pipeline-run-success-unit-test-1-9l9zj",
+			Name:        "test-pipeline-run-success-unit-test-1",
 			Namespace:   "foo",
 			Annotations: map[string]string{},
 			Labels: map[string]string{
@@ -8219,7 +8209,7 @@ func TestReconcile_OptionalWorkspacesOmitted(t *testing.T) {
 	if len(reconciledRun.Status.TaskRuns) != 1 {
 		t.Errorf("Expected PipelineRun status to include the TaskRun status item that ran immediately: %v", reconciledRun.Status.TaskRuns)
 	}
-	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1-9l9zj"]; !exists {
+	if _, exists := reconciledRun.Status.TaskRuns["test-pipeline-run-success-unit-test-1"]; !exists {
 		t.Errorf("Expected PipelineRun status to include TaskRun status but was %v", reconciledRun.Status.TaskRuns)
 	}
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"strconv"
 
+	"knative.dev/pkg/kmeta"
+
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/list"
-	"github.com/tektoncd/pipeline/pkg/names"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"knative.dev/pkg/apis"
@@ -550,7 +551,7 @@ func getConditionCheckName(taskRunStatus map[string]*v1beta1.PipelineRunTaskRunS
 			}
 		}
 	}
-	return names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%s", trName, conditionRegisterName))
+	return kmeta.ChildName(trName, fmt.Sprintf("-%s", conditionRegisterName))
 }
 
 // GetTaskRunName should return a unique name for a `TaskRun` if one has not already been defined, and the existing one otherwise.
@@ -561,7 +562,7 @@ func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus,
 		}
 	}
 
-	return names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%s", prName, ptName))
+	return kmeta.ChildName(prName, fmt.Sprintf("-%s", ptName))
 }
 
 // getRunName should return a unique name for a `Run` if one has not already
@@ -572,8 +573,7 @@ func getRunName(runsStatus map[string]*v1beta1.PipelineRunRunStatus, ptName, prN
 			return k
 		}
 	}
-
-	return names.SimpleNameGenerator.RestrictLengthWithRandomSuffix(fmt.Sprintf("%s-%s", prName, ptName))
+	return kmeta.ChildName(prName, fmt.Sprintf("-%s", ptName))
 }
 
 func resolveConditionChecks(pt *v1beta1.PipelineTask, taskRunStatus map[string]*v1beta1.PipelineRunTaskRunStatus, taskRunName string, getTaskRun resources.GetTaskRun, getCondition GetCondition, providedResources map[string]*resourcev1alpha1.PipelineResource) ([]*ResolvedConditionCheck, error) {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1808,7 +1808,7 @@ func TestResolvePipelineRun(t *testing.T) {
 	}
 	expectedState := PipelineRunState{{
 		PipelineTask: &p.Spec.Tasks[0],
-		TaskRunName:  "pipelinerun-mytask1-9l9zj",
+		TaskRunName:  "pipelinerun-mytask1",
 		TaskRun:      nil,
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskName: task.Name,
@@ -1820,7 +1820,7 @@ func TestResolvePipelineRun(t *testing.T) {
 		},
 	}, {
 		PipelineTask: &p.Spec.Tasks[1],
-		TaskRunName:  "pipelinerun-mytask2-mz4c7",
+		TaskRunName:  "pipelinerun-mytask2",
 		TaskRun:      nil,
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskName: task.Name,
@@ -1832,7 +1832,7 @@ func TestResolvePipelineRun(t *testing.T) {
 		},
 	}, {
 		PipelineTask: &p.Spec.Tasks[2],
-		TaskRunName:  "pipelinerun-mytask3-mssqb",
+		TaskRunName:  "pipelinerun-mytask3",
 		TaskRun:      nil,
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskName: task.Name,
@@ -1844,7 +1844,7 @@ func TestResolvePipelineRun(t *testing.T) {
 		},
 	}, {
 		PipelineTask: &p.Spec.Tasks[3],
-		TaskRunName:  "pipelinerun-mytask4-78c5n",
+		TaskRunName:  "pipelinerun-mytask4",
 		TaskRun:      nil,
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskName: "",
@@ -1881,7 +1881,7 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	}
 	run := &v1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "run-exists-abcde"}}
 	getRun := func(name string) (*v1alpha1.Run, error) {
-		if name == "pipelinerun-run-exists-mssqb" {
+		if name == "pipelinerun-run-exists" {
 			return run, nil
 		}
 		return nil, kerrors.NewNotFound(v1beta1.Resource("run"), name)
@@ -1908,17 +1908,17 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	expectedState := PipelineRunState{{
 		PipelineTask: &pts[0],
 		CustomTask:   true,
-		RunName:      "pipelinerun-customtask-9l9zj",
+		RunName:      "pipelinerun-customtask",
 		Run:          nil,
 	}, {
 		PipelineTask: &pts[1],
 		CustomTask:   true,
-		RunName:      "pipelinerun-customtask-spec-mz4c7",
+		RunName:      "pipelinerun-customtask-spec",
 		Run:          nil,
 	}, {
 		PipelineTask: &pts[2],
 		CustomTask:   true,
-		RunName:      "pipelinerun-run-exists-mssqb",
+		RunName:      "pipelinerun-run-exists",
 		Run:          run,
 	}}
 	if d := cmp.Diff(expectedState, pipelineState); d != "" {
@@ -2105,7 +2105,7 @@ func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 	}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{"git-resource": r}
 	taskrunStatus := map[string]*v1beta1.PipelineRunTaskRunStatus{}
-	taskrunStatus["pipelinerun-mytask-with-a-really-long-name-to-trigger-tru-9l9zj"] = &v1beta1.PipelineRunTaskRunStatus{
+	taskrunStatus["pipelinerun-mytask-with-a-really-long-name-to-trigger-tru"] = &v1beta1.PipelineRunTaskRunStatus{
 		PipelineTaskName: "mytask-with-a-really-long-name-to-trigger-truncation",
 		Status:           &v1beta1.TaskRunStatus{},
 	}
@@ -2132,7 +2132,7 @@ func TestResolvePipelineRun_withExistingTaskRuns(t *testing.T) {
 	}
 	expectedTask := &ResolvedPipelineRunTask{
 		PipelineTask: &p.Spec.Tasks[0],
-		TaskRunName:  "pipelinerun-mytask-with-a-really-long-name-to-trigger-tru-9l9zj",
+		TaskRunName:  "pipelinerun-mytask-with-a-really-long-name-to-trigger-tru",
 		TaskRun:      nil,
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskName: task.Name,
@@ -2200,7 +2200,7 @@ func TestResolvedPipelineRun_PipelineTaskHasOptionalResources(t *testing.T) {
 	}
 	expectedTask := &ResolvedPipelineRunTask{
 		PipelineTask: &p.Spec.Tasks[0],
-		TaskRunName:  "pipelinerun-mytask1-9l9zj",
+		TaskRunName:  "pipelinerun-mytask1",
 		TaskRun:      nil,
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskName: taskWithOptionalResources.Name,
@@ -2221,7 +2221,7 @@ func TestResolvedPipelineRun_PipelineTaskHasOptionalResources(t *testing.T) {
 
 func TestResolveConditionChecks(t *testing.T) {
 	names.TestingSeed()
-	ccName := "pipelinerun-mytask1-9l9zj-always-true-mz4c7"
+	ccName := "pipelinerun-mytask1-always-true"
 
 	cc := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2256,9 +2256,9 @@ func TestResolveConditionChecks(t *testing.T) {
 		name: "conditionCheck exists",
 		getTaskRun: func(name string) (*v1beta1.TaskRun, error) {
 			switch name {
-			case "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7":
+			case "pipelinerun-mytask1-always-true-0":
 				return cc, nil
-			case "pipelinerun-mytask1-9l9zj":
+			case "pipelinerun-mytask1":
 				return &trs[0], nil
 			default:
 				return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
@@ -2266,7 +2266,7 @@ func TestResolveConditionChecks(t *testing.T) {
 		},
 		expectedConditionCheck: TaskConditionCheckState{{
 			ConditionRegisterName: "always-true-0",
-			ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7",
+			ConditionCheckName:    "pipelinerun-mytask1-always-true-0",
 			Condition:             &condition,
 			ConditionCheck:        v1beta1.NewConditionCheck(cc),
 			PipelineTaskCondition: &ptc,
@@ -2275,16 +2275,16 @@ func TestResolveConditionChecks(t *testing.T) {
 	}, {
 		name: "conditionCheck doesn't exist",
 		getTaskRun: func(name string) (*v1beta1.TaskRun, error) {
-			if name == "pipelinerun-mytask1-mssqb-always-true-0-78c5n" {
+			if name == "pipelinerun-mytask1-always-true-0" {
 				return nil, nil
-			} else if name == "pipelinerun-mytask1-mssqb" {
+			} else if name == "pipelinerun-mytask1" {
 				return &trs[0], nil
 			}
 			return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
 		},
 		expectedConditionCheck: TaskConditionCheckState{{
 			ConditionRegisterName: "always-true-0",
-			ConditionCheckName:    "pipelinerun-mytask1-mssqb-always-true-0-78c5n",
+			ConditionCheckName:    "pipelinerun-mytask1-always-true-0",
 			Condition:             &condition,
 			PipelineTaskCondition: &ptc,
 			ResolvedResources:     providedResources,
@@ -2306,8 +2306,8 @@ func TestResolveConditionChecks(t *testing.T) {
 
 func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 	names.TestingSeed()
-	ccName1 := "pipelinerun-mytask1-9l9zj-always-true-mz4c7"
-	ccName2 := "pipelinerun-mytask1-9l9zj-always-true-mssqb"
+	ccName1 := "pipelinerun-mytask1-always-true"
+	ccName2 := "pipelinerun-mytask1-always-true"
 
 	cc1 := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2356,25 +2356,25 @@ func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) {
 		switch name {
-		case "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7":
+		case "pipelinerun-mytask1-always-true-0":
 			return cc1, nil
-		case "pipelinerun-mytask1-9l9zj":
+		case "pipelinerun-mytask1":
 			return &trs[0], nil
-		case "pipelinerun-mytask1-9l9zj-always-true-1-mssqb":
+		case "pipelinerun-mytask1-always-true-1":
 			return cc2, nil
 		}
 		return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
 	}
 	expectedConditionCheck := TaskConditionCheckState{{
 		ConditionRegisterName: "always-true-0",
-		ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7",
+		ConditionCheckName:    "pipelinerun-mytask1-always-true-0",
 		Condition:             &condition,
 		ConditionCheck:        v1beta1.NewConditionCheck(cc1),
 		PipelineTaskCondition: &ptc1,
 		ResolvedResources:     providedResources,
 	}, {
 		ConditionRegisterName: "always-true-1",
-		ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-1-mssqb",
+		ConditionCheckName:    "pipelinerun-mytask1-always-true-1",
 		Condition:             &condition,
 		ConditionCheck:        v1beta1.NewConditionCheck(cc2),
 		PipelineTaskCondition: &ptc2,
@@ -2393,8 +2393,8 @@ func TestResolveConditionChecks_MultipleConditions(t *testing.T) {
 }
 func TestResolveConditionChecks_ConditionDoesNotExist(t *testing.T) {
 	names.TestingSeed()
-	trName := "pipelinerun-mytask1-9l9zj"
-	ccName := "pipelinerun-mytask1-9l9zj-does-not-exist-mz4c7"
+	trName := "pipelinerun-mytask1"
+	ccName := "pipelinerun-mytask1-does-not-exist"
 
 	pt := v1beta1.PipelineTask{
 		Name:    "mytask1",
@@ -2438,7 +2438,7 @@ func TestResolveConditionChecks_ConditionDoesNotExist(t *testing.T) {
 func TestResolveConditionCheck_UseExistingConditionCheckName(t *testing.T) {
 	names.TestingSeed()
 
-	trName := "pipelinerun-mytask1-9l9zj"
+	trName := "pipelinerun-mytask1"
 	ccName := "some-random-name"
 
 	cc := &v1beta1.TaskRun{
@@ -2591,7 +2591,7 @@ func TestResolvedConditionCheck_WithResources(t *testing.T) {
 				pipelineState := PipelineRunState{ps}
 				expectedConditionChecks := TaskConditionCheckState{{
 					ConditionRegisterName: "always-true-0",
-					ConditionCheckName:    "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7",
+					ConditionCheckName:    "pipelinerun-mytask1-always-true-0",
 					Condition:             condition,
 					PipelineTaskCondition: &ptc,
 					ResolvedResources:     tc.expected,
@@ -3034,7 +3034,7 @@ func TestValidateServiceaccountMapping(t *testing.T) {
 
 func TestResolvePipeline_WhenExpressions(t *testing.T) {
 	names.TestingSeed()
-	tName1 := "pipelinerun-mytask1-9l9zj-always-true-mz4c7"
+	tName1 := "pipelinerun-mytask1-always-true"
 
 	t1 := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3066,9 +3066,9 @@ func TestResolvePipeline_WhenExpressions(t *testing.T) {
 
 	getTaskRun := func(name string) (*v1beta1.TaskRun, error) {
 		switch name {
-		case "pipelinerun-mytask1-9l9zj-always-true-0-mz4c7":
+		case "pipelinerun-mytask1-always-true-0":
 			return t1, nil
-		case "pipelinerun-mytask1-9l9zj":
+		case "pipelinerun-mytask1":
 			return &trs[0], nil
 		}
 		return nil, fmt.Errorf("getTaskRun called with unexpected name %s", name)
@@ -3409,4 +3409,102 @@ func TestResolvedPipelineRunTask_IsFinalTask(t *testing.T) {
 		t.Fatalf("Didn't get expected isFinallySkipped from finally task %s: %s", finallyTaskName, diff.PrintWantGot(d))
 	}
 
+}
+
+func TestGetTaskRunName(t *testing.T) {
+	prName := "pipeline-run"
+	taskRunsStatus := map[string]*v1beta1.PipelineRunTaskRunStatus{
+		"taskrun-for-task1": {
+			PipelineTaskName: "task1",
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		ptName     string
+		prName     string
+		wantTrName string
+	}{{
+		name:       "existing taskrun",
+		ptName:     "task1",
+		wantTrName: "taskrun-for-task1",
+	}, {
+		name:       "new taskrun",
+		ptName:     "task2",
+		wantTrName: "pipeline-run-task2",
+	}, {
+		name:       "new taskrun with long name",
+		ptName:     "task2-0123456789-0123456789-0123456789-0123456789-0123456789",
+		wantTrName: "pipeline-runee4a397d6eab67777d4e6f9991cd19e6-task2-0123456789-0",
+	}, {
+		name:       "new taskrun, pr with long name",
+		ptName:     "task3",
+		prName:     "pipeline-run-0123456789-0123456789-0123456789-0123456789",
+		wantTrName: "pipeline-run-0123456789-0123456789-0123456789-0123456789-task3",
+	}, {
+		name:       "new taskrun, taskrun and pr with long name",
+		ptName:     "task2-0123456789-0123456789-0123456789-0123456789-0123456789",
+		prName:     "pipeline-run-0123456789-0123456789-0123456789-0123456789",
+		wantTrName: "pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b5c",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			testPrName := prName
+			if tc.prName != "" {
+				testPrName = tc.prName
+			}
+			gotTrName := GetTaskRunName(taskRunsStatus, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, gotTrName); d != "" {
+				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestGetRunName(t *testing.T) {
+	prName := "pipeline-run"
+	runsStatus := map[string]*v1beta1.PipelineRunRunStatus{
+		"run-for-task1": {
+			PipelineTaskName: "task1",
+		},
+	}
+
+	for _, tc := range []struct {
+		name       string
+		ptName     string
+		prName     string
+		wantTrName string
+	}{{
+		name:       "existing run",
+		ptName:     "task1",
+		wantTrName: "run-for-task1",
+	}, {
+		name:       "new run",
+		ptName:     "task2",
+		wantTrName: "pipeline-run-task2",
+	}, {
+		name:       "new run with long name",
+		ptName:     "task2-12345678901234567890123456789012345678901234567890",
+		wantTrName: "pipeline-run155b61773fd25b1fbd46dba34cd7cbeb-task2-123456789012",
+	}, {
+		name:       "new run, pr with long name",
+		ptName:     "task2",
+		prName:     "pipeline-run-12345678901234567890123456789012345678901234567890",
+		wantTrName: "pipeline-run-123456789012f022e3ec9d06c5795de718d2f11bdd71-task2",
+	}, {
+		name:       "new run, run and pr with long name",
+		ptName:     "task2-12345678901234567890123456789012345678901234567890",
+		prName:     "pipeline-run-1234567890123456789012345678901234567890",
+		wantTrName: "pipeline-run-1234567890123456782725b0120d3afbb59a451b67da5eb51c",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			testPrName := prName
+			if tc.prName != "" {
+				testPrName = tc.prName
+			}
+			gotTrName := getRunName(runsStatus, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, gotTrName); d != "" {
+				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -710,7 +710,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 	}{{
 		name:    "success",
 		taskRun: taskRunSuccess,
-		wantPod: expectedPod("test-taskrun-run-success-pod-abcde", "test-task", "test-taskrun-run-success", "foo", defaultSAName, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-run-success-pod", "test-task", "test-taskrun-run-success", "foo", defaultSAName, false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
@@ -718,7 +718,7 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 	}, {
 		name:    "serviceaccount",
 		taskRun: taskRunWithSaSuccess,
-		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod-abcde", "test-with-sa", "test-taskrun-with-sa-run-success", "foo", "test-sa", false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod", "test-with-sa", "test-taskrun-with-sa-run-success", "foo", "test-sa", false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "sa-step",
 			cmd:   "/mycmd",
@@ -834,7 +834,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 		name:        "disable-home-env-overwrite",
 		taskRun:     taskRunWithDisableHomeEnv,
 		featureFlag: "disable-home-env-overwrite",
-		wantPod: expectedPod("test-taskrun-run-home-env-pod-abcde", "test-task-with-env-var", "test-taskrun-run-home-env", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-run-home-env-pod", "test-task-with-env-var", "test-taskrun-run-home-env", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			image:   "foo",
 			name:    "simple-step",
 			cmd:     "/mycmd",
@@ -844,7 +844,7 @@ func TestReconcile_FeatureFlags(t *testing.T) {
 		name:        "disable-working-dir-overwrite",
 		taskRun:     taskRunWithDisableWorkingDirOverwrite,
 		featureFlag: "disable-working-directory-overwrite",
-		wantPod: expectedPod("test-taskrun-run-working-dir-pod-abcde", "test-task", "test-taskrun-run-working-dir", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-run-working-dir-pod", "test-task", "test-taskrun-run-working-dir", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
@@ -1309,7 +1309,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-run-success-pod-abcde", "test-task", "test-taskrun-run-success", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-run-success-pod", "test-task", "test-taskrun-run-success", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "simple-step",
 			cmd:   "/mycmd",
@@ -1321,7 +1321,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod-abcde", "test-with-sa", "test-taskrun-with-sa-run-success", "foo", "test-sa", false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-sa-run-success-pod", "test-with-sa", "test-taskrun-with-sa-run-success", "foo", "test-sa", false, nil, []stepForExpectedPod{{
 			image: "foo",
 			name:  "sa-step",
 			cmd:   "/mycmd",
@@ -1333,7 +1333,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-substitution-pod-abcde", "test-task-with-substitution", "test-taskrun-substitution", "foo", config.DefaultServiceAccountValue, false, []corev1.Volume{{
+		wantPod: expectedPod("test-taskrun-substitution-pod", "test-task-with-substitution", "test-taskrun-substitution", "foo", config.DefaultServiceAccountValue, false, []corev1.Volume{{
 			Name: "volume-configmap",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
@@ -1397,7 +1397,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-taskspec-pod-abcde", "", "test-taskrun-with-taskspec", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{
+		wantPod: expectedPod("test-taskrun-with-taskspec-pod", "", "test-taskrun-with-taskspec", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{
 			{
 				name:  "git-source-workspace-9l9zj",
 				image: "override-with-git:latest",
@@ -1426,7 +1426,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-cluster-task-pod-abcde", "test-cluster-task", "test-taskrun-with-cluster-task", "foo", config.DefaultServiceAccountValue, true, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-cluster-task-pod", "test-cluster-task", "test-taskrun-with-cluster-task", "foo", config.DefaultServiceAccountValue, true, nil, []stepForExpectedPod{{
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
@@ -1438,7 +1438,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-resource-spec-pod-abcde", "", "test-taskrun-with-resource-spec", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{
+		wantPod: expectedPod("test-taskrun-with-resource-spec-pod", "", "test-taskrun-with-resource-spec", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{
 			{
 				name:  "git-source-workspace-9l9zj",
 				image: "override-with-git:latest",
@@ -1466,7 +1466,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-pod-pod-abcde", "test-task", "test-taskrun-with-pod", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-pod-pod", "test-task", "test-taskrun-with-pod", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",
@@ -1478,7 +1478,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-with-credentials-variable-pod-abcde", "", "test-taskrun-with-credentials-variable", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-with-credentials-variable-pod", "", "test-taskrun-with-credentials-variable", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:  "mycontainer",
 			image: "myimage",
 			cmd:   "/mycmd /tekton/creds",
@@ -1490,7 +1490,7 @@ func TestReconcile(t *testing.T) {
 			"Normal Started ",
 			"Normal Running Not all Steps",
 		},
-		wantPod: expectedPod("test-taskrun-bundle-pod-abcde", "test-task", "test-taskrun-bundle", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
+		wantPod: expectedPod("test-taskrun-bundle-pod", "test-task", "test-taskrun-bundle", "foo", config.DefaultServiceAccountValue, false, nil, []stepForExpectedPod{{
 			name:  "simple-step",
 			image: "foo",
 			cmd:   "/mycmd",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a reconciler generates a child resource, it risks creating a
duplicate resource because of stale informer cache. This may happen
for instance when two reconciliations of the same resource happen
almost at the same time.
To avoid this risk, children resources should use a name that is uniquely
associated to that of the parent, so that any attempt of recreation would
fail. Such failure, when it happens, is considered as a transient error,
and it does not cause the TaskRun or the PipelineRun to fail.

We use kmeta.ChildName to generate the names. This applies to Pods
generated by TaskRuns and TaskRuns and Runs generated by PipelineRuns.
ChildName combines a base name with a suffix, and if the resulting name is
too long it shortens it by truncating it and appending an hash of the
original name: https://pkg.go.dev/github.com/knative/pkg/kmeta#ChildName

Resources that are not k8s resources, such as steps or scripts, are not
affected by this change.

Fixes #4358

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
Name of `Pods` and  `TaskRuns` created by Tekton controllers are now generated with [`kmeta.ChildName`](https://pkg.go.dev/github.com/knative/pkg/kmeta#ChildName):

> ChildName generates a name for the resource based upon the parent resource and suffix. If the concatenated name is longer than K8s permits the name is hashed and truncated to permit construction of the resource, but still keeps it unique. If the suffix itself is longer than 31 characters, then the whole string will be hashed and `parent|hash|suffix` will be returned, where parent and suffix will be trimmed to fit (prefix of parent at most of length 31, and prefix of suffix at most length 30).

The name of the `Pods` owned by a `TaskRun`  is univocally associated to the owning resource. If a `TaskRun` resource is deleted and created with the same name, the child `Pod` will be created with the same name as before.
The base format of the name is `<taskrun-name>-pod`. The name may vary as described above if it becomes too long.
In case of retries, starting from the first retry, the base format of the name is `<taskrun-name>-retry<N>` where `N` is the retry number.

The name of the `TaskRuns` and `Runs` owned by a `PipelineRun`  are univocally associated to the owning resource. If a `PipelineRun` resource is deleted and created with the same name, the child `TaskRuns` will be created with the same name as before.
The base format of the name is `<pipelinerun-name>-<pipelinetask-name>`. The name may vary as described above if it becomes too long.
```