### PR TITLE
Reduce RBAC permissions for Tekton controller/webhook roles.

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -47,10 +47,14 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
-  # Read-write access to create Pods, K8s Events and PVCs (for Workspaces)
+  # Read-write access to create Pods and PVCs (for Workspaces)
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "events", "persistentvolumeclaims"]
+    resources: ["pods", "persistentvolumeclaims"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Write permissions to publish events.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
   # Read-only access to these.
   - apiGroups: [""]
     resources: ["configmaps", "limitranges", "secrets", "serviceaccounts"]
@@ -69,11 +73,24 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
-  # The webhook needs to be able to list and update customresourcedefinitions,
+  # The webhook needs to be able to get and update customresourcedefinitions,
   # mainly to update the webhook certificates.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
-    verbs: ["get", "list", "update", "patch", "watch"]
+    verbs: ["get", "update", "patch"]
+    resourceNames:
+      - pipelines.tekton.dev
+      - pipelineruns.tekton.dev
+      - runs.tekton.dev
+      - tasks.tekton.dev
+      - clustertasks.tekton.dev
+      - taskruns.tekton.dev
+      - pipelineresources.tekton.dev
+      - conditions.tekton.dev
+  # knative.dev/pkg needs list/watch permissions to set up informers for the webhook.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     # The webhook performs a reconciliation on these two resources and continuously
     # updates configuration.


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

These are recommendations from a recent security audit.

Controller permissions modified (`tekton-pipelines-controller-tenant-access`):

- Remove pod/logs permissions - generally users access logs with their
own permissions. We only use this in our own code for tests, where the
test user is accessing as a cluster admin anyway.
- Restricts event permissions to only create/update/patch, which I
believe is the minimum set necessary for publishing with client-go
(based on
https://pkg.go.dev/k8s.io/client-go@v0.23.0/tools/events#EventSink)

Webhook permissions modified (`tekton-pipelines-webhook-cluster-access`):

- Adds resourceName restriction on CRD permissions to only allow
modification of Tekton Pipelines CRDs.

/kind cleanup


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Tekton tekton-pipelines-controller-tenant-access and tekton-pipelines-webhook-cluster-access
ClusterRole permissions are reduced to better fit least privilege.
This should have no effect on the Pipelines Controller/Webhook itself, but may impact users
if they were relying on these roles for other uses.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
