### PR TITLE
Merge default PodTemplate's affinity field

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -90,6 +90,9 @@ func mergePodTemplateWithDefault(tpl, defaultTpl *PodTemplate) *PodTemplate {
 		if tpl.Tolerations == nil {
 			tpl.Tolerations = defaultTpl.Tolerations
 		}
+		if tpl.Affinity == nil {
+			tpl.Affinity = defaultTpl.Affinity
+		}
 		if tpl.SecurityContext == nil {
 			tpl.SecurityContext = defaultTpl.SecurityContext
 		}


### PR DESCRIPTION
# Changes

Currently, default PodTemplate's affinity field is ignored since `mergePodTemplateWithDefault` doesn't merge `affinity` field.

This PR will merge default PodTemplate's affinity field.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

- Bug fixes

```release-note
Fixes an issue that default PodTemplate's affinity field is ignored.
```