### PR TITLE
Patch temp GOPATH hack script to handle nounset option

### DIFF
--- a/hack/setup-temporary-gopath.sh
+++ b/hack/setup-temporary-gopath.sh
@@ -13,13 +13,16 @@ function shim_gopath() {
   local TEMP_PIPELINE="${TEMP_TEKTONCD}/pipeline"
   local NEEDS_MOVE=1
 
+  # Checks if GOPATH exists without triggering nounset panic.
+  EXISTING_GOPATH=${GOPATH:-}
+
   # Check if repo is in GOPATH already and return early if so.
   # Unfortunately this doesn't respect a repo that's symlinked into
   # GOPATH and will create a temporary anyway. I couldn't figure out
   # a way to get the absolute path to the symlinked repo root.
-  if [ ! -z $GOPATH ] ; then
+  if [ ! -z $EXISTING_GOPATH ] ; then
     case $REPO_DIR/ in
-      $GOPATH/*) NEEDS_MOVE=0;;
+      $EXISTING_GOPATH/*) NEEDS_MOVE=0;;
       *) NEEDS_MOVE=1;;
     esac
   fi


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


Prior to this commit the setup-temporary-gopath.sh hack script referenced the GOPATH env variable without first checking that it was set. When `set -o nounset` is working (which it isn't on my machine 😖 ) this causes the script to exit with an error.

This commit adds a variable wrapping $GOPATH and setting a default if it's missing, which should work around the `nounset`.

/kind bug


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
