### PR TITLE
set the param type based on the default value

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -57,7 +57,17 @@ func (pp *ParamSpec) SetDefaults(ctx context.Context) {
 	if pp != nil && pp.Type == "" {
 		if pp.Default != nil {
 			// propagate the parsed ArrayOrString's type to the parent ParamSpec's type
-			pp.Type = pp.Default.Type
+			if pp.Default.Type != "" {
+				// propagate the default type if specified
+				pp.Type = pp.Default.Type
+			} else {
+				// determine the type based on the array or string values when default value is specified but not the type
+				if pp.Default.ArrayVal != nil {
+					pp.Type = ParamTypeArray
+				} else {
+					pp.Type = ParamTypeString
+				}
+			}
 		} else {
 			// ParamTypeString is the default value (when no type can be inferred from the default value)
 			pp.Type = ParamTypeString

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -42,15 +42,34 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 			Type: v1beta1.ParamTypeString,
 		},
 	}, {
-		name: "inferred type from default value",
+		name: "inferred type from default value - array",
 		before: &v1beta1.ParamSpec{
-			Name:    "parametername",
-			Default: v1beta1.NewArrayOrString("an", "array"),
+			Name: "parametername",
+			Default: &v1beta1.ArrayOrString{
+				ArrayVal: []string{"array"},
+			},
 		},
 		defaultsApplied: &v1beta1.ParamSpec{
-			Name:    "parametername",
-			Type:    v1beta1.ParamTypeArray,
-			Default: v1beta1.NewArrayOrString("an", "array"),
+			Name: "parametername",
+			Type: v1beta1.ParamTypeArray,
+			Default: &v1beta1.ArrayOrString{
+				ArrayVal: []string{"array"},
+			},
+		},
+	}, {
+		name: "inferred type from default value - string",
+		before: &v1beta1.ParamSpec{
+			Name: "parametername",
+			Default: &v1beta1.ArrayOrString{
+				StringVal: "an",
+			},
+		},
+		defaultsApplied: &v1beta1.ParamSpec{
+			Name: "parametername",
+			Type: v1beta1.ParamTypeString,
+			Default: &v1beta1.ArrayOrString{
+				StringVal: "an",
+			},
 		},
 	}, {
 		name: "fully defined ParamSpec",
@@ -58,13 +77,17 @@ func TestParamSpec_SetDefaults(t *testing.T) {
 			Name:        "parametername",
 			Type:        v1beta1.ParamTypeArray,
 			Description: "a description",
-			Default:     v1beta1.NewArrayOrString("an", "array"),
+			Default: &v1beta1.ArrayOrString{
+				ArrayVal: []string{"array"},
+			},
 		},
 		defaultsApplied: &v1beta1.ParamSpec{
 			Name:        "parametername",
 			Type:        v1beta1.ParamTypeArray,
 			Description: "a description",
-			Default:     v1beta1.NewArrayOrString("an", "array"),
+			Default: &v1beta1.ArrayOrString{
+				ArrayVal: []string{"array"},
+			},
 		},
 	}}
 	for _, tc := range tests {

--- a/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_defaults_test.go
@@ -82,6 +82,21 @@ func TestPipelineSpec_SetDefaults(t *testing.T) {
 			}},
 		},
 	}, {
+		desc: "param type - param type must be derived based on the default value " + string(v1beta1.ParamTypeString),
+		ps: &v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name: "string-param",
+				Default: &v1beta1.ArrayOrString{
+					StringVal: "foo",
+				},
+			}},
+		},
+		want: &v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{{
+				Name: "string-param", Type: v1beta1.ParamTypeString, Default: &v1beta1.ArrayOrString{StringVal: "foo"},
+			}},
+		},
+	}, {
 		desc: "pipeline task with taskSpec - default param type must be " + string(v1beta1.ParamTypeString),
 		ps: &v1beta1.PipelineSpec{
 			Tasks: []v1beta1.PipelineTask{{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`(pp *ParamSpec) SetDefaults` sets the param type based on the default type. But, it is possible that the `default` value is specified without specifying the type. Also, the `else` block sets the `type` to `string` when `default` is `nil` not when the type can not be inferred from the default value (like its explained in the comment): 

https://github.com/tektoncd/pipeline/blob/99b8b196ea753af36befda8c0e0e1eaa9490ae68/pkg/apis/pipeline/v1beta1/param_types.go#L58-L64

The unit tests does not catch this since the test uses `v1beta1.NewArrayOrString` which sets the type explicitly:

https://github.com/tektoncd/pipeline/blob/99b8b196ea753af36befda8c0e0e1eaa9490ae68/pkg/apis/pipeline/v1beta1/param_types.go#L139-L150

This commit checks if the `type` is not specified, infer it from the default value and sets the param type based on the default value.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


For pull requests with a release note:

```release-note
Set the type of the param based on the default value when the type is not specified or cannot be inferred from the default value.
```