### PR TITLE
WIP Batch yaml examples in integration test runs to see if it affects timings

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -241,7 +241,7 @@ func TestYamls(t *testing.T) {
 
 func testYamls(t *testing.T, baseDir string, createFunc createFunc, filter pathFilter) {
 	t.Parallel()
-	batchSize := 20
+	batchSize := 40
 	batches := [][]string{}
 	allPaths := getExamplePaths(t, baseDir, filter)
 	for i := 0; i < len(allPaths); i += batchSize {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Looking at test run times for the example yamls in our CI it's noticeable
that many individual tests fluctuate in their runtime. One run they'll take more than
two minutes, other runs less than 50 seconds. One possible explanation
for this is that the cluster is becoming overwhelmed with so many pipelineruns
and taskruns executing all at once.

This commit tries batching the example yamls so that smaller sets are
processed at one time in the cluster.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```