### PR TITLE
use helper functions - MarkResource*

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -324,12 +324,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 
 	// When pipeline run is pending, return to avoid creating the task
 	if pr.IsPending() {
-		pr.Status.SetCondition(&apis.Condition{
-			Type:    apis.ConditionSucceeded,
-			Status:  corev1.ConditionUnknown,
-			Reason:  ReasonPending,
-			Message: fmt.Sprintf("PipelineRun %q is pending", pr.Name),
-		})
+		pr.Status.MarkRunning(ReasonPending, fmt.Sprintf("PipelineRun %q is pending", pr.Name))
 		return nil
 	}
 
@@ -734,10 +729,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 		// is a retry
 		addRetryHistory(tr)
 		clearStatus(tr)
-		tr.Status.SetCondition(&apis.Condition{
-			Type:   apis.ConditionSucceeded,
-			Status: corev1.ConditionUnknown,
-		})
+		tr.Status.MarkResourceOngoing("", "")
 		logger.Infof("Updating taskrun %s with cleared status and retry history (length: %d).", tr.GetName(), len(tr.Status.RetriesStatus))
 		return c.PipelineClientSet.TektonV1beta1().TaskRuns(pr.Namespace).UpdateStatus(ctx, tr, metav1.UpdateOptions{})
 	}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Replace updating the conditions directly with the helper functions - `MarkResourceRunning` and `MarkRunning`.

No functional change expected.

/kind cleanup


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
