### PR TITLE
Bump GoogleContainerTools/skaffold revision from v0.32.0 to v1.32.0

### DIFF
--- a/examples/v1alpha1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1alpha1/pipelineruns/pipelinerun.yaml
@@ -44,7 +44,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: v0.32.0
+    value: v1.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---
@@ -86,6 +86,9 @@ spec:
     - name: pathToContext
       description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
       default: /workspace/workspace
+    - name: baseImage
+      description: Base image for GoogleContainerTools/skaffold microservice apps
+      default: BASE=alpine:3.9
   outputs:
     resources:
     - name: builtImage
@@ -103,6 +106,7 @@ spec:
     - --dockerfile=$(inputs.params.pathToDockerFile)
     - --destination=$(outputs.resources.builtImage.url)
     - --context=$(inputs.params.pathToContext)
+    - --build-arg=$(inputs.params.baseImage)
 ---
 # This task deploys with kubectl apply -f <filename>
 apiVersion: tekton.dev/v1alpha1
@@ -235,7 +239,7 @@ spec:
     - name: path
       value: /workspace/workspace/examples/microservices/leeroy-web/kubernetes/deployment.yaml
     - name: yqArg
-      value: "-d1"
+      value: "-d0"
     - name: yamlPathToImage
       value: "spec.template.spec.containers[0].image"
 ---

--- a/examples/v1alpha1/taskruns/build-push-kaniko.yaml
+++ b/examples/v1alpha1/taskruns/build-push-kaniko.yaml
@@ -16,7 +16,7 @@ spec:
   type: git
   params:
   - name: revision
-    value: v0.32.0
+    value: v1.32.0
   - name: url
     value: https://github.com/GoogleContainerTools/skaffold
 ---
@@ -37,6 +37,9 @@ spec:
     - name: pathToContext
       description: The build context used by Kaniko (https://github.com/GoogleContainerTools/kaniko#kaniko-build-contexts)
       default: /workspace/workspace
+    - name: baseImage
+      description: Base image for GoogleContainerTools/skaffold microservice apps
+      default: BASE=alpine:3.9
   outputs:
     resources:
     - name: builtImage
@@ -53,6 +56,7 @@ spec:
     - --destination=$(outputs.resources.builtImage.url)
     - --context=$(inputs.params.pathToContext)
     - --oci-layout-path=$(inputs.resources.builtImage.path)
+    - --build-arg=$(inputs.params.baseImage)
     securityContext:
       runAsUser: 0
   sidecars:

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -141,6 +141,9 @@ spec:
   - name: BUILDER_IMAGE
     description: The image on which builds will run
     default: gcr.io/kaniko-project/executor:v1.3.0
+  - name: baseImage
+    description: Base image for GoogleContainerTools/skaffold microservice apps
+    default: BASE=alpine:3.9
   results:
   - name: IMAGE_DIGEST
     description: Digest of the image just built.
@@ -160,6 +163,7 @@ spec:
     - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
     - --destination=$(params.IMAGE)
     - --oci-layout-path=$(workspaces.source.path)/$(params.CONTEXT)/image-digest
+    - --build-arg=$(inputs.params.baseImage)
     # kaniko assumes it is running as root, which means this example fails on platforms
     # that default to run containers as random uid (like OpenShift). Adding this securityContext
     # makes it explicit that it needs to run as root.
@@ -237,7 +241,7 @@ spec:
     - name: url
       value: https://github.com/GoogleContainerTools/skaffold
     - name: revision
-      value: v0.32.0
+      value: v1.32.0
     workspaces:
     - name: output
       workspace: git-source
@@ -300,7 +304,7 @@ spec:
     - name: path
       value: $(workspaces.source.path)/examples/microservices/leeroy-web/kubernetes/deployment.yaml
     - name: yqArg
-      value: "-d1"
+      value: "-d0"
     - name: yamlPathToImage
       value: "spec.template.spec.containers[0].image"
     workspaces:

--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -145,8 +145,6 @@ func initExcludedTests() sets.String {
 			// examples
 			"TestExamples/v1alpha1/taskruns/gcs-resource",
 			"TestExamples/v1beta1/taskruns/gcs-resource",
-			"TestExamples/v1beta1/pipelineruns/pipelinerun",
-			"TestYamls/yamls/v1beta1/pipelineruns/pipelinerun.yaml",
 		)
 	}
 

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
@@ -141,6 +141,9 @@ spec:
   - name: BUILDER_IMAGE
     description: The image on which builds will run
     default: gcr.io/kaniko-project/executor:v1.3.0
+  - name: baseImage
+    description: Base image for GoogleContainerTools/skaffold microservice apps
+    default: BASE=alpine:3.9
   results:
   - name: IMAGE_DIGEST
     description: Digest of the image just built.
@@ -160,6 +163,7 @@ spec:
     - --context=$(workspaces.source.path)/$(params.CONTEXT)  # The user does not need to care the workspace and the source.
     - --destination=$(params.IMAGE)
     - --oci-layout-path=$(workspaces.source.path)/$(params.CONTEXT)/image-digest
+    - --build-arg=$(inputs.params.baseImage)
     # kaniko assumes it is running as root, which means this example fails on platforms
     # that default to run containers as random uid (like OpenShift). Adding this securityContext
     # makes it explicit that it needs to run as root.
@@ -237,7 +241,7 @@ spec:
     - name: url
       value: https://github.com/GoogleContainerTools/skaffold
     - name: revision
-      value: v0.32.0
+      value: v1.32.0
     workspaces:
     - name: output
       workspace: git-source
@@ -300,7 +304,7 @@ spec:
     - name: path
       value: $(workspaces.source.path)/examples/microservices/leeroy-web/kubernetes/deployment.yaml
     - name: yqArg
-      value: "-d1"
+      value: "-d0"
     - name: yamlPathToImage
       value: "spec.template.spec.containers[0].image"
     workspaces:


### PR DESCRIPTION
Fixes #4334. 

Older versions of `GoogleContainerTools/skaffold` fail to build microservice images on ppc64le due to issue in golang image.


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
- Update skaffold from v0.32.0 to v1.32.0 revision to fix failing tests on ppc64le.
- Remove failing tests from ppc64le exclude test list.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

/kind bug
/cc @afrittoli