### PR TITLE
[refactor] Remove ImplicitParamEnabled context.

### DIFF
--- a/pkg/apis/pipeline/v1beta1/implicit_params_test.go
+++ b/pkg/apis/pipeline/v1beta1/implicit_params_test.go
@@ -34,240 +34,223 @@ func TestImplicitParams(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.FromContextOrDefaults(ctx)
 	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+	ctx = config.ToContext(ctx, cfg)
 
-	ctxs := []struct {
-		name string
-		ctx  context.Context
+	for _, tc := range []struct {
+		// Expect in and want to be the same type.
+		in   apis.Defaultable
+		want interface{}
 	}{
+		// This data needs to be inlined to ensure unique copies on each test.
 		{
-			name: "direct implicit context",
-			ctx:  v1beta1.WithImplicitParamsEnabled(ctx, true),
-		},
-		{
-			name: "alpha context",
-			ctx:  config.ToContext(ctx, cfg),
-		},
-	}
-
-	for _, tctx := range ctxs {
-		t.Run(tctx.name, func(t *testing.T) {
-			for _, tc := range []struct {
-				// Expect in and want to be the same type.
-				in   apis.Defaultable
-				want interface{}
-			}{
-				// This data needs to be inlined to ensure unique copies on each test.
-				{
-					in: &v1beta1.PipelineRunSpec{
-						Params: []v1beta1.Param{
-							{
-								Name: "foo",
-								Value: v1beta1.ArrayOrString{
-									StringVal: "a",
-								},
-							},
-							{
-								Name: "bar",
-								Value: v1beta1.ArrayOrString{
-									ArrayVal: []string{"b"},
-								},
+			in: &v1beta1.PipelineRunSpec{
+				Params: []v1beta1.Param{
+					{
+						Name: "foo",
+						Value: v1beta1.ArrayOrString{
+							StringVal: "a",
+						},
+					},
+					{
+						Name: "bar",
+						Value: v1beta1.ArrayOrString{
+							ArrayVal: []string{"b"},
+						},
+					},
+				},
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Tasks: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{},
 							},
 						},
-						PipelineSpec: &v1beta1.PipelineSpec{
-							Tasks: []v1beta1.PipelineTask{
-								{
-									TaskSpec: &v1beta1.EmbeddedTask{
-										TaskSpec: v1beta1.TaskSpec{},
-									},
-								},
-								{
-									TaskRef: &v1beta1.TaskRef{
-										Name: "baz",
-									},
-								},
-							},
-							Finally: []v1beta1.PipelineTask{
-								{
-									TaskSpec: &v1beta1.EmbeddedTask{
-										TaskSpec: v1beta1.TaskSpec{},
-									},
-								},
-								{
-									TaskRef: &v1beta1.TaskRef{
-										Name: "baz",
-									},
-								},
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
 							},
 						},
 					},
-					want: &v1beta1.PipelineRunSpec{
-						ServiceAccountName: config.DefaultServiceAccountValue,
-						Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
-						Params: []v1beta1.Param{
-							{
-								Name: "foo",
-								Value: v1beta1.ArrayOrString{
-									StringVal: "a",
-								},
-							},
-							{
-								Name: "bar",
-								Value: v1beta1.ArrayOrString{
-									ArrayVal: []string{"b"},
-								},
+					Finally: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{},
 							},
 						},
-						PipelineSpec: &v1beta1.PipelineSpec{
-							Tasks: []v1beta1.PipelineTask{
-								{
-									TaskSpec: &v1beta1.EmbeddedTask{
-										TaskSpec: v1beta1.TaskSpec{
-											Params: []v1beta1.ParamSpec{
-												{
-													Name: "foo",
-													Type: v1beta1.ParamTypeString,
-												},
-												{
-													Name: "bar",
-													Type: v1beta1.ParamTypeArray,
-												},
-											},
-										},
-									},
-									Params: []v1beta1.Param{
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+							},
+						},
+					},
+				},
+			},
+			want: &v1beta1.PipelineRunSpec{
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+				Params: []v1beta1.Param{
+					{
+						Name: "foo",
+						Value: v1beta1.ArrayOrString{
+							StringVal: "a",
+						},
+					},
+					{
+						Name: "bar",
+						Value: v1beta1.ArrayOrString{
+							ArrayVal: []string{"b"},
+						},
+					},
+				},
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Tasks: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{
+									Params: []v1beta1.ParamSpec{
 										{
 											Name: "foo",
-											Value: v1beta1.ArrayOrString{
-												Type:      v1beta1.ParamTypeString,
-												StringVal: "$(params.foo)",
-											},
+											Type: v1beta1.ParamTypeString,
 										},
 										{
 											Name: "bar",
-											Value: v1beta1.ArrayOrString{
-												Type:     v1beta1.ParamTypeArray,
-												ArrayVal: []string{"$(params.bar[*])"},
-											},
+											Type: v1beta1.ParamTypeArray,
 										},
-									},
-								},
-								{
-									TaskRef: &v1beta1.TaskRef{
-										Name: "baz",
-										Kind: v1beta1.NamespacedTaskKind,
 									},
 								},
 							},
-							Finally: []v1beta1.PipelineTask{
-								{
-									TaskSpec: &v1beta1.EmbeddedTask{
-										TaskSpec: v1beta1.TaskSpec{
-											Params: []v1beta1.ParamSpec{
-												{
-													Name: "foo",
-													Type: v1beta1.ParamTypeString,
-												},
-												{
-													Name: "bar",
-													Type: v1beta1.ParamTypeArray,
-												},
-											},
-										},
-									},
-									Params: []v1beta1.Param{
-										{
-											Name: "foo",
-											Value: v1beta1.ArrayOrString{
-												Type:      v1beta1.ParamTypeString,
-												StringVal: "$(params.foo)",
-											},
-										},
-										{
-											Name: "bar",
-											Value: v1beta1.ArrayOrString{
-												Type:     v1beta1.ParamTypeArray,
-												ArrayVal: []string{"$(params.bar[*])"},
-											},
-										},
-									},
-								},
-								{
-									TaskRef: &v1beta1.TaskRef{
-										Name: "baz",
-										Kind: v1beta1.NamespacedTaskKind,
-									},
-								},
-							},
-							Params: []v1beta1.ParamSpec{
+							Params: []v1beta1.Param{
 								{
 									Name: "foo",
-									Type: v1beta1.ParamTypeString,
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(params.foo)",
+									},
 								},
 								{
 									Name: "bar",
-									Type: v1beta1.ParamTypeArray,
+									Value: v1beta1.ArrayOrString{
+										Type:     v1beta1.ParamTypeArray,
+										ArrayVal: []string{"$(params.bar[*])"},
+									},
 								},
 							},
+						},
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+								Kind: v1beta1.NamespacedTaskKind,
+							},
+						},
+					},
+					Finally: []v1beta1.PipelineTask{
+						{
+							TaskSpec: &v1beta1.EmbeddedTask{
+								TaskSpec: v1beta1.TaskSpec{
+									Params: []v1beta1.ParamSpec{
+										{
+											Name: "foo",
+											Type: v1beta1.ParamTypeString,
+										},
+										{
+											Name: "bar",
+											Type: v1beta1.ParamTypeArray,
+										},
+									},
+								},
+							},
+							Params: []v1beta1.Param{
+								{
+									Name: "foo",
+									Value: v1beta1.ArrayOrString{
+										Type:      v1beta1.ParamTypeString,
+										StringVal: "$(params.foo)",
+									},
+								},
+								{
+									Name: "bar",
+									Value: v1beta1.ArrayOrString{
+										Type:     v1beta1.ParamTypeArray,
+										ArrayVal: []string{"$(params.bar[*])"},
+									},
+								},
+							},
+						},
+						{
+							TaskRef: &v1beta1.TaskRef{
+								Name: "baz",
+								Kind: v1beta1.NamespacedTaskKind,
+							},
+						},
+					},
+					Params: []v1beta1.ParamSpec{
+						{
+							Name: "foo",
+							Type: v1beta1.ParamTypeString,
+						},
+						{
+							Name: "bar",
+							Type: v1beta1.ParamTypeArray,
 						},
 					},
 				},
-				{
-					in: &v1beta1.TaskRunSpec{
-						TaskSpec: &v1beta1.TaskSpec{},
-						Params: []v1beta1.Param{
-							{
-								Name: "string-param",
-								Value: v1beta1.ArrayOrString{
-									StringVal: "a",
-								},
-							},
-							{
-								Name: "array-param",
-								Value: v1beta1.ArrayOrString{
-									ArrayVal: []string{"b"},
-								},
-							},
+			},
+		},
+		{
+			in: &v1beta1.TaskRunSpec{
+				TaskSpec: &v1beta1.TaskSpec{},
+				Params: []v1beta1.Param{
+					{
+						Name: "string-param",
+						Value: v1beta1.ArrayOrString{
+							StringVal: "a",
 						},
 					},
-					want: &v1beta1.TaskRunSpec{
-						TaskSpec: &v1beta1.TaskSpec{
-							Params: []v1beta1.ParamSpec{
-								{
-									Name: "string-param",
-									Type: v1beta1.ParamTypeString,
-								},
-								{
-									Name: "array-param",
-									Type: v1beta1.ParamTypeArray,
-								},
-							},
+					{
+						Name: "array-param",
+						Value: v1beta1.ArrayOrString{
+							ArrayVal: []string{"b"},
 						},
-						Params: []v1beta1.Param{
-							{
-								Name: "string-param",
-								Value: v1beta1.ArrayOrString{
-									StringVal: "a",
-								},
-							},
-							{
-								Name: "array-param",
-								Value: v1beta1.ArrayOrString{
-									ArrayVal: []string{"b"},
-								},
-							},
-						},
-						ServiceAccountName: config.DefaultServiceAccountValue,
-						Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
 					},
 				},
-			} {
-				t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
-					tc.in.SetDefaults(tctx.ctx)
+			},
+			want: &v1beta1.TaskRunSpec{
+				TaskSpec: &v1beta1.TaskSpec{
+					Params: []v1beta1.ParamSpec{
+						{
+							Name: "string-param",
+							Type: v1beta1.ParamTypeString,
+						},
+						{
+							Name: "array-param",
+							Type: v1beta1.ParamTypeArray,
+						},
+					},
+				},
+				Params: []v1beta1.Param{
+					{
+						Name: "string-param",
+						Value: v1beta1.ArrayOrString{
+							StringVal: "a",
+						},
+					},
+					{
+						Name: "array-param",
+						Value: v1beta1.ArrayOrString{
+							ArrayVal: []string{"b"},
+						},
+					},
+				},
+				ServiceAccountName: config.DefaultServiceAccountValue,
+				Timeout:            &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
+			tc.in.SetDefaults(ctx)
 
-					if d := cmp.Diff(tc.want, tc.in, cmpOptions...); d != "" {
-						t.Error(diff.PrintWantGot(d))
-					}
-				})
+			if d := cmp.Diff(tc.want, tc.in, cmpOptions...); d != "" {
+				t.Error(diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -314,160 +297,53 @@ func TestImplicitParams_Pipeline(t *testing.T) {
 
 	ctx := context.Background()
 
-	// When only alpha flag is enabled, this should not apply implicit params.
-	t.Run("alpha context", func(t *testing.T) {
-		cfg := config.FromContextOrDefaults(ctx)
-		cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
-		config.ToContext(ctx, cfg)
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags = &config.FeatureFlags{EnableAPIFields: "alpha"}
+	config.ToContext(ctx, cfg)
 
-		p := pipeline.DeepCopy()
-		p.SetDefaults(ctx)
+	p := pipeline.DeepCopy()
+	p.SetDefaults(ctx)
 
-		want := &v1beta1.PipelineSpec{
-			Params: []v1beta1.ParamSpec{
-				{
-					Name: "foo",
-					Type: v1beta1.ParamTypeString,
-				},
-				{
-					Name: "bar",
-					Type: v1beta1.ParamTypeArray,
+	want := &v1beta1.PipelineSpec{
+		Params: []v1beta1.ParamSpec{
+			{
+				Name: "foo",
+				Type: v1beta1.ParamTypeString,
+			},
+			{
+				Name: "bar",
+				Type: v1beta1.ParamTypeArray,
+			},
+		},
+		Tasks: []v1beta1.PipelineTask{
+			{
+				TaskSpec: &v1beta1.EmbeddedTask{
+					TaskSpec: v1beta1.TaskSpec{},
 				},
 			},
-			Tasks: []v1beta1.PipelineTask{
-				{
-					TaskSpec: &v1beta1.EmbeddedTask{
-						TaskSpec: v1beta1.TaskSpec{},
-					},
-				},
-				{
-					TaskRef: &v1beta1.TaskRef{
-						Name: "baz",
-						Kind: v1beta1.NamespacedTaskKind,
-					},
+			{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "baz",
+					Kind: v1beta1.NamespacedTaskKind,
 				},
 			},
-			Finally: []v1beta1.PipelineTask{
-				{
-					TaskSpec: &v1beta1.EmbeddedTask{
-						TaskSpec: v1beta1.TaskSpec{},
-					},
-				},
-				{
-					TaskRef: &v1beta1.TaskRef{
-						Name: "baz",
-						Kind: v1beta1.NamespacedTaskKind,
-					},
+		},
+		Finally: []v1beta1.PipelineTask{
+			{
+				TaskSpec: &v1beta1.EmbeddedTask{
+					TaskSpec: v1beta1.TaskSpec{},
 				},
 			},
-		}
+			{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "baz",
+					Kind: v1beta1.NamespacedTaskKind,
+				},
+			},
+		},
+	}
 
-		if d := cmp.Diff(want, p, cmpOptions...); d != "" {
-			t.Error(diff.PrintWantGot(d))
-		}
-	})
-
-	// When the Implicit Param context value is set directly, implicit param
-	// behavior should be enabled.
-	t.Run("direct implicit context", func(t *testing.T) {
-		p := pipeline.DeepCopy()
-		p.SetDefaults(v1beta1.WithImplicitParamsEnabled(ctx, true))
-
-		want := &v1beta1.PipelineSpec{
-			Params: []v1beta1.ParamSpec{
-				{
-					Name: "foo",
-					Type: v1beta1.ParamTypeString,
-				},
-				{
-					Name: "bar",
-					Type: v1beta1.ParamTypeArray,
-				},
-			},
-			Tasks: []v1beta1.PipelineTask{
-				{
-					Params: []v1beta1.Param{
-						{
-							Name: "foo",
-							Value: v1beta1.ArrayOrString{
-								Type:      v1beta1.ParamTypeString,
-								StringVal: "$(params.foo)",
-							},
-						},
-						{
-							Name: "bar",
-							Value: v1beta1.ArrayOrString{
-								Type:     v1beta1.ParamTypeArray,
-								ArrayVal: []string{"$(params.bar[*])"},
-							},
-						},
-					},
-					TaskSpec: &v1beta1.EmbeddedTask{
-						TaskSpec: v1beta1.TaskSpec{
-							Params: []v1beta1.ParamSpec{
-								{
-									Name: "foo",
-									Type: v1beta1.ParamTypeString,
-								},
-								{
-									Name: "bar",
-									Type: v1beta1.ParamTypeArray,
-								},
-							},
-						},
-					},
-				},
-				{
-					TaskRef: &v1beta1.TaskRef{
-						Name: "baz",
-						Kind: v1beta1.NamespacedTaskKind,
-					},
-				},
-			},
-			Finally: []v1beta1.PipelineTask{
-				{
-					Params: []v1beta1.Param{
-						{
-							Name: "foo",
-							Value: v1beta1.ArrayOrString{
-								Type:      v1beta1.ParamTypeString,
-								StringVal: "$(params.foo)",
-							},
-						},
-						{
-							Name: "bar",
-							Value: v1beta1.ArrayOrString{
-								Type:     v1beta1.ParamTypeArray,
-								ArrayVal: []string{"$(params.bar[*])"},
-							},
-						},
-					},
-					TaskSpec: &v1beta1.EmbeddedTask{
-						TaskSpec: v1beta1.TaskSpec{
-							Params: []v1beta1.ParamSpec{
-								{
-									Name: "foo",
-									Type: v1beta1.ParamTypeString,
-								},
-								{
-									Name: "bar",
-									Type: v1beta1.ParamTypeArray,
-								},
-							},
-						},
-					},
-				},
-				{
-					TaskRef: &v1beta1.TaskRef{
-						Name: "baz",
-						Kind: v1beta1.NamespacedTaskKind,
-					},
-				},
-			},
-		}
-
-		if d := cmp.Diff(want, p, cmpOptions...); d != "" {
-			t.Error(diff.PrintWantGot(d))
-		}
-	})
+	if d := cmp.Diff(want, p, cmpOptions...); d != "" {
+		t.Error(diff.PrintWantGot(d))
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/param_context.go
+++ b/pkg/apis/pipeline/v1beta1/param_context.go
@@ -19,13 +19,6 @@ import (
 	"fmt"
 )
 
-// enableImplicitParamContextKeyType is the unique type for referencing whether
-// Implicit Param behavior is enabled for the given request context.
-// See [TEP-0023](https://github.com/tektoncd/community/blob/main/teps/0023-implicit-mapping.md).
-//
-// +k8s:openapi-gen=false
-type enableImplicitParamContextKeyType struct{}
-
 // paramCtxKey is the unique type for referencing param information from
 // a context.Context. See [context.Context.Value](https://pkg.go.dev/context#Context)
 // for more details.
@@ -34,8 +27,7 @@ type enableImplicitParamContextKeyType struct{}
 type paramCtxKeyType struct{}
 
 var (
-	enableImplicitParamContextKey = enableImplicitParamContextKeyType{}
-	paramCtxKey                   = paramCtxKeyType{}
+	paramCtxKey = paramCtxKeyType{}
 )
 
 // paramCtxVal is the data type stored in the param context.
@@ -46,10 +38,6 @@ type paramCtxVal map[string]ParamSpec
 // preserves the fields included in ParamSpec - Name and Type.
 func addContextParams(ctx context.Context, in []Param) context.Context {
 	if in == nil {
-		return ctx
-	}
-
-	if !GetImplicitParamsEnabled(ctx) {
 		return ctx
 	}
 
@@ -82,10 +70,6 @@ func addContextParams(ctx context.Context, in []Param) context.Context {
 // addContextParamSpec adds the given ParamSpecs to the param context.
 func addContextParamSpec(ctx context.Context, in []ParamSpec) context.Context {
 	if in == nil {
-		return ctx
-	}
-
-	if !GetImplicitParamsEnabled(ctx) {
 		return ctx
 	}
 
@@ -181,22 +165,4 @@ func getContextParamSpecs(ctx context.Context) []ParamSpec {
 		})
 	}
 	return out
-}
-
-// WithImplicitParamsEnabled enables implicit parameter behavior for the
-// request context. If enabled, parameters will propagate down embedded request
-// objects (e.g. PipelineRun -> Pipeline -> Task, Pipeline -> Task,
-// TaskRun -> Task) during defaulting.
-func WithImplicitParamsEnabled(ctx context.Context, v bool) context.Context {
-	return context.WithValue(ctx, enableImplicitParamContextKey, v)
-}
-
-// GetImplicitParamsEnabled returns whether implicit parameters are enabled for
-// the given context.
-func GetImplicitParamsEnabled(ctx context.Context) bool {
-	v := ctx.Value(enableImplicitParamContextKey)
-	if v == nil {
-		return false
-	}
-	return v.(bool)
 }

--- a/pkg/apis/pipeline/v1beta1/param_context_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_context_test.go
@@ -25,16 +25,6 @@ import (
 func TestAddContextParams(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("not-enabled", func(t *testing.T) {
-		ctx := addContextParams(ctx, []Param{{Name: "a"}})
-		if v := ctx.Value(paramCtxKey); v != nil {
-			t.Errorf("expected no param context values, got %v", v)
-		}
-	})
-
-	// Enable Alpha features.
-	ctx = WithImplicitParamsEnabled(ctx, true)
-
 	// These test cases should run sequentially. Each step will modify the
 	// above context.
 	for _, tc := range []struct {
@@ -117,16 +107,6 @@ func TestAddContextParams(t *testing.T) {
 func TestAddContextParamSpec(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("not-enabled", func(t *testing.T) {
-		ctx := addContextParamSpec(ctx, []ParamSpec{{Name: "a"}})
-		if v := ctx.Value(paramCtxKey); v != nil {
-			t.Errorf("expected no param context values, got %v", v)
-		}
-	})
-
-	// Enable Alpha features.
-	ctx = WithImplicitParamsEnabled(ctx, true)
-
 	// These test cases should run sequentially. Each step will modify the
 	// above context.
 	for _, tc := range []struct {
@@ -208,15 +188,6 @@ func TestGetContextParams(t *testing.T) {
 			Description: "racecar",
 		},
 	}
-	t.Run("not-enabled", func(t *testing.T) {
-		ctx := addContextParamSpec(ctx, want)
-		if v := getContextParamSpecs(ctx); v != nil {
-			t.Errorf("expected no param context values, got %v", v)
-		}
-	})
-
-	// Enable Alpha features.
-	ctx = WithImplicitParamsEnabled(ctx, true)
 
 	ctx = addContextParamSpec(ctx, want)
 
@@ -287,15 +258,6 @@ func TestGetContextParamSpecs(t *testing.T) {
 			Description: "racecar",
 		},
 	}
-	t.Run("not-enabled", func(t *testing.T) {
-		ctx := addContextParamSpec(ctx, want)
-		if v := getContextParamSpecs(ctx); v != nil {
-			t.Errorf("expected no param context values, got %v", v)
-		}
-	})
-
-	// Enable Alpha features.
-	ctx = WithImplicitParamsEnabled(ctx, true)
 
 	ctx = addContextParamSpec(ctx, want)
 	got := getContextParamSpecs(ctx)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_defaults.go
@@ -34,10 +34,6 @@ func (pr *PipelineRun) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
-	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-		ctx = WithImplicitParamsEnabled(ctx, true)
-	}
-
 	cfg := config.FromContextOrDefaults(ctx)
 	if prs.Timeout == nil && prs.Timeouts == nil {
 		prs.Timeout = &metav1.Duration{Duration: time.Duration(cfg.Defaults.DefaultTimeoutMinutes) * time.Minute}
@@ -56,9 +52,9 @@ func (prs *PipelineRunSpec) SetDefaults(ctx context.Context) {
 	prs.PodTemplate = mergePodTemplateWithDefault(prs.PodTemplate, defaultPodTemplate)
 
 	if prs.PipelineSpec != nil {
-		if GetImplicitParamsEnabled(ctx) {
-			ctx = addContextParams(ctx, prs.Params)
-		}
 		prs.PipelineSpec.SetDefaults(ctx)
+		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+			prs.PipelineSpec.applyImplicitParams(addContextParams(ctx, prs.Params))
+		}
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/task_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/task_defaults.go
@@ -34,8 +34,11 @@ func (ts *TaskSpec) SetDefaults(ctx context.Context) {
 	for i := range ts.Params {
 		ts.Params[i].SetDefaults(ctx)
 	}
-	if GetImplicitParamsEnabled(ctx) {
-		ctx = addContextParamSpec(ctx, ts.Params)
-		ts.Params = getContextParamSpecs(ctx)
-	}
+}
+
+// applyImplicitParams propagates implicit params from the parent context
+// through the Task.
+func (ts *TaskSpec) applyImplicitParams(ctx context.Context) {
+	ctx = addContextParamSpec(ctx, ts.Params)
+	ts.Params = getContextParamSpecs(ctx)
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_defaults.go
@@ -48,10 +48,6 @@ func (tr *TaskRun) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
-	if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
-		ctx = WithImplicitParamsEnabled(ctx, true)
-	}
-
 	cfg := config.FromContextOrDefaults(ctx)
 	if trs.TaskRef != nil && trs.TaskRef.Kind == "" {
 		trs.TaskRef.Kind = NamespacedTaskKind
@@ -71,10 +67,11 @@ func (trs *TaskRunSpec) SetDefaults(ctx context.Context) {
 
 	// If this taskrun has an embedded task, apply the usual task defaults
 	if trs.TaskSpec != nil {
-		if GetImplicitParamsEnabled(ctx) {
-			ctx = addContextParams(ctx, trs.Params)
-		}
 		trs.TaskSpec.SetDefaults(ctx)
+
+		if config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" {
+			trs.TaskSpec.applyImplicitParams(addContextParams(ctx, trs.Params))
+		}
 	}
 }
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change does not introduce any different behavior - it refactors the
code to remove the use of the ImplicitParamEnabled context in favor of
direct function calls.

/kind cleanup

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE