### PR TITLE
Add GetStatusCondition for Run

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -163,6 +163,11 @@ type RunList struct {
 	Items           []Run `json:"items"`
 }
 
+// GetStatusCondition returns the task run status as a ConditionAccessor
+func (r *Run) GetStatusCondition() apis.ConditionAccessor {
+	return &r.Status
+}
+
 // GetGroupVersionKind implements kmeta.OwnerRefable.
 func (*Run) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind(pipeline.RunControllerName)

--- a/pkg/reconciler/events/cloudevent/interface.go
+++ b/pkg/reconciler/events/cloudevent/interface.go
@@ -22,7 +22,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-// objectWithCondition is implemented by TaskRun and PipelineRun
+// objectWithCondition is implemented by TaskRun, PipelineRun and Run
 type objectWithCondition interface {
 
 	// Object requires GetObjectKind() and DeepCopyObject()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The "Run" type does not have a GetStatusCondition which means it
doesn't fit the "objectWithCondition" interface used to send
cloudevents.

Add GetStatusCondition to make the type more consistent with
TaskRun and Pipelinerun and make it possible to use it as an
"objectWithCondition" when sending events.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```

/cc @vdemeester @lbernick 