### PR TITLE
TEP-0090: Refactor execution status validation

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -296,6 +296,82 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 	return errs
 }
 
+func (pt *PipelineTask) validateExecutionStatusVariablesDisallowed() (errs *apis.FieldError) {
+	for _, param := range pt.Params {
+		if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
+			errs = errs.Also(validateContainsExecutionStatusVariablesDisallowed(expressions, "value").
+				ViaFieldKey("params", param.Name))
+		}
+	}
+	for i, we := range pt.WhenExpressions {
+		if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
+			errs = errs.Also(validateContainsExecutionStatusVariablesDisallowed(expressions, "").
+				ViaFieldIndex("when", i))
+		}
+	}
+	return errs
+}
+
+func (pt *PipelineTask) validateExecutionStatusVariablesAllowed(ptNames sets.String) (errs *apis.FieldError) {
+	for _, param := range pt.Params {
+		if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
+			errs = errs.Also(validateExecutionStatusVariablesExpressions(expressions, ptNames, "value").
+				ViaFieldKey("params", param.Name))
+		}
+	}
+	for i, we := range pt.WhenExpressions {
+		if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
+			errs = errs.Also(validateExecutionStatusVariablesExpressions(expressions, ptNames, "").
+				ViaFieldIndex("when", i))
+		}
+	}
+	return errs
+}
+
+func validateContainsExecutionStatusVariablesDisallowed(expressions []string, path string) (errs *apis.FieldError) {
+	if containsExecutionStatusReferences(expressions) {
+		errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("pipeline tasks can not refer to execution status"+
+			" of any other pipeline task or aggregate status of tasks"), path))
+	}
+	return errs
+}
+
+func containsExecutionStatusReferences(expressions []string) bool {
+	// validate tasks.pipelineTask.status/tasks.status if this expression is not a result reference
+	if !LooksLikeContainsResultRefs(expressions) {
+		for _, e := range expressions {
+			// check if it contains context variable accessing execution status - $(tasks.taskname.status)
+			// or an aggregate status - $(tasks.status)
+			if containsExecutionStatusRef(e) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func validateExecutionStatusVariablesExpressions(expressions []string, ptNames sets.String, fieldPath string) (errs *apis.FieldError) {
+	// validate tasks.pipelineTask.status if this expression is not a result reference
+	if !LooksLikeContainsResultRefs(expressions) {
+		for _, expression := range expressions {
+			// its a reference to aggregate status of dag tasks - $(tasks.status)
+			if expression == PipelineTasksAggregateStatus {
+				continue
+			}
+			// check if it contains context variable accessing execution status - $(tasks.taskname.status)
+			if containsExecutionStatusRef(expression) {
+				// strip tasks. and .status from tasks.taskname.status to further verify task name
+				pt := strings.TrimSuffix(strings.TrimPrefix(expression, "tasks."), ".status")
+				// report an error if the task name does not exist in the list of dag tasks
+				if !ptNames.Has(pt) {
+					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("pipeline task %s is not defined in the pipeline", pt), fieldPath))
+				}
+			}
+		}
+	}
+	return errs
+}
+
 // TaskSpecMetadata returns the metadata of the PipelineTask's EmbeddedTask spec.
 func (pt *PipelineTask) TaskSpecMetadata() PipelineTaskMetadata {
 	return pt.TaskSpec.Metadata

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -205,89 +205,23 @@ func containsExecutionStatusRef(p string) bool {
 // dag tasks cannot have param value as $(tasks.pipelineTask.status)
 func validateExecutionStatusVariablesInTasks(tasks []PipelineTask) (errs *apis.FieldError) {
 	for idx, t := range tasks {
-		for _, param := range t.Params {
-			// retrieve a list of substitution expression from a param
-			if ps, ok := GetVarSubstitutionExpressionsForParam(param); ok {
-				// validate tasks.pipelineTask.status/tasks.status if this expression is not a result reference
-				if !LooksLikeContainsResultRefs(ps) {
-					for _, p := range ps {
-						// check if it contains context variable accessing execution status - $(tasks.taskname.status)
-						// or an aggregate status - $(tasks.status)
-						if containsExecutionStatusRef(p) {
-							errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("pipeline tasks can not refer to execution status of any other pipeline task"+
-								" or aggregate status of tasks"), "value").ViaFieldKey("params", param.Name).ViaFieldIndex("tasks", idx))
-						}
-					}
-				}
-			}
-		}
-		for i, we := range t.WhenExpressions {
-			// retrieve a list of substitution expression from a when expression
-			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
-				// validate tasks.pipelineTask.status/tasks.status if this expression is not a result reference
-				if !LooksLikeContainsResultRefs(expressions) {
-					for _, e := range expressions {
-						// check if it contains context variable accessing execution status - $(tasks.taskname.status)
-						// or an aggregate status - $(tasks.status)
-						if containsExecutionStatusRef(e) {
-							errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("when expressions in pipeline tasks can not refer to execution status of any other pipeline task"+
-								" or aggregate status of tasks"), "").ViaFieldIndex("when", i).ViaFieldIndex("tasks", idx))
-						}
-					}
-				}
-			}
-		}
+		errs = errs.Also(t.validateExecutionStatusVariablesDisallowed()).ViaIndex(idx)
 	}
 	return errs
 }
 
 // validate finally tasks accessing execution status of a dag task specified in the pipeline
 // $(tasks.pipelineTask.status) is invalid if pipelineTask is not defined as a dag task
