### PR TITLE
[RFC] Add default k8s resources for init containers

### DIFF
--- a/pkg/internal/limitrange/transformer_test.go
+++ b/pkg/internal/limitrange/transformer_test.go
@@ -431,6 +431,7 @@ func TestTransformerOneContainer(t *testing.T) {
 }
 
 func TestTransformerMultipleContainer(t *testing.T) {
+	// TODO: Add tests for multiple init containers
 	for _, tc := range []struct {
 		description string
 		limitranges []corev1.LimitRangeItem

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -93,6 +94,16 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1beta
 		Command:      []string{shellCommand},
 		Args:         []string{shellArg, ""},
 		VolumeMounts: []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("300Mi"),
+				corev1.ResourceCPU:    resource.MustParse("300m"),
+			},
+		},
 	}
 
 	breakpoints := []string{}

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -64,5 +65,15 @@ func workingDirInit(workingdirinitImage string, stepContainers []corev1.Containe
 		Args:         relativeDirs,
 		WorkingDir:   pipeline.WorkspaceDir,
 		VolumeMounts: implicitVolumeMounts,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
 	}
 }


### PR DESCRIPTION
# Changes
This commit adds resource requests and limits for CPU and memory to Tekton-controlled init containers.
Prior to this commit, if a ResourceQuota was defined in a namespace, Tekton could not be used in that namespace
because not all containers in the generated pods had CPU and memory requests and limits. Closes #2933.

This commit does not affect Tekton's handling of LimitRange. Tekton will continue to transform container
resource requests and limits to fit LimitRanges.

**What do these init containers do?**
- "place-tools" runs the entrypoint binary and writes it into each step container
- "place-scripts" encodes each step's script and writes it to the container that will run it.
We do not limit the size of scripts.
- "step-init" initializes /tekton/steps with one file per step
- "working-dir-initializer" creates a working dir for each step that needs it

**Where do these resource requirements come from?**
- The latest entrypoint binary is about 80MB. Previous builds were closer to 40-50MB.
- CPU requirements, and memory requirements for non-entrypoint containers, are guesses with some simple local experimentation.
(It's challenging to get metrics for resource usage of Tekton init containers, and we'd need
some sort of performance or load tests to really get a good estimate.)

**Side effects**
- Tekton pods now have "burstable" quality of service by default instead of "best effort", meaning they will
be more likely to be scheduled and less likely to be evicted.
It's no longer possible to create a Tekton pod with "best effort" quality of service.

**Drawbacks**
- If we update the entrypoint code and the binary changes size, the resource requirements will need to be adjusted.
Because Tekton releases include building the entrypoint binary, this could break a release and we'd have to backport a fix.
- If a pod is OOMkilled due to exceeding resource requirements, the user will not be able to work around this problem.
This can be mitigated by setting the init container's resource requirements to higher than what it likely needs.
- If resource requirements are set too high, the pod may not be schedulable anywhere.

**Alternatives**
- We could apply resource requirements from a Task's StepTemplate to init containers. However, the StepTemplate
is meant to be used for Steps, which likely have higher resource requirements than Tekton's init containers,
and this would require users to understand what Tekton's init containers do.
- We could try to set resource requirements dynamically based on the number of Steps, the size of scripts, or other parameters.
- We could apply resource requirements to init containers only when ResourceQuotas are present in the namespace.

**Future work**
- Combine Tekton init containers into one init container (#4519).

**References**
- Resource quota docs: https://kubernetes.io/docs/concepts/policy/resource-quotas/
- Pod quality of service docs: https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/
- Tekton entrypoint images: https://pantheon.corp.google.com/gcr/images/tekton-releases/us/github.com/tektoncd/pipeline/cmd/entrypoint?project=tekton-releases

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
[Bug fix]: apply resource requests to init containers, allowing Tekton to be used in namespaces with resourcequotas.
[Side effect]: Pods will now have "burstable" QoS by default, instead of "best effort".
```