### PR TITLE
Fix conflicting docs for /tekton/steps API Compatibility.

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -202,7 +202,6 @@ The following directories are covered by the
 relied on for stability:
 
 - `/tekton/results`
-- `/tekton/steps`
 
 All other files/directories are internal implementation details of Tekton -
 **users should not rely on specific paths or behaviors as it may change in the


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
   
Previously the developer docs listed that /tekton/steps was in scope for
the API compatibility policy, where-as the [user
docs](https://github.com/tektoncd/pipeline/blob/aceb5880f009884be14f9a7409f428cc84157a75/docs/tasks.md#reserved-directories)
did not say it was in scope.

After discussion in
[PR #4352](https://github.com/tektoncd/pipeline/pull/4352#discussion_r743215305),
we have come to agreement that this is **not** in scope.

While this change in itself is not a breaking change, this opens the
door for breaking changes (such as #4352). Our stance is that users
should use the [`$(steps.step-<step-name>.exitCode.path)`
syntax](https://github.com/tektoncd/pipeline/blob/aceb5880f009884be14f9a7409f428cc84157a75/docs/tasks.md#accessing-steps-exitcode-in-subsequent-steps) instead to ensure compatibility.


<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
action required: Users should not assume the directory/file structure of /tekton/steps. Use $(steps.step-<step-name>.exitCode.path) instead.
```