### PR TITLE
Set explicit timeoutSeconds on example's readinessProbe

### DIFF
--- a/examples/v1alpha1/taskruns/sidecar-ready.yaml
+++ b/examples/v1alpha1/taskruns/sidecar-ready.yaml
@@ -17,6 +17,7 @@ spec:
           - sh
           - -c
           - sleep 5 && touch /shared/ready
+        timeoutSeconds: 10
       volumeMounts:
       - name: shared
         mountPath: /shared

--- a/examples/v1beta1/taskruns/sidecar-ready.yaml
+++ b/examples/v1beta1/taskruns/sidecar-ready.yaml
@@ -17,6 +17,7 @@ spec:
           - sh
           - -c
           - sleep 5 && touch /shared/ready
+        timeoutSeconds: 10
       volumeMounts:
       - name: shared
         mountPath: /shared


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

[Prior to kubernetes 1.20 the timeoutSeconds field was ignored for
exec readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes). Our CI clusters are k8s 1.18 so the sidecar-ready
examples works there, but in other situations (such as devs running
newer versions of k8s locally) these examples didn't work, which was baffling. Shout out to @wlynch for catching this!

This commit explicitly sets the timeoutSeconds field of the readiness
probes in the sidecar-ready examples.


<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```