### PR TITLE
Cherry-picks for Release v0.28.3

### DIFF
--- a/images/windows/entrypoint/Dockerfile
+++ b/images/windows/entrypoint/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
 
-FROM golang:1.16.4 AS builder
+FROM golang:1.16.13 AS builder
 
 COPY . c:/gopath/src/github.com/tektoncd/pipeline
 

--- a/images/windows/nop/Dockerfile
+++ b/images/windows/nop/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
 
-FROM golang:1.16.4 AS builder
+FROM golang:1.16.13 AS builder
 
 COPY . c:/gopath/src/github.com/tektoncd/pipeline
 

--- a/pkg/apis/pipeline/v1beta1/implicit_params_test.go
+++ b/pkg/apis/pipeline/v1beta1/implicit_params_test.go
@@ -1,0 +1,473 @@
+package v1beta1_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+var (
+	cmpOptions = []cmp.Option{
+		cmpopts.SortSlices(func(x, y v1beta1.ParamSpec) bool {
+			return x.Name < y.Name
+		}),
+		cmpopts.SortSlices(func(x, y v1beta1.Param) bool {
+			return x.Name < y.Name
+		}),
+		cmpopts.SortSlices(func(x, y v1beta1.PipelineTask) bool {
+			return x.Name < y.Name
+		}),
+	}
+)
+
+func TestImplicitParams(t *testing.T) {
+	// Configure alpha API config.
+	ctx := context.Background()
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+
+	ctxs := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{
+			name: "direct implicit context",
+			ctx:  v1beta1.WithImplicitParamsEnabled(ctx, true),
+		},
+		{
+			name: "alpha context",
+			ctx:  config.ToContext(ctx, cfg),
+		},
+	}
+
+	for _, tctx := range ctxs {
+		t.Run(tctx.name, func(t *testing.T) {
+			for _, tc := range []struct {
+				// Expect in and want to be the same type.
+				in   apis.Defaultable
+				want interface{}
+			}{
+				// This data needs to be inlined to ensure unique copies on each test.
+				{
+					in: &v1beta1.PipelineRunSpec{
+						Params: []v1beta1.Param{
+							{
+								Name: "foo",
+								Value: v1beta1.ArrayOrString{
+									StringVal: "a",
+								},
+							},
+							{
+								Name: "bar",
+								Value: v1beta1.ArrayOrString{
+									ArrayVal: []string{"b"},
+								},
+							},
+						},
+						PipelineSpec: &v1beta1.PipelineSpec{
+							Tasks: []v1beta1.PipelineTask{
+								{
+									TaskSpec: &v1beta1.EmbeddedTask{
+										TaskSpec: v1beta1.TaskSpec{},
+									},
+								},
+								{
+									TaskRef: &v1beta1.TaskRef{
+										Name: "baz",
+									},
+								},
+							},
+							Finally: []v1beta1.PipelineTask{
+								{
+									TaskSpec: &v1beta1.EmbeddedTask{
+										TaskSpec: v1beta1.TaskSpec{},
+									},
+								},
+								{
+									TaskRef: &v1beta1.TaskRef{
+										Name: "baz",
+									},
+								},
+							},
+						},
+					},
+					want: &v1beta1.PipelineRunSpec{
+						ServiceAccountName: config.DefaultServiceAccountValue,
+						Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+						Params: []v1beta1.Param{
+							{
+								Name: "foo",
+								Value: v1beta1.ArrayOrString{
+									StringVal: "a",
+								},
+							},
+							{
+								Name: "bar",
+								Value: v1beta1.ArrayOrString{
+									ArrayVal: []string{"b"},
+								},
+							},
+						},
+						PipelineSpec: &v1beta1.PipelineSpec{
+							Tasks: []v1beta1.PipelineTask{
+								{
+									TaskSpec: &v1beta1.EmbeddedTask{
+										TaskSpec: v1beta1.TaskSpec{
+											Params: []v1beta1.ParamSpec{
+												{
+													Name: "foo",
+													Type: v1beta1.ParamTypeString,
+												},
+												{
+													Name: "bar",
+													Type: v1beta1.ParamTypeArray,
+												},
+											},
+										},
+									},
+									Params: []v1beta1.Param{
+										{
+											Name: "foo",
+											Value: v1beta1.ArrayOrString{
+												Type:      v1beta1.ParamTypeString,
+												StringVal: "$(params.foo)",
+											},
+										},
+										{
+											Name: "bar",
+											Value: v1beta1.ArrayOrString{
+												Type:     v1beta1.ParamTypeArray,
+												ArrayVal: []string{"$(params.bar[*])"},
+											},
+										},
+									},
+								},
+								{
+									TaskRef: &v1beta1.TaskRef{
+										Name: "baz",
+										Kind: v1beta1.NamespacedTaskKind,
+									},
+								},
+							},
+							Finally: []v1beta1.PipelineTask{
+								{
+									TaskSpec: &v1beta1.EmbeddedTask{
+										TaskSpec: v1beta1.TaskSpec{
+											Params: []v1beta1.ParamSpec{
+												{
+													Name: "foo",
+													Type: v1beta1.ParamTypeString,
+												},
+												{
+													Name: "bar",
+													Type: v1beta1.ParamTypeArray,
+												},
+											},
+										},
+									},
+									Params: []v1beta1.Param{
+										{
+											Name: "foo",
+											Value: v1beta1.ArrayOrString{
+												Type:      v1beta1.ParamTypeString,
+												StringVal: "$(params.foo)",
+											},
+										},
+										{
+											Name: "bar",
+											Value: v1beta1.ArrayOrString{
+												Type:     v1beta1.ParamTypeArray,
+												ArrayVal: []string{"$(params.bar[*])"},
+											},
+										},
+									},
+								},
+								{
+									TaskRef: &v1beta1.TaskRef{
+										Name: "baz",
+										Kind: v1beta1.NamespacedTaskKind,
+									},
+								},
+							},
+							Params: []v1beta1.ParamSpec{
+								{
+									Name: "foo",
+									Type: v1beta1.ParamTypeString,
+								},
+								{
+									Name: "bar",
+									Type: v1beta1.ParamTypeArray,
+								},
+							},
+						},
+					},
+				},
+				{
+					in: &v1beta1.TaskRunSpec{
+						TaskSpec: &v1beta1.TaskSpec{},
+						Params: []v1beta1.Param{
+							{
+								Name: "string-param",
+								Value: v1beta1.ArrayOrString{
+									StringVal: "a",
+								},
+							},
+							{
+								Name: "array-param",
+								Value: v1beta1.ArrayOrString{
+									ArrayVal: []string{"b"},
+								},
+							},
+						},
+					},
+					want: &v1beta1.TaskRunSpec{
+						TaskSpec: &v1beta1.TaskSpec{
+							Params: []v1beta1.ParamSpec{
+								{
+									Name: "string-param",
+									Type: v1beta1.ParamTypeString,
+								},
+								{
+									Name: "array-param",
+									Type: v1beta1.ParamTypeArray,
+								},
+							},
+						},
+						Params: []v1beta1.Param{
+							{
+								Name: "string-param",
+								Value: v1beta1.ArrayOrString{
+									StringVal: "a",
+								},
+							},
+							{
+								Name: "array-param",
+								Value: v1beta1.ArrayOrString{
+									ArrayVal: []string{"b"},
+								},
+							},
+						},
+						ServiceAccountName: config.DefaultServiceAccountValue,
+						Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+					},
+				},
+			} {
+				t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
+					tc.in.SetDefaults(tctx.ctx)
+
+					if d := cmp.Diff(tc.want, tc.in, cmpOptions...); d != "" {
+						t.Error(diff.PrintWantGot(d))
+					}
+				})
+			}
+		})
+	}
+}
+
+// Pipelines have different behavior than PipelineRuns/TaskRuns - break this into its own test.
+func TestImplicitParams_Pipeline(t *testing.T) {
+	pipeline := &v1beta1.PipelineSpec{
+		Params: []v1beta1.ParamSpec{
+			{
+				Name: "foo",
+				Type: v1beta1.ParamTypeString,
+			},
+			{
+				Name: "bar",
+				Type: v1beta1.ParamTypeArray,
+			},
+		},
+		Tasks: []v1beta1.PipelineTask{
+			{
+				TaskSpec: &v1beta1.EmbeddedTask{
+					TaskSpec: v1beta1.TaskSpec{},
+				},
+			},
+			{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "baz",
+				},
+			},
+		},
+		Finally: []v1beta1.PipelineTask{
+			{
+				TaskSpec: &v1beta1.EmbeddedTask{
+					TaskSpec: v1beta1.TaskSpec{},
+				},
+			},
+			{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "baz",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	// When only alpha flag is enabled, this should not apply implicit params.
+	t.Run("alpha context", func(t *testing.T) {
+		cfg := config.FromContextOrDefaults(ctx)
+		cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+		config.ToContext(ctx, cfg)
+
+		p := pipeline.DeepCopy()
+		p.SetDefaults(ctx)
+
+		want := &v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{
+					Name: "foo",
+					Type: v1beta1.ParamTypeString,
+				},
+				{
+					Name: "bar",
+					Type: v1beta1.ParamTypeArray,
+				},
+			},
+			Tasks: []v1beta1.PipelineTask{
+				{
+					TaskSpec: &v1beta1.EmbeddedTask{
+						TaskSpec: v1beta1.TaskSpec{},
+					},
+				},
+				{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "baz",
+						Kind: v1beta1.NamespacedTaskKind,
+					},
+				},
+			},
+			Finally: []v1beta1.PipelineTask{
+				{
+					TaskSpec: &v1beta1.EmbeddedTask{
+						TaskSpec: v1beta1.TaskSpec{},
+					},
+				},
+				{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "baz",
+						Kind: v1beta1.NamespacedTaskKind,
+					},
+				},
+			},
+		}
+
+		if d := cmp.Diff(want, p, cmpOptions...); d != "" {
+			t.Error(diff.PrintWantGot(d))
+		}
+	})
+
+	// When the Implicit Param context value is set directly, implicit param
+	// behavior should be enabled.
+	t.Run("direct implicit context", func(t *testing.T) {
+		p := pipeline.DeepCopy()
+		p.SetDefaults(v1beta1.WithImplicitParamsEnabled(ctx, true))
+
+		want := &v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{
+					Name: "foo",
+					Type: v1beta1.ParamTypeString,
+				},
+				{
+					Name: "bar",
+					Type: v1beta1.ParamTypeArray,
+				},
+			},
+			Tasks: []v1beta1.PipelineTask{
+				{
+					Params: []v1beta1.Param{
+						{
+							Name: "foo",
+							Value: v1beta1.ArrayOrString{
+								Type:      v1beta1.ParamTypeString,
+								StringVal: "$(params.foo)",
+							},
+						},
+						{
+							Name: "bar",
+							Value: v1beta1.ArrayOrString{
+								Type:     v1beta1.ParamTypeArray,
+								ArrayVal: []string{"$(params.bar[*])"},
+							},
+						},
+					},
+					TaskSpec: &v1beta1.EmbeddedTask{
+						TaskSpec: v1beta1.TaskSpec{
+							Params: []v1beta1.ParamSpec{
+								{
+									Name: "foo",
+									Type: v1beta1.ParamTypeString,
+								},
+								{
+									Name: "bar",
+									Type: v1beta1.ParamTypeArray,
+								},
+							},
+						},
+					},
+				},
+				{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "baz",
+						Kind: v1beta1.NamespacedTaskKind,
+					},
+				},
+			},
+			Finally: []v1beta1.PipelineTask{
+				{
+					Params: []v1beta1.Param{
+						{
+							Name: "foo",
+							Value: v1beta1.ArrayOrString{
+								Type:      v1beta1.ParamTypeString,
+								StringVal: "$(params.foo)",
+							},
+						},
+						{
+							Name: "bar",
+							Value: v1beta1.ArrayOrString{
+								Type:     v1beta1.ParamTypeArray,
+								ArrayVal: []string{"$(params.bar[*])"},
+							},
+						},
+					},
+					TaskSpec: &v1beta1.EmbeddedTask{
+						TaskSpec: v1beta1.TaskSpec{
+							Params: []v1beta1.ParamSpec{
+								{
+									Name: "foo",
+									Type: v1beta1.ParamTypeString,
+								},
+								{
+									Name: "bar",
+									Type: v1beta1.ParamTypeArray,
+								},
+							},
+						},
+					},
+				},
+				{
+					TaskRef: &v1beta1.TaskRef{
+						Name: "baz",
+						Kind: v1beta1.NamespacedTaskKind,
+					},
+				},
+			},
+		}
+
+		if d := cmp.Diff(want, p, cmpOptions...); d != "" {
+			t.Error(diff.PrintWantGot(d))
+		}
+	})
+}

