### PR TITLE
Fix for some arm64 machines.

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -76,9 +76,9 @@ spec:
           # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
           "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
           # The shell image must be root in order to create directories and copy files to PVCs.
-          # gcr.io/distroless/base:debug as of October 21, 2021
+          # gcr.io/distroless/base:debug as of February 17, 2022
           # image shall not contains tag, so it will be supported on a runtime like cri-o
-          "-shell-image", "gcr.io/distroless/base@sha256:cfdc553400d41b47fd231b028403469811fcdbc0e69d66ea8030c5a0b5fbac2b",
+          "-shell-image", "gcr.io/distroless/base@sha256:3cebc059e7e52a4f5a389aa6788ac2b582227d7953933194764ea434f4d70d64",
           # for script mode to work with windows we need a powershell image
           # pinning to nanoserver tag as of July 15 2021
           "-shell-image-win", "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6",


### PR DESCRIPTION
# Changes
As said in https://github.com/GoogleContainerTools/distroless/issues/657, in the past, distroless/base:debug used an arm32 busybox binary in its arm64 image. Which doesn't work on some arm64 machines, e.g., Ubuntu 21 arm64 on Parallel Desktop on Apple Silicon M1. It caused this error:
```
$ docker run -it gcr.io/distroless/base@sha256:cfdc553400d41b47fd231b028403469811fcdbc0e69d66ea8030c5a0b5fbac2b
standard_init_linux.go:228: exec user process caused: exec format error
```
Fortunately, this PR https://github.com/GoogleContainerTools/distroless/pull/960 fixes this bug. Hence, I update the distroless/base:debug used by Tekton Pipeline in this commit.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
Fix problems on some arm64 machines.
```
