### PR TITLE
Fix Task(Run)/Pipeline(Run) metadata propagation

### DIFF
--- a/docs/labels.md
+++ b/docs/labels.md
@@ -1,10 +1,10 @@
 <!--
 ---
-linkTitle: "Labels"
+linkTitle: "Labels and Annotations"
 weight: 1300
 ---
 -->
-# Labels
+# Labels and Annotations
 
 Tekton allows you to use custom [Kubernetes Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 to easily mark Tekton entities belonging to the same conceptual execution chain. Tekton also automatically adds select labels
@@ -25,14 +25,16 @@ Labels propagate among Tekton entities as follows:
 
 - For `Pipelines` instantiated using a `PipelineRun`, labels propagate
 automatically from `Pipelines` to `PipelineRuns` to `TaskRuns`, and then to
-the associated `Pods`.
+the associated `Pods`. If a label is present in both `Pipeline` and
+`PipelineRun`, the label in `PipelineRun` takes precedence.
 
 - Labels from `Tasks` referenced by `TaskRuns` within a `PipelineRun` propagate to the corresponding `TaskRuns`,
-and then to the associated `Pods`.
+and then to the associated `Pods`. As for `Pipeline` and `PipelineRun`, if a label is present in both `Task` and
+`TaskRun`, the label in `TaskRun` takes precedence.
 
 - For standalone `TaskRuns` (that is, ones not executing as part of a `Pipeline`), labels
 propagate from the [referenced `Task`](taskruns.md#specifying-the-target-task), if one exists, to
-the corresponding `TaskRun`, and then to the associated `Pod`.
+the corresponding `TaskRun`, and then to the associated `Pod`. The same as above applies.
 
 - For `Conditions`, labels propagate to the corresponding `TaskRuns`, and then to the associated `Pods`.
 
@@ -116,3 +118,22 @@ The following command finds all `TaskRuns` that reference a `ClusterTask` named 
 ```shell
 kubectl get taskruns --all-namespaces -l tekton.dev/clusterTask=test-clustertask
 ```
+
+## Annotations propagation
+
+Annotation propagate among Tekton entities as follows (similar to Labels):
+
+- For `Pipelines` instantiated using a `PipelineRun`, annotations propagate
+automatically from `Pipelines` to `PipelineRuns` to `TaskRuns`, and then to
+the associated `Pods`. If a annotation is present in both `Pipeline` and
+`PipelineRun`, the annotation in `PipelineRun` takes precedence.
+
+- Annotations from `Tasks` referenced by `TaskRuns` within a `PipelineRun` propagate to the corresponding `TaskRuns`,
+and then to the associated `Pods`. As for `Pipeline` and `PipelineRun`, if a annotation is present in both `Task` and
+`TaskRun`, the annotation in `TaskRun` takes precedence.
+
+- For standalone `TaskRuns` (that is, ones not executing as part of a `Pipeline`), annotations
+propagate from the [referenced `Task`](taskruns.md#specifying-the-target-task), if one exists, to
+the corresponding `TaskRun`, and then to the associated `Pod`. The same as above applies.
+
+- For `Conditions`, annotations propagate to the corresponding `TaskRuns`, and then to the associated `Pods`.

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1133,7 +1133,11 @@ func storePipelineSpecAndMergeMeta(pr *v1beta1.PipelineRun, ps *v1beta1.Pipeline
 			pr.ObjectMeta.Labels = make(map[string]string, len(meta.Labels)+1)
 		}
 		for key, value := range meta.Labels {
-			pr.ObjectMeta.Labels[key] = value
+			// Do not override duplicates between PipelineRun and Pipeline
+			// PipelineRun labels take precedences over Pipeline
+			if _, ok := pr.ObjectMeta.Labels[key]; !ok {
+				pr.ObjectMeta.Labels[key] = value
+			}
 		}
 		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = meta.Name
 
@@ -1142,7 +1146,11 @@ func storePipelineSpecAndMergeMeta(pr *v1beta1.PipelineRun, ps *v1beta1.Pipeline
 			pr.ObjectMeta.Annotations = make(map[string]string, len(meta.Annotations))
 		}
 		for key, value := range meta.Annotations {
-			pr.ObjectMeta.Annotations[key] = value
+			// Do not override duplicates between PipelineRun and Pipeline
+			// PipelineRun labels take precedences over Pipeline
+			if _, ok := pr.ObjectMeta.Annotations[key]; !ok {
+				pr.ObjectMeta.Annotations[key] = value
+			}
 		}
 
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -6038,6 +6038,29 @@ func Test_storePipelineSpec(t *testing.T) {
 	}
 }
 
+func Test_storePipelineSpec_metadata(t *testing.T) {
+	pipelinerunlabels := map[string]string{"lbl1": "value1", "lbl2": "value2"}
+	pipelinerunannotations := map[string]string{"io.annotation.1": "value1", "io.annotation.2": "value2"}
+	pipelinelabels := map[string]string{"lbl1": "another value", "lbl3": "value3"}
+	pipelineannotations := map[string]string{"io.annotation.1": "another value", "io.annotation.3": "value3"}
+	wantedlabels := map[string]string{"lbl1": "value1", "lbl2": "value2", "lbl3": "value3", pipeline.PipelineLabelKey: "bar"}
+	wantedannotations := map[string]string{"io.annotation.1": "value1", "io.annotation.2": "value2", "io.annotation.3": "value3"}
+
+	pr := &v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: pipelinerunlabels, Annotations: pipelinerunannotations},
+	}
+	meta := metav1.ObjectMeta{Name: "bar", Labels: pipelinelabels, Annotations: pipelineannotations}
+	if err := storePipelineSpecAndMergeMeta(pr, &v1beta1.PipelineSpec{}, &meta); err != nil {
+		t.Errorf("storePipelineSpecAndMergeMeta error = %v", err)
+	}
+	if d := cmp.Diff(pr.ObjectMeta.Labels, wantedlabels); d != "" {
+		t.Fatalf(diff.PrintWantGot(d))
+	}
+	if d := cmp.Diff(pr.ObjectMeta.Annotations, wantedannotations); d != "" {
+		t.Fatalf(diff.PrintWantGot(d))
+	}
+}
+
 func TestReconcileOutOfSyncPipelineRun(t *testing.T) {
 	// It may happen that a PipelineRun creates one or more TaskRuns during reconcile
 	// but it fails to sync the update on the status back. This test verifies that

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -785,14 +785,22 @@ func storeTaskSpecAndMergeMeta(tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec, meta *
 			tr.ObjectMeta.Annotations = make(map[string]string, len(meta.Annotations))
 		}
 		for key, value := range meta.Annotations {
-			tr.ObjectMeta.Annotations[key] = value
+			// Do not override duplicates between TaskRun and Task
+			// TaskRun labels take precedences over Task
+			if _, ok := tr.ObjectMeta.Annotations[key]; !ok {
+				tr.ObjectMeta.Annotations[key] = value
+			}
 		}
 		// Propagate labels from Task to TaskRun.
 		if tr.ObjectMeta.Labels == nil {
 			tr.ObjectMeta.Labels = make(map[string]string, len(meta.Labels)+1)
 		}
 		for key, value := range meta.Labels {
-			tr.ObjectMeta.Labels[key] = value
+			// Do not override duplicates between TaskRun and Task
+			// TaskRun labels take precedences over Task
+			if _, ok := tr.ObjectMeta.Labels[key]; !ok {
+				tr.ObjectMeta.Labels[key] = value
+			}
 		}
 		if tr.Spec.TaskRef != nil {
 			if tr.Spec.TaskRef.Kind == "ClusterTask" {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -3939,7 +3939,7 @@ func TestFailTaskRun(t *testing.T) {
 }
 
 func Test_storeTaskSpec(t *testing.T) {
-	labels := map[string]string{"lbl": "value"}
+	labels := map[string]string{"lbl1": "value1"}
 	annotations := map[string]string{"io.annotation": "value"}
 	tr := &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3981,6 +3981,29 @@ func Test_storeTaskSpec(t *testing.T) {
 		t.Errorf("storeTaskSpec() error = %v", err)
 	}
 	if d := cmp.Diff(tr, want); d != "" {
+		t.Fatalf(diff.PrintWantGot(d))
+	}
+}
+
+func Test_storeTaskSpec_metadata(t *testing.T) {
+	taskrunlabels := map[string]string{"lbl1": "value1", "lbl2": "value2"}
+	taskrunannotations := map[string]string{"io.annotation.1": "value1", "io.annotation.2": "value2"}
+	tasklabels := map[string]string{"lbl1": "another value", "lbl3": "value3"}
+	taskannotations := map[string]string{"io.annotation.1": "another value", "io.annotation.3": "value3"}
+	wantedlabels := map[string]string{"lbl1": "value1", "lbl2": "value2", "lbl3": "value3"}
+	wantedannotations := map[string]string{"io.annotation.1": "value1", "io.annotation.2": "value2", "io.annotation.3": "value3"}
+
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Labels: taskrunlabels, Annotations: taskrunannotations},
+	}
+	meta := metav1.ObjectMeta{Labels: tasklabels, Annotations: taskannotations}
+	if err := storeTaskSpecAndMergeMeta(tr, &v1beta1.TaskSpec{}, &meta); err != nil {
+		t.Errorf("storeTaskSpecAndMergeMeta error = %v", err)
+	}
+	if d := cmp.Diff(tr.ObjectMeta.Labels, wantedlabels); d != "" {
+		t.Fatalf(diff.PrintWantGot(d))
+	}
+	if d := cmp.Diff(tr.ObjectMeta.Annotations, wantedannotations); d != "" {
 		t.Fatalf(diff.PrintWantGot(d))
 	}
 }


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

For annotations and labels, do not override the Run metadata with the
definition (Pipeline/Task) if they are the same. If an annotation or
label is present in both Pipeline and PipelineRun, the value in the
Run type takes precedence (same for Task and TaskRun).

Closes #4636

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix Task(Run)/Pipeline(Run) metadata propagation,  If an annotation or
label is present in both Pipeline and PipelineRun, the value in the
Run type takes precedence (same for Task and TaskRun)
```
