### PR TITLE
Update docs to reflect resource requests of pods

### DIFF
--- a/docs/limitrange.md
+++ b/docs/limitrange.md
@@ -35,20 +35,21 @@ Resource types for both are:
 The next question is : how pods with resource and limits are run/scheduled ?
 The scheduler *computes* the amount of CPU and memory requests (using **Requests**) and tries to find a node to schedule it.
 
-Requests and limits can be applied to both Containers and Init Containers.
-- For init containers, the max of each type is taken
-- For containers, it sums all requests/limits for each containers
+A pod's [effective resource requests and limits](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources) are the higher of:
+- the sum of all app containers request/limit for a resource
+- the effective init request/limit for a resource
 
-This means, if you got the following:
--   initContainer1 : 1 CPU, 100m memory
--   initContainer2 : 2 CPU, 200m memory
--   container1 : 1 CPU, 50m memory
--   container2 : 2 CPU, 250m memory
--   container3 : 3 CPU, 500m memory
+For example, if you have the following requests:
+-   initContainer1 : 1 CPU, 100Mi memory
+-   initContainer2 : 2 CPU, 200Mi memory
+-   container1 : 1 CPU, 50Mi memory
+-   container2 : 2 CPU, 250Mi memory
+-   container3 : 3 CPU, 500Mi memory
 
 The computation will be:
--   CPU : 2 (max init containers) + 6 (sum of containers) = 8 CPU
--   Memory: 200m (max init containers) + 800m (sum of containers) = 1000m (1G)
+-   CPU : the max init container CPU is 2, and the sum of the container CPUs is 6. The resulting pod will use 6 CPUs, the max of the init container and container CPU values.
+-   Memory: the max init container memory is 200Mi, and the sum of the container memory requests is 800Mi.
+  The resulting pod will use 800Mi, the max of the init container and container memory values.
 
 ## Tekton support
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -163,15 +163,9 @@ The following requirements apply to each container image referenced in a `steps`
 
 - The container image must abide by the [container contract](./container-contract.md).
 - Each container image runs to completion or until the first failure occurs.
-- The CPU, memory, and ephemeral storage resource requests will be set
-  to zero (also known as
-  [BestEffort](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-besteffort)),
-  or, if specified, the minimums set through `LimitRanges` in that
-  `Namespace`, if the container image does not have the largest
-  resource request out of all container images in the `Task.` This
-  ensures that the Pod that executes the `Task` only requests enough
-  resources to run a single container image in the `Task` rather than
-  hoard resources for all container images in the `Task` at once.
+- The CPU, memory, and ephemeral storage resource requests set on `Step`s
+  will be adjusted to comply with any [`LimitRange`](https://kubernetes.io/docs/concepts/policy/limit-range/)s
+  present in the `Namespace`. For more detail, see [LimitRange support in Pipeline](./limitrange.md).
 
 Below is an example of setting the resource requests and limits for a step:
 


### PR DESCRIPTION
# Changes
Tekton previously modified step resource requests to request one large container (with the max resource request of any Step)
and resource requests of 0 in all other containers. This behavior was modified in v0.28.0 (#4176). Now, the Step resource requests are preserved
(unless any LimitRanges are present). This commit updates the documentation to reflect this change.

This commit also updates the description of how init container and container resource requests are combined to determine the resulting pod's
resource requests, based on [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources).

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
