### PR TITLE
scripts: remove set -x by default 🧣

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -213,7 +213,7 @@ line will have the following default preamble prepended:
 
 ```bash
 #!/bin/sh
-set -xe
+set -e
 ```
 
 You can override this default preamble by prepending a shebang that specifies the desired parser.

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -34,7 +34,7 @@ const (
 	debugInfoVolumeName    = "tekton-internal-debug-info"
 	scriptsDir             = "/tekton/scripts"
 	debugScriptsDir        = "/tekton/debug/scripts"
-	defaultScriptPreamble  = "#!/bin/sh\nset -xe\n"
+	defaultScriptPreamble  = "#!/bin/sh\nset -e\n"
 	debugInfoDir           = "/tekton/debug/info"
 )
 

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -173,7 +173,7 @@ _EOF_
 scriptfile="/tekton/scripts/script-3-mssqb"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
-IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
+IyEvYmluL3NoCnNldCAtZQpuby1zaGViYW5n
 _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
@@ -268,14 +268,14 @@ _EOF_
 scriptfile="/tekton/scripts/script-3-mssqb"
 touch ${scriptfile} && chmod +x ${scriptfile}
 cat > ${scriptfile} << '_EOF_'
-IyEvYmluL3NoCnNldCAteGUKbm8tc2hlYmFuZw==
+IyEvYmluL3NoCnNldCAtZQpuby1zaGViYW5n
 _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 tmpfile="/tekton/debug/scripts/debug-continue"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'debug-continue-heredoc-randomly-generated-78c5n'
 #!/bin/sh
-set -xe
+set -e
 
 numberOfSteps=4
 debugInfo=/tekton/debug/info
@@ -297,7 +297,7 @@ tmpfile="/tekton/debug/scripts/debug-fail-continue"
 touch ${tmpfile} && chmod +x ${tmpfile}
 cat > ${tmpfile} << 'debug-fail-continue-heredoc-randomly-generated-6nl7g'
 #!/bin/sh
-set -xe
+set -e
 
 numberOfSteps=4
 debugInfo=/tekton/debug/info

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -184,7 +184,7 @@ spec:
 			if err != nil {
 				t.Fatalf("Error getting pod logs for pod `%s` and container `%s` in namespace `%s`", tr.Status.PodName, stat.Name, namespace)
 			}
-			if !strings.Contains(string(logContent), "echo Hello") {
+			if !strings.Contains(string(logContent), "Hello") {
 				t.Fatalf("Expected logs to say hello but received %v", logContent)
 			}
 		}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This remove the `-x` default flag on script that do not use a shebang.
The `-x` flag print commands before they are executed, which might
leak data by default that we might not want to, hence removing it by
default.

To "revert" to the previous behavior, one might need to add the
following to its Task's scripts.

```
script: |
  #!/bin/sh
  set -xe
  # […]
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>


Fixes #4444


/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Removed `-x` set flag from script that do not use a shebang, in order to reduce potential unwanted data leak from scripts execution.
```
