### PR TITLE
Build tekton pipelines with golang 1.17

### DIFF
--- a/images/windows/entrypoint/Dockerfile
+++ b/images/windows/entrypoint/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
 
-FROM golang:1.16.13 AS builder
+FROM golang:1.17.7 AS builder
 
 COPY . c:/gopath/src/github.com/tektoncd/pipeline
 

--- a/images/windows/nop/Dockerfile
+++ b/images/windows/nop/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/windows/nanoserver:1809
 
-FROM golang:1.16.13 AS builder
+FROM golang:1.17.7 AS builder
 
 COPY . c:/gopath/src/github.com/tektoncd/pipeline
 

--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -23,7 +23,7 @@ spec:
       description: The secret that contains a service account authorized to push to the imageRegistry and to the output bucket
   steps:
 
-  - image: gcr.io/tekton-releases/dogfooding/buildx-gcloud:latest
+  - image: gcr.io/tekton-releases/dogfooding/buildx-gcloud@sha256:57a4971011f57f5ba940e54192c435445f24b495bfc6f3d3542f189a50fb7882
     name: build-image
     env:
     # Connect to the sidecar over TCP, with TLS.

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -80,7 +80,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: create-ko-yaml
-    image: golang:1.16
+    image: golang:1.17.7
     script: |
       #!/bin/sh
       set -ex
@@ -116,7 +116,7 @@ spec:
       cat ${PROJECT_ROOT}/.ko.yaml
 
   - name: run-ko
-    image: gcr.io/tekton-releases/dogfooding/ko:latest
+    image: gcr.io/tekton-releases/dogfooding/ko@sha256:ec55b9dd6c7af2b237cc7c38a974cc42212d53a026ee2a84f685f02c471c6c9e
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update the tekton pipelines docker files and build pipeline to build
using golang 1.17.7:

- The windows base images are now built using golang:1.17.7 official
  docker image
- The non-windows bases images are based on distroless and need to
  update. We now reference the docker-buildx base image by sha instead
  of tag which is better for attestation
- Controller images, entrypoint and pipeline resource images are built
  using ko. Updating the ko image in the publish task to one that
  includes golang 1.17.7 (golang:1.17.7-alpine3.15). Reference the ko
  image by sha instead of tag. This will require an extra step to
  update the image in future (plumbing first, pipeline then) but it's
  best for attestations and also it allows updating the image on
  plumbing side and in the registry without direct side effect on
  pipeline.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Tekton is now built using golang 1.17.7
```