### PR TITLE
Add log line to debg workspace-in-sidecar  example

### DIFF
--- a/examples/v1beta1/taskruns/alpha/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/alpha/workspace-in-sidecar.yaml
@@ -24,6 +24,7 @@ spec:
           cpu: "100m"
       script: |
         #!/usr/bin/env ash
+        echo "Creating FIFO..."
         mkfifo "$(workspaces.signals.path)/channel"
         echo "Greeting sidecar..."
         echo "hello there" > "$(workspaces.signals.path)/channel"

--- a/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
@@ -25,6 +25,7 @@ spec:
           cpu: "100m"
       script: |
         #!/usr/bin/env ash
+        echo "Creating FIFO..."
         mkfifo "$(workspaces.signals.path)/channel"
         echo "Greeting sidecar..."
         echo "hello there" > "$(workspaces.signals.path)/channel"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes


Prior to this commit the workspace-in-sidecar example didn't print anything before creating a fifo file in its first Step. When the example fails we are missing information here that would be useful to debug whether the Step ever started or is blocking on that `mkfifo` call.

This commit adds the log line we need to debug whether the Step ever starts. More info available at https://github.com/tektoncd/pipeline/issues/4169

/kind flake

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```