### PR TITLE
Add instructions for replacing CloudEvent PipelineResource to pipeline docs

### DIFF
--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -207,6 +207,10 @@ For examples of replacing an `image` resource, see the following Catalog `Tasks`
 
 You can replace a `cluster` resource with the [`kubeconfig-creator` Catalog `Task`](https://github.com/tektoncd/catalog/tree/main/task/kubeconfig-creator).
 
+### Replacing a `cloudEvent` resource
+
+You can replace a `cloudEvent` resource with the [`CloudEvent` Catalog `Task`](https://github.com/tektoncd/catalog/tree/main/task/cloudevent).
+
 ## Changes to PipelineResources
 
 In Tekton `v1beta1`, `PipelineResources` have been moved from `spec.input.resources`


### PR DESCRIPTION
# Changes

PipelineResources are now deprecated and users are encouraged to use Tasks from the Catalog instead.
The `cloudEvent` PipelineResource has been replaced by a Task of the same name.
FYI @bobcatfish 

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```