### PR TITLE
Implement Step and Sidecar Overrides for TaskRun

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -404,10 +404,9 @@ and reasons.
 ### Overriding Task Steps and Sidecars
 
 **([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
-**Warning: This feature is still under development and is not yet functional. Do not use it.**
 
 A TaskRun can specify `StepOverrides` or `SidecarOverrides` to override Step or Sidecar
-configuration specified in a Task.
+configuration specified in a Task. Only named Steps and Sidecars may be overridden.
 
 For example, given the following Task definition:
 
@@ -450,6 +449,15 @@ spec:
 ```
 `StepOverrides` and `SidecarOverrides` must include the `name` field and may include `resources`.
 No other fields can be overridden.
+If the overridden `Task` uses a [`StepTemplate`](./tasks.md#specifying-a-step-template), configuration on
+`Step` will take precedence over configuration in `StepTemplate`, and configuration in `StepOverride` will
+take precedence over both.
+
+When merging resource requirements, different resource types are considered independently.
+For example, if a `Step` configures both CPU and memory, and a `StepOverride` configures only memory,
+the CPU values from the `Step` will be preserved. Requests and limits are also considered independently.
+For example, if a `Step` configures a memory request and limit, and a `StepOverride` configures only a
+memory request, the memory limit from the `Step` will be preserved.
 
 ### Specifying `LimitRange` values
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -534,6 +534,8 @@ func (pr *PipelineRun) GetTaskRunSpec(pipelineTaskName string) PipelineTaskRunSp
 			if task.TaskServiceAccountName != "" {
 				s.TaskServiceAccountName = task.TaskServiceAccountName
 			}
+			s.StepOverrides = task.StepOverrides
+			s.SidecarOverrides = task.SidecarOverrides
 		}
 	}
 	return s

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -749,6 +749,8 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 			ServiceAccountName: taskRunSpec.TaskServiceAccountName,
 			Timeout:            getTimeoutFunc(ctx, pr, rprt, c.Clock),
 			PodTemplate:        taskRunSpec.TaskPodTemplate,
+			StepOverrides:      taskRunSpec.StepOverrides,
+			SidecarOverrides:   taskRunSpec.SidecarOverrides,
 		}}
 
 	if rprt.ResolvedTaskResources.TaskName != "" {

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -4451,6 +4451,8 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 						"workloadtype": "tekton",
 					},
 				},
+				StepOverrides:    []v1beta1.TaskRunStepOverride{{Name: "foo"}},
+				SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{Name: "bar"}},
 			}},
 		},
 	}}
@@ -4487,8 +4489,10 @@ func TestReconcileAndPropagateCustomPipelineTaskRunSpec(t *testing.T) {
 					"workloadtype": "tekton",
 				},
 			},
-			Resources: &v1beta1.TaskRunResources{},
-			Timeout:   &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			Resources:        &v1beta1.TaskRunResources{},
+			Timeout:          &metav1.Duration{Duration: config.DefaultTimeoutMinutes * time.Minute},
+			StepOverrides:    []v1beta1.TaskRunStepOverride{{Name: "foo"}},
+			SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{Name: "bar"}},
 		},
 	}
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -358,6 +358,12 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		}
 	}
 
+	if err := validateOverrides(ctx, taskSpec, &tr.Spec); err != nil {
+		logger.Errorf("TaskRun %q step or sidecar overrides are invalid: %v", tr.Name, err)
+		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
+		return nil, nil, controller.NewPermanentError(err)
+	}
+
 	// Initialize the cloud events if at least a CloudEventResource is defined
 	// and they have not been initialized yet.
 	// FIXME(afrittoli) This resource specific logic will have to be replaced


### PR DESCRIPTION
# Changes
This implements [TEP-0094: Configuring Resources at Runtime](https://github.com/tektoncd/community/blob/main/teps/0094-configuring-resources-at-runtime.md).
StepOverrides and SidecarOverrides were added to the API in a previous commit.
This commit allows them to override resource requirements specified in the Task spec.
The same merging strategy that is currently used for stepTemplate is also used for
step and sidecar overrides, except that only the resources field of the container is overridden,
and unlike with templates, the overrides take precedence over the Task spec.

Closes #4326.

Tested E2E locally. Happy to split into separate PRs if this would be helpful.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
[Feature] Implement Step and Sidecar Overrides for TaskRun
```
