### PR TITLE
Fix `TestDAGPipelineRun` flakiness.

### DIFF
--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -34,7 +34,7 @@ import (
 	knativetest "knative.dev/pkg/test"
 )
 
-const sleepDuration = 30 * time.Second
+const sleepDuration = 15 * time.Second
 
 // TestDAGPipelineRun creates a graph of arbitrary Tasks, then looks at the corresponding
 // TaskRun start times to ensure they were run in the order intended, which is:

--- a/test/dag_test.go
+++ b/test/dag_test.go
@@ -34,6 +34,8 @@ import (
 	knativetest "knative.dev/pkg/test"
 )
 
+const sleepDuration = 30 * time.Second
+
 // TestDAGPipelineRun creates a graph of arbitrary Tasks, then looks at the corresponding
 // TaskRun start times to ensure they were run in the order intended, which is:
 //                               |
@@ -74,8 +76,12 @@ spec:
   - image: busybox
     script: 'echo $(params["text"])'
   - image: busybox
+    # Sleep for N seconds so that we can check that tasks that
+    # should be run in parallel have overlap.
+    script: 'sleep %d'
+  - image: busybox
     script: 'ln -s $(resources.inputs.repo.path) $(resources.outputs.repo.path)'
-`, namespace))
+`, namespace, int(sleepDuration.Seconds())))
 	if _, err := c.TaskClient.Create(ctx, echoTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create echo Task: %s", err)
 	}
@@ -242,7 +248,7 @@ func verifyExpectedOrder(ctx context.Context, t *testing.T, c clientset.TaskRunI
 	s1 := taskRuns[1].Status.StartTime.Time
 	s2 := taskRuns[2].Status.StartTime.Time
 	absDiff := time.Duration(math.Abs(float64(s2.Sub(s1))))
-	if absDiff > (time.Second * 5) {
+	if absDiff > sleepDuration {
 		t.Errorf("Expected parallel tasks to execute more or less at the same time, but they were %v apart", absDiff)
 	}
 }

--- a/test/v1alpha1/dag_test.go
+++ b/test/v1alpha1/dag_test.go
@@ -35,7 +35,7 @@ import (
 	knativetest "knative.dev/pkg/test"
 )
 
-const sleepDuration = 30 * time.Second
+const sleepDuration = 15 * time.Second
 
 // TestDAGPipelineRun creates a graph of arbitrary Tasks, then looks at the corresponding
 // TaskRun start times to ensure they were run in the order intended, which is:


### PR DESCRIPTION
_See also the linked issue for a detailed explanation of the issue this fixes._

This change alters the DAG tests in two meaningful ways:
1. Have the tasks sleep, to actually increase the likelihood of task execution overlap,
2. Use the sleep duration for the minimum delta in start times.

These changes combine should guarantee that the tasks *actually* executed in parallel, but the second part also enables this test to be less flaky on busy clusters where `5s` may not be sufficient for the task to start.

A fun anecdote to note here is that the Kubernetes [SLO for Pod startup latency](https://github.com/kubernetes/community/blob/master/sig-scalability/slos/pod_startup_latency.md#definition) is `5s` at `99P`, which means Tekton had effectively zero room for overhead. 😅 

Fixes: https://github.com/tektoncd/pipeline/issues/4418

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```
