### PR TITLE
Let Kaniko E2E test work with a KO_DOCKER_REPO env

### DIFF
--- a/test/helm_task_test.go
+++ b/test/helm_task_test.go
@@ -41,10 +41,12 @@ var (
 // TestHelmDeployPipelineRun is an integration test that will verify a pipeline build an image
 // and then using helm to deploy it
 func TestHelmDeployPipelineRun(t *testing.T) {
-	repo := ensureDockerRepo(t)
+	repo := ensureDockerRepo(t, "helmtasktest")
+
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
 	c, namespace := setup(ctx, t)
 	setupClusterBindingForHelm(ctx, c, t, namespace)
 

--- a/test/v1alpha1/ko_test.go
+++ b/test/v1alpha1/ko_test.go
@@ -22,24 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"testing"
 )
-
-var (
-	// Wether missing KO_DOCKER_REPO environment variable should be fatal or not
-	missingKoFatal = "true"
-)
-
-func ensureDockerRepo(t *testing.T, name string) string {
-	repo, err := getDockerRepo(name)
-	if err != nil {
-		if missingKoFatal == "false" {
-			t.Skip(fmt.Sprintf("KO_DOCKER_REPO env variable is required for %s", name))
-		}
-		t.Fatal(fmt.Sprintf("KO_DOCKER_REPO env variable is required for %s", name))
-	}
-	return repo
-}
 
 func getDockerRepo(name string) (string, error) {
 	// according to knative/test-infra readme (https://github.com/knative/test-infra/blob/13055d769cc5e1756e605fcb3bcc1c25376699f1/scripts/README.md)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If test runner set a KO_DOCKER_REPO variable, use it, so we run the tests
against an external container registry. If not set, the kaniko tests
will spin up its own local registry. Bring back the GCP secret support
so this works in the existing CI, but also supports the case where
KO_DOCKER_REPO points to a container registry where no secret required,
like in the kind based tests.

Add a "test_setup" function to the e2e script, which is picked up after
the setup of the cluster, which provisions a GCP service account to be
used by tests via the GCP_SERVICE_ACCOUNT_KEY_PATH env variable.

Since the local registry runs on HTTP (not HTTPS), the local registry
approach does not work for the helm test as the kubelet tries to use
HTTPS. If KO_DOCKER_REPO is not specified we either fail or skip the
test (no change in behaviour) depending on the value of missingKoFatal

This setup makes it easier to run E2E tests in different environments,
where a registry may or may not be available.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>
/kind misc


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [-] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```