### PR TITLE
Breakout sidecar stopping if TaskSpec has no sidecar

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -225,6 +225,11 @@ func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1beta1.TaskRun) (*co
 		return nil, nil
 	}
 
+	// do not continue if the TaskSpec had no sidecars
+	if tr.Status.TaskSpec != nil && len(tr.Status.TaskSpec.Sidecars) == 0 {
+		return nil, nil
+	}
+
 	// do not continue if the TaskRun was canceled or timed out as this caused the pod to be deleted in failTaskRun
 	condition := tr.Status.GetCondition(apis.ConditionSucceeded)
 	if condition != nil {


### PR DESCRIPTION
This prevents the call into podconvert.StopSidecars which would try to
get the pod.

Signed-off-by: Sascha Schwarze <schwarzs@de.ibm.com>

# Changes

Based on discussion in [slack](https://tektoncd.slack.com/archives/CK3HBG7CM/p1636965530045300?thread_ts=1636722092.041100&cid=CK3HBG7CM). Adding an optimization to break out of stopping sidecars if there are not any.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
The reconciliation of a completed TaskRun has been optimized so that it does not anymore try to stop sidecars for TaskRuns who have no sidecars in their TaskSpec.
```
