### PR TITLE
Add image replacement for amd64 specific image

### DIFF
--- a/test/multiarch_utils.go
+++ b/test/multiarch_utils.go
@@ -111,6 +111,7 @@ func imageNamesMapping() map[string]string {
 			"docker":                                "docker:18.06.3",
 			"mikefarah/yq:3":                        "danielxlee/yq:2.4.0",
 			"stedolan/jq":                           "ibmcom/jq-s390x:latest",
+			"amd64/ubuntu":                          "s390x/ubuntu",
 			"gcr.io/kaniko-project/executor:v1.3.0": getTestImage(kanikoImage),
 		}
 	case "ppc64le":


### PR DESCRIPTION
# Changes

In the TestExamples/v1beta1/taskruns/entrypoint-resolution test amd64/ubuntu image is used. The test fails for linux/s390x platform, because s390x specific image is required. 
The fix uses existing replacement logic to replace amd64/ubuntu to s390x/ubuntu for tests,
executed on linux/s390x platform.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
