### PR TITLE
Include Windows builds of cmd/nop in release process

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -103,8 +103,9 @@ spec:
       # This matches the value configured in .ko.yaml
       defaultBaseImage: gcr.io/distroless/static:nonroot
       baseImageOverrides:
-        # Use the combined base image for entrypoint.
+        # Use the combined base image for entrypoint and nop images.
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}
+        $(params.package)/cmd/nop: ${COMBINED_BASE_IMAGE}
 
         $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/git-init-build-base:latest
         # These match values configured in .ko.yaml


### PR DESCRIPTION
Fixes https://github.com/tektoncd/pipeline/issues/4471

# Changes

This uses the same multi-platform-and-multi-OS base image used for the `entrypoint` image to ensure that the `nop` image used for Affinity Assistant, etc., is also built for Windows.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Include Windows support for the nop image, to enable Affinity Assistant for Windows, and more.
```