### PR TITLE
Update IsFailure method to reflect Run retries

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -231,7 +231,7 @@ func (state PipelineRunState) getNextTasks(candidateTasks sets.String) []*Resolv
 		if _, ok := candidateTasks[t.PipelineTask.Name]; ok {
 			if t.TaskRun == nil && t.Run == nil {
 				tasks = append(tasks, t)
-			} else if t.TaskRun != nil { // only TaskRun currently supports retry
+			} else if t.TaskRun != nil { // TODO(lbernick): Return custom tasks with retries remaining
 				status := t.TaskRun.Status.GetCondition(apis.ConditionSucceeded)
 				if status != nil && status.IsFalse() {
 					if !(t.TaskRun.IsCancelled() || status.Reason == v1beta1.TaskRunReasonCancelled.String() || status.Reason == ReasonConditionCheckFailed) {


### PR DESCRIPTION
# Changes
Custom Tasks support retries (as of #4327); however, there are some places in the code base that consider
retries only for TaskRuns. This commit updates ResolvedPipelineRunTask.IsFailure to recognize
Run retries and adds tests for this method. The function PipelineRunState.getNextTasks will
be updated in a future commit. No functional changes for TaskRuns.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
[Bug Fix]: Runs that have remaining retries are not failed
```
