### PR TITLE
Support workingDir init on Windows

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -57,6 +57,7 @@ func main() {
 	flag.StringVar(&opts.Images.GsutilImage, "gsutil-image", "", "The container image containing gsutil")
 	flag.StringVar(&opts.Images.PRImage, "pr-image", "", "The container image containing our PR binary.")
 	flag.StringVar(&opts.Images.ImageDigestExporterImage, "imagedigest-exporter-image", "", "The container image containing our image digest exporter binary.")
+	flag.StringVar(&opts.Images.WorkingDirInitImage, "workingdirinit-image", "", "The container image containing our working dir init binary.")
 
 	// This parses flags.
 	cfg := injection.ParseAndGetRESTConfigOrDie()

--- a/cmd/workingdirinit/main.go
+++ b/cmd/workingdirinit/main.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	for _, d := range os.Args {
+		p := filepath.Clean(d)
+		if !filepath.IsAbs(p) || strings.HasPrefix(p, "/workspace/") {
+			if err := os.MkdirAll(p, 0755); err != nil {
+				log.Fatalf("Failed to mkdir %q: %v", p, err)
+			}
+		}
+	}
+}

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -71,6 +71,7 @@ spec:
           "-nop-image", "ko://github.com/tektoncd/pipeline/cmd/nop",
           "-imagedigest-exporter-image", "ko://github.com/tektoncd/pipeline/cmd/imagedigestexporter",
           "-pr-image", "ko://github.com/tektoncd/pipeline/cmd/pullrequest-init",
+          "-workingdirinit-image", "ko://github.com/tektoncd/pipeline/cmd/workingdirinit",
 
           # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
           "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",

--- a/pkg/apis/pipeline/images.go
+++ b/pkg/apis/pipeline/images.go
@@ -42,6 +42,8 @@ type Images struct {
 	PRImage string
 	// ImageDigestExporterImage is the container image containing our image digest exporter binary.
 	ImageDigestExporterImage string
+	// WorkingDirInitImage is the container image containing our working dir init binary.
+	WorkingDirInitImage string
 
 	// NOTE: Make sure to add any new images to Validate below!
 }
