### PR TITLE
Ignore variant when looking up command for platform in entrypoint

### DIFF
--- a/cmd/entrypoint/namespaces.go
+++ b/cmd/entrypoint/namespaces.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package main

--- a/cmd/entrypoint/namespaces_test.go
+++ b/cmd/entrypoint/namespaces_test.go
@@ -1,4 +1,21 @@
+//go:build linux
 // +build linux
+
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package main
 

--- a/cmd/entrypoint/platform_test.go
+++ b/cmd/entrypoint/platform_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSelectCommandForPlatform(t *testing.T) {
+	for _, c := range []struct {
+		desc    string
+		m       map[string][]string
+		plat    string
+		want    []string
+		wantErr bool
+	}{{
+		desc: "platform exists",
+		m: map[string][]string{
+			"linux/amd64": {"my", "command"},
+			"linux/s390x": {"other", "one"},
+		},
+		plat: "linux/amd64",
+		want: []string{"my", "command"},
+	}, {
+		desc: "platform not found",
+		m: map[string][]string{
+			"linux/amd64": {"my", "command"},
+			"linux/s390x": {"other", "one"},
+		},
+		plat:    "linux/ppc64le",
+		wantErr: true,
+	}, {
+		desc: "platform fallback",
+		m: map[string][]string{
+			"linux/amd64": {"my", "command"},
+			"linux/s390x": {"other", "one"},
+		},
+		plat: "linux/amd64/v8",
+		want: []string{"my", "command"},
+	}, {
+		desc: "platform fallback not needed",
+		m: map[string][]string{
+			"linux/amd64":    {"other", "one"},
+			"linux/amd64/v8": {"my", "command"},
+		},
+		plat: "linux/amd64/v8",
+		want: []string{"my", "command"},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			got, err := selectCommandForPlatform(c.m, c.plat)
+			if err != nil {
+				if c.wantErr {
+					return
+				}
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if d := cmp.Diff(c.want, got); d != "" {
+				t.Fatalf("Diff(-want,+got):\n%s", d)
+			}
+		})
+	}
+}

--- a/cmd/entrypoint/runner.go
+++ b/cmd/entrypoint/runner.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/cmd/entrypoint/runner_windows.go
+++ b/cmd/entrypoint/runner_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
# Changes

Fixes #4548 

/kind bug

This change changes our runtime platform selection logic to allow matching platforms that don't match the CPU variant, since some indexes only provide the variant-less platform, and should be chosen in that case rather than failing.

If the platform's command is found including the CPU variant, it will be used. If not, we'll also check if there's a variant-less platform that matches, and if so, we'll use that command.

cc @vaikas 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Loosen runtime platform selection logic to account for platforms with CPU variants
```

