### PR TITLE
cleanup - ApplyContext parameters

### DIFF
--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -111,10 +111,10 @@ func ApplyResources(spec *v1beta1.TaskSpec, resolvedResources map[string]v1beta1
 
 // ApplyContexts applies the substitution from $(context.(taskRun|task).*) with the specified values.
 // Uses "" as a default if a value is not available.
-func ApplyContexts(spec *v1beta1.TaskSpec, rtr *ResolvedTaskResources, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
+func ApplyContexts(spec *v1beta1.TaskSpec, taskName string, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
 	replacements := map[string]string{
 		"context.taskRun.name":      tr.Name,
-		"context.task.name":         rtr.TaskName,
+		"context.task.name":         taskName,
 		"context.taskRun.namespace": tr.Namespace,
 		"context.taskRun.uid":       string(tr.ObjectMeta.UID),
 		"context.task.retry-count":  strconv.Itoa(len(tr.Status.RetriesStatus)),

--- a/pkg/reconciler/taskrun/resources/apply_test.go
+++ b/pkg/reconciler/taskrun/resources/apply_test.go
@@ -876,16 +876,14 @@ func TestApplyWorkspaces_IsolatedWorkspaces(t *testing.T) {
 func TestContext(t *testing.T) {
 	for _, tc := range []struct {
 		description string
-		rtr         resources.ResolvedTaskResources
+		taskName    string
 		tr          v1beta1.TaskRun
 		spec        v1beta1.TaskSpec
 		want        v1beta1.TaskSpec
 	}{{
 		description: "context taskName replacement without taskRun in spec container",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
-		tr: v1beta1.TaskRun{},
+		taskName:    "Task1",
+		tr:          v1beta1.TaskRun{},
 		spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{
 				Container: corev1.Container{
@@ -904,9 +902,7 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context taskName replacement with taskRun in spec container",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
+		taskName:    "Task1",
 		tr: v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "taskrunName",
@@ -930,9 +926,7 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context taskRunName replacement with defined taskRun in spec container",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
+		taskName:    "Task1",
 		tr: v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "taskrunName",
@@ -956,10 +950,8 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context taskRunName replacement with no defined taskRun name in spec container",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
-		tr: v1beta1.TaskRun{},
+		taskName:    "Task1",
+		tr:          v1beta1.TaskRun{},
 		spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{
 				Container: corev1.Container{
@@ -978,10 +970,8 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context taskRun namespace replacement with no defined namepsace in spec container",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
-		tr: v1beta1.TaskRun{},
+		taskName:    "Task1",
+		tr:          v1beta1.TaskRun{},
 		spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{
 				Container: corev1.Container{
@@ -1000,9 +990,7 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context taskRun namespace replacement with defined namepsace in spec container",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
+		taskName:    "Task1",
 		tr: v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "taskrunName",
@@ -1027,7 +1015,6 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context taskRunName replacement with no defined taskName in spec container",
-		rtr:         resources.ResolvedTaskResources{},
 		tr:          v1beta1.TaskRun{},
 		spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{
@@ -1047,9 +1034,7 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context UID replacement",
-		rtr: resources.ResolvedTaskResources{
-			TaskName: "Task1",
-		},
+		taskName:    "Task1",
 		tr: v1beta1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{
 				UID: "UID-1",
@@ -1073,7 +1058,6 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context retry count replacement",
-		rtr:         resources.ResolvedTaskResources{},
 		tr: v1beta1.TaskRun{
 			Status: v1beta1.TaskRunStatus{
 				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
@@ -1113,7 +1097,6 @@ func TestContext(t *testing.T) {
 		},
 	}, {
 		description: "context retry count replacement with task that never retries",
-		rtr:         resources.ResolvedTaskResources{},
 		tr:          v1beta1.TaskRun{},
 		spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{{
@@ -1133,7 +1116,7 @@ func TestContext(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			got := resources.ApplyContexts(&tc.spec, &tc.rtr, &tc.tr)
+			got := resources.ApplyContexts(&tc.spec, tc.taskName, &tc.tr)
 			if d := cmp.Diff(&tc.want, got); d != "" {
 				t.Errorf(diff.PrintWantGot(d))
 			}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -631,7 +631,7 @@ func (c *Reconciler) createPod(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	ts = resources.ApplyParameters(ts, tr, defaults...)
 
 	// Apply context substitution from the taskrun
-	ts = resources.ApplyContexts(ts, rtr, tr)
+	ts = resources.ApplyContexts(ts, rtr.TaskName, tr)
 
 	// Apply bound resource substitution from the taskrun.
 	ts = resources.ApplyResources(ts, inputResources, "inputs")


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Instead of passing around the entire `resolvedTaskResources`, which is not necessary at this point, just pass the task name.

No functional changes expected.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
