### PR TITLE
Update the release notes to describe kustomize usage

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -92,7 +92,17 @@ Install Task from plumbing too:
 # Apply the Tasks we are using from the catalog
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-build/0.3/golang-build.yaml
 kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/golang-test/0.2/golang-test.yaml
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/plumbing/main/tekton/resources/release/
+
+# Apply Tasks and other resources from Plumbing.
+#
+# If you want to install everything, including tekton-nightly components,
+# run this command from the root of the plumbing repo (this requires
+# "tekton-nightly" namespace to already be created in your cluster):
+kubectl kustomize ./tekton/resources/release | kubectl apply -f -
+
+# If you don't want the tekton-nightly components then run the following
+# command from the root of the plumbing repo:
+kubectl kustomize ./tekton/resources/release/overlay/default | kubectl apply -f -
 ```
 
 Apply the tasks from the `pipeline` repo:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit our release notes asked the user to `kubectl apply`
all the resources from a subdirectory of the plumbing repo. The plumbing
repo was updated to use kustomize a while ago, so these notes also
needed an update.

This commit adds instructions for piping kustomize output to an
invocation of kubectl apply.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
