### PR TITLE
Assume task not skipped if the run is associated

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -665,7 +665,7 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 	// when expressions, so reset the skipped cache
 	pipelineRunFacts.ResetSkippedCache()
 
-	// GetFinalTasks only returns tasks when a DAG is complete
+	// GetFinalTasks only returns final tasks when a DAG is complete
 	fnextRprts := pipelineRunFacts.GetFinalTasks()
 	if len(fnextRprts) != 0 {
 		// apply the runtime context just before creating taskRuns for final tasks in queue

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -209,6 +209,15 @@ func (t ResolvedPipelineRunTask) isCancelled() bool {
 	}
 }
 
+// isScheduled returns true when the PipelineRunTask itself has a TaskRun
+// or Run associated.
+func (t ResolvedPipelineRunTask) isScheduled() bool {
+	if t.IsCustomTask() {
+		return t.Run != nil
+	}
+	return t.TaskRun != nil
+}
+
 // isStarted returns true only if the PipelineRunTask itself has a TaskRun or
 // Run associated that has a Succeeded-type condition.
 func (t ResolvedPipelineRunTask) isStarted() bool {
@@ -249,7 +258,7 @@ func (t *ResolvedPipelineRunTask) skip(facts *PipelineRunFacts) TaskSkipStatus {
 	var skippingReason v1beta1.SkippingReason
 
 	switch {
-	case facts.isFinalTask(t.PipelineTask.Name) || t.isStarted():
+	case facts.isFinalTask(t.PipelineTask.Name) || t.isScheduled():
 		skippingReason = v1beta1.None
 	case facts.IsStopping():
 		skippingReason = v1beta1.StoppingSkip
@@ -349,7 +358,7 @@ func (t *ResolvedPipelineRunTask) IsFinallySkipped(facts *PipelineRunFacts) Task
 	var skippingReason v1beta1.SkippingReason
 
 	switch {
-	case t.isStarted():
+	case t.isScheduled():
 		skippingReason = v1beta1.None
 	case facts.checkDAGTasksDone() && facts.isFinalTask(t.PipelineTask.Name):
 		switch {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -156,6 +156,12 @@ var trs = []v1beta1.TaskRun{{
 		Name:      "pipelinerun-mytask2",
 	},
 	Spec: v1beta1.TaskRunSpec{},
+}, {
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "namespace",
+		Name:      "pipelinerun-mytask4",
+	},
+	Spec: v1beta1.TaskRunSpec{},
 }}
 
 var runs = []v1alpha1.Run{{
@@ -392,6 +398,22 @@ var finalScheduledState = PipelineRunState{{
 	PipelineTask: &pts[1],
 	TaskRunName:  "pipelinerun-mytask2",
 	TaskRun:      makeScheduled(trs[1]),
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var retryableFinalState = PipelineRunState{{
+	PipelineTask: &pts[0],
+	TaskRunName:  "pipelinerun-mytask1",
+	TaskRun:      makeSucceeded(trs[0]),
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[3],
+	TaskRunName:  "pipelinerun-mytask4",
+	TaskRun:      makeFailed(trs[2]),
 	ResolvedTaskResources: &resources.ResolvedTaskResources{
 		TaskSpec: &task.Spec,
 	},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -402,7 +402,7 @@ func (facts *PipelineRunFacts) DAGExecutionQueue() (PipelineRunState, error) {
 	return tasks, nil
 }
 
-// GetFinalTasks returns a list of final tasks without any taskRun associated with it
+// GetFinalTasks returns a list of final tasks which needs to be executed next
 // GetFinalTasks returns final tasks only when all DAG tasks have finished executing or have been skipped
 func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
 	tasks := PipelineRunState{}
@@ -412,7 +412,7 @@ func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
 	if facts.checkDAGTasksDone() {
 		// return list of tasks with all final tasks
 		for _, t := range facts.State {
-			if facts.isFinalTask(t.PipelineTask.Name) && !t.isScheduled() {
+			if facts.isFinalTask(t.PipelineTask.Name) {
 				finalCandidates.Insert(t.PipelineTask.Name)
 			}
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -412,7 +412,7 @@ func (facts *PipelineRunFacts) GetFinalTasks() PipelineRunState {
 	if facts.checkDAGTasksDone() {
 		// return list of tasks with all final tasks
 		for _, t := range facts.State {
-			if facts.isFinalTask(t.PipelineTask.Name) && !t.isSuccessful() {
+			if facts.isFinalTask(t.PipelineTask.Name) && !t.isScheduled() {
 				finalCandidates.Insert(t.PipelineTask.Name)
 			}
 		}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -1194,6 +1194,15 @@ func TestPipelineRunState_GetFinalTasks(t *testing.T) {
 		DAGTasks:           []v1beta1.PipelineTask{pts[0]},
 		finalTasks:         []v1beta1.PipelineTask{pts[1]},
 		expectedFinalTasks: PipelineRunState{},
+	}, {
+		// tasks: [ mytask1]
+		// finally: [mytask4]
+		name:               "07 - DAG tasks succeeded, return retryable final tasks",
+		desc:               "DAG task (mytask1) finished successfully - retry failed final tasks (mytask4)",
+		state:              retryableFinalState,
+		DAGTasks:           []v1beta1.PipelineTask{pts[0]},
+		finalTasks:         []v1beta1.PipelineTask{pts[3]},
+		expectedFinalTasks: PipelineRunState{retryableFinalState[1]},
 	}}
 	for _, tc := range tcs {
 		dagGraph, err := dag.Build(v1beta1.PipelineTaskList(tc.DAGTasks), v1beta1.PipelineTaskList(tc.DAGTasks).Deps())


### PR DESCRIPTION
# Changes

Resolves https://github.com/tektoncd/pipeline/issues/4582

Currently, the status of PipelineRun with Finally is flakey. For example, PipelineRun's completionTime is earlier than the last TaskRun's completionTime, and also Running Finally tasks are marked as Skipped.

This issue occurs when TaskRun has no conditions. Because [the task state context is not applied to the running Final tasks](https://github.com/tektoncd/pipeline/blob/62c9b0d861bd2ae01263dfa67ba41fb0fa2bc9a9/pkg/reconciler/pipelinerun/pipelinerun.go#L635-L652) and [IsFinallySkipped](https://github.com/tektoncd/pipeline/blob/62c9b0d861bd2ae01263dfa67ba41fb0fa2bc9a9/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L314-L339) assumes [TaskRun with no conditions as not started](https://github.com/tektoncd/pipeline/blob/62c9b0d861bd2ae01263dfa67ba41fb0fa2bc9a9/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L167-L175).

This commit resolves this issue by assuming the finally task is not skipped if the run is associated.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fixes controller with the high value of `ThreadsPerController` to report the correct status of PipelineRun, which contains Finally tasks.
```