### PR TITLE
Fix incorrect format specifier in test files

### DIFF
--- a/test/remote_test.go
+++ b/test/remote_test.go
@@ -47,28 +47,28 @@ metadata:
 
 	ref, err := CreateImage(u.Host+"/task/test-create-image", task)
 	if err != nil {
-		t.Errorf("uploading image failed unexpectedly with an error: %w", err)
+		t.Errorf("uploading image failed unexpectedly with an error: %v", err)
 	}
 
 	// Pull the image and ensure the layers are composed correctly.
 	imgRef, err := name.ParseReference(ref)
 	if err != nil {
-		t.Errorf("digest %s is not a valid reference: %w", ref, err)
+		t.Errorf("digest %s is not a valid reference: %v", ref, err)
 	}
 
 	img, err := remote.Image(imgRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
-		t.Errorf("could not fetch created image: %w", err)
+		t.Errorf("could not fetch created image: %v", err)
 	}
 
 	m, err := img.Manifest()
 	if err != nil {
-		t.Errorf("failed to fetch img manifest: %w", err)
+		t.Errorf("failed to fetch img manifest: %v", err)
 	}
 
 	layers, err := img.Layers()
 	if err != nil || len(layers) != 1 {
-		t.Errorf("img layers were incorrect. Num Layers: %d. Err: %w", len(layers), err)
+		t.Errorf("img layers were incorrect. Num Layers: %d. Err: %v", len(layers), err)
 	}
 
 	if diff := cmp.Diff(m.Layers[0].Annotations[tkremote.TitleAnnotation], "test-create-image"); diff != "" {
@@ -84,19 +84,19 @@ metadata:
 	// Read the layer's contents and ensure it matches the task we uploaded.
 	rc, err := layers[0].Uncompressed()
 	if err != nil {
-		t.Errorf("layer contents were corrupted: %w", err)
+		t.Errorf("layer contents were corrupted: %v", err)
 	}
 	defer rc.Close()
 
 	reader := tar.NewReader(rc)
 	header, err := reader.Next()
 	if err != nil {
-		t.Errorf("failed to load tar bundle: %w", err)
+		t.Errorf("failed to load tar bundle: %v", err)
 	}
 
 	actual := make([]byte, header.Size)
 	if _, err := reader.Read(actual); err != nil && err != io.EOF {
-		t.Errorf("failed to read contents of tar bundle: %w", err)
+		t.Errorf("failed to read contents of tar bundle: %v", err)
 	}
 
 	raw, err := yaml.Marshal(task)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit the unit tests of [remote_test.go](https://github.com/tektoncd/pipeline/blob/main/test/remote_test.go) will fail in Go 1.18. 
error log:
```
# github.com/tektoncd/pipeline/test
test/remote_test.go:50:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:56:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:61:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:66:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:71:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:87:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:94:3: (*testing.common).Errorf does not support error-wrapping directive %w
test/remote_test.go:99:3: (*testing.common).Errorf does not support error-wrapping directive %w

FAIL    github.com/tektoncd/pipeline/test [build failed]
```

Related issues:

- https://github.com/golang/go/issues/47641
- https://github.com/kubernetes/kubernetes/issues/105097

This commit converts all the %w in [ remote_test.go](https://github.com/tektoncd/pipeline/blob/main/test/remote_test.go) to %v to fix failing tests.

Please let me know if this makes sense or you have better ideas. Thanks in advance!


<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```