### PR TITLE
Update API reference docs for TaskRun

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -66,7 +66,7 @@ A `TaskRun` definition supports the following fields:
   - [`serviceAccountName`](#specifying-serviceaccount-credentials) - Specifies a `ServiceAccount`
     object that provides custom credentials for executing the `TaskRun`.
   - [`params`](#specifying-parameters) - Specifies the desired execution parameters for the `Task`.
-  - [`resources`](#specifying-resources) - Specifies the desired `PipelineResource` values.
+  - [`resources` (deprecated)](#specifying-resources) - Specifies the desired `PipelineResource` values.
     - [`inputs`](#specifying-resources) - Specifies the input resources.
     - [`outputs`](#specifying-resources) - Specifies the output resources.
   - [`timeout`](#configuring-the-failure-timeout) - Specifies the timeout before the `TaskRun` fails.
@@ -74,6 +74,9 @@ A `TaskRun` definition supports the following fields:
     the starting point for configuring the `Pods` for the `Task`.
   - [`workspaces`](#specifying-workspaces) - Specifies the physical volumes to use for the
     [`Workspaces`](workspaces.md#using-workspaces-in-tasks) declared by a `Task`.
+  - [`debug`](#debugging-a-taskrun)- Specifies any breakpoints and debugging configuration for the `Task` execution.
+  - [`stepOverrides`](#overriding-task-steps-and-sidecars) - Specifies configuration to use to override the `Task`'s `Step`s.
+  - [`sidecarOverrides`](#overriding-task-steps-and-sidecars) - Specifies configuration to use to override the `Task`'s `Sidecar`s.
 
 [kubernetes-overview]:
   https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields


### PR DESCRIPTION
# Changes
This commit adds missing optional fields to "Configuring a TaskRun".
Other than these changes, the TaskRun documentation looks up to date. Closes #4656.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
