### PR TITLE
Implicit params: only propagate params to embedded TaskSpecs in Pipelines.

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -41,32 +41,35 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	}
 	for i, pt := range ps.Tasks {
 		ctx := ctx // Ensure local scoping per Task
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = addContextParams(ctx, pt.Params)
-			ps.Tasks[i].Params = getContextParams(ctx, pt.Params...)
-		}
+
 		if pt.TaskRef != nil {
 			if pt.TaskRef.Kind == "" {
 				pt.TaskRef.Kind = NamespacedTaskKind
 			}
 		}
 		if pt.TaskSpec != nil {
+			// Only propagate param context to the spec - ref params should
+			// still be explicitly set.
+			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+				ctx = addContextParams(ctx, pt.Params)
+				ps.Tasks[i].Params = getContextParams(ctx, pt.Params...)
+			}
 			pt.TaskSpec.SetDefaults(ctx)
 		}
 	}
 
 	for i, ft := range ps.Finally {
 		ctx := ctx // Ensure local scoping per Task
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = addContextParams(ctx, ft.Params)
-			ps.Finally[i].Params = getContextParams(ctx, ft.Params...)
-		}
 		if ft.TaskRef != nil {
 			if ft.TaskRef.Kind == "" {
 				ft.TaskRef.Kind = NamespacedTaskKind
 			}
 		}
 		if ft.TaskSpec != nil {
+			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+				ctx = addContextParams(ctx, ft.Params)
+				ps.Finally[i].Params = getContextParams(ctx, ft.Params...)
+			}
 			ft.TaskSpec.SetDefaults(ctx)
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -107,11 +107,30 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 					},
 				},
 				PipelineSpec: &v1beta1.PipelineSpec{
-					Tasks: []v1beta1.PipelineTask{{
-						TaskSpec: &v1beta1.EmbeddedTask{
-							TaskSpec: v1beta1.TaskSpec{},
+					Tasks: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{},
+							},
 						},
-					}},
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+							},
+						},
+					},
+					Finally: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{},
+							},
+						},
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+							},
+						},
+					},
 				},
 			},
 			want: &v1beta1.PipelineRunSpec{
@@ -132,38 +151,86 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 					},
 				},
 				PipelineSpec: &v1beta1.PipelineSpec{
-					Tasks: []v1beta1.PipelineTask{{
-						TaskSpec: &v1beta1.EmbeddedTask{
-							TaskSpec: v1beta1.TaskSpec{
-								Params: []v1beta1.ParamSpec{
-									{
-										Name: "foo",
-										Type: v1beta1.ParamTypeString,
+					Tasks: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{
+									Params: []v1beta1.ParamSpec{
+										{
+											Name: "foo",
+											Type: v1beta1.ParamTypeString,
+										},
+										{
+											Name: "bar",
+											Type: v1beta1.ParamTypeArray,
+										},
 									},
-									{
-										Name: "bar",
-										Type: v1beta1.ParamTypeArray,
+								},
+							},
+							Params: []v1beta1.Param{
+								{
+									Name: "foo",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(params.foo)",
+									},
+								},
+								{
+									Name: "bar",
+									Value: v1beta1.ArrayOrString{
+										Type:     v1beta1.ParamTypeArray,
+										ArrayVal: []string{"$(params.bar[*])"},
 									},
 								},
 							},
 						},
-						Params: []v1beta1.Param{
-							{
-								Name: "foo",
-								Value: v1beta1.ArrayOrString{
-									Type:      v1beta1.ParamTypeString,
-									StringVal: "$(params.foo)",
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+								Kind: v1beta1.NamespacedTaskKind,
+							},
+						},
+					},
+					Finally: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{
+									Params: []v1beta1.ParamSpec{
+										{
+											Name: "foo",
+											Type: v1beta1.ParamTypeString,
+										},
+										{
+											Name: "bar",
+											Type: v1beta1.ParamTypeArray,
+										},
+									},
 								},
 							},
-							{
-								Name: "bar",
-								Value: v1beta1.ArrayOrString{
-									Type:     v1beta1.ParamTypeArray,
-									ArrayVal: []string{"$(params.bar[*])"},
+							Params: []v1beta1.Param{
+								{
+									Name: "foo",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(params.foo)",
+									},
+								},
+								{
+									Name: "bar",
+									Value: v1beta1.ArrayOrString{
+										Type:     v1beta1.ParamTypeArray,
+										ArrayVal: []string{"$(params.bar[*])"},
+									},
 								},
 							},
 						},
-					}},
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+								Kind: v1beta1.NamespacedTaskKind,
+							},
+						},
+					},
 					Params: []v1beta1.ParamSpec{
 						{
 							Name: "foo",
@@ -186,13 +253,16 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 			}
 			tc.prs.SetDefaults(ctx)
 
-			sortPS := func(x, y v1beta1.ParamSpec) bool {
+			sortParamSpecs := func(x, y v1beta1.ParamSpec) bool {
 				return x.Name < y.Name
 			}
-			sortP := func(x, y v1beta1.Param) bool {
+			sortParams := func(x, y v1beta1.Param) bool {
 				return x.Name < y.Name
 			}
-			if d := cmp.Diff(tc.want, tc.prs, cmpopts.SortSlices(sortPS), cmpopts.SortSlices(sortP)); d != "" {
+			sortTasks := func(x, y v1beta1.PipelineTask) bool {
+				return x.Name < y.Name
+			}
+			if d := cmp.Diff(tc.want, tc.prs, cmpopts.SortSlices(sortParamSpecs), cmpopts.SortSlices(sortParams), cmpopts.SortSlices(sortTasks)); d != "" {
 				t.Errorf("Mismatch of PipelineRunSpec %s", diff.PrintWantGot(d))
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously we were appling the params to all PipelineTasks, including
refs. This is incorrect behavior since the parameters should only be
propagated to things within the same document.

Fixes #4483 

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-notes
[alpha only] Fixes bug where implicit params were erroneously passed to TaskRefs within ParamSpecs.
```
