### PR TITLE
Pass explicit platforms list when publishing images

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -136,9 +136,13 @@ spec:
           value: $(params.releaseAsLatest)
         - name: serviceAccountPath
           value: $(params.serviceAccountPath)
-        # NOTE: We're purposefully *not* passing the pipeline's platforms to
-        # this task. We want to use the task's default platforms, which include
-        # windows.
+        - name: platforms
+          # Important: This param value includes windows, which differs
+          # from the platforms param defined at the top of this release
+          # pipeline. The reason for this is that the build-images
+          # PipelineTask doesn't build the windows base image, but the
+          # publish-release PipelineTask does.
+          value: linux/amd64,linux/arm,linux/arm64,linux/s390x,linux/ppc64le,windows/amd64
       workspaces:
         - name: source
           workspace: workarea


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit the pipeline-release Pipeline relied on default
params to ensure that the publish-release task emits a windows
entrypoint image. It looks like this no longer works because the
dogfooding cluster is using alpha API fields, including implicit params.

With implicit params it is not possible to _skip_ a param in a PipelineTask if it
shares a name with a Param in the Pipeline. So before we were intentionally omitting the
platforms param and relying on the default param value in the
publish-release Task but with implicit params this is no longer
possible.

This commit overrides the param passed to publish-release with the full
string of platforms including windows. We don't want to update the
Pipeline's `platforms` param because our build-images
PipelineTask can't build the windows image. Confusing.

/kind bug


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```