### PR TITLE
Add listType annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-containerregistry v0.8.1-0.20220216220642-00c59d91847c
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220328141311-efc62d802606
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jenkins-x/go-scm v1.10.10
@@ -90,7 +91,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/hashicorp/errwrap v1.0.0
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/hack/ignored-openapi-violations.list
+++ b/hack/ignored-openapi-violations.list
@@ -1,0 +1,10 @@
+# This a list of API field name vs JSON tag rule violations which predate the addition of such violations causing failures.
+# They are in the specific order they are printed out by k8s.io/kube-openapi/cmd/openapi-gen.
+# No additional violations should be added to this ignored list.
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,CloudEventDeliveryState,Error
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,PipelineResourceResult,ResultType
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,PipelineTask,WhenExpressions
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,SidecarState,ContainerName
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,StepState,ContainerName
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1,TaskRunStatusFields,TaskRunResults
+API rule violation: names_match,github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1,PipelineResourceSpec,SecretParams

--- a/pkg/apis/pipeline/pod/affinity_assitant_template.go
+++ b/pkg/apis/pipeline/pod/affinity_assitant_template.go
@@ -35,10 +35,12 @@ type AffinityAssistantTemplate struct {
 
 	// If specified, the pod's tolerations.
 	// +optional
+	// +listType=atomic
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
 	// +optional
+	// +listType=atomic
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 

--- a/pkg/apis/pipeline/pod/template.go
+++ b/pkg/apis/pipeline/pod/template.go
@@ -34,6 +34,7 @@ type Template struct {
 
 	// If specified, the pod's tolerations.
 	// +optional
+	// +listType=atomic
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 
 	// If specified, the pod's scheduling constraints
@@ -50,6 +51,7 @@ type Template struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
+	// +listType=atomic
 	Volumes []corev1.Volume `json:"volumes,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
 
 	// RuntimeClassName refers to a RuntimeClass object in the node.k8s.io
@@ -99,11 +101,13 @@ type Template struct {
 
 	// ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified
 	// +optional
+	// +listType=atomic
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
 	// HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
 	// file if specified. This is only valid for non-hostNetwork pods.
 	// +optional
+	// +listType=atomic
 	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 
 	// HostNetwork specifies whether the pod may use the node network namespace

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -143,6 +143,11 @@ func schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref common.Reference
 						},
 					},
 					"tolerations": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "If specified, the pod's tolerations.",
 							Type:        []string{"array"},
@@ -157,6 +162,11 @@ func schema_pkg_apis_pipeline_pod_AffinityAssistantTemplate(ref common.Reference
 						},
 					},
 					"imagePullSecrets": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
 							Type:        []string{"array"},
@@ -202,6 +212,11 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 						},
 					},
 					"tolerations": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "If specified, the pod's tolerations.",
 							Type:        []string{"array"},
@@ -230,6 +245,7 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 					"volumes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
+								"x-kubernetes-list-type":       "atomic",
 								"x-kubernetes-patch-merge-key": "name",
 								"x-kubernetes-patch-strategy":  "merge,retainKeys",
 							},
@@ -296,6 +312,11 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 						},
 					},
 					"imagePullSecrets": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "ImagePullSecrets gives the name of the secret used by the pod to pull the image if specified",
 							Type:        []string{"array"},
@@ -310,6 +331,11 @@ func schema_pkg_apis_pipeline_pod_Template(ref common.ReferenceCallback) common.
 						},
 					},
 					"hostAliases": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
 							Type:        []string{"array"},
@@ -361,6 +387,11 @@ func schema_pkg_apis_pipeline_v1beta1_ArrayOrString(ref common.ReferenceCallback
 						},
 					},
 					"arrayVal": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -415,6 +446,11 @@ func schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref common.ReferenceC
 						},
 					},
 					"conditionChecks": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "ConditionChecks is the the list of condition checks, including their names and statuses, for the PipelineTask. Deprecated: This field will be removed when conditions are removed.",
 							Type:        []string{"array"},
@@ -428,6 +464,11 @@ func schema_pkg_apis_pipeline_v1beta1_ChildStatusReference(ref common.ReferenceC
 						},
 					},
 					"whenExpressions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
 							Type:        []string{"array"},
@@ -828,6 +869,11 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Params is a list of input parameters required to run the task. Params must be supplied as inputs in TaskRuns unless they declare a default value.",
 							Type:        []string{"array"},
@@ -849,6 +895,11 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 						},
 					},
 					"steps": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Steps are the steps of the build; each step is run sequentially with the source mounted into /workspace.",
 							Type:        []string{"array"},
@@ -863,6 +914,11 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 						},
 					},
 					"volumes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Volumes is a collection of volumes that are available to mount into the steps of the build.",
 							Type:        []string{"array"},
@@ -883,6 +939,11 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 						},
 					},
 					"sidecars": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Sidecars are run alongside the Task's step containers. They begin before the steps start and end after the steps complete.",
 							Type:        []string{"array"},
@@ -897,6 +958,11 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workspaces are the volumes that this Task requires.",
 							Type:        []string{"array"},
@@ -911,6 +977,11 @@ func schema_pkg_apis_pipeline_v1beta1_EmbeddedTask(ref common.ReferenceCallback)
 						},
 					},
 					"results": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Results are values that this Task can output",
 							Type:        []string{"array"},
@@ -939,7 +1010,12 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 				Description: "InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"StepsToPrepend": {
+					"stepsToPrepend": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -952,7 +1028,12 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 							},
 						},
 					},
-					"StepsToAppend": {
+					"stepsToAppend": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -965,7 +1046,12 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 							},
 						},
 					},
-					"Volumes": {
+					"volumes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -979,7 +1065,7 @@ func schema_pkg_apis_pipeline_v1beta1_InternalTaskModifier(ref common.ReferenceC
 						},
 					},
 				},
-				Required: []string{"StepsToPrepend", "StepsToAppend", "Volumes"},
+				Required: []string{"stepsToPrepend", "stepsToAppend", "volumes"},
 			},
 		},
 		Dependencies: []string{
@@ -1577,6 +1663,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunRunStatus(ref common.ReferenceC
 						},
 					},
 					"whenExpressions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
 							Type:        []string{"array"},
@@ -1616,6 +1707,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 						},
 					},
 					"resources": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources is a list of bindings specifying which actual instances of PipelineResources to use for the resources the Pipeline has declared it needs.",
 							Type:        []string{"array"},
@@ -1630,6 +1726,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Params is a list of parameter names and values.",
 							Type:        []string{"array"},
@@ -1650,6 +1751,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 						},
 					},
 					"serviceAccountNames": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Deprecated: use taskRunSpecs.ServiceAccountName instead",
 							Type:        []string{"array"},
@@ -1689,6 +1795,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workspaces holds a set of workspace bindings that must match names with those declared in the pipeline.",
 							Type:        []string{"array"},
@@ -1703,6 +1814,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunSpec(ref common.ReferenceCallba
 						},
 					},
 					"taskRunSpecs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskRunSpecs holds a set of runtime specs",
 							Type:        []string{"array"},
@@ -1840,6 +1956,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 						},
 					},
 					"pipelineResults": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineResults are the list of results written out by the pipeline task's containers",
 							Type:        []string{"array"},
@@ -1860,6 +1981,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 						},
 					},
 					"skippedTasks": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "list of tasks that were skipped due to when expressions evaluating to false",
 							Type:        []string{"array"},
@@ -1874,6 +2000,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 						},
 					},
 					"childReferences": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.",
 							Type:        []string{"array"},
@@ -1943,6 +2074,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 						},
 					},
 					"pipelineResults": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "PipelineResults are the list of results written out by the pipeline task's containers",
 							Type:        []string{"array"},
@@ -1963,6 +2099,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 						},
 					},
 					"skippedTasks": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "list of tasks that were skipped due to when expressions evaluating to false",
 							Type:        []string{"array"},
@@ -1977,6 +2118,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 						},
 					},
 					"childReferences": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.",
 							Type:        []string{"array"},
@@ -2033,6 +2179,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunTaskRunStatus(ref common.Refere
 						},
 					},
 					"whenExpressions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
 							Type:        []string{"array"},
@@ -2069,6 +2220,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 						},
 					},
 					"resources": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources declares the names and types of the resources given to the Pipeline's tasks as inputs and outputs.",
 							Type:        []string{"array"},
@@ -2083,6 +2239,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 						},
 					},
 					"tasks": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Tasks declares the graph of Tasks that execute when this Pipeline is run.",
 							Type:        []string{"array"},
@@ -2097,6 +2258,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Params declares a list of input parameters that must be supplied when this Pipeline is run.",
 							Type:        []string{"array"},
@@ -2111,6 +2277,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workspaces declares a set of named workspaces that are expected to be provided by a PipelineRun.",
 							Type:        []string{"array"},
@@ -2125,6 +2296,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 						},
 					},
 					"results": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Results are values that this pipeline can output once run",
 							Type:        []string{"array"},
@@ -2139,6 +2315,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineSpec(ref common.ReferenceCallback)
 						},
 					},
 					"finally": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Finally declares the list of Tasks that execute just before leaving the Pipeline i.e. either after all Tasks are finished executing successfully or after a failure which would result in ending the Pipeline",
 							Type:        []string{"array"},
@@ -2187,6 +2368,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 						},
 					},
 					"conditions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Conditions is a list of conditions that need to be true for the task to run Conditions are deprecated, use WhenExpressions instead",
 							Type:        []string{"array"},
@@ -2222,6 +2408,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 						},
 					},
 					"runAfter": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "RunAfter is the list of PipelineTask names that should be executed before this Task executes. (Used to force a specific ordering in graph execution.)",
 							Type:        []string{"array"},
@@ -2243,6 +2434,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters declares parameters passed to this task.",
 							Type:        []string{"array"},
@@ -2257,6 +2453,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 						},
 					},
 					"matrix": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Matrix declares parameters used to fan out this task.",
 							Type:        []string{"array"},
@@ -2271,6 +2472,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTask(ref common.ReferenceCallback)
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workspaces maps workspaces from the pipeline spec to the workspaces declared in the Task.",
 							Type:        []string{"array"},
@@ -2314,6 +2520,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskCondition(ref common.Reference
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Params declare parameters passed to this Condition",
 							Type:        []string{"array"},
@@ -2328,6 +2539,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskCondition(ref common.Reference
 						},
 					},
 					"resources": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources declare the resources provided to this Condition as input",
 							Type:        []string{"array"},
@@ -2374,6 +2590,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskInputResource(ref common.Refer
 						},
 					},
 					"from": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "From is the list of PipelineTask names that the resource has to come from. (Implies an ordering in the execution graph.)",
 							Type:        []string{"array"},
@@ -2504,6 +2725,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref common.Reference
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"inputs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Inputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
 							Type:        []string{"array"},
@@ -2518,6 +2744,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskResources(ref common.Reference
 						},
 					},
 					"outputs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Outputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
 							Type:        []string{"array"},
@@ -2583,6 +2814,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 						},
 					},
 					"stepOverrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -2596,6 +2832,11 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 						},
 					},
 					"sidecarOverrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -2659,7 +2900,7 @@ func schema_pkg_apis_pipeline_v1beta1_ResolverParam(ref common.ReferenceCallback
 				Description: "ResolverParam is a single parameter passed to a resolver.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"Name": {
+					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name is the name of the parameter that will be passed to the resolver.",
 							Default:     "",
@@ -2667,7 +2908,7 @@ func schema_pkg_apis_pipeline_v1beta1_ResolverParam(ref common.ReferenceCallback
 							Format:      "",
 						},
 					},
-					"Value": {
+					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Value is the string value of the parameter that will be passed to the resolver.",
 							Default:     "",
@@ -2676,7 +2917,7 @@ func schema_pkg_apis_pipeline_v1beta1_ResolverParam(ref common.ReferenceCallback
 						},
 					},
 				},
-				Required: []string{"Name", "Value"},
+				Required: []string{"name", "value"},
 			},
 		},
 	}
@@ -2697,6 +2938,11 @@ func schema_pkg_apis_pipeline_v1beta1_ResolverRef(ref common.ReferenceCallback) 
 						},
 					},
 					"resource": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Resource contains the parameters used to identify the referenced Tekton resource. Example entries might include \"repo\" or \"path\" but the set of params ultimately depends on the chosen resolver.",
 							Type:        []string{"array"},
@@ -2725,14 +2971,14 @@ func schema_pkg_apis_pipeline_v1beta1_ResultRef(ref common.ReferenceCallback) co
 				Description: "ResultRef is a type that represents a reference to a task run result",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"PipelineTask": {
+					"pipelineTask": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
 							Type:    []string{"string"},
 							Format:  "",
 						},
 					},
-					"Result": {
+					"result": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
 							Type:    []string{"string"},
@@ -2740,7 +2986,7 @@ func schema_pkg_apis_pipeline_v1beta1_ResultRef(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"PipelineTask", "Result"},
+				Required: []string{"pipelineTask", "result"},
 			},
 		},
 	}
@@ -2991,6 +3237,11 @@ func schema_pkg_apis_pipeline_v1beta1_Sidecar(ref common.ReferenceCallback) comm
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported.\n\nWorkspaces is a list of workspaces from the Task that this Sidecar wants exclusive access to. Adding a workspace to this list means that any other Step or Sidecar that does not also request this Workspace will not have access to it.",
 							Type:        []string{"array"},
@@ -3080,6 +3331,11 @@ func schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref common.ReferenceCallback) 
 						},
 					},
 					"whenExpressions": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "WhenExpressions is the list of checks guarding the execution of the PipelineTask",
 							Type:        []string{"array"},
@@ -3353,6 +3609,11 @@ func schema_pkg_apis_pipeline_v1beta1_Step(ref common.ReferenceCallback) common.
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "This is an alpha field. You must set the \"enable-api-fields\" feature flag to \"alpha\" for this field to be supported.\n\nWorkspaces is a list of workspaces from the Task that this Step wants exclusive access to. Adding a workspace to this list means that any other Step or Sidecar that does not also request this Workspace will not have access to it.",
 							Type:        []string{"array"},
@@ -3643,6 +3904,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResourceBinding(ref common.ReferenceCa
 						},
 					},
 					"paths": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Paths will probably be removed in #1284, and then PipelineResourceBinding can be used instead. The optional Path field corresponds to a path on disk at which the Resource can be found (used when providing the resource via mounted volume, overriding the default logic to fetch the Resource).",
 							Type:        []string{"array"},
@@ -3673,6 +3939,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResources(ref common.ReferenceCallback
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"inputs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Inputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
 							Type:        []string{"array"},
@@ -3687,6 +3958,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResources(ref common.ReferenceCallback
 						},
 					},
 					"outputs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Outputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
 							Type:        []string{"array"},
@@ -3793,6 +4069,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunDebug(ref common.ReferenceCallback)
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"breakpoint": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -3820,6 +4101,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref common.ReferenceCallback
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"resources": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -3833,6 +4119,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunInputs(ref common.ReferenceCallback
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -3910,6 +4201,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunOutputs(ref common.ReferenceCallbac
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"resources": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -3938,6 +4234,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref common.ReferenceCallb
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"inputs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Inputs holds the inputs resources this task was invoked with",
 							Type:        []string{"array"},
@@ -3952,6 +4253,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunResources(ref common.ReferenceCallb
 						},
 					},
 					"outputs": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Outputs holds the inputs resources this task was invoked with",
 							Type:        []string{"array"},
@@ -4010,7 +4316,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSidecarOverride(ref common.Referenc
 				Description: "TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"Name": {
+					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the Sidecar to override.",
 							Default:     "",
@@ -4018,7 +4324,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSidecarOverride(ref common.Referenc
 							Format:      "",
 						},
 					},
-					"Resources": {
+					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The resource requirements to apply to the Sidecar.",
 							Default:     map[string]interface{}{},
@@ -4026,7 +4332,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSidecarOverride(ref common.Referenc
 						},
 					},
 				},
-				Required: []string{"Name", "Resources"},
+				Required: []string{"name", "resources"},
 			},
 		},
 		Dependencies: []string{
@@ -4047,6 +4353,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -4102,6 +4413,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workspaces is a list of WorkspaceBindings from volumes to workspaces.",
 							Type:        []string{"array"},
@@ -4116,6 +4432,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 						},
 					},
 					"stepOverrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Overrides to apply to Steps in this TaskRun. If a field is specified in both a Step and a StepOverride, the value from the StepOverride will be used. This field is only supported when the alpha feature gate is enabled.",
 							Type:        []string{"array"},
@@ -4130,6 +4451,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 						},
 					},
 					"sidecarOverrides": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Overrides to apply to Sidecars in this TaskRun. If a field is specified in both a Sidecar and a SidecarOverride, the value from the SidecarOverride will be used. This field is only supported when the alpha feature gate is enabled.",
 							Type:        []string{"array"},
@@ -4222,6 +4548,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 						},
 					},
 					"steps": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Steps describes the state of each build step container.",
 							Type:        []string{"array"},
@@ -4236,6 +4567,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 						},
 					},
 					"cloudEvents": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "CloudEvents describe the state of each cloud event requested via a CloudEventResource.",
 							Type:        []string{"array"},
@@ -4250,6 +4586,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 						},
 					},
 					"retriesStatus": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures. All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.",
 							Type:        []string{"array"},
@@ -4264,6 +4605,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 						},
 					},
 					"resourcesResult": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Results from Resources built during the taskRun. currently includes the digest of build container images",
 							Type:        []string{"array"},
@@ -4278,6 +4624,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 						},
 					},
 					"taskResults": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskRunResults are the list of results written out by the task's containers",
 							Type:        []string{"array"},
@@ -4292,6 +4643,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatus(ref common.ReferenceCallback
 						},
 					},
 					"sidecars": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "The list has one entry per sidecar in the manifest. Each entry is represents the imageid of the corresponding sidecar.",
 							Type:        []string{"array"},
@@ -4348,6 +4704,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 						},
 					},
 					"steps": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Steps describes the state of each build step container.",
 							Type:        []string{"array"},
@@ -4362,6 +4723,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 						},
 					},
 					"cloudEvents": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "CloudEvents describe the state of each cloud event requested via a CloudEventResource.",
 							Type:        []string{"array"},
@@ -4376,6 +4742,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 						},
 					},
 					"retriesStatus": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures. All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.",
 							Type:        []string{"array"},
@@ -4390,6 +4761,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 						},
 					},
 					"resourcesResult": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Results from Resources built during the taskRun. currently includes the digest of build container images",
 							Type:        []string{"array"},
@@ -4404,6 +4780,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 						},
 					},
 					"taskResults": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "TaskRunResults are the list of results written out by the task's containers",
 							Type:        []string{"array"},
@@ -4418,6 +4799,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStatusFields(ref common.ReferenceCa
 						},
 					},
 					"sidecars": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "The list has one entry per sidecar in the manifest. Each entry is represents the imageid of the corresponding sidecar.",
 							Type:        []string{"array"},
@@ -4453,7 +4839,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStepOverride(ref common.ReferenceCa
 				Description: "TaskRunStepOverride is used to override the values of a Step in the corresponding Task.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"Name": {
+					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the Step to override.",
 							Default:     "",
@@ -4461,7 +4847,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStepOverride(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
-					"Resources": {
+					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The resource requirements to apply to the Step.",
 							Default:     map[string]interface{}{},
@@ -4469,7 +4855,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunStepOverride(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"Name", "Resources"},
+				Required: []string{"name", "resources"},
 			},
 		},
 		Dependencies: []string{
@@ -4491,6 +4877,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Params is a list of input parameters required to run the task. Params must be supplied as inputs in TaskRuns unless they declare a default value.",
 							Type:        []string{"array"},
@@ -4512,6 +4903,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 						},
 					},
 					"steps": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Steps are the steps of the build; each step is run sequentially with the source mounted into /workspace.",
 							Type:        []string{"array"},
@@ -4526,6 +4922,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 						},
 					},
 					"volumes": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Volumes is a collection of volumes that are available to mount into the steps of the build.",
 							Type:        []string{"array"},
@@ -4546,6 +4947,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 						},
 					},
 					"sidecars": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Sidecars are run alongside the Task's step containers. They begin before the steps start and end after the steps complete.",
 							Type:        []string{"array"},
@@ -4560,6 +4966,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 						},
 					},
 					"workspaces": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Workspaces are the volumes that this Task requires.",
 							Type:        []string{"array"},
@@ -4574,6 +4985,11 @@ func schema_pkg_apis_pipeline_v1beta1_TaskSpec(ref common.ReferenceCallback) com
 						},
 					},
 					"results": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Results are values that this Task can output",
 							Type:        []string{"array"},
@@ -4652,6 +5068,11 @@ func schema_pkg_apis_pipeline_v1beta1_WhenExpression(ref common.ReferenceCallbac
 						},
 					},
 					"values": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Values is an array of strings, which is compared against the input, for guard checking It must be non-empty",
 							Type:        []string{"array"},
@@ -4970,6 +5391,11 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref common.Reference
 						},
 					},
 					"params": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
@@ -4983,6 +5409,11 @@ func schema_pkg_apis_resource_v1alpha1_PipelineResourceSpec(ref common.Reference
 						},
 					},
 					"secrets": {
+						VendorExtensible: spec.VendorExtensible{
+							Extensions: spec.Extensions{
+								"x-kubernetes-list-type": "atomic",
+							},
+						},
 						SchemaProps: spec.SchemaProps{
 							Description: "Secrets to fetch to populate some of resource fields",
 							Type:        []string{"array"},

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -106,7 +106,8 @@ var AllParamTypes = []ParamType{ParamTypeString, ParamTypeArray}
 type ArrayOrString struct {
 	Type      ParamType `json:"type"` // Represents the stored type of ArrayOrString.
 	StringVal string    `json:"stringVal"`
-	ArrayVal  []string  `json:"arrayVal"`
+	// +listType=atomic
+	ArrayVal []string `json:"arrayVal"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -92,22 +92,28 @@ type PipelineSpec struct {
 	Description string `json:"description,omitempty"`
 	// Resources declares the names and types of the resources given to the
 	// Pipeline's tasks as inputs and outputs.
+	// +listType=atomic
 	Resources []PipelineDeclaredResource `json:"resources,omitempty"`
 	// Tasks declares the graph of Tasks that execute when this Pipeline is run.
+	// +listType=atomic
 	Tasks []PipelineTask `json:"tasks,omitempty"`
 	// Params declares a list of input parameters that must be supplied when
 	// this Pipeline is run.
+	// +listType=atomic
 	Params []ParamSpec `json:"params,omitempty"`
 	// Workspaces declares a set of named workspaces that are expected to be
 	// provided by a PipelineRun.
 	// +optional
+	// +listType=atomic
 	Workspaces []PipelineWorkspaceDeclaration `json:"workspaces,omitempty"`
 	// Results are values that this pipeline can output once run
 	// +optional
+	// +listType=atomic
 	Results []PipelineResult `json:"results,omitempty"`
 	// Finally declares the list of Tasks that execute just before leaving the Pipeline
 	// i.e. either after all Tasks are finished executing successfully
 	// or after a failure which would result in ending the Pipeline
+	// +listType=atomic
 	Finally []PipelineTask `json:"finally,omitempty"`
 }
 
@@ -169,6 +175,7 @@ type PipelineTask struct {
 	// Conditions is a list of conditions that need to be true for the task to run
 	// Conditions are deprecated, use WhenExpressions instead
 	// +optional
+	// +listType=atomic
 	Conditions []PipelineTaskCondition `json:"conditions,omitempty"`
 
 	// WhenExpressions is a list of when expressions that need to be true for the task to run
@@ -182,6 +189,7 @@ type PipelineTask struct {
 	// RunAfter is the list of PipelineTask names that should be executed before
 	// this Task executes. (Used to force a specific ordering in graph execution.)
 	// +optional
+	// +listType=atomic
 	RunAfter []string `json:"runAfter,omitempty"`
 
 	// Resources declares the resources given to this task as inputs and
@@ -191,15 +199,18 @@ type PipelineTask struct {
 
 	// Parameters declares parameters passed to this task.
 	// +optional
+	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
 
 	// Matrix declares parameters used to fan out this task.
 	// +optional
+	// +listType=atomic
 	Matrix []Param `json:"matrix,omitempty"`
 
 	// Workspaces maps workspaces from the pipeline spec to the workspaces
 	// declared in the Task.
 	// +optional
+	// +listType=atomic
 	Workspaces []WorkspacePipelineTaskBinding `json:"workspaces,omitempty"`
 
 	// Time after which the TaskRun times out. Defaults to 1 hour.
@@ -562,9 +573,11 @@ type PipelineTaskCondition struct {
 
 	// Params declare parameters passed to this Condition
 	// +optional
+	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
 
 	// Resources declare the resources provided to this Condition as input
+	// +listType=atomic
 	Resources []PipelineTaskInputResource `json:"resources,omitempty"`
 }
 
@@ -590,9 +603,11 @@ type PipelineDeclaredResource struct {
 type PipelineTaskResources struct {
 	// Inputs holds the mapping from the PipelineResources declared in
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
+	// +listType=atomic
 	Inputs []PipelineTaskInputResource `json:"inputs,omitempty"`
 	// Outputs holds the mapping from the PipelineResources declared in
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
+	// +listType=atomic
 	Outputs []PipelineTaskOutputResource `json:"outputs,omitempty"`
 }
 
@@ -607,6 +622,7 @@ type PipelineTaskInputResource struct {
 	// From is the list of PipelineTask names that the resource has to come from.
 	// (Implies an ordering in the execution graph.)
 	// +optional
+	// +listType=atomic
 	From []string `json:"from,omitempty"`
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -204,14 +204,17 @@ type PipelineRunSpec struct {
 	// Resources is a list of bindings specifying which actual instances of
 	// PipelineResources to use for the resources the Pipeline has declared
 	// it needs.
+	// +listType=atomic
 	Resources []PipelineResourceBinding `json:"resources,omitempty"`
 	// Params is a list of parameter names and values.
+	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Deprecated: use taskRunSpecs.ServiceAccountName instead
 	// +optional
+	// +listType=atomic
 	ServiceAccountNames []PipelineRunSpecServiceAccountName `json:"serviceAccountNames,omitempty"`
 	// Used for cancelling a pipelinerun (and maybe more later on)
 	// +optional
@@ -234,9 +237,11 @@ type PipelineRunSpec struct {
 	// Workspaces holds a set of workspace bindings that must match names
 	// with those declared in the pipeline.
 	// +optional
+	// +listType=atomic
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
 	// TaskRunSpecs holds a set of runtime specs
 	// +optional
+	// +listType=atomic
 	TaskRunSpecs []PipelineTaskRunSpec `json:"taskRunSpecs,omitempty"`
 }
 
@@ -409,9 +414,11 @@ type ChildStatusReference struct {
 	// ConditionChecks is the the list of condition checks, including their names and statuses, for the PipelineTask.
 	// Deprecated: This field will be removed when conditions are removed.
 	// +optional
+	// +listType=atomic
 	ConditionChecks []*PipelineRunChildConditionCheckStatus `json:"conditionChecks,omitempty"`
 	// WhenExpressions is the list of checks guarding the execution of the PipelineTask
 	// +optional
+	// +listType=atomic
 	WhenExpressions []WhenExpression `json:"whenExpressions,omitempty"`
 }
 
@@ -439,6 +446,7 @@ type PipelineRunStatusFields struct {
 
 	// PipelineResults are the list of results written out by the pipeline task's containers
 	// +optional
+	// +listType=atomic
 	PipelineResults []PipelineRunResult `json:"pipelineResults,omitempty"`
 
 	// PipelineRunSpec contains the exact spec used to instantiate the run
@@ -446,10 +454,12 @@ type PipelineRunStatusFields struct {
 
 	// list of tasks that were skipped due to when expressions evaluating to false
 	// +optional
+	// +listType=atomic
 	SkippedTasks []SkippedTask `json:"skippedTasks,omitempty"`
 
 	// list of TaskRun and Run names, PipelineTask names, and API versions/kinds for children of this PipelineRun.
 	// +optional
+	// +listType=atomic
 	ChildReferences []ChildStatusReference `json:"childReferences,omitempty"`
 }
 
@@ -461,6 +471,7 @@ type SkippedTask struct {
 	Name string `json:"name"`
 	// WhenExpressions is the list of checks guarding the execution of the PipelineTask
 	// +optional
+	// +listType=atomic
 	WhenExpressions []WhenExpression `json:"whenExpressions,omitempty"`
 }
 
@@ -485,6 +496,7 @@ type PipelineRunTaskRunStatus struct {
 	ConditionChecks map[string]*PipelineRunConditionCheckStatus `json:"conditionChecks,omitempty"`
 	// WhenExpressions is the list of checks guarding the execution of the PipelineTask
 	// +optional
+	// +listType=atomic
 	WhenExpressions []WhenExpression `json:"whenExpressions,omitempty"`
 }
 
@@ -497,6 +509,7 @@ type PipelineRunRunStatus struct {
 	Status *runv1alpha1.RunStatus `json:"status,omitempty"`
 	// WhenExpressions is the list of checks guarding the execution of the PipelineTask
 	// +optional
+	// +listType=atomic
 	WhenExpressions []WhenExpression `json:"whenExpressions,omitempty"`
 }
 
@@ -542,11 +555,13 @@ type PipelineTaskRun struct {
 // PipelineTaskRunSpec  can be used to configure specific
 // specs for a concrete Task
 type PipelineTaskRunSpec struct {
-	PipelineTaskName       string                   `json:"pipelineTaskName,omitempty"`
-	TaskServiceAccountName string                   `json:"taskServiceAccountName,omitempty"`
-	TaskPodTemplate        *PodTemplate             `json:"taskPodTemplate,omitempty"`
-	StepOverrides          []TaskRunStepOverride    `json:"stepOverrides,omitempty"`
-	SidecarOverrides       []TaskRunSidecarOverride `json:"sidecarOverrides,omitempty"`
+	PipelineTaskName       string       `json:"pipelineTaskName,omitempty"`
+	TaskServiceAccountName string       `json:"taskServiceAccountName,omitempty"`
+	TaskPodTemplate        *PodTemplate `json:"taskPodTemplate,omitempty"`
+	// +listType=atomic
+	StepOverrides []TaskRunStepOverride `json:"stepOverrides,omitempty"`
+	// +listType=atomic
+	SidecarOverrides []TaskRunSidecarOverride `json:"sidecarOverrides,omitempty"`
 }
 
 // GetTaskRunSpec returns the task specific spec for a given

--- a/pkg/apis/pipeline/v1beta1/resolver_types.go
+++ b/pkg/apis/pipeline/v1beta1/resolver_types.go
@@ -33,6 +33,7 @@ type ResolverRef struct {
 	// "repo" or "path" but the set of params ultimately depends on
 	// the chosen resolver.
 	// +optional
+	// +listType=atomic
 	Resource []ResolverParam `json:"resource,omitempty"`
 }
 
@@ -40,8 +41,8 @@ type ResolverRef struct {
 type ResolverParam struct {
 	// Name is the name of the parameter that will be passed to the
 	// resolver.
-	Name string
+	Name string `json:"name"`
 	// Value is the string value of the parameter that will be
 	// passed to the resolver.
-	Value string
+	Value string `json:"value"`
 }

--- a/pkg/apis/pipeline/v1beta1/resource_types.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types.go
@@ -64,9 +64,11 @@ var AllResourceTypes = resource.AllResourceTypes
 type TaskResources struct {
 	// Inputs holds the mapping from the PipelineResources declared in
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
+	// +listType=atomic
 	Inputs []TaskResource `json:"inputs,omitempty"`
 	// Outputs holds the mapping from the PipelineResources declared in
 	// DeclaredPipelineResources to the input PipelineResources required by the Task.
+	// +listType=atomic
 	Outputs []TaskResource `json:"outputs,omitempty"`
 }
 
@@ -82,8 +84,10 @@ type TaskResource struct {
 // TaskRunResources allows a TaskRun to declare inputs and outputs TaskResourceBinding
 type TaskRunResources struct {
 	// Inputs holds the inputs resources this task was invoked with
+	// +listType=atomic
 	Inputs []TaskResourceBinding `json:"inputs,omitempty"`
 	// Outputs holds the inputs resources this task was invoked with
+	// +listType=atomic
 	Outputs []TaskResourceBinding `json:"outputs,omitempty"`
 }
 
@@ -95,6 +99,7 @@ type TaskResourceBinding struct {
 	// The optional Path field corresponds to a path on disk at which the Resource can be found
 	// (used when providing the resource via mounted volume, overriding the default logic to fetch the Resource).
 	// +optional
+	// +listType=atomic
 	Paths []string `json:"paths,omitempty"`
 }
 
@@ -209,9 +214,12 @@ type TaskModifier interface {
 
 // InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.
 type InternalTaskModifier struct {
-	StepsToPrepend []Step
-	StepsToAppend  []Step
-	Volumes        []v1.Volume
+	// +listType=atomic
+	StepsToPrepend []Step `json:"stepsToPrepend"`
+	// +listType=atomic
+	StepsToAppend []Step `json:"stepsToAppend"`
+	// +listType=atomic
+	Volumes []v1.Volume `json:"volumes"`
 }
 
 // GetStepsToPrepend returns a set of Steps to prepend to the Task.

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -24,8 +24,8 @@ import (
 
 // ResultRef is a type that represents a reference to a task run result
 type ResultRef struct {
-	PipelineTask string
-	Result       string
+	PipelineTask string `json:"pipelineTask"`
+	Result       string `json:"result"`
 }
 
 const (

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -17,7 +17,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.LocalObjectReference"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "nodeSelector": {
           "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
@@ -33,7 +34,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Toleration"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -67,7 +69,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.HostAlias"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "hostNetwork": {
           "description": "HostNetwork specifies whether the pod may use the node network namespace",
@@ -79,7 +82,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.LocalObjectReference"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "nodeSelector": {
           "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
@@ -111,7 +115,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Toleration"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "volumes": {
           "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
@@ -120,6 +125,7 @@
             "default": {},
             "$ref": "#/definitions/v1.Volume"
           },
+          "x-kubernetes-list-type": "atomic",
           "x-kubernetes-patch-merge-key": "name",
           "x-kubernetes-patch-strategy": "merge,retainKeys"
         }
@@ -197,7 +203,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1alpha1.ResourceParam"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "secrets": {
           "description": "Secrets to fetch to populate some of resource fields",
@@ -205,7 +212,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1alpha1.SecretParam"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "type": {
           "type": "string",
@@ -304,7 +312,8 @@
           "items": {
             "type": "string",
             "default": ""
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "stringVal": {
           "description": "Represents the stored type of ArrayOrString.",
@@ -329,7 +338,8 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/v1beta1.PipelineRunChildConditionCheckStatus"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "kind": {
           "type": "string"
@@ -348,7 +358,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WhenExpression"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -573,7 +584,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.ParamSpec"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources is a list input and output resource to run the task Resources are represented in TaskRuns as bindings to instances of PipelineResources.",
@@ -585,7 +597,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "sidecars": {
           "description": "Sidecars are run alongside the Task's step containers. They begin before the steps start and end after the steps complete.",
@@ -593,7 +606,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Sidecar"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "spec": {
           "description": "Spec is a specification of a custom task",
@@ -610,7 +624,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Step"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "volumes": {
           "description": "Volumes is a collection of volumes that are available to mount into the steps of the build.",
@@ -618,7 +633,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Volume"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "workspaces": {
           "description": "Workspaces are the volumes that this Task requires.",
@@ -626,7 +642,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspaceDeclaration"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -634,31 +651,34 @@
       "description": "InternalTaskModifier implements TaskModifier for resources that are built-in to Tekton Pipelines.",
       "type": "object",
       "required": [
-        "StepsToPrepend",
-        "StepsToAppend",
-        "Volumes"
+        "stepsToPrepend",
+        "stepsToAppend",
+        "volumes"
       ],
       "properties": {
-        "StepsToAppend": {
+        "stepsToAppend": {
           "type": "array",
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Step"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
-        "StepsToPrepend": {
+        "stepsToPrepend": {
           "type": "array",
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Step"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
-        "Volumes": {
+        "volumes": {
           "type": "array",
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Volume"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1005,7 +1025,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WhenExpression"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1019,7 +1040,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Param"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "pipelineRef": {
           "$ref": "#/definitions/v1beta1.PipelineRef"
@@ -1037,7 +1059,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineResourceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "serviceAccountName": {
           "type": "string"
@@ -1048,7 +1071,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineRunSpecServiceAccountName"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "status": {
           "description": "Used for cancelling a pipelinerun (and maybe more later on)",
@@ -1060,7 +1084,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTaskRunSpec"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "timeout": {
           "description": "Time after which the Pipeline times out. Defaults to never. Refer to Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",
@@ -1076,7 +1101,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspaceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1110,7 +1136,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.ChildStatusReference"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "completionTime": {
           "description": "CompletionTime is the time the PipelineRun completed.",
@@ -1137,7 +1164,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineRunResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "pipelineSpec": {
           "description": "PipelineRunSpec contains the exact spec used to instantiate the run",
@@ -1156,7 +1184,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.SkippedTask"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "startTime": {
           "description": "StartTime is the time the PipelineRun is actually started.",
@@ -1181,7 +1210,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.ChildStatusReference"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "completionTime": {
           "description": "CompletionTime is the time the PipelineRun completed.",
@@ -1193,7 +1223,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineRunResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "pipelineSpec": {
           "description": "PipelineRunSpec contains the exact spec used to instantiate the run",
@@ -1212,7 +1243,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.SkippedTask"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "startTime": {
           "description": "StartTime is the time the PipelineRun is actually started.",
@@ -1252,7 +1284,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WhenExpression"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1270,7 +1303,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTask"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "params": {
           "description": "Params declares a list of input parameters that must be supplied when this Pipeline is run.",
@@ -1278,7 +1312,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.ParamSpec"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources declares the names and types of the resources given to the Pipeline's tasks as inputs and outputs.",
@@ -1286,7 +1321,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineDeclaredResource"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "results": {
           "description": "Results are values that this pipeline can output once run",
@@ -1294,7 +1330,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "tasks": {
           "description": "Tasks declares the graph of Tasks that execute when this Pipeline is run.",
@@ -1302,7 +1339,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTask"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "workspaces": {
           "description": "Workspaces declares a set of named workspaces that are expected to be provided by a PipelineRun.",
@@ -1310,7 +1348,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineWorkspaceDeclaration"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1324,7 +1363,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTaskCondition"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "matrix": {
           "description": "Matrix declares parameters used to fan out this task.",
@@ -1332,7 +1372,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Param"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "name": {
           "description": "Name is the name of this task within the context of a Pipeline. Name is used as a coordinate with the `from` and `runAfter` fields to establish the execution order of tasks relative to one another.",
@@ -1344,7 +1385,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Param"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources declares the resources given to this task as inputs and outputs.",
@@ -1361,7 +1403,8 @@
           "items": {
             "type": "string",
             "default": ""
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskRef": {
           "description": "TaskRef is a reference to a task definition.",
@@ -1389,7 +1432,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspacePipelineTaskBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1411,7 +1455,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Param"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources declare the resources provided to this Condition as input",
@@ -1419,7 +1464,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTaskInputResource"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1437,7 +1483,8 @@
           "items": {
             "type": "string",
             "default": ""
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "name": {
           "description": "Name is the name of the PipelineResource as declared by the Task.",
@@ -1519,7 +1566,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTaskInputResource"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "outputs": {
           "description": "Outputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
@@ -1527,7 +1575,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineTaskOutputResource"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1552,14 +1601,16 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunSidecarOverride"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "stepOverrides": {
           "type": "array",
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunStepOverride"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskPodTemplate": {
           "$ref": "#/definitions/pod.Template"
@@ -1595,16 +1646,16 @@
       "description": "ResolverParam is a single parameter passed to a resolver.",
       "type": "object",
       "required": [
-        "Name",
-        "Value"
+        "name",
+        "value"
       ],
       "properties": {
-        "Name": {
+        "name": {
           "description": "Name is the name of the parameter that will be passed to the resolver.",
           "type": "string",
           "default": ""
         },
-        "Value": {
+        "value": {
           "description": "Value is the string value of the parameter that will be passed to the resolver.",
           "type": "string",
           "default": ""
@@ -1625,7 +1676,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.ResolverParam"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1633,15 +1685,15 @@
       "description": "ResultRef is a type that represents a reference to a task run result",
       "type": "object",
       "required": [
-        "PipelineTask",
-        "Result"
+        "pipelineTask",
+        "result"
       ],
       "properties": {
-        "PipelineTask": {
+        "pipelineTask": {
           "type": "string",
           "default": ""
         },
-        "Result": {
+        "result": {
           "type": "string",
           "default": ""
         }
@@ -1795,7 +1847,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspaceUsage"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -1844,7 +1897,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WhenExpression"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2004,7 +2058,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspaceUsage"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2154,7 +2209,8 @@
           "items": {
             "type": "string",
             "default": ""
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resourceRef": {
           "description": "ResourceRef is a reference to the instance of the actual PipelineResource that should be used",
@@ -2176,7 +2232,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResource"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "outputs": {
           "description": "Outputs holds the mapping from the PipelineResources declared in DeclaredPipelineResources to the input PipelineResources required by the Task.",
@@ -2184,7 +2241,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResource"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2242,7 +2300,8 @@
           "items": {
             "type": "string",
             "default": ""
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2255,14 +2314,16 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Param"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "type": "array",
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResourceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2303,7 +2364,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResourceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2317,7 +2379,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResourceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "outputs": {
           "description": "Outputs holds the inputs resources this task was invoked with",
@@ -2325,7 +2388,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResourceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2353,16 +2417,16 @@
       "description": "TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.",
       "type": "object",
       "required": [
-        "Name",
-        "Resources"
+        "name",
+        "resources"
       ],
       "properties": {
-        "Name": {
+        "name": {
           "description": "The name of the Sidecar to override.",
           "type": "string",
           "default": ""
         },
-        "Resources": {
+        "resources": {
           "description": "The resource requirements to apply to the Sidecar.",
           "default": {},
           "$ref": "#/definitions/v1.ResourceRequirements"
@@ -2381,7 +2445,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Param"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "podTemplate": {
           "description": "PodTemplate holds pod specific configuration",
@@ -2400,7 +2465,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunSidecarOverride"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "status": {
           "description": "Used for cancelling a taskrun (and maybe more later on)",
@@ -2412,7 +2478,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunStepOverride"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskRef": {
           "description": "no more than one of the TaskRef and TaskSpec may be specified.",
@@ -2431,7 +2498,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspaceBinding"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2456,7 +2524,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.CloudEventDelivery"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "completionTime": {
           "description": "CompletionTime is the time the build completed.",
@@ -2488,7 +2557,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineResourceResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "retriesStatus": {
           "description": "RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures. All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.",
@@ -2496,7 +2566,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunStatus"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "sidecars": {
           "description": "The list has one entry per sidecar in the manifest. Each entry is represents the imageid of the corresponding sidecar.",
@@ -2504,7 +2575,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.SidecarState"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "startTime": {
           "description": "StartTime is the time the build is actually started.",
@@ -2516,7 +2588,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.StepState"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskResults": {
           "description": "TaskRunResults are the list of results written out by the task's containers",
@@ -2524,7 +2597,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskSpec": {
           "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
@@ -2545,7 +2619,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.CloudEventDelivery"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "completionTime": {
           "description": "CompletionTime is the time the build completed.",
@@ -2562,7 +2637,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.PipelineResourceResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "retriesStatus": {
           "description": "RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures. All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.",
@@ -2570,7 +2646,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunStatus"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "sidecars": {
           "description": "The list has one entry per sidecar in the manifest. Each entry is represents the imageid of the corresponding sidecar.",
@@ -2578,7 +2655,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.SidecarState"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "startTime": {
           "description": "StartTime is the time the build is actually started.",
@@ -2590,7 +2668,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.StepState"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskResults": {
           "description": "TaskRunResults are the list of results written out by the task's containers",
@@ -2598,7 +2677,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskRunResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "taskSpec": {
           "description": "TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.",
@@ -2610,16 +2690,16 @@
       "description": "TaskRunStepOverride is used to override the values of a Step in the corresponding Task.",
       "type": "object",
       "required": [
-        "Name",
-        "Resources"
+        "name",
+        "resources"
       ],
       "properties": {
-        "Name": {
+        "name": {
           "description": "The name of the Step to override.",
           "type": "string",
           "default": ""
         },
-        "Resources": {
+        "resources": {
           "description": "The resource requirements to apply to the Step.",
           "default": {},
           "$ref": "#/definitions/v1.ResourceRequirements"
@@ -2640,7 +2720,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.ParamSpec"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "resources": {
           "description": "Resources is a list input and output resource to run the task Resources are represented in TaskRuns as bindings to instances of PipelineResources.",
@@ -2652,7 +2733,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.TaskResult"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "sidecars": {
           "description": "Sidecars are run alongside the Task's step containers. They begin before the steps start and end after the steps complete.",
@@ -2660,7 +2742,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Sidecar"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "stepTemplate": {
           "description": "StepTemplate can be used as the basis for all step containers within the Task, so that the steps inherit settings on the base container.",
@@ -2672,7 +2755,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.Step"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "volumes": {
           "description": "Volumes is a collection of volumes that are available to mount into the steps of the build.",
@@ -2680,7 +2764,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1.Volume"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "workspaces": {
           "description": "Workspaces are the volumes that this Task requires.",
@@ -2688,7 +2773,8 @@
           "items": {
             "default": {},
             "$ref": "#/definitions/v1beta1.WorkspaceDeclaration"
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },
@@ -2735,7 +2821,8 @@
           "items": {
             "type": "string",
             "default": ""
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         }
       }
     },

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -90,6 +90,7 @@ type TaskSpec struct {
 	// must be supplied as inputs in TaskRuns unless they declare a default
 	// value.
 	// +optional
+	// +listType=atomic
 	Params []ParamSpec `json:"params,omitempty"`
 
 	// Description is a user-facing description of the task that may be
@@ -99,10 +100,12 @@ type TaskSpec struct {
 
 	// Steps are the steps of the build; each step is run sequentially with the
 	// source mounted into /workspace.
+	// +listType=atomic
 	Steps []Step `json:"steps,omitempty"`
 
 	// Volumes is a collection of volumes that are available to mount into the
 	// steps of the build.
+	// +listType=atomic
 	Volumes []corev1.Volume `json:"volumes,omitempty"`
 
 	// StepTemplate can be used as the basis for all step containers within the
@@ -111,12 +114,15 @@ type TaskSpec struct {
 
 	// Sidecars are run alongside the Task's step containers. They begin before
 	// the steps start and end after the steps complete.
+	// +listType=atomic
 	Sidecars []Sidecar `json:"sidecars,omitempty"`
 
 	// Workspaces are the volumes that this Task requires.
+	// +listType=atomic
 	Workspaces []WorkspaceDeclaration `json:"workspaces,omitempty"`
 
 	// Results are values that this Task can output
+	// +listType=atomic
 	Results []TaskResult `json:"results,omitempty"`
 }
 
@@ -154,6 +160,7 @@ type Step struct {
 	// other Step or Sidecar that does not also request this Workspace will
 	// not have access to it.
 	// +optional
+	// +listType=atomic
 	Workspaces []WorkspaceUsage `json:"workspaces,omitempty"`
 
 	// OnError defines the exiting behavior of a container on error
@@ -181,6 +188,7 @@ type Sidecar struct {
 	// other Step or Sidecar that does not also request this Workspace will
 	// not have access to it.
 	// +optional
+	// +listType=atomic
 	Workspaces []WorkspaceUsage `json:"workspaces,omitempty"`
 }
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -38,6 +38,7 @@ type TaskRunSpec struct {
 	// +optional
 	Debug *TaskRunDebug `json:"debug,omitempty"`
 	// +optional
+	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
 	// +optional
 	Resources *TaskRunResources `json:"resources,omitempty"`
@@ -60,18 +61,21 @@ type TaskRunSpec struct {
 	PodTemplate *PodTemplate `json:"podTemplate,omitempty"`
 	// Workspaces is a list of WorkspaceBindings from volumes to workspaces.
 	// +optional
+	// +listType=atomic
 	Workspaces []WorkspaceBinding `json:"workspaces,omitempty"`
 	// Overrides to apply to Steps in this TaskRun.
 	// If a field is specified in both a Step and a StepOverride,
 	// the value from the StepOverride will be used.
 	// This field is only supported when the alpha feature gate is enabled.
 	// +optional
+	// +listType=atomic
 	StepOverrides []TaskRunStepOverride `json:"stepOverrides,omitempty"`
 	// Overrides to apply to Sidecars in this TaskRun.
 	// If a field is specified in both a Sidecar and a SidecarOverride,
 	// the value from the SidecarOverride will be used.
 	// This field is only supported when the alpha feature gate is enabled.
 	// +optional
+	// +listType=atomic
 	SidecarOverrides []TaskRunSidecarOverride `json:"sidecarOverrides,omitempty"`
 }
 
@@ -87,20 +91,24 @@ const (
 // TaskRunDebug defines the breakpoint config for a particular TaskRun
 type TaskRunDebug struct {
 	// +optional
+	// +listType=atomic
 	Breakpoint []string `json:"breakpoint,omitempty"`
 }
 
 // TaskRunInputs holds the input values that this task was invoked with.
 type TaskRunInputs struct {
 	// +optional
+	// +listType=atomic
 	Resources []TaskResourceBinding `json:"resources,omitempty"`
 	// +optional
+	// +listType=atomic
 	Params []Param `json:"params,omitempty"`
 }
 
 // TaskRunOutputs holds the output values that this task was invoked with.
 type TaskRunOutputs struct {
 	// +optional
+	// +listType=atomic
 	Resources []TaskResourceBinding `json:"resources,omitempty"`
 }
 
@@ -192,29 +200,35 @@ type TaskRunStatusFields struct {
 
 	// Steps describes the state of each build step container.
 	// +optional
+	// +listType=atomic
 	Steps []StepState `json:"steps,omitempty"`
 
 	// CloudEvents describe the state of each cloud event requested via a
 	// CloudEventResource.
 	// +optional
+	// +listType=atomic
 	CloudEvents []CloudEventDelivery `json:"cloudEvents,omitempty"`
 
 	// RetriesStatus contains the history of TaskRunStatus in case of a retry in order to keep record of failures.
 	// All TaskRunStatus stored in RetriesStatus will have no date within the RetriesStatus as is redundant.
 	// +optional
+	// +listType=atomic
 	RetriesStatus []TaskRunStatus `json:"retriesStatus,omitempty"`
 
 	// Results from Resources built during the taskRun. currently includes
 	// the digest of build container images
 	// +optional
+	// +listType=atomic
 	ResourcesResult []PipelineResourceResult `json:"resourcesResult,omitempty"`
 
 	// TaskRunResults are the list of results written out by the task's containers
 	// +optional
+	// +listType=atomic
 	TaskRunResults []TaskRunResult `json:"taskResults,omitempty"`
 
 	// The list has one entry per sidecar in the manifest. Each entry is
 	// represents the imageid of the corresponding sidecar.
+	// +listType=atomic
 	Sidecars []SidecarState `json:"sidecars,omitempty"`
 
 	// TaskSpec contains the Spec from the dereferenced Task definition used to instantiate this TaskRun.
@@ -233,17 +247,17 @@ type TaskRunResult struct {
 // TaskRunStepOverride is used to override the values of a Step in the corresponding Task.
 type TaskRunStepOverride struct {
 	// The name of the Step to override.
-	Name string
+	Name string `json:"name"`
 	// The resource requirements to apply to the Step.
-	Resources corev1.ResourceRequirements
+	Resources corev1.ResourceRequirements `json:"resources"`
 }
 
 // TaskRunSidecarOverride is used to override the values of a Sidecar in the corresponding Task.
 type TaskRunSidecarOverride struct {
 	// The name of the Sidecar to override.
-	Name string
+	Name string `json:"name"`
 	// The resource requirements to apply to the Sidecar.
-	Resources corev1.ResourceRequirements
+	Resources corev1.ResourceRequirements `json:"resources"`
 }
 
 // GetGroupVersionKind implements kmeta.OwnerRefable.

--- a/pkg/apis/pipeline/v1beta1/when_types.go
+++ b/pkg/apis/pipeline/v1beta1/when_types.go
@@ -34,6 +34,7 @@ type WhenExpression struct {
 
 	// Values is an array of strings, which is compared against the input, for guard checking
 	// It must be non-empty
+	// +listType=atomic
 	Values []string `json:"values"`
 }
 

--- a/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
+++ b/pkg/apis/resource/v1alpha1/pipeline_resource_types.go
@@ -95,9 +95,11 @@ type PipelineResourceSpec struct {
 	// +optional
 	Description string               `json:"description,omitempty"`
 	Type        PipelineResourceType `json:"type"`
-	Params      []ResourceParam      `json:"params"`
+	// +listType=atomic
+	Params []ResourceParam `json:"params"`
 	// Secrets to fetch to populate some of resource fields
 	// +optional
+	// +listType=atomic
 	SecretParams []SecretParam `json:"secrets,omitempty"`
 }
 


### PR DESCRIPTION
# Changes

We need to have a `// +listType=...` annotation on all list fields in API types
to get `k8s.io/kube-openapi/cmd/openapi-gen` to not throw rules violations for
list fields without that annotation. I chose to use `atomic` because it seemed
the simplest option - it means that when updates are written, the whole list
will be updated, rather than individual elements in the list, and without any
special logic on uniqueness within the list or ordering by some field in the
structs in the list.

See https://github.com/kubernetes/kube-openapi/blob/3ee0da9b0b4211c407396d9c233b38b77ce19773/pkg/idl/doc.go#L21-L63 for more information on `listType`s.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

Not sure what to do re: release note here. =)

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
