### PR TITLE
Clean up RunsToCompletion interface

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -152,11 +152,6 @@ func (pr *PipelineRun) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: pr.Namespace, Name: pr.Name}
 }
 
-// IsTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout
-func (pr *PipelineRun) IsTimedOut() bool {
-	return pr.HasTimedOut()
-}
-
 // HasTimedOut returns true if a pipelinerun has exceeded its spec.Timeout based on its status.Timeout
 func (pr *PipelineRun) HasTimedOut() bool {
 	pipelineTimeout := pr.Spec.Timeout

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -263,8 +263,8 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				}},
 			}
 
-			if pr.IsTimedOut() != tc.expected {
-				t.Fatalf("Expected isTimedOut to be %t", tc.expected)
+			if pr.HasTimedOut() != tc.expected {
+				t.Fatalf("Expected HasTimedOut to be %t", tc.expected)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -132,7 +132,7 @@ func (trs *TaskRunStatus) GetStartedReason() string {
 }
 
 // GetRunningReason returns the reason set to the "Succeeded" condition when
-// the RunsToCompletion starts running. This is used indicate that the resource
+// the TaskRun starts running. This is used indicate that the resource
 // could be validated is starting to perform its job.
 func (trs *TaskRunStatus) GetRunningReason() string {
 	return TaskRunReasonRunning.String()

--- a/pkg/reconciler/events/cloudevent/interface.go
+++ b/pkg/reconciler/events/cloudevent/interface.go
@@ -31,6 +31,6 @@ type objectWithCondition interface {
 	// ObjectMetaAccessor requires a GetObjectMeta that returns the ObjectMeta
 	metav1.ObjectMetaAccessor
 
-	// GetStatusCondition returns a ConditionAccessor for the status of the RunsToCompletion
+	// GetStatusCondition returns a ConditionAccessor for the status of the objectWithCondition
 	GetStatusCondition() apis.ConditionAccessor
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -603,7 +603,7 @@ func (c *Reconciler) processRunTimeouts(ctx context.Context, pr *v1beta1.Pipelin
 	}
 	for _, rprt := range pipelineState {
 		if rprt.IsCustomTask() {
-			if rprt.Run != nil && !rprt.Run.IsCancelled() && (pr.IsTimedOut() || (rprt.Run.HasTimedOut() && !rprt.Run.IsDone())) {
+			if rprt.Run != nil && !rprt.Run.IsCancelled() && (pr.HasTimedOut() || (rprt.Run.HasTimedOut() && !rprt.Run.IsDone())) {
 				logger.Infof("Cancelling run task: %s due to timeout.", rprt.RunName)
 				err := cancelRun(ctx, rprt.RunName, pr.Namespace, c.PipelineClientSet)
 				if err != nil {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -327,7 +327,7 @@ func (facts *PipelineRunFacts) GetPipelineConditionStatus(pr *v1beta1.PipelineRu
 	// 2. All tasks are done and at least one has failed or has been cancelled -> Failed
 	// 3. All tasks are done or are skipped (i.e. condition check failed).-> Success
 	// 4. A Task or Condition is running right now or there are things left to run -> Running
-	if pr.IsTimedOut() {
+	if pr.HasTimedOut() {
 		return &apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionFalse,


### PR DESCRIPTION
# Changes

The RunsToCompletion interface was introduced so that PipelineRuns and Runs
could conform to a common interface for CloudEvents and subsequently removed (both in #2677).

This commit removes the redundant function PipelineRun.IsTimedOut (redundant with PipelineRun.HasTimedOut). PipelineRun.HasTimedOut was introduced so that PipelineRun would implement RunsToCompletion.
"HasTimedOut" was kept (as opposed to "IsTimedOut") for the sake of consistency with TaskRun and Run.

It also removes stale references to RunsToCompletion. No functional changes.
This PR moves cleanup code out of #4440.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
