### PR TITLE
Move Events test helpers to test package

### DIFF
--- a/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/test/diff"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -598,11 +599,11 @@ func TestSendCloudEventWithRetries(t *testing.T) {
 				t.Fatalf("Unexpected error sending cloud events: %v", err)
 			}
 			ceClient := Get(ctx).(FakeClient)
-			if err := CheckCloudEvents(t, &ceClient, tc.name, tc.wantCEvents); err != nil {
+			if err := eventstest.CheckEventsUnordered(t, ceClient.Events, tc.name, tc.wantCEvents); err != nil {
 				t.Fatalf(err.Error())
 			}
 			recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
-			if err := CheckEvents(t, recorder, tc.name, tc.wantEvents); err != nil {
+			if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 				t.Fatalf(err.Error())
 			}
 		})

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -142,7 +143,7 @@ func TestSendKubernetesEvents(t *testing.T) {
 		tr := &corev1.Pod{}
 		sendKubernetesEvents(fr, ts.before, ts.after, tr)
 
-		err := cloudevent.CheckEvents(t, fr, ts.name, ts.wantEvents)
+		err := eventstest.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -169,7 +170,7 @@ func TestEmitError(t *testing.T) {
 		tr := &corev1.Pod{}
 		EmitError(fr, ts.err, tr)
 
-		err := cloudevent.CheckEvents(t, fr, ts.name, ts.wantEvents)
+		err := eventstest.CheckEventsOrdered(t, fr.Events, ts.name, ts.wantEvents)
 		if err != nil {
 			t.Errorf(err.Error())
 		}
@@ -234,10 +235,10 @@ func TestEmit(t *testing.T) {
 
 		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
 		Emit(ctx, nil, after, object)
-		if err := cloudevent.CheckEvents(t, recorder, tc.name, tc.wantEvents); err != nil {
+		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatalf(err.Error())
 		}
-		if err := cloudevent.CheckCloudEvents(t, &fakeClient, tc.name, tc.wantCloudEvents); err != nil {
+		if err := eventstest.CheckEventsUnordered(t, fakeClient.Events, tc.name, tc.wantCloudEvents); err != nil {
 			t.Fatalf(err.Error())
 		}
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	"gomodules.xyz/jsonpatch/v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -2693,7 +2694,7 @@ func TestReconcileCancelledRunFinallyFailsTaskRunCancellation(t *testing.T) {
 		"Normal PipelineRunCouldntCancel PipelineRun \"test-pipeline-fails-to-cancel\" was cancelled but had errors trying to cancel TaskRuns",
 		"Warning InternalError 1 error occurred",
 	}
-	err = cloudevent.CheckEvents(t, testAssets.Recorder, prName, wantEvents)
+	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -3292,7 +3293,7 @@ func TestReconcileCancelledFailsTaskRunCancellation(t *testing.T) {
 		"Normal PipelineRunCouldntCancel PipelineRun \"test-pipeline-fails-to-cancel\" was cancelled but had errors trying to cancel TaskRuns",
 		"Warning InternalError 1 error occurred",
 	}
-	err = cloudevent.CheckEvents(t, testAssets.Recorder, prName, wantEvents)
+	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, prName, wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -7473,7 +7474,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		`(?s)dev.tekton.event.pipelinerun.running.v1.*test-pipelinerun`,
 	}
 	ceClient := clients.CloudEvents.(cloudevent.FakeClient)
-	err := cloudevent.CheckCloudEvents(t, &ceClient, "reconcile-cloud-events", wantCloudEvents)
+	err := eventstest.CheckEventsUnordered(t, ceClient.Events, "reconcile-cloud-events", wantCloudEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -7996,7 +7997,7 @@ func (prt PipelineRunTest) reconcileRun(namespace, pipelineRunName string, wantE
 
 	// Check generated events match what's expected
 	if len(wantEvents) > 0 {
-		if err := cloudevent.CheckEvents(prt.Test, prt.TestAssets.Recorder, pipelineRunName, wantEvents); err != nil {
+		if err := eventstest.CheckEventsOrdered(prt.Test, prt.TestAssets.Recorder.Events, pipelineRunName, wantEvents); err != nil {
 			prt.Test.Errorf(err.Error())
 		}
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/workspace"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -907,7 +908,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		"Normal Start",
 		"Normal Running",
 	}
-	err = cloudevent.CheckEvents(t, testAssets.Recorder, "reconcile-cloud-events", wantEvents)
+	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -917,7 +918,7 @@ func TestReconcile_CloudEvents(t *testing.T) {
 		`(?s)dev.tekton.event.taskrun.running.v1.*test-taskrun-not-started`,
 	}
 	ceClient := clients.CloudEvents.(cloudevent.FakeClient)
-	err = cloudevent.CheckCloudEvents(t, &ceClient, "reconcile-cloud-events", wantCloudEvents)
+	err = eventstest.CheckEventsUnordered(t, ceClient.Events, "reconcile-cloud-events", wantCloudEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -1462,7 +1463,7 @@ func TestReconcile(t *testing.T) {
 				t.Fatalf("Expected actions to be logged in the kubeclient, got none")
 			}
 
-			err = cloudevent.CheckEvents(t, testAssets.Recorder, tc.name, tc.wantEvents)
+			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -1625,7 +1626,7 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 				t.Errorf("expected 2 actions, got %d. Actions: %#v", len(actions), actions)
 			}
 
-			err := cloudevent.CheckEvents(t, testAssets.Recorder, tc.name, tc.wantEvents)
+			err := eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -1924,7 +1925,7 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 		"Normal Running Not all Steps",
 		"Normal Succeeded",
 	}
-	err = cloudevent.CheckEvents(t, testAssets.Recorder, "test-reconcile-pod-updateStatus", wantEvents)
+	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-pod-updateStatus", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2034,7 +2035,7 @@ func TestReconcileOnCancelledTaskRun(t *testing.T) {
 		"Normal Started",
 		"Warning Failed TaskRun \"test-taskrun-run-cancelled\" was cancelled",
 	}
-	err = cloudevent.CheckEvents(t, testAssets.Recorder, "test-reconcile-on-cancelled-taskrun", wantEvents)
+	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "test-reconcile-on-cancelled-taskrun", wantEvents)
 	if !(err == nil) {
 		t.Errorf(err.Error())
 	}
@@ -2188,7 +2189,7 @@ func TestReconcileTimeouts(t *testing.T) {
 			if d := cmp.Diff(tc.expectedStatus, condition, ignoreLastTransitionTime); d != "" {
 				t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 			}
-			err = cloudevent.CheckEvents(t, testAssets.Recorder, tc.taskRun.Name, tc.wantEvents)
+			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tc.taskRun.Name, tc.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}
@@ -3465,7 +3466,7 @@ func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 				}
 			}
 
