### PR TITLE
Refactor PipelineRun timeout logic

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -4007,6 +4007,28 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			},
 		},
 		expected: &metav1.Duration{Duration: 2 * time.Minute},
+	}, {
+		name: "tasks.timeout < pipeline.tasks[].timeout",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: baseObjectMeta(prName, ns),
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{Name: p},
+				Timeouts: &v1beta1.TimeoutFields{
+					Tasks: &metav1.Duration{Duration: 1 * time.Minute},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+		rprt: &resources.ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{
+				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
+			},
+		},
+		expected: &metav1.Duration{Duration: 1 * time.Minute},
 	},
 	}
 
@@ -4105,6 +4127,26 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 		},
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
 	}, {
+		name: "only timeouts.finally set",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: baseObjectMeta(prName, ns),
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{Name: p},
+				Timeouts: &v1beta1.TimeoutFields{
+					Finally: &metav1.Duration{Duration: 20 * time.Minute},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+		rprt: &resources.ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{},
+		},
+		expected: &metav1.Duration{Duration: 20 * time.Minute},
+	}, {
 		name: "40m timeout duration, 20m taskstimeout duration, 20m finallytimeout duration",
 		pr: &v1beta1.PipelineRun{
 			ObjectMeta: baseObjectMeta(prName, ns),
@@ -4126,6 +4168,48 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
+	}, {
+		name: "use pipeline.finally[].timeout",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: baseObjectMeta(prName, ns),
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{Name: p},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+		rprt: &resources.ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{
+				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
+			},
+		},
+		expected: &metav1.Duration{Duration: 2 * time.Minute},
+	}, {
+		name: "finally timeout < pipeline.finally[].timeout",
+		pr: &v1beta1.PipelineRun{
+			ObjectMeta: baseObjectMeta(prName, ns),
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{Name: p},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 40 * time.Minute},
+					Finally:  &metav1.Duration{Duration: 1 * time.Minute},
+				},
+			},
+			Status: v1beta1.PipelineRunStatus{
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: time.Now()},
+				},
+			},
+		},
+		rprt: &resources.ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{
+				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
+			},
+		},
+		expected: &metav1.Duration{Duration: 1 * time.Minute},
 	},
 	}
 


### PR DESCRIPTION
# Changes

This commit simplifies the logic used to determine the timeout of a new PipelineRun Task or finally Task.
It documents the behavior of existing functions and does not attempt to make large behavior changes;
however, it does fix three small bugs:
- getFinallyTaskRunTimeout would return 0 if only timeouts.finally (and not timeouts.pipeline) was set
- getTaskRunTimeout would return an incorrect result if tasks[].timeout > timeouts.tasks, and likewise for
getFinallyTaskRunTimeout
- pr.GetTimeout assumes that it is not possible for timeouts.tasks or timeouts.finally to be set when timeouts.pipeline is not set, but this assumption is not validated anywhere

It also adds test cases.
Further behavior changes/bug fixes will be in subsequent PRs.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
[Bug fix] Handle cases where PipelineRun task timeouts are greater than Pipeline.Timeouts.Task or Pipeline.Timeouts.Finally
```
