### PR TITLE
Update hack scripts to shim temp GOPATH as needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ cmd/*/kodata/source.tar.gz
 test/pullrequest/pullrequest-init
 /.bin/
 /bin/
+
+# Temporary GOPATH used during code gen if user's Tekton checkout is
+# not already in GOPATH.
+.gopath

--- a/hack/setup-temporary-gopath.sh
+++ b/hack/setup-temporary-gopath.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+# Conditionally create a temporary GOPATH for codegen
+# and openapigen to execute in. This is only done if
+# the current repo directory is not within GOPATH.
+function shim_gopath() {
+  local REPO_DIR=$(git rev-parse --show-toplevel)
+  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  local TEMP_TEKTONCD="${TEMP_GOPATH}/src/github.com/tektoncd"
+  local TEMP_PIPELINE="${TEMP_TEKTONCD}/pipeline"
+  local NEEDS_MOVE=1
+
+  # Check if repo is in GOPATH already and return early if so.
+  # Unfortunately this doesn't respect a repo that's symlinked into
+  # GOPATH and will create a temporary anyway. I couldn't figure out
+  # a way to get the absolute path to the symlinked repo root.
+  if [ ! -z $GOPATH ] ; then
+    case $REPO_DIR/ in
+      $GOPATH/*) NEEDS_MOVE=0;;
+      *) NEEDS_MOVE=1;;
+    esac
+  fi
+
+  if [ $NEEDS_MOVE -eq 0 ]; then
+    return
+  fi
+
+  echo "You appear to be running from outside of GOPATH."
+  echo "This script will create a temporary GOPATH at $TEMP_GOPATH for code generation."
+
+  # Ensure that the temporary pipelines symlink doesn't exist
+  # before proceeding.
+  delete_pipeline_repo_symlink
+
+  mkdir -p "$TEMP_TEKTONCD"
+  # This will create a symlink from
+  # (repo-root)/.gopath/src/github.com/tektoncd/pipeline
+  # to the user's pipeline checkout.
+  ln -s "$REPO_DIR" "$TEMP_TEKTONCD"
+  echo "Moving to $TEMP_PIPELINE"
+  cd "$TEMP_PIPELINE"
+  export GOPATH="$TEMP_GOPATH"
+}
+
+# Helper that wraps deleting the temp pipelines repo symlink
+# and prints a message about deleting the temp GOPATH.
+#
+# Why doesn't this func just delete the temp GOPATH outright?
+# Because it might be reused across multiple hack scripts and many
+# packages seem to be installed into GOPATH with read-only
+# permissions, requiring sudo to delete the directory. Rather
+# than surprise the dev with a password entry at the end of the
+# script's execution we just print a message to let them know.
+function shim_gopath_clean() {
+  local REPO_DIR=$(git rev-parse --show-toplevel)
+  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  if [ -d "$TEMP_GOPATH" ] ; then
+    # Put the user back at the root of the pipelines repo
+    # after all the symlink shenanigans.
+    echo "Moving to $REPO_DIR"
+    cd "$REPO_DIR"
+    delete_pipeline_repo_symlink
+    echo "When you are finished with codegen you can safely run the following:"
+    echo "sudo rm -rf \".gopath\""
+   fi
+}
+
+# Delete the temp symlink to pipelines repo from the temp GOPATH dir.
+function delete_pipeline_repo_symlink() {
+  local REPO_DIR=$(git rev-parse --show-toplevel)
+  local TEMP_GOPATH="${REPO_DIR}/.gopath"
+  if [ -d "$TEMP_GOPATH" ] ; then
+    local REPO_SYMLINK="${TEMP_GOPATH}/src/github.com/tektoncd/pipeline"
+    if [ -L $REPO_SYMLINK ] ; then
+      echo "Deleting symlink to pipelines repo $REPO_SYMLINK"
+      rm -f "${REPO_SYMLINK}"
+    fi
+  fi
+}

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+source $(git rev-parse --show-toplevel)/hack/setup-temporary-gopath.sh
+shim_gopath
+trap shim_gopath_clean EXIT
+
 source $(git rev-parse --show-toplevel)/vendor/github.com/tektoncd/plumbing/scripts/library.sh
 
 PREFIX=${GOBIN:-${GOPATH}/bin}

--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -17,6 +17,10 @@
 set -o errexit
 set -o nounset
 
+source $(git rev-parse --show-toplevel)/hack/setup-temporary-gopath.sh
+shim_gopath
+trap shim_gopath_clean EXIT
+
 echo "Generating OpenAPI specification ..."
 go run k8s.io/kube-openapi/cmd/openapi-gen \
     --input-dirs ./pkg/apis/pipeline/v1beta1,./pkg/apis/pipeline/pod,./pkg/apis/resource/v1alpha1,knative.dev/pkg/apis,knative.dev/pkg/apis/duck/v1beta1 \
@@ -25,4 +29,3 @@ go run k8s.io/kube-openapi/cmd/openapi-gen \
 
 echo "Generating swagger file ..."
 go run hack/spec-gen/main.go v0.17.2 > pkg/apis/pipeline/v1beta1/swagger.json
-


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


When we run our codegen and openapigen scripts from a directory that is
not under GOPATH the generated output uses relative prefixes instead of
absolute prefixes.

The new hack/setup-temporary-gopath.sh script detects if the repo is not in
GOPATH and creates a temporary one under ".gopath" if so. codegen and
openapigen scripts now depend on setup-temporary-gopath.sh before
generating anything.

Fixes https://github.com/tektoncd/pipeline/issues/3884
Fixes https://github.com/tektoncd/pipeline/issues/4430

... for some definition of "fixes" ...

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```