### PR TITLE
cleaning up a unit test to use YAMLParser

### DIFF
--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -64,6 +64,16 @@ kind: Task
 	return &task
 }
 
+// MustParseClusterTask takes YAML and parses it into a *v1beta1.ClusterTask
+func MustParseClusterTask(t *testing.T, yaml string) *v1beta1.ClusterTask {
+	var task v1beta1.ClusterTask
+	yaml = `apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+` + yaml
+	mustParseYAML(t, yaml, &task)
+	return &task
+}
+
 // MustParsePipelineRun takes YAML and parses it into a *v1beta1.PipelineRun
 func MustParsePipelineRun(t *testing.T, yaml string) *v1beta1.PipelineRun {
 	var pr v1beta1.PipelineRun


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is the first unit test in `pipelinerun_test.go` to be converted such that the objects initializations are replaced with YAMLParser for readability.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes


```release-note
NONE
```
