### PR TITLE
test/sidecar_test.go: replace t.Errorfs with t.Fatalfs

### DIFF
--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 /*
@@ -102,21 +103,21 @@ spec:
 
 			t.Logf("Creating Task %q", sidecarTaskName)
 			if _, err := clients.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
-				t.Errorf("Failed to create Task %q: %v", sidecarTaskName, err)
+				t.Fatalf("Failed to create Task %q: %v", sidecarTaskName, err)
 			}
 
 			t.Logf("Creating TaskRun %q", sidecarTaskRunName)
 			if _, err := clients.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
-				t.Errorf("Failed to create TaskRun %q: %v", sidecarTaskRunName, err)
+				t.Fatalf("Failed to create TaskRun %q: %v", sidecarTaskRunName, err)
 			}
 
 			if err := WaitForTaskRunState(ctx, clients, sidecarTaskRunName, Succeed(sidecarTaskRunName), "TaskRunSucceed"); err != nil {
-				t.Errorf("Error waiting for TaskRun %q to finish: %v", sidecarTaskRunName, err)
+				t.Fatalf("Error waiting for TaskRun %q to finish: %v", sidecarTaskRunName, err)
 			}
 
 			tr, err := clients.TaskRunClient.Get(ctx, sidecarTaskRunName, metav1.GetOptions{})
 			if err != nil {
-				t.Errorf("Error getting Taskrun: %v", err)
+				t.Fatalf("Error getting Taskrun: %v", err)
 			}
 			podName := tr.Status.PodName
 
@@ -129,12 +130,12 @@ spec:
 				}
 				return terminatedCount == 2, nil
 			}, "PodContainersTerminated"); err != nil {
-				t.Errorf("Error waiting for Pod %q to terminate both the primary and sidecar containers: %v", podName, err)
+				t.Fatalf("Error waiting for Pod %q to terminate both the primary and sidecar containers: %v", podName, err)
 			}
 
 			pod, err := clients.KubeClient.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 			if err != nil {
-				t.Errorf("Error getting TaskRun pod: %v", err)
+				t.Fatalf("Error getting TaskRun pod: %v", err)
 			}
 
 			primaryTerminated := false
@@ -163,7 +164,7 @@ spec:
 
 			trCheckSidecarStatus, err := clients.TaskRunClient.Get(ctx, sidecarTaskRunName, metav1.GetOptions{})
 			if err != nil {
-				t.Errorf("Error getting TaskRun: %v", err)
+				t.Fatalf("Error getting TaskRun: %v", err)
 			}
 
 			sidecarFromStatus := trCheckSidecarStatus.Status.Sidecars[0]


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

t.Fatalf causes the test to fail and return (or in this case, move on to
the next t.Run), while t.Errorf casues the test to fail but keeps going.
There's a bunch of dependent logic in this test where if one step fails,
we try to access it and nil panic.

This change replaces a bunch of Errorfs -> Fatalfs where we rely on these
condition assumptions. Cases where we are just examining the result for
certain properties are left as Errorf so we can check multiple things
before returning out.

/kind bug

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```