@@ -61,6 +63,7 @@ func (i Images) Validate() error {
 		{i.GsutilImage, "gsutil-image"},
 		{i.PRImage, "pr-image"},
 		{i.ImageDigestExporterImage, "imagedigest-exporter-image"},
+		{i.WorkingDirInitImage, "workingdirinit-image"},
 	} {
 		if f.v == "" {
 			unset = append(unset, f.name)

--- a/pkg/apis/pipeline/images_test.go
+++ b/pkg/apis/pipeline/images_test.go
@@ -17,6 +17,7 @@ func TestValidate(t *testing.T) {
 		GsutilImage:              "set",
 		PRImage:                  "set",
 		ImageDigestExporterImage: "set",
+		WorkingDirInitImage:      "set",
 	}
 	if err := valid.Validate(); err != nil {
 		t.Errorf("valid Images returned error: %v", err)
@@ -33,7 +34,7 @@ func TestValidate(t *testing.T) {
 		PRImage:                  "", // unset!
 		ImageDigestExporterImage: "set",
 	}
-	wantErr := "found unset image flags: [git-image pr-image shell-image]"
+	wantErr := "found unset image flags: [git-image pr-image shell-image workingdirinit-image]"
 	if err := invalid.Validate(); err == nil {
 		t.Error("invalid Images expected error, got nil")
 	} else if err.Error() != wantErr {

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -156,7 +156,7 @@ func (b *Builder) Build(ctx context.Context, taskRun *v1beta1.TaskRun, taskSpec 
 	}
 
 	// Initialize any workingDirs under /workspace.
-	if workingDirInit := workingDirInit(b.Images.ShellImage, stepContainers); workingDirInit != nil {
+	if workingDirInit := workingDirInit(b.Images.WorkingDirInitImage, stepContainers); workingDirInit != nil {
 		initContainers = append(initContainers, *workingDirInit)
 	}
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -477,9 +477,9 @@ func TestPodBuild(t *testing.T) {
 				tektonDirInit(images.EntrypointImage, []v1beta1.Step{{Container: corev1.Container{Name: "name"}}}),
 				{
 					Name:         "working-dir-initializer",
-					Image:        images.ShellImage,
-					Command:      []string{"sh"},
-					Args:         []string{"-c", fmt.Sprintf("mkdir -p %s", filepath.Join(pipeline.WorkspaceDir, "test"))},
+					Image:        images.WorkingDirInitImage,
+					Command:      []string{"/ko-app/workingdirinit"},
+					Args:         []string{filepath.Join(pipeline.WorkspaceDir, "test")},
 					WorkingDir:   pipeline.WorkspaceDir,
 					VolumeMounts: implicitVolumeMounts,
 				},

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -31,7 +31,7 @@ import (
 //
 // If no such directories need to be created (i.e., no relative workingDirs
 // are specified), this method returns nil, as no init container is necessary.
-func workingDirInit(shellImage string, stepContainers []corev1.Container) *corev1.Container {
+func workingDirInit(workingdirinitImage string, stepContainers []corev1.Container) *corev1.Container {
 	// Gather all unique workingDirs.
 	workingDirs := sets.NewString()
 	for _, step := range stepContainers {
@@ -59,9 +59,9 @@ func workingDirInit(shellImage string, stepContainers []corev1.Container) *corev
 
 	return &corev1.Container{
 		Name:         "working-dir-initializer",
-		Image:        shellImage,
-		Command:      []string{"sh"},
-		Args:         []string{"-c", "mkdir -p " + strings.Join(relativeDirs, " ")},
+		Image:        workingdirinitImage,
+		Command:      []string{"/ko-app/workingdirinit"},
+		Args:         relativeDirs,
 		WorkingDir:   pipeline.WorkspaceDir,
 		VolumeMounts: implicitVolumeMounts,
 	}

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -57,15 +57,15 @@ func TestWorkingDirInit(t *testing.T) {
 		}},
 		want: &corev1.Container{
 			Name:         "working-dir-initializer",
-			Image:        images.ShellImage,
-			Command:      []string{"sh"},
-			Args:         []string{"-c", "mkdir -p /workspace/bbb aaa zzz"},
+			Image:        images.WorkingDirInitImage,
+			Command:      []string{"/ko-app/workingdirinit"},
+			Args:         []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:   pipeline.WorkspaceDir,
 			VolumeMounts: implicitVolumeMounts,
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {
-			got := workingDirInit(images.ShellImage, c.stepContainers)
+			got := workingDirInit(images.WorkingDirInitImage, c.stepContainers)
 			if d := cmp.Diff(c.want, got); d != "" {
 				t.Fatalf("Diff %s", diff.PrintWantGot(d))
 			}

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -11,7 +11,7 @@ spec:
       default: github.com/tektoncd/pipeline
     - name: images
       description: List of cmd/* paths to be published as images
-      default: "controller webhook entrypoint nop kubeconfigwriter git-init imagedigestexporter pullrequest-init"
+      default: "controller webhook entrypoint nop kubeconfigwriter git-init imagedigestexporter pullrequest-init workingdirinit"
     - name: versionTag
       description: The vX.Y.Z version that the artifacts should be tagged with (including `v`)
     - name: imageRegistry
@@ -103,9 +103,10 @@ spec:
       # This matches the value configured in .ko.yaml
       defaultBaseImage: gcr.io/distroless/static:nonroot
       baseImageOverrides:
-        # Use the combined base image for entrypoint and nop images.
+        # Use the combined base image for images that should include Windows support.
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/nop: ${COMBINED_BASE_IMAGE}
+        $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
 
         $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/git-init-build-base:latest
         # These match values configured in .ko.yaml


### PR DESCRIPTION
Previously, we used --shell-image (typically distroless/base) to invoke
`mkdir -p <dirs>` to initialize any working dirs that were needed by
steps in a TaskRun.

This isn't portable to Windows, since distroless/base doesn't provide
Windows images, and since invoking `mkdir -p` won't work on Windows.

Instead, with this change, we init working dirs using a very simple Go
binary that can be cross-compiled to run on both OSes.

Fixes https://github.com/tektoncd/pipeline/issues/4473

cc @lippertmarkus 

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
Working dir initialization is now done using a Go binary in a new container image included in the release, which makes it portable to run on Windows nodes.
```

