### PR TITLE
debug is an alpha feature

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -23,6 +23,9 @@ weight: 11
 `Debug` spec is used for troubleshooting and breakpointing runtime resources. This doc helps understand the inner 
 workings of debug in Tekton. Currently only the `TaskRun` resource is supported. 
 
+This is an alpha feature. The `enable-api-fields` feature flag [must be set to `"alpha"`](./install.md)
+to specify `debug` in a `taskRun`.
+
 ## Debugging TaskRuns
 
 The following provides explanation on how Debugging TaskRuns is possible through Tekton. To understand how to use 

--- a/docs/install.md
+++ b/docs/install.md
@@ -413,6 +413,7 @@ Features currently in "alpha" are:
 | [Implicit `Parameters`](./taskruns.md#implicit-parameters)                                            | [TEP-0023](https://github.com/tektoncd/community/blob/main/teps/0023-implicit-mapping.md)                   | [v0.28.0](https://github.com/tektoncd/pipeline/releases/tag/v0.28.0) |                             |
 | [Windows Scripts](./tasks.md#windows-scripts)                                                         | [TEP-0057](https://github.com/tektoncd/community/blob/main/teps/0057-windows-support.md)                    | [v0.28.0](https://github.com/tektoncd/pipeline/releases/tag/v0.28.0) |                             |
 | [Remote Tasks](./taskruns.md#remote-tasks) and [Remote Pipelines](./pipelineruns.md#remote-pipelines) | [TEP-0060](https://github.com/tektoncd/community/blob/main/teps/0060-remote-resolutiond.md)                 |                                                                      |                             |
+| [Debug](./debug.md) | [TEP-0042](https://github.com/tektoncd/community/blob/main/teps/0042-taskrun-breakpoint-on-failure.md) | [v0.26.0](https://github.com/tektoncd/pipeline/releases/tag/v0.26.0) | |
 
 ## Configuring High Availability
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -273,10 +273,10 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 				Name: "my-task",
 			},
 			Debug: &v1beta1.TaskRunDebug{
-				Breakpoint: []string{"bReaKdAnCe"},
+				Breakpoint: []string{"onFailure"},
 			},
 		},
-		wantErr: apis.ErrDisallowedFields("debug"),
+		wantErr: apis.ErrGeneric("debug requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "invalid breakpoint",
 		spec: v1beta1.TaskRunSpec{


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Documenting that the debug feature is still alpha. The feature was introduced in pipelines release 0.26 behind enable-api-fields flag.

Reference: https://github.com/tektoncd/pipeline/pull/3857/files#r667058866

/kind documentation


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