--- a/pkg/apis/pipeline/v1beta1/param_context.go
+++ b/pkg/apis/pipeline/v1beta1/param_context.go
@@ -17,14 +17,26 @@ package v1beta1
 import (
 	"context"
 	"fmt"
-
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 )
 
-// paramCtxKey is the unique identifier for referencing param information from
+// enableImplicitParamContextKeyType is the unique type for referencing whether
+// Implicit Param behavior is enabled for the given request context.
+// See [TEP-0023](https://github.com/tektoncd/community/blob/main/teps/0023-implicit-mapping.md).
+//
+// +k8s:openapi-gen=false
+type enableImplicitParamContextKeyType struct{}
+
+// paramCtxKey is the unique type for referencing param information from
 // a context.Context. See [context.Context.Value](https://pkg.go.dev/context#Context)
 // for more details.
-var paramCtxKey struct{}
+//
+// +k8s:openapi-gen=false
+type paramCtxKeyType struct{}
+
+var (
+	enableImplicitParamContextKey = enableImplicitParamContextKeyType{}
+	paramCtxKey                   = paramCtxKeyType{}
+)
 
 // paramCtxVal is the data type stored in the param context.
 // This maps param names -> ParamSpec.
@@ -37,7 +49,7 @@ func AddContextParams(ctx context.Context, in []Param) context.Context {
 		return ctx
 	}
 
