### PR TITLE
Increase lease time of controller and webhook

### DIFF
--- a/config/config-leader-election.yaml
+++ b/config/config-leader-election.yaml
@@ -22,6 +22,6 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 data:
   # An inactive but valid configuration follows; see example.
-  leaseDuration: "15s"
-  renewDeadline: "10s"
-  retryPeriod: "2s"
+  lease-duration: "60s"
+  renew-deadline: "40s"
+  retry-period: "10s"


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Knative increased their default lease duration. Tekton can also do it
and be less aggressive with the k8s API.

In case of reboot/restart, the controller will take more time to
recover.

Related to https://github.com/knative/pkg/issues/2383
Tekton controller is also issuing 2 calls per second to the apiserver. Webhook and even triggers components are impacted.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
Increase lease duration of Tekton components in order to be more gentle with the k8s apiserver.
```