-			err = cloudevent.CheckEvents(t, testAssets.Recorder, tt.desc, tt.wantEvents)
+			err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, tt.desc, tt.wantEvents)
 			if !(err == nil) {
 				t.Errorf(err.Error())
 			}

--- a/test/events/events.go
+++ b/test/events/events.go
@@ -13,33 +13,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package cloudevent
+package events
 
 import (
 	"fmt"
 	"regexp"
 	"testing"
 	"time"
-
-	"k8s.io/client-go/tools/record"
 )
 
-// CheckEvents checks that the events received by the FakeRecorder are the same as wantEvents,
+// CheckEventsOrdered checks that the events received via the given chan are the same as wantEvents,
 // in the same order.
-func CheckEvents(t *testing.T, fr *record.FakeRecorder, testName string, wantEvents []string) error {
+func CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wantEvents []string) error {
 	t.Helper()
-	err := eventsFromChannel(fr.Events, wantEvents)
+	err := eventsFromChannel(eventChan, wantEvents)
 	if err != nil {
 		return fmt.Errorf("error in test %s: %v", testName, err)
 	}
 	return nil
 }
 
-// CheckCloudEvents checks that all events in wantEvents, and no others, were received by the FakeClient
-// in any order.
-func CheckCloudEvents(t *testing.T, fce *FakeClient, testName string, wantEvents []string) error {
+// CheckEventsUnordered checks that all events in wantEvents, and no others,
+// were received via the given chan, in any order.
+func CheckEventsUnordered(t *testing.T, eventChan chan string, testName string, wantEvents []string) error {
 	t.Helper()
-	err := eventsFromChannelUnordered(fce.Events, wantEvents)
+	err := eventsFromChannelUnordered(eventChan, wantEvents)
 	if err != nil {
 		return fmt.Errorf("error in test %s: %v", testName, err)
 	}


### PR DESCRIPTION
# Changes


Previously the helpers in pkg/reconciler/events/event_test.go were
exported publicly as part of the pkg/reconciler/events package.

This commit moves the helpers to the dedicated test package. The
helpers' signatures have been updated to prevent a circular dependency with
the pkg/reconciler/events/cloudevent package.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
