### PR TITLE
Revert 49a7fa to remove fake AWS creds

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -93,17 +93,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # These phony AWS credentials are here to work around a bug in the aws go sdk
-        # that causes extremely long delays in the execution of tasks after the initial
-        # deployment of the Tekton Pipelines controller. See issue https://github.com/tektoncd/pipeline/issues/4087
-        # for more information.
-        - name: AWS_ACCESS_KEY_ID
-          value: foobarbaz
-        - name: AWS_SECRET_ACCESS_KEY
-          value: foobarbaz
-        - name: AWS_DEFAULT_REGION
-          value: foobarbaz
-
         # If you are changing these names, you will also need to update
         # the controller's Role in 200-role.yaml to include the new
         # values in the "configmaps" "get" rule.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I tested the changes @ImJasonH made in adf030 without these fake aws
credentials and it does appear that the ten minute slow down we were
observing in https://github.com/tektoncd/pipeline/issues/4087 is fixed.

This PR backs out the phony AWS creds that were in place on the
controller to work around long delays on initial image fetches for
entrypoint lookup (and bundles) related to k8schain.

Closes https://github.com/tektoncd/pipeline/issues/4087

/kind misc 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
The pipelines controller config previously included AWS environment variables as a workaround for a performance-related issue. The underlying issue appears to be fixed and so the environment variables have been removed from the controller.
```