### PR TITLE
Drop resource `requests:` from `gohelloworld`.

### DIFF
--- a/test/gohelloworld/gohelloworld-chart/values.yaml
+++ b/test/gohelloworld/gohelloworld-chart/values.yaml
@@ -18,6 +18,3 @@ resources:
   limits:
     cpu: 100m
     memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi


### PR DESCRIPTION
Resource requests are used to decide whether a pod may be scheduled on a node.  In some of our downstream testing we have been seeing a rash of flakes in `TestHelmDeployPipelineRun` which manifest as follows.

The pipeline itself times out waiting for the test to complete:
```
2022-02-05T03:06:49.873527563Z stderr F wait.go:244: [debug] Deployment is not ready: arendelle-7wpjd/gohelloworld-chart. 0 out of 1 expected pods are ready
2022-02-05T03:06:51.905640413Z stderr F wait.go:244: [debug] Deployment is not ready: arendelle-7wpjd/gohelloworld-chart. 0 out of 1 expected pods are ready
2022-02-05T03:06:54.013351746Z stderr F wait.go:244: [debug] Deployment is not ready: arendelle-7wpjd/gohelloworld-chart. 0 out of 1 expected pods are ready
2022-02-05T03:06:55.814048343Z stderr F wait.go:244: [debug] Deployment is not ready: arendelle-7wpjd/gohelloworld-chart. 0 out of 1 expected pods are ready
2022-02-05T03:06:55.822633914Z stderr F wait.go:244: [debug] Deployment is not ready: arendelle-7wpjd/gohelloworld-chart. 0 out of 1 expected pods are ready
2022-02-05T03:06:56.162347025Z stderr F Error: timed out waiting for the condition
2022-02-05T03:06:56.165538751Z stderr F helm.go:81: [debug] timed out waiting for the condition
```

However, a brief while later:
```
2022-02-05T03:08:36.385531093Z stderr F 2022/02/05 03:08:36 Hello world sample started.
2022-02-05T03:08:37.246650188Z stderr F 2022/02/05 03:08:37 Hello world received a request.
2022-02-05T03:08:45.852975472Z stderr F 2022/02/05 03:08:45 Hello world received a request.
2022-02-05T03:08:45.856908405Z stderr F 2022/02/05 03:08:45 Hello world received a request.
2022-02-05T03:08:55.851238051Z stderr F 2022/02/05 03:08:55 Hello world received a request.
2022-02-05T03:08:55.855837089Z stderr F 2022/02/05 03:08:55 Hello world received a request.
```

I believe that the core issue here is that it times out because the pod cannot be scheduled, likely because the KinD cluster we're on is very busy.

An alternative here might be to (dramatically) lower the resource requests, but I'm not sure they are providing any real value today.

Related: https://github.com/tektoncd/pipeline/issues/4455

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
