### PR TITLE
Update Dockerfiles using golang images to Go 1.16.13

### DIFF
--- a/images/windows/entrypoint/Dockerfile
+++ b/images/windows/entrypoint/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
 
-FROM golang:1.16.4 AS builder
+FROM golang:1.16.13 AS builder
 
 COPY . c:/gopath/src/github.com/tektoncd/pipeline
 

--- a/images/windows/nop/Dockerfile
+++ b/images/windows/nop/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
 
-FROM golang:1.16.4 AS builder
+FROM golang:1.16.13 AS builder
 
 COPY . c:/gopath/src/github.com/tektoncd/pipeline
 


### PR DESCRIPTION
# Changes

Prior to this commit the Dockerfiles for windows images relied on an
older version of the official golang images.

This PR updates the windows images to use Go 1.16.13.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Updated windows images to use golang 1.16.13
```
