### PR TITLE
Change Default Metrics Level for Taskrun and Pipelinerun

### DIFF
--- a/config/config-observability.yaml
+++ b/config/config-observability.yaml
@@ -54,7 +54,7 @@ data:
     # charge.  If metrics.backend-destination is not Stackdriver, this is
     # ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
-    metrics.taskrun.level: "taskrun"
+    metrics.taskrun.level: "task"
     metrics.taskrun.duration-type: "histogram"
-    metrics.pipelinerun.level: "pipelinerun"
+    metrics.pipelinerun.level: "pipeline"
     metrics.pipelinerun.duration-type: "histogram"

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -31,12 +31,11 @@ The Labels/Tag marked as "*" are optional. And there's a choice between Histogra
 A sample config-map has been provided as [config-observability](./../config/config-observability.yaml). By default, taskrun and pipelinerun metrics have these values:
 
 ``` yaml
-    metrics.taskrun.level: "taskrun"
+    metrics.taskrun.level: "task"
     metrics.taskrun.duration-type: "histogram"
-    metrics.pipelinerun.level: "pipelinerun"
+    metrics.pipelinerun.level: "pipeline"
     metrics.pipelinerun.duration-type: "histogram"
 ```
-Levels for taskrun and pipelinerun will be changed to task and pipeline respectively in the next release.
 
 Following values are available in the configmap:
 

--- a/pkg/apis/config/metrics.go
+++ b/pkg/apis/config/metrics.go
@@ -38,9 +38,7 @@ const (
 
 	// DefaultTaskrunLevel determines to what level to aggregate metrics
 	// when it isn't specified in configmap
-	// TBD: Change to task in next
-	// relase and taskrun level will be deprecated
-	DefaultTaskrunLevel = "taskrun"
+	DefaultTaskrunLevel = TaskrunLevelAtTask
 	// TaskrunLevelAtTaskrun specify that aggregation will be done at
 	// taskrun level
 	TaskrunLevelAtTaskrun = "taskrun"
@@ -50,9 +48,7 @@ const (
 	TaskrunLevelAtNS = "namespace"
 	// DefaultPipelinerunLevel determines to what level to aggregate metrics
 	// when it isn't specified in configmap
-	// TBD: Change to pipeline in next
-	// relase and pipelinerun level will be deprecated
-	DefaultPipelinerunLevel = "pipelinerun"
+	DefaultPipelinerunLevel = PipelinerunLevelAtPipeline
 	// PipelinerunLevelAtPipelinerun specify that aggregation will be done at
 	// pipelienrun level
 	PipelinerunLevelAtPipelinerun = "pipelinerun"

--- a/pkg/apis/config/metrics_test.go
+++ b/pkg/apis/config/metrics_test.go
@@ -60,8 +60,8 @@ func TestNewMetricsFromConfigMap(t *testing.T) {
 func TestNewMetricsFromEmptyConfigMap(t *testing.T) {
 	MetricsConfigEmptyName := "config-observability-empty"
 	expectedConfig := &config.Metrics{
-		TaskrunLevel:            config.TaskrunLevelAtTaskrun,
-		PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
+		TaskrunLevel:            config.TaskrunLevelAtTask,
+		PipelinerunLevel:        config.PipelinerunLevelAtPipeline,
 		DurationTaskrunType:     config.DurationPipelinerunTypeHistogram,
 		DurationPipelinerunType: config.DurationPipelinerunTypeHistogram,
 	}

--- a/pkg/pipelinerunmetrics/metrics_test.go
+++ b/pkg/pipelinerunmetrics/metrics_test.go
@@ -46,8 +46,8 @@ func getConfigContext() context.Context {
 	ctx := context.Background()
 	cfg := &config.Config{
 		Metrics: &config.Metrics{
-			TaskrunLevel:            config.DefaultTaskrunLevel,
-			PipelinerunLevel:        config.DefaultPipelinerunLevel,
+			TaskrunLevel:            config.TaskrunLevelAtTaskrun,
+			PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
 			DurationTaskrunType:     config.DefaultDurationTaskrunType,
 			DurationPipelinerunType: config.DefaultDurationPipelinerunType,
 		},

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -47,8 +47,8 @@ func getConfigContext() context.Context {
 	ctx := context.Background()
 	cfg := &config.Config{
 		Metrics: &config.Metrics{
-			TaskrunLevel:            config.DefaultTaskrunLevel,
-			PipelinerunLevel:        config.DefaultPipelinerunLevel,
+			TaskrunLevel:            config.TaskrunLevelAtTaskrun,
+			PipelinerunLevel:        config.PipelinerunLevelAtPipelinerun,
 			DurationTaskrunType:     config.DefaultDurationTaskrunType,
 			DurationPipelinerunType: config.DefaultDurationPipelinerunType,
 		},


### PR DESCRIPTION
Change default metrics level for Taskrun to task and
Pipelinerun to pipeline. Part of TEP0073

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Metrics Default Changes:
The Level for taskrun and pipelinerun metrics will change in this release.
By default, taskrun and pipelinerun metrics have these values:

``` yaml
    metrics.taskrun.level: "task"
    metrics.taskrun.duration-type: "histogram"
    metrics.pipelinerun.level: "pipeline"
    metrics.pipelinerun.duration-type: "histogram"
```