### PR TITLE
Drop minishift instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -109,7 +109,6 @@ for more information.
    uses the default `system:admin` user:
 
    ```bash
-   # For MiniShift: oc login -u admin:admin
    oc login -u system:admin
    ```
 


### PR DESCRIPTION
# Changes

This commit drops instructions for minishift since it's not in active development anymore and has been replaced by CRC which does not need any specific instructions. See https://github.com/minishift/minishift#welcome-to-minishift.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

```release-note
NONE
```

ping @vdemeester, WDYT?