-	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields != "alpha" {
+	if !GetImplicitParamsEnabled(ctx) {
 		return ctx
 	}
 
@@ -73,7 +85,7 @@ func AddContextParamSpec(ctx context.Context, in []ParamSpec) context.Context {
 		return ctx
 	}
 
-	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields != "alpha" {
+	if !GetImplicitParamsEnabled(ctx) {
 		return ctx
 	}
 
@@ -169,4 +181,22 @@ func GetContextParamSpecs(ctx context.Context) []ParamSpec {
 		})
 	}
 	return out
+}
+
+// WithImplicitParamsEnabled enables implicit parameter behavior for the
+// request context. If enabled, parameters will propagate down embedded request
+// objects (e.g. PipelineRun -> Pipeline -> Task, Pipeline -> Task,
+// TaskRun -> Task) during defaulting.
+func WithImplicitParamsEnabled(ctx context.Context, v bool) context.Context {
+	return context.WithValue(ctx, enableImplicitParamContextKey, v)
+}
+
+// GetImplicitParamsEnabled returns whether implicit parameters are enabled for
+// the given context.
+func GetImplicitParamsEnabled(ctx context.Context) bool {
+	v := ctx.Value(enableImplicitParamContextKey)
+	if v == nil {
+		return false
+	}
+	return v.(bool)
 }

