### PR TITLE
Explicitly annotate TaskRuns with release version.

### DIFF
--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -286,7 +286,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 		priorityClassName = *podTemplate.PriorityClassName
 	}
 
-	podAnnotations := taskRun.Annotations
+	podAnnotations := kmeta.CopyMap(taskRun.Annotations)
 	version, err := changeset.Get()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Previously we were expecting TaskRuns to be decorated with an annotation specifying
the release version of the tekton controller, however, the place that was populating
these annotations was extremely subtle and fragile.  The annotation was set as part
of synthesizing the `Pod` to create where the Pod's annotations were based on the
`TaskRun`'s.

This contains two main changes:
1. Explicitly copy the `TaskRun`'s annotations when populating the pod's annotations
  to eliminate this implicit and fragile back-propagation of annotations.

2. Add an explicit decoration of the annotation, which is less fragile and executed 
  regardless of whether the Pod is being created during this reconciliation pass.

Fixes: https://github.com/tektoncd/pipeline/issues/4421


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
More consistently apply the pipeline.tekton.dev/release annotation to TaskRun resources.
```
