### PR TITLE
Update getNextTasks to support Run retries

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -254,6 +254,11 @@ func withCancelledBySpec(tr *v1beta1.TaskRun) *v1beta1.TaskRun {
 	return tr
 }
 
+func withRunCancelledBySpec(run *v1alpha1.Run) *v1alpha1.Run {
+	run.Spec.Status = v1alpha1.RunSpecStatusCancelled
+	return run
+}
+
 func makeRetried(tr v1beta1.TaskRun) (newTr *v1beta1.TaskRun) {
 	newTr = newTaskRun(tr)
 	newTr = withRetries(newTr)


### PR DESCRIPTION
# Changes
Custom Tasks support retries (as of #4327); however, there are some places in the code base that consider
retries only for TaskRuns. This commit updates PipelineRunState.getNextTasks to recognize
Run retries and adds tests for this method. No functional changes for TaskRuns. E2E tests for run retries will be added in a subsequent commit.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
[Bug fix]: schedule Runs with remaining retries
```