--- a/pkg/apis/pipeline/v1beta1/param_context_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_context_test.go
@@ -20,13 +20,12 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 )
 
 func TestAddContextParams(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("no-alpha", func(t *testing.T) {
+	t.Run("not-enabled", func(t *testing.T) {
 		ctx := AddContextParams(ctx, []Param{{Name: "a"}})
 		if v := ctx.Value(paramCtxKey); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
@@ -34,9 +33,7 @@ func TestAddContextParams(t *testing.T) {
 	})
 
 	// Enable Alpha features.
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-	ctx = config.ToContext(ctx, cfg)
+	ctx = WithImplicitParamsEnabled(ctx, true)
 
 	// These test cases should run sequentially. Each step will modify the
 	// above context.
@@ -120,7 +117,7 @@ func TestAddContextParams(t *testing.T) {
 func TestAddContextParamSpec(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("no-alpha", func(t *testing.T) {
+	t.Run("not-enabled", func(t *testing.T) {
 		ctx := AddContextParamSpec(ctx, []ParamSpec{{Name: "a"}})
 		if v := ctx.Value(paramCtxKey); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
@@ -128,9 +125,7 @@ func TestAddContextParamSpec(t *testing.T) {
 	})
 
 	// Enable Alpha features.
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-	ctx = config.ToContext(ctx, cfg)
+	ctx = WithImplicitParamsEnabled(ctx, true)
 
 	// These test cases should run sequentially. Each step will modify the
 	// above context.
@@ -213,7 +208,7 @@ func TestGetContextParams(t *testing.T) {
 			Description: "racecar",
 		},
 	}
-	t.Run("no-alpha", func(t *testing.T) {
+	t.Run("not-enabled", func(t *testing.T) {
 		ctx := AddContextParamSpec(ctx, want)
 		if v := GetContextParamSpecs(ctx); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
@@ -221,9 +216,7 @@ func TestGetContextParams(t *testing.T) {
 	})
 
 	// Enable Alpha features.
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-	ctx = config.ToContext(ctx, cfg)
+	ctx = WithImplicitParamsEnabled(ctx, true)
 
 	ctx = AddContextParamSpec(ctx, want)
 
@@ -294,7 +287,7 @@ func TestGetContextParamSpecs(t *testing.T) {
 			Description: "racecar",
 		},
 	}
-	t.Run("no-alpha", func(t *testing.T) {
+	t.Run("not-enabled", func(t *testing.T) {
 		ctx := AddContextParamSpec(ctx, want)
 		if v := GetContextParamSpecs(ctx); v != nil {
 			t.Errorf("expected no param context values, got %v", v)
@@ -302,9 +295,7 @@ func TestGetContextParamSpecs(t *testing.T) {
 	})
 
 	// Enable Alpha features.
-	cfg := config.FromContextOrDefaults(ctx)
-	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-	ctx = config.ToContext(ctx, cfg)
+	ctx = WithImplicitParamsEnabled(ctx, true)
 
 	ctx = AddContextParamSpec(ctx, want)
 	got := GetContextParamSpecs(ctx)

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"knative.dev/pkg/apis"
 )
 
@@ -33,7 +32,7 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	for i := range ps.Params {
 		ps.Params[i].SetDefaults(ctx)
 	}
-	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+	if GetImplicitParamsEnabled(ctx) {
 		ctx = AddContextParamSpec(ctx, ps.Params)
 		ps.Params = GetContextParamSpecs(ctx)
 	}
@@ -47,9 +46,9 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 		if pt.TaskSpec != nil {
 			// Only propagate param context to the spec - ref params should
 			// still be explicitly set.
-			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-				ctx = addContextParams(ctx, pt.Params)
-				ps.Tasks[i].Params = getContextParams(ctx, pt.Params...)
+			if GetImplicitParamsEnabled(ctx) {
+				ctx = AddContextParams(ctx, pt.Params)
+				ps.Tasks[i].Params = GetContextParams(ctx, pt.Params...)
 			}
 			pt.TaskSpec.SetDefaults(ctx)
 		}
@@ -63,9 +62,9 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 			}
 		}
 		if ft.TaskSpec != nil {
-			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-				ctx = addContextParams(ctx, ft.Params)
-				ps.Finally[i].Params = getContextParams(ctx, ft.Params...)
+			if GetImplicitParamsEnabled(ctx) {
+				ctx = AddContextParams(ctx, ft.Params)
+				ps.Finally[i].Params = GetContextParams(ctx, ft.Params...)
 			}
 			ft.TaskSpec.SetDefaults(ctx)
 		}

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults.go
@@ -39,32 +39,34 @@ func (ps *PipelineSpec) SetDefaults(ctx context.Context) {
 	}
 	for i, pt := range ps.Tasks {
 		ctx := ctx // Ensure local scoping per Task
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = AddContextParams(ctx, pt.Params)
-			ps.Tasks[i].Params = GetContextParams(ctx, pt.Params...)
-		}
 		if pt.TaskRef != nil {
 			if pt.TaskRef.Kind == "" {
 				pt.TaskRef.Kind = NamespacedTaskKind
 			}
 		}
 		if pt.TaskSpec != nil {
+			// Only propagate param context to the spec - ref params should
+			// still be explicitly set.
+			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+				ctx = addContextParams(ctx, pt.Params)
+				ps.Tasks[i].Params = getContextParams(ctx, pt.Params...)
+			}
 			pt.TaskSpec.SetDefaults(ctx)
 		}
 	}
 
 	for i, ft := range ps.Finally {
 		ctx := ctx // Ensure local scoping per Task
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-			ctx = AddContextParams(ctx, ft.Params)
-			ps.Finally[i].Params = GetContextParams(ctx, ft.Params...)
-		}
 		if ft.TaskRef != nil {
 			if ft.TaskRef.Kind == "" {
 				ft.TaskRef.Kind = NamespacedTaskKind
 			}
 		}
 		if ft.TaskSpec != nil {
+			if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+				ctx = addContextParams(ctx, ft.Params)
+				ps.Finally[i].Params = getContextParams(ctx, ft.Params...)
+			}
 			ft.TaskSpec.SetDefaults(ctx)
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -32,6 +32,10 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 }
 
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+		ctx = WithImplicitParamsEnabled(ctx, true)
+	}
+
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil && prs.Timeouts == nil {
 		prs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
@@ -50,7 +54,7 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	prs.PodTemplate = mergePodTemplateWithDefault(prs.PodTemplate, defaultPodTemplate)
 
 	if prs.PipelineSpec != nil {
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+		if GetImplicitParamsEnabled(ctx) {
 			ctx = AddContextParams(ctx, prs.Params)
 		}
 		prs.PipelineSpec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults_test.go
@@ -35,10 +35,9 @@ import (
 
 func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 	cases := []struct {
-		desc  string
-		prs   *v1beta1.PipelineRunSpec
-		want  *v1beta1.PipelineRunSpec
-		ctxFn func(context.Context) context.Context
+		desc string
+		prs  *v1beta1.PipelineRunSpec
+		want *v1beta1.PipelineRunSpec
 	}{
 		{
 			desc: "timeout is nil",
@@ -85,173 +84,10 @@ func TestPipelineRunSpec_SetDefaults(t *testing.T) {
 				},
 			},
 		},
-		{
-			desc: "implicit params",
-			ctxFn: func(ctx context.Context) context.Context {
-				cfg := config.FromContextOrDefaults(ctx)
-				cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-				return config.ToContext(ctx, cfg)
-			},
-			prs: &v1beta1.PipelineRunSpec{
-				Params: []v1beta1.Param{
-					{
-						Name: "foo",
-						Value: v1beta1.ArrayOrString{
-							StringVal: "a",
-						},
-					},
-					{
-						Name: "bar",
-						Value: v1beta1.ArrayOrString{
-							ArrayVal: []string{"b"},
-						},
-					},
-				},
-				PipelineSpec: &v1beta1.PipelineSpec{
-					Tasks: []v1beta1.PipelineTask{
-						{
-							TaskSpec: &v1beta1.EmbeddedTask{
-								TaskSpec: v1beta1.TaskSpec{},
-							},
-						},
-						{
-							TaskRef: &v1beta1.TaskRef{
-								Name: "baz",
-							},
-						},
-					},
-					Finally: []v1beta1.PipelineTask{
-						{
-							TaskSpec: &v1beta1.EmbeddedTask{
-								TaskSpec: v1beta1.TaskSpec{},
-							},
-						},
-						{
-							TaskRef: &v1beta1.TaskRef{
-								Name: "baz",
-							},
-						},
-					},
-				},
-			},
-			want: &v1beta1.PipelineRunSpec{
-				ServiceAccountName: config.DefaultServiceAccountValue,
-				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-				Params: []v1beta1.Param{
-					{
-						Name: "foo",
-						Value: v1beta1.ArrayOrString{
-							StringVal: "a",
-						},
-					},
-					{
-						Name: "bar",
-						Value: v1beta1.ArrayOrString{
-							ArrayVal: []string{"b"},
-						},
-					},
-				},
-				PipelineSpec: &v1beta1.PipelineSpec{
-					Tasks: []v1beta1.PipelineTask{
-						{
-							TaskSpec: &v1beta1.EmbeddedTask{
-								TaskSpec: v1beta1.TaskSpec{
-									Params: []v1beta1.ParamSpec{
-										{
-											Name: "foo",
-											Type: v1beta1.ParamTypeString,
-										},
-										{
-											Name: "bar",
-											Type: v1beta1.ParamTypeArray,
-										},
-									},
-								},
-							},
-							Params: []v1beta1.Param{
-								{
-									Name: "foo",
-									Value: v1beta1.ArrayOrString{
-										Type:      v1beta1.ParamTypeString,
-										StringVal: "$(params.foo)",
-									},
-								},
-								{
-									Name: "bar",
-									Value: v1beta1.ArrayOrString{
-										Type:     v1beta1.ParamTypeArray,
-										ArrayVal: []string{"$(params.bar[*])"},
-									},
-								},
-							},
-						},
-						{
-							TaskRef: &v1beta1.TaskRef{
-								Name: "baz",
-								Kind: v1beta1.NamespacedTaskKind,
-							},
-						},
-					},
-					Finally: []v1beta1.PipelineTask{
-						{
-							TaskSpec: &v1beta1.EmbeddedTask{
-								TaskSpec: v1beta1.TaskSpec{
-									Params: []v1beta1.ParamSpec{
-										{
-											Name: "foo",
-											Type: v1beta1.ParamTypeString,
-										},
-										{
-											Name: "bar",
-											Type: v1beta1.ParamTypeArray,
-										},
-									},
-								},
-							},
-							Params: []v1beta1.Param{
-								{
-									Name: "foo",
-									Value: v1beta1.ArrayOrString{
-										Type:      v1beta1.ParamTypeString,
-										StringVal: "$(params.foo)",
-									},
-								},
-								{
-									Name: "bar",
-									Value: v1beta1.ArrayOrString{
-										Type:     v1beta1.ParamTypeArray,
-										ArrayVal: []string{"$(params.bar[*])"},
-									},
-								},
-							},
-						},
-						{
-							TaskRef: &v1beta1.TaskRef{
-								Name: "baz",
-								Kind: v1beta1.NamespacedTaskKind,
-							},
-						},
-					},
-					Params: []v1beta1.ParamSpec{
-						{
-							Name: "foo",
-							Type: v1beta1.ParamTypeString,
-						},
-						{
-							Name: "bar",
-							Type: v1beta1.ParamTypeArray,
-						},
-					},
-				},
-			},
-		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
-			if tc.ctxFn != nil {
-				ctx = tc.ctxFn(ctx)
-			}
 			tc.prs.SetDefaults(ctx)
 
 			sortParamSpecs := func(x, y v1beta1.ParamSpec) bool {

--- a/pkg/apis/pipeline/v1beta1/task_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/task_defaults.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	"context"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"knative.dev/pkg/apis"
 )
 
@@ -34,7 +33,7 @@ func (ts *TaskSpec) SetDefaults(ctx context.Context) {
 	for i := range ts.Params {
 		ts.Params[i].SetDefaults(ctx)
 	}
-	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+	if GetImplicitParamsEnabled(ctx) {
 		ctx = AddContextParamSpec(ctx, ts.Params)
 		ts.Params = GetContextParamSpecs(ctx)
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -45,6 +45,10 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 }
 
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
+	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+		ctx = WithImplicitParamsEnabled(ctx, true)
+	}
+
 	cfg := config.FromContextOrDefaults(ctx)
 	if trs.TaskRef != nil && trs.TaskRef.Kind == "" {
 		trs.TaskRef.Kind = NamespacedTaskKind
@@ -64,7 +68,7 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 
 	// If this taskrun has an embedded task, apply the usual task defaults
 	if trs.TaskSpec != nil {
-		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+		if GetImplicitParamsEnabled(ctx) {
 			ctx = AddContextParams(ctx, trs.Params)
 		}
 		trs.TaskSpec.SetDefaults(ctx)

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults_test.go
@@ -39,10 +39,9 @@ var (
 
 func TestTaskRunSpec_SetDefaults(t *testing.T) {
 	cases := []struct {
-		desc  string
-		trs   *v1beta1.TaskRunSpec
-		want  *v1beta1.TaskRunSpec
-		ctxFn func(context.Context) context.Context
+		desc string
+		trs  *v1beta1.TaskRunSpec
+		want *v1beta1.TaskRunSpec
 	}{{
 		desc: "taskref is nil",
 		trs: &v1beta1.TaskRunSpec{
@@ -119,79 +118,10 @@ func TestTaskRunSpec_SetDefaults(t *testing.T) {
 			ServiceAccountName: config.DefaultServiceAccountValue,
 			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 		},
-	}, {
-		desc: "implicit string param",
-		ctxFn: func(ctx context.Context) context.Context {
-			cfg := config.FromContextOrDefaults(ctx)
-			cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-			return config.ToContext(ctx, cfg)
-		},
-		trs: &v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{},
-			Params: []v1beta1.Param{{
-				Name: "param-name",
-				Value: v1beta1.ArrayOrString{
-					StringVal: "a",
-				},
-			}},
-		},
-		want: &v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Params: []v1beta1.ParamSpec{{
-					Name: "param-name",
-					Type: v1beta1.ParamTypeString,
-				}},
-			},
-			Params: []v1beta1.Param{{
-				Name: "param-name",
-				Value: v1beta1.ArrayOrString{
-					StringVal: "a",
-				},
-			}},
-			ServiceAccountName: config.DefaultServiceAccountValue,
-			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-		},
-	}, {
-		desc: "implicit array param",
-		ctxFn: func(ctx context.Context) context.Context {
-			cfg := config.FromContextOrDefaults(ctx)
-			cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-			return config.ToContext(ctx, cfg)
-		},
-		trs: &v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{},
-			Params: []v1beta1.Param{{
-				Name: "param-name",
-				Value: v1beta1.ArrayOrString{
-					Type:     v1beta1.ParamTypeArray,
-					ArrayVal: []string{"a"},
-				},
-			}},
-		},
-		want: &v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Params: []v1beta1.ParamSpec{{
-					Name: "param-name",
-					Type: v1beta1.ParamTypeArray,
-				}},
-			},
-			Params: []v1beta1.Param{{
-				Name: "param-name",
-				Value: v1beta1.ArrayOrString{
-					Type:     v1beta1.ParamTypeArray,
-					ArrayVal: []string{"a"},
-				},
-			}},
-			ServiceAccountName: config.DefaultServiceAccountValue,
-			Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-		},
 	}}
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := context.Background()
-			if tc.ctxFn != nil {
-				ctx = tc.ctxFn(ctx)
-			}
 			tc.trs.SetDefaults(ctx)
 
 			if d := cmp.Diff(tc.want, tc.trs); d != "" {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -367,25 +367,8 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	}
 
 	// Store the fetched PipelineSpec on the PipelineRun for auditing
-	if err := storePipelineSpec(ctx, pr, pipelineSpec); err != nil {
+	if err := storePipelineSpecAndMergeMeta(pr, pipelineSpec, pipelineMeta); err != nil {
 		logger.Errorf("Failed to store PipelineSpec on PipelineRun.Status for pipelinerun %s: %v", pr.Name, err)
-	}
-
-	// Propagate labels from Pipeline to PipelineRun.
-	if pr.ObjectMeta.Labels == nil {
-		pr.ObjectMeta.Labels = make(map[string]string, len(pipelineMeta.Labels)+1)
-	}
-	for key, value := range pipelineMeta.Labels {
-		pr.ObjectMeta.Labels[key] = value
-	}
-	pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = pipelineMeta.Name
-
-	// Propagate annotations from Pipeline to PipelineRun.
-	if pr.ObjectMeta.Annotations == nil {
-		pr.ObjectMeta.Annotations = make(map[string]string, len(pipelineMeta.Annotations))
-	}
-	for key, value := range pipelineMeta.Annotations {
-		pr.ObjectMeta.Annotations[key] = value
 	}
 
 	d, err := dag.Build(v1beta1.PipelineTaskList(pipelineSpec.Tasks), v1beta1.PipelineTaskList(pipelineSpec.Tasks).Deps())
@@ -1221,10 +1204,28 @@ func (c *Reconciler) makeConditionCheckContainer(ctx context.Context, rprt *reso
 	return &cc, err
 }
 
-func storePipelineSpec(ctx context.Context, pr *v1beta1.PipelineRun, ps *v1beta1.PipelineSpec) error {
+func storePipelineSpecAndMergeMeta(pr *v1beta1.PipelineRun, ps *v1beta1.PipelineSpec, meta *metav1.ObjectMeta) error {
 	// Only store the PipelineSpec once, if it has never been set before.
 	if pr.Status.PipelineSpec == nil {
 		pr.Status.PipelineSpec = ps
+
+		// Propagate labels from Pipeline to PipelineRun.
+		if pr.ObjectMeta.Labels == nil {
+			pr.ObjectMeta.Labels = make(map[string]string, len(meta.Labels)+1)
+		}
+		for key, value := range meta.Labels {
+			pr.ObjectMeta.Labels[key] = value
+		}
+		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = meta.Name
+
+		// Propagate annotations from Pipeline to PipelineRun.
+		if pr.ObjectMeta.Annotations == nil {
+			pr.ObjectMeta.Annotations = make(map[string]string, len(meta.Annotations))
+		}
+		for key, value := range meta.Annotations {
+			pr.ObjectMeta.Annotations[key] = value
+		}
+
 	}
 	return nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -4721,26 +4721,40 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 }
 
 func Test_storePipelineSpec(t *testing.T) {
-	ctx := context.Background()
-	pr := tb.PipelineRun("foo")
+	labels := map[string]string{"lbl": "value"}
+	annotations := map[string]string{"io.annotation": "value"}
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "foo",
+			Labels:      labels,
+			Annotations: annotations,
+		},
+	}
 
-	ps := tb.Pipeline("some-pipeline", tb.PipelineSpec(tb.PipelineDescription("foo-pipeline"))).Spec
-	ps1 := tb.Pipeline("some-pipeline", tb.PipelineSpec(tb.PipelineDescription("bar-pipeline"))).Spec
-	want := ps.DeepCopy()
+	ps := v1beta1.PipelineSpec{Description: "foo-pipeline"}
+	ps1 := v1beta1.PipelineSpec{Description: "bar-pipeline"}
+
+	want := pr.DeepCopy()
+	want.Status = v1beta1.PipelineRunStatus{
+		PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+			PipelineSpec: ps.DeepCopy(),
+		},
+	}
+	want.ObjectMeta.Labels["tekton.dev/pipeline"] = pr.ObjectMeta.Name
 
 	// The first time we set it, it should get copied.
-	if err := storePipelineSpec(ctx, pr, &ps); err != nil {
+	if err := storePipelineSpecAndMergeMeta(pr, &ps, &pr.ObjectMeta); err != nil {
 		t.Errorf("storePipelineSpec() error = %v", err)
 	}
-	if d := cmp.Diff(pr.Status.PipelineSpec, want); d != "" {
+	if d := cmp.Diff(pr, want); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 
 	// The next time, it should not get overwritten
-	if err := storePipelineSpec(ctx, pr, &ps1); err != nil {
+	if err := storePipelineSpecAndMergeMeta(pr, &ps1, &metav1.ObjectMeta{}); err != nil {
 		t.Errorf("storePipelineSpec() error = %v", err)
 	}
-	if d := cmp.Diff(pr.Status.PipelineSpec, want); d != "" {
+	if d := cmp.Diff(pr, want); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 }

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -314,31 +314,8 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 	}
 
 	// Store the fetched TaskSpec on the TaskRun for auditing
-	if err := storeTaskSpec(ctx, tr, taskSpec); err != nil {
+	if err := storeTaskSpecAndMergeMeta(tr, taskSpec, taskMeta); err != nil {
 		logger.Errorf("Failed to store TaskSpec on TaskRun.Statusfor taskrun %s: %v", tr.Name, err)
-	}
-
-	// Propagate labels from Task to TaskRun.
-	if tr.ObjectMeta.Labels == nil {
-		tr.ObjectMeta.Labels = make(map[string]string, len(taskMeta.Labels)+1)
-	}
-	for key, value := range taskMeta.Labels {
-		tr.ObjectMeta.Labels[key] = value
-	}
-	if tr.Spec.TaskRef != nil {
-		if tr.Spec.TaskRef.Kind == "ClusterTask" {
-			tr.ObjectMeta.Labels[pipeline.ClusterTaskLabelKey] = taskMeta.Name
-		} else {
-			tr.ObjectMeta.Labels[pipeline.TaskLabelKey] = taskMeta.Name
-		}
-	}
-
-	// Propagate annotations from Task to TaskRun.
-	if tr.ObjectMeta.Annotations == nil {
-		tr.ObjectMeta.Annotations = make(map[string]string, len(taskMeta.Annotations))
-	}
-	for key, value := range taskMeta.Annotations {
-		tr.ObjectMeta.Annotations[key] = value
 	}
 
 	inputs := []v1beta1.TaskResourceBinding{}
@@ -801,10 +778,31 @@ func applyVolumeClaimTemplates(workspaceBindings []v1beta1.WorkspaceBinding, own
 	return taskRunWorkspaceBindings
 }
 
-func storeTaskSpec(ctx context.Context, tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec) error {
+func storeTaskSpecAndMergeMeta(tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec, meta *metav1.ObjectMeta) error {
 	// Only store the TaskSpec once, if it has never been set before.
 	if tr.Status.TaskSpec == nil {
 		tr.Status.TaskSpec = ts
+		// Propagate annotations from Task to TaskRun.
+		if tr.ObjectMeta.Annotations == nil {
+			tr.ObjectMeta.Annotations = make(map[string]string, len(meta.Annotations))
+		}
+		for key, value := range meta.Annotations {
+			tr.ObjectMeta.Annotations[key] = value
+		}
+		// Propagate labels from Task to TaskRun.
+		if tr.ObjectMeta.Labels == nil {
+			tr.ObjectMeta.Labels = make(map[string]string, len(meta.Labels)+1)
+		}
+		for key, value := range meta.Labels {
+			tr.ObjectMeta.Labels[key] = value
+		}
+		if tr.Spec.TaskRef != nil {
+			if tr.Spec.TaskRef.Kind == "ClusterTask" {
+				tr.ObjectMeta.Labels[pipeline.ClusterTaskLabelKey] = meta.Name
+			} else {
+				tr.ObjectMeta.Labels[pipeline.TaskLabelKey] = meta.Name
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -3685,27 +3685,48 @@ func TestFailTaskRun(t *testing.T) {
 }
 
 func Test_storeTaskSpec(t *testing.T) {
+	labels := map[string]string{"lbl": "value"}
+	annotations := map[string]string{"io.annotation": "value"}
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "foo",
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "foo-task",
+			},
+		},
+	}
 
-	ctx, _ := ttesting.SetupFakeContext(t)
-	tr := tb.TaskRun("foo", tb.TaskRunSpec(tb.TaskRunTaskRef("foo-task")))
-
-	ts := tb.Task("some-task", tb.TaskSpec(tb.TaskDescription("foo-task"))).Spec
-	ts1 := tb.Task("some-task", tb.TaskSpec(tb.TaskDescription("foo-task"))).Spec
-	want := ts.DeepCopy()
+	ts := v1beta1.TaskSpec{
+		Description: "foo-task",
+	}
+	ts1 := v1beta1.TaskSpec{
+		Description: "bar-task",
+	}
+	want := tr.DeepCopy()
+	want.Status = v1beta1.TaskRunStatus{
+		TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+			TaskSpec: ts.DeepCopy(),
+		},
+	}
+	want.ObjectMeta.Labels["tekton.dev/task"] = tr.ObjectMeta.Name
 
 	// The first time we set it, it should get copied.
-	if err := storeTaskSpec(ctx, tr, &ts); err != nil {
+	if err := storeTaskSpecAndMergeMeta(tr, &ts, &tr.ObjectMeta); err != nil {
 		t.Errorf("storeTaskSpec() error = %v", err)
 	}
-	if d := cmp.Diff(tr.Status.TaskSpec, want); d != "" {
+	if d := cmp.Diff(tr, want); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 
 	// The next time, it should not get overwritten
-	if err := storeTaskSpec(ctx, tr, &ts1); err != nil {
+	if err := storeTaskSpecAndMergeMeta(tr, &ts1, &metav1.ObjectMeta{}); err != nil {
 		t.Errorf("storeTaskSpec() error = %v", err)
 	}
-	if d := cmp.Diff(tr.Status.TaskSpec, want); d != "" {
+	if d := cmp.Diff(tr, want); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Cherry-picks for the v0.28.3 release of Tekton Pipelines.

### Patches, Oldest -> Newest
d8425c2f0578b71d0f61cf8febeda77b81f13c4e - @vdemeester label propagation patch
ef5a83c9c6ae5687925da7862248d586c3e5d0ec - @wlynch implicit params taskref patch
4186dc96dfeea5bc465f94cf2c9cf359902973d2 - @wlynch implicit params pipelinespec patch
ed1440f66996d12e7055674a16a6d180b1308afa - @sbwsg golang images patch

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```
