### PR TITLE
Fix kustomize invocation typo

### DIFF
--- a/tekton/README.md
+++ b/tekton/README.md
@@ -102,7 +102,7 @@ kubectl kustomize ./tekton/resources/release | kubectl apply -f -
 
 # If you don't want the tekton-nightly components then run the following
 # command from the root of the plumbing repo:
-kubectl kustomize ./tekton/resources/release/overlay/default | kubectl apply -f -
+kubectl kustomize ./tekton/resources/release/overlays/default | kubectl apply -f -
 ```
 
 Apply the tasks from the `pipeline` repo:


### PR DESCRIPTION
# Changes

In 411d033c5e4bf3409f01b175531cbc1a0a75fadb we added a note on using kustomize to build resources from the
plumbing repo. One of those documented kustomize invocations included a
typo.

This commit updates the kustomize invocation to use `overlays` instead
of `overlay`.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
