### PR TITLE
Retry TaskRef resolution on etcd errors

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -294,6 +294,9 @@ func (c *Reconciler) resolvePipelineState(
 			task, providedResources,
 		)
 		if err != nil {
+			if tresources.IsGetTaskErrTransient(err) {
+				return nil, err
+			}
 			switch err := err.(type) {
 			case *resources.TaskNotFoundError:
 				pr.Status.MarkFailed(ReasonCouldntGetTask,


### PR DESCRIPTION
# Changes

Prior to this change, querying etcd for a Task referenced by a TaskRun
could fail due to an error "etcdserver: leader changed", as reported in #4116.
I believe this error is transient.

This error doesn't appear to be wrapped in any error type exported by
the Kubernetes Go client or Knative, so I've reported this upstream to
the Go client in #kubernetes/kubernetes/106491.
To address the user issue until the upstream issue can be resolved,
this commit uses string comparison to detect and retry the error.
A similar strategy is used in Knative for retrying this error
during their integration tests (see
https://github.com/knative/pkg/blob/517ef0292b5362ec316d227a866821bc31ec99a8/reconciler/retry.go#L50-L66).

We don't currently have a strategy for reproducing this error, so it's
not known whether this commit will solve the problem.
We will have to see if this error continues to occur after this commit is released.

Co-authored-by: Dibyo Mukherjee dibyajyoti@google.com @dibyom 
Co-authored-by: Scott Seaward sbws@google.com @sbwsg 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Retry Task resolution on transient etcd errors
```
