### PR TITLE
Refactor When Expressions Validation

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -372,6 +372,13 @@ func validateExecutionStatusVariablesExpressions(expressions []string, ptNames s
 	return errs
 }
 
+func (pt *PipelineTask) validateOneOfWhenExpressionsOrConditions() *apis.FieldError {
+	if pt.WhenExpressions != nil && pt.Conditions != nil {
+		return apis.ErrMultipleOneOf("when", "conditions")
+	}
+	return nil
+}
+
 // TaskSpecMetadata returns the metadata of the PipelineTask's EmbeddedTask spec.
 func (pt *PipelineTask) TaskSpecMetadata() PipelineTaskMetadata {
 	return pt.TaskSpec.Metadata

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -255,6 +255,34 @@ func TestPipelineSpec_Validate_Failure(t *testing.T) {
 			Paths:   []string{"tasks[0].conditions", "tasks[0].when"},
 		},
 	}, {
+		name: "invalid pipeline with one pipeline task having both conditions and when expressions in finally",
+		ps: &PipelineSpec{
+			Description: "this is an invalid pipeline with invalid pipeline task",
+			Tasks: []PipelineTask{{
+				Name:    "invalid-pipeline-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+			}},
+			Finally: []PipelineTask{{
+				Name:    "invalid-pipeline-final-task",
+				TaskRef: &TaskRef{Name: "foo-task"},
+				WhenExpressions: []WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"bar"},
+				}},
+				Conditions: []PipelineTaskCondition{{
+					ConditionRef: "some-condition",
+				}},
+			}},
+		},
+		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
+			Message: `expected exactly one, got both`,
+			Paths:   []string{"finally[0].conditions", "finally[0].when"},
+		}).Also(&apis.FieldError{
+			Message: `invalid value: no conditions allowed under spec.finally, final task invalid-pipeline-final-task has conditions specified`,
+			Paths:   []string{"finally[0]"},
+		}),
+	}, {
 		name: "invalid pipeline with one pipeline task having when expression with invalid operator (not In/NotIn)",
 		ps: &PipelineSpec{
 			Description: "this is an invalid pipeline with invalid pipeline task",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In this change, we refactor the validation for `when` expressions
to remove duplications, including:
- moving the validation that "only one of `conditions` or `when`
expressions is used" to a member function of `pipelinetask`
- simplifying the overall `when` expressions validation function to
handle one list of `pipelinetasks`, then reusing it for both `tasks`
and `finally` fields

cc @pritidesai 

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```