### PR TITLE
Bump knative.dev/pkg vendoring. Use klog/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	k8s.io/code-generator v0.22.5
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20220114203427-a0453230fd26
-	knative.dev/pkg v0.0.0-20220104185830-52e42b760b54
+	knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006
 )
 
 require (
@@ -37,12 +37,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.11.0 // indirect
 	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
-	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20220120123041-d22850aca581 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/net v0.0.0-20220114011407-0dd24b26b47d // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
-	k8s.io/klog/v2 v2.40.1 // indirect
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2183,9 +2183,9 @@ k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20211208161948-7d6a63dca704 h1:ZKMMxTvduyf5WUtREOqg5LiXaN1KO/+0oOQPRFrClpo=
 k8s.io/utils v0.0.0-20211208161948-7d6a63dca704/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/hack v0.0.0-20211203062838-e11ac125e707/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
-knative.dev/pkg v0.0.0-20220104185830-52e42b760b54 h1:rSu9UPVufkvSTKhPoF5vTJTPNmvzwW4Dza1pD9GgO2w=
-knative.dev/pkg v0.0.0-20220104185830-52e42b760b54/go.mod h1:189cvGP0mwpqwZGFrLk5WuERIsNI/J6HuQ1CIX7SXxY=
+knative.dev/hack v0.0.0-20220128200847-51a42b2eb63e/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
+knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006 h1:0Kv7dIOimyHno/7jbQ6LCi15ME+e/b5tY0pwi99kanQ=
+knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006/go.mod h1:bZMFTPDPHV3wXuiQ09UJuEGYYQnfpe81MCxNvsMAiJk=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=

--- a/vendor/knative.dev/pkg/apis/duck/v1/source_types.go
+++ b/vendor/knative.dev/pkg/apis/duck/v1/source_types.go
@@ -181,9 +181,10 @@ func (s *Source) Validate(ctx context.Context) *apis.FieldError {
 
 func (s *SourceSpec) Validate(ctx context.Context) *apis.FieldError {
 	if s == nil {
-		return nil
+		return apis.ErrMissingField("spec")
 	}
-	return s.CloudEventOverrides.Validate(ctx).ViaField("ceOverrides")
+	return s.Sink.Validate(ctx).ViaField("sink").
+		Also(s.CloudEventOverrides.Validate(ctx).ViaField("ceOverrides"))
 }
 
 func (ceOverrides *CloudEventOverrides) Validate(ctx context.Context) *apis.FieldError {

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/client.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/client.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // clientGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/duck.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/duck.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // duckGenerator produces logic to register a duck.InformerFactory for a particular

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/factory.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/factory.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // factoryTestGenerator produces a file of factory injection of a given type.

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_client.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_client.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // fakeClientGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_duck.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_duck.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // fakeDuckGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_factory.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_factory.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // fakeFactoryGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_filtered_factory.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_filtered_factory.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // fakeFilteredFactoryGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_filtered_informer.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_filtered_informer.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // fakeFilteredInformerGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_informer.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/fake_informer.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // fakeInformerGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/filtered_factory.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/filtered_factory.go
@@ -22,8 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // factoryTestGenerator produces a file of factory injection of a given type.

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/filtered_informer.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/filtered_informer.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // injectionTestGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/informer.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/informer.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // injectionTestGenerator produces a file of listers for a given GroupVersion and

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/packages.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/packages.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	informergenargs "knative.dev/pkg/codegen/cmd/injection-gen/args"
 )

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // reconcilerControllerGenerator produces a file for setting up the reconciler

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_controller_stub.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // reconcilerControllerStubGenerator produces a file of the stub of the

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // reconcilerReconcilerGenerator produces a reconciler struct for the given type.

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_reconciler_stub.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // reconcilerReconcilerStubGenerator produces a file of the stub of how to

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_state.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/generators/reconciler_state.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // reconcilerStateGenerator produces a reconciler state object to manage reconciliation runs.

--- a/vendor/knative.dev/pkg/codegen/cmd/injection-gen/main.go
+++ b/vendor/knative.dev/pkg/codegen/cmd/injection-gen/main.go
@@ -22,7 +22,7 @@ import (
 
 	"k8s.io/code-generator/pkg/util"
 	"k8s.io/gengo/args"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"github.com/spf13/pflag"
 	generatorargs "knative.dev/pkg/codegen/cmd/injection-gen/args"

--- a/vendor/knative.dev/pkg/injection/config.go
+++ b/vendor/knative.dev/pkg/injection/config.go
@@ -21,7 +21,7 @@ import (
 	"log"
 
 	"k8s.io/client-go/rest"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"knative.dev/pkg/environment"
 )
 

--- a/vendor/knative.dev/pkg/leaderelection/config.go
+++ b/vendor/knative.dev/pkg/leaderelection/config.go
@@ -98,9 +98,9 @@ func (c *Config) GetComponentConfig(name string) ComponentConfig {
 func defaultConfig() *Config {
 	return &Config{
 		Buckets:       1,
-		LeaseDuration: 15 * time.Second,
-		RenewDeadline: 10 * time.Second,
-		RetryPeriod:   2 * time.Second,
+		LeaseDuration: 60 * time.Second,
+		RenewDeadline: 40 * time.Second,
+		RetryPeriod:   10 * time.Second,
 	}
 }
 

--- a/vendor/knative.dev/pkg/leaderelection/doc.go
+++ b/vendor/knative.dev/pkg/leaderelection/doc.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// LeaderElection provides an interface for controllers implementing using
+// controller injection:
+// https://github.com/knative/pkg/blob/main/injection/README.md
+//
+// Leaderelection uses the context-stuffing mechanism to provide config-driven
+// management of multiple election strategies (currently, using Kubernetes
+// etcd-based election primitives or StatefulSet indexes and counts).
+//
+// For more details, see the original design document:
+// https://docs.google.com/document/d/e/2PACX-1vTh40N-Kk6EPNzYpITiLg8YJk0qZyZv7KgMpcQS72T9Lv_F2PQeGybx4TtH0E1N1aUgLQer7b8u3lDc/pub
+package leaderelection

--- a/vendor/knative.dev/pkg/test/logging/logging.go
+++ b/vendor/knative.dev/pkg/test/logging/logging.go
@@ -33,7 +33,7 @@ import (
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 const (

--- a/vendor/knative.dev/pkg/version/version.go
+++ b/vendor/knative.dev/pkg/version/version.go
@@ -33,7 +33,7 @@ const (
 	// NOTE: If you are changing this line, please also update the minimum kubernetes
 	// version listed here:
 	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
-	defaultMinimumVersion = "v1.20.0"
+	defaultMinimumVersion = "v1.21.0"
 )
 
 func getMinimumVersion() string {

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
+
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
@@ -42,6 +43,7 @@ func NewAdmissionController(
 	handlers map[schema.GroupVersionKind]resourcesemantics.GenericCRD,
 	wc func(context.Context) context.Context,
 	disallowUnknownFields bool,
+	callbacks ...map[schema.GroupVersionKind]Callback,
 ) *controller.Impl {
 
 	client := kubeclient.Get(ctx)
@@ -50,6 +52,19 @@ func NewAdmissionController(
 	options := webhook.GetOptions(ctx)
 
 	key := types.NamespacedName{Name: name}
+
+	// This not ideal, we are using a variadic argument to effectively make callbacks optional
+	// This allows this addition to be non-breaking to consumers of /pkg
+	// TODO: once all sub-repos have adopted this, we might move this back to a traditional param.
+	var unwrappedCallbacks map[schema.GroupVersionKind]Callback
+	switch len(callbacks) {
+	case 0:
+		unwrappedCallbacks = map[schema.GroupVersionKind]Callback{}
+	case 1:
+		unwrappedCallbacks = callbacks[0]
+	default:
+		panic("NewAdmissionController may not be called with multiple callback maps")
+	}
 
 	wh := &reconciler{
 		LeaderAwareFuncs: pkgreconciler.LeaderAwareFuncs{
@@ -60,9 +75,10 @@ func NewAdmissionController(
 			},
 		},
 
-		key:      key,
-		path:     path,
-		handlers: handlers,
+		key:       key,
+		path:      path,
+		handlers:  handlers,
+		callbacks: unwrappedCallbacks,
 
 		withContext:           wc,
 		disallowUnknownFields: disallowUnknownFields,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,7 +187,6 @@ github.com/go-kit/log/level
 # github.com/go-logfmt/logfmt v0.5.0
 github.com/go-logfmt/logfmt
 # github.com/go-logr/logr v1.2.2
-## explicit
 github.com/go-logr/logr
 # github.com/go-openapi/jsonpointer v0.19.5
 github.com/go-openapi/jsonpointer
@@ -997,7 +996,6 @@ k8s.io/gengo/types
 ## explicit
 k8s.io/klog
 # k8s.io/klog/v2 v2.40.1
-## explicit
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20220114203427-a0453230fd26
 ## explicit
@@ -1015,7 +1013,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/pkg v0.0.0-20220104185830-52e42b760b54
+# knative.dev/pkg v0.0.0-20220131144930-f4b57aef0006
 ## explicit
 knative.dev/pkg/apis
 knative.dev/pkg/apis/duck


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Kubernetes vendoring is using klog v2 but knative is using v1.
When knative configure the logging, it doesn't configure the underlying
kubernetes logging.

Related to https://github.com/tektoncd/triggers/issues/1301

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:


-->
```release-note
Flags used by Kubernetes logging system are now working
```