### PR TITLE
Use pr.Timeouts.Pipeline in Custom Task reconcile

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -153,12 +153,11 @@ func (pr *PipelineRun) GetNamespacedName() types.NamespacedName {
 }
 
 // HasTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout
-func (pr *PipelineRun) HasTimedOut() bool {
-	pipelineTimeout := pr.Spec.Timeout
+func (pr *PipelineRun) HasTimedOut(ctx context.Context) bool {
+	timeout := pr.PipelineTimeout(ctx)
 	startTime := pr.Status.StartTime
 
-	if !startTime.IsZero() && pipelineTimeout != nil {
-		timeout := pipelineTimeout.Duration
+	if !startTime.IsZero() {
 		if timeout == config.NoTimeoutDuration {
 			return false
 		}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -252,7 +253,7 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		t.Run(t.Name(), func(t *testing.T) {
+		t.Run("pipeline.timeout "+tc.name, func(t *testing.T) {
 			pr := &v1beta1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
 				Spec: v1beta1.PipelineRunSpec{
@@ -262,9 +263,23 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 					StartTime: &metav1.Time{Time: tc.starttime},
 				}},
 			}
+			if pr.HasTimedOut(context.Background()) != tc.expected {
+				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeout", tc.expected)
+			}
+		})
+		t.Run("pipeline.timeouts.pipeline "+tc.name, func(t *testing.T) {
+			pr := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.PipelineRunSpec{
+					Timeouts: &v1beta1.TimeoutFields{Pipeline: &metav1.Duration{Duration: tc.timeout}},
+				},
+				Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: tc.starttime},
+				}},
+			}
 
-			if pr.HasTimedOut() != tc.expected {
-				t.Fatalf("Expected HasTimedOut to be %t", tc.expected)
+			if pr.HasTimedOut(context.Background()) != tc.expected {
+				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -570,7 +570,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	// Reset the skipped status to trigger recalculation
 	pipelineRunFacts.ResetSkippedCache()
 
-	after := pipelineRunFacts.GetPipelineConditionStatus(pr, logger)
+	after := pipelineRunFacts.GetPipelineConditionStatus(ctx, pr, logger)
 	switch after.Status {
 	case corev1.ConditionTrue:
 		pr.Status.MarkSucceeded(after.Reason, after.Message)
@@ -603,7 +603,7 @@ func (c *Reconciler) processRunTimeouts(ctx context.Context, pr *v1beta1.Pipelin
 	}
 	for _, rprt := range pipelineState {
 		if rprt.IsCustomTask() {
-			if rprt.Run != nil && !rprt.Run.IsCancelled() && (pr.HasTimedOut() || (rprt.Run.HasTimedOut() && !rprt.Run.IsDone())) {
+			if rprt.Run != nil && !rprt.Run.IsCancelled() && (pr.HasTimedOut(ctx) || (rprt.Run.HasTimedOut() && !rprt.Run.IsDone())) {
 				logger.Infof("Cancelling run task: %s due to timeout.", rprt.RunName)
 				err := cancelRun(ctx, rprt.RunName, pr.Namespace, c.PipelineClientSet)
 				if err != nil {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -321,18 +322,18 @@ func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
 
 // GetPipelineConditionStatus will return the Condition that the PipelineRun prName should be
 // updated with, based on the status of the TaskRuns in state.
-func (facts *PipelineRunFacts) GetPipelineConditionStatus(pr *v1beta1.PipelineRun, logger *zap.SugaredLogger) *apis.Condition {
+func (facts *PipelineRunFacts) GetPipelineConditionStatus(ctx context.Context, pr *v1beta1.PipelineRun, logger *zap.SugaredLogger) *apis.Condition {
 	// We have 4 different states here:
 	// 1. Timed out -> Failed
 	// 2. All tasks are done and at least one has failed or has been cancelled -> Failed
 	// 3. All tasks are done or are skipped (i.e. condition check failed).-> Success
 	// 4. A Task or Condition is running right now or there are things left to run -> Running
-	if pr.HasTimedOut() {
+	if pr.HasTimedOut(ctx) {
 		return &apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionFalse,
 			Reason:  v1beta1.PipelineRunReasonTimedOut.String(),
-			Message: fmt.Sprintf("PipelineRun %q failed to finish within %q", pr.Name, pr.Spec.Timeout.Duration.String()),
+			Message: fmt.Sprintf("PipelineRun %q failed to finish within %q", pr.Name, pr.PipelineTimeout(ctx).String()),
 		}
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -1143,7 +1144,7 @@ func TestGetPipelineConditionStatus(t *testing.T) {
 				TasksGraph:      d,
 				FinalTasksGraph: dfinally,
 			}
-			c := facts.GetPipelineConditionStatus(pr, zap.NewNop().Sugar())
+			c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar())
 			wantCondition := &apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: tc.expectedStatus,
@@ -1285,7 +1286,7 @@ func TestGetPipelineConditionStatus_WithFinalTasks(t *testing.T) {
 				TasksGraph:      d,
 				FinalTasksGraph: df,
 			}
-			c := facts.GetPipelineConditionStatus(pr, zap.NewNop().Sugar())
+			c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar())
 			wantCondition := &apis.Condition{
 				Type:   apis.ConditionSucceeded,
 				Status: tc.expectedStatus,
@@ -1322,7 +1323,7 @@ func TestGetPipelineConditionStatus_PipelineTimeouts(t *testing.T) {
 		TasksGraph:      d,
 		FinalTasksGraph: &dag.Graph{},
 	}
-	c := facts.GetPipelineConditionStatus(pr, zap.NewNop().Sugar())
+	c := facts.GetPipelineConditionStatus(context.Background(), pr, zap.NewNop().Sugar())
 	if c.Status != corev1.ConditionFalse && c.Reason != v1beta1.PipelineRunReasonTimedOut.String() {
 		t.Fatalf("Expected to get status %s but got %s for state %v", corev1.ConditionFalse, c.Status, oneFinishedState)
 	}


### PR DESCRIPTION
# Changes

Prior to this change, the PipelineRun controller used only the deprecated field PipelineRun.Spec.Timeout to determine if a
PipelineRun containing a custom Task had passed its timeout. This commit uses the appropriate PipelineRun timeout value,
whether from spec.Timeout, spec.Timeouts.Pipeline, or defaults.

This commit DOES NOT address any issues with how spec.Timeouts is used to determine the timeout of a TaskRun, Run,
or finally TaskRun (e.g. #4071). That logic will be addressed in a separate commit.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing (N/A)
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
[Bug fix]: Use pipeline.spec.timeouts.pipeline to determine pipeline timeout during custom task reconcile
```
