### PR TITLE
Add hostAliases to podTemplate doc

### DIFF
--- a/docs/podtemplates.md
+++ b/docs/podtemplates.md
@@ -92,6 +92,10 @@ Pod templates support fields listed in the table below.
 			<td><code>hostNetwork</code></td>
 			<td><b>Default:</b> <code>false</code>. Determines whether to use the host network namespace.</td>
 		</tr>
+		<tr>
+			<td><code>hostAliases</code></td>
+			<td>Adds entries to a Pod's `/etc/hosts` to provide Pod-level overrides of hostnames. For further info see [Kubernetes' docs for this field](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/).</td>
+		</tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The hostAliases field is supported by the podTemplate field that TaskRuns and
PipelineRuns can specify.

This commit adds hostAliases to the podTemplate docs so users can find
it.

Fixes https://github.com/tektoncd/pipeline/issues/4674

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Added docs for the hostAliases field in TaskRun and PipelineRun podTemplates.
```