### PR TITLE
subcommands_test: Group command tests with t.Run.

### DIFF
--- a/cmd/entrypoint/subcommands/subcommands_test.go
+++ b/cmd/entrypoint/subcommands/subcommands_test.go
@@ -29,14 +29,25 @@ func TestProcessSuccessfulSubcommands(t *testing.T) {
 		t.Fatalf("error writing source file: %v", err)
 	}
 
-	returnValue := Process([]string{CopyCommand, src, dst})
-	if _, ok := returnValue.(SubcommandSuccessful); !ok {
-		t.Errorf("unexpected return value from cp command: %v", returnValue)
-	}
-
-	returnValue = Process([]string{DecodeScriptCommand, src})
-	if _, ok := returnValue.(SubcommandSuccessful); !ok {
-		t.Errorf("unexpected return value from decode-script command: %v", returnValue)
+	for _, tc := range []struct {
+		command string
+		args    []string
+	}{
+		{
+			command: CopyCommand,
+			args:    []string{src, dst},
+		},
+		{
+			command: DecodeScriptCommand,
+			args:    []string{src},
+		},
+	} {
+		t.Run(tc.command, func(t *testing.T) {
+			returnValue := Process(append([]string{tc.command}, tc.args...))
+			if _, ok := returnValue.(SubcommandSuccessful); !ok {
+				t.Errorf("unexpected return value from command: %v", returnValue)
+			}
+		})
 	}
 }
 
@@ -52,19 +63,24 @@ func TestProcessIgnoresNonSubcommands(t *testing.T) {
 		t.Errorf("unexpected error processing 0 args: %v", err)
 	}
 
-	if err := Process([]string{CopyCommand}); err != nil {
-		t.Errorf("unexpected error processing decode-script command with 0 additional args: %v", err)
-	}
+	t.Run(CopyCommand, func(t *testing.T) {
+		if err := Process([]string{CopyCommand}); err != nil {
+			t.Errorf("unexpected error processing command with 0 additional args: %v", err)
+		}
 
-	if err := Process([]string{CopyCommand, "foo.txt", "bar.txt", "baz.txt"}); err != nil {
-		t.Errorf("unexpected error processing cp command with invalid number of args: %v", err)
-	}
+		if err := Process([]string{CopyCommand, "foo.txt", "bar.txt", "baz.txt"}); err != nil {
+			t.Errorf("unexpected error processing command with invalid number of args: %v", err)
+		}
+	})
 
-	if err := Process([]string{DecodeScriptCommand}); err != nil {
-		t.Errorf("unexpected error processing decode-script command with 0 additional args: %v", err)
-	}
+	t.Run(DecodeScriptCommand, func(t *testing.T) {
 
-	if err := Process([]string{DecodeScriptCommand, "foo.txt", "bar.txt"}); err != nil {
-		t.Errorf("unexpected error processing decode-script command with invalid number of args: %v", err)
-	}
+		if err := Process([]string{DecodeScriptCommand}); err != nil {
+			t.Errorf("unexpected error processing command with 0 additional args: %v", err)
+		}
+
+		if err := Process([]string{DecodeScriptCommand, "foo.txt", "bar.txt"}); err != nil {
+			t.Errorf("unexpected error processing command with invalid number of args: %v", err)
+		}
+	})
 }


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Simple clean up to help display/group command tests together and cut
down on some of the repetition.

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```