-func validateExecutionStatusVariablesInFinally(tasks []PipelineTask, finally []PipelineTask) (errs *apis.FieldError) {
-	// creating a list of pipelineTask names to validate tasks.<name>.status
-	ptNames := PipelineTaskList(tasks).Names()
+func validateExecutionStatusVariablesInFinally(tasksNames sets.String, finally []PipelineTask) (errs *apis.FieldError) {
 	for idx, t := range finally {
-		for _, param := range t.Params {
-			if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {
-				errs = errs.Also(validateExecutionStatusVariablesExpressions(expressions, ptNames, "value").ViaFieldKey(
-					"params", param.Name).ViaFieldIndex("finally", idx))
-			}
-		}
-		for i, we := range t.WhenExpressions {
-			if expressions, ok := we.GetVarSubstitutionExpressions(); ok {
-				errs = errs.Also(validateExecutionStatusVariablesExpressions(expressions, ptNames, "").ViaFieldIndex(
-					"when", i).ViaFieldIndex("finally", idx))
-			}
-		}
-	}
-	return errs
-}
-
-func validateExecutionStatusVariablesExpressions(expressions []string, ptNames sets.String, fieldPath string) (errs *apis.FieldError) {
-	// validate tasks.pipelineTask.status if this expression is not a result reference
-	if !LooksLikeContainsResultRefs(expressions) {
-		for _, expression := range expressions {
-			// its a reference to aggregate status of dag tasks - $(tasks.status)
-			if expression == PipelineTasksAggregateStatus {
-				continue
-			}
-			// check if it contains context variable accessing execution status - $(tasks.taskname.status)
-			if containsExecutionStatusRef(expression) {
-				// strip tasks. and .status from tasks.taskname.status to further verify task name
-				pt := strings.TrimSuffix(strings.TrimPrefix(expression, "tasks."), ".status")
-				// report an error if the task name does not exist in the list of dag tasks
-				if !ptNames.Has(pt) {
-					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("pipeline task %s is not defined in the pipeline", pt), fieldPath))
-				}
-			}
-		}
+		errs = errs.Also(t.validateExecutionStatusVariablesAllowed(tasksNames).ViaIndex(idx))
 	}
 	return errs
 }
 
 func validateExecutionStatusVariables(tasks []PipelineTask, finallyTasks []PipelineTask) (errs *apis.FieldError) {
-	errs = errs.Also(validateExecutionStatusVariablesInTasks(tasks))
-	errs = errs.Also(validateExecutionStatusVariablesInFinally(tasks, finallyTasks))
+	errs = errs.Also(validateExecutionStatusVariablesInTasks(tasks).ViaField("tasks"))
+	errs = errs.Also(validateExecutionStatusVariablesInFinally(PipelineTaskList(tasks).Names(), finallyTasks).ViaField("finally"))
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -2420,10 +2420,7 @@ func TestPipelineTasksExecutionStatus(t *testing.T) {
 		}},
 		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
 			Message: `invalid value: pipeline tasks can not refer to execution status of any other pipeline task or aggregate status of tasks`,
-			Paths:   []string{"tasks[0].params[bar-status].value"},
-		}).Also(&apis.FieldError{
-			Message: `invalid value: when expressions in pipeline tasks can not refer to execution status of any other pipeline task or aggregate status of tasks`,
-			Paths:   []string{"tasks[0].when[0]"},
+			Paths:   []string{"tasks[0].params[bar-status].value", "tasks[0].when[0]"},
 		}),
 	}, {
 		name: "invalid string variable in dag task accessing aggregate status of tasks",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Today, the execution status validation is long and has duplicated code. We need to validate execution status in matrix, a feature proposed in [TEP-0090][tep-0090]. To set up for that, we are refactoring the execution status validation in this change which includes splitting up the function and reusing common logic.

cc @pritidesai 

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```