### PR TITLE
git: Remove usage of git symbolic-ref.

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -119,12 +119,6 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 		logger.Warnf("Failed to set http.sslVerify in git config: %s", err)
 		return err
 	}
-	if spec.Revision == "" {
-		spec.Revision = "HEAD"
-		if _, err := run(logger, "", "symbolic-ref", spec.Revision, "refs/remotes/origin/HEAD"); err != nil {
-			return err
-		}
-	}
 
 	fetchArgs := []string{"fetch"}
 	if spec.Submodules {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Not 100% sure why we were doing this before, but as of
https://github.com/git/git/commit/9081a421a6dbeeda637df8edb0ebf0da11a05b69
this is causing Git to return this error when trying to call `git
checkout -f FETCH_HEAD`:

```
BUG: builtin/checkout.c:1102: should be able to skip past 'refs/heads/' in 'refs/remotes/origin/HEAD'!
```

IIUC, the symbolic-ref command isn't necessary so we can safely remove
it. Local HEAD will be set on the final `git checkout` call.

New command flow:

```
[git init /tmp/git-init-3587814010]
[git remote add origin /tmp/git-init-3399927535]
[git config http.sslVerify false]
[git fetch origin --force ]
[git show -q --pretty=format:%H FETCH_HEAD]
[git checkout -f FETCH_HEAD]
```

/kind bug

Fixes #4463 

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->


```release-note
NONE
```