### PR TITLE
Fix links to Why Aren't PipelineResources in Beta? v0.29.x

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -144,7 +144,7 @@ for that data to be put so that it can be shared between Tasks in the Pipeline.
 **Note:** Pipeline Resources are in alpha and are currently undergoing considerable redesign. Therefore
 this storage configuration is possibly going to change in future. Writing Tasks and Pipelines today that rely
 on this feature may mean you'll need to rewrite those Tasks and Pipelines when the redesign is complete. See
-the [explanation for the redesign in the PipelineResources doc](./resources.md#why-arent-pipelineresources-in-beta)
+the [explanation for the redesign in the PipelineResources doc](./resources.md#why-aren-t-pipelineresources-in-beta)
 and [issue 1673](https://github.com/tektoncd/pipeline/issues/1673) to follow along with the redesign work.
 
 The storage options available for sharing PipelineResources between Tasks in a Pipeline are:

--- a/docs/migrating-v1alpha1-to-v1beta1.md
+++ b/docs/migrating-v1alpha1-to-v1beta1.md
@@ -83,7 +83,7 @@ removed entirely, and until this has been resolved, we encourage people to use `
 `PipelineResources` when they can.
 
 _More on the reasoning and what's left to do in
-[Why aren't PipelineResources in Beta?](resources.md#why-arent-pipelineresources-in-beta)._
+[Why aren't PipelineResources in Beta?](resources.md#why-aren-t-pipelineresources-in-beta)._
 
 To ease migration away from `PipelineResources`
 [some types have an equivalent `Task` in the Catalog](#replacing-pipelineresources-with-tasks).

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -30,7 +30,7 @@ For example:
 > which lists each PipelineResource type and a suggested option for replacing it.
 >
 > For more information on why PipelineResources are remaining alpha [see the description
-> of their problems, along with next steps, below](#why-arent-pipelineresources-in-beta).
+> of their problems, along with next steps, below](#why-aren-t-pipelineresources-in-beta).
 
 --------------------------------------------------------------------------------
 
@@ -49,7 +49,7 @@ For example:
     -   [Storage Resource](#storage-resource)
         -   [GCS Storage Resource](#gcs-storage-resource)
     -   [Cloud Event Resource](#cloud-event-resource)
--   [Why Aren't PipelineResources in Beta?](#why-arent-pipelineresources-in-beta)
+-   [Why Aren't PipelineResources in Beta?](#why-aren-t-pipelineresources-in-beta)
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Backport https://github.com/tektoncd/pipeline/pull/4572

Links to the "Why Aren't PipelineResources in Beta?" section in the docs
should have `aren-t` in the fragment instead of `arent`. This can be
confirmed by clicking the link icon beside the heading and checking the
browser address bar.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

/release-note-none