### PR TITLE
Pipeline Context Variables - Fix Validation Tests

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -2262,7 +2262,7 @@ func TestContextValid(t *testing.T) {
 		name  string
 		tasks []PipelineTask
 	}{{
-		name: "valid string context variable for task name",
+		name: "valid string context variable for Pipeline name",
 		tasks: []PipelineTask{{
 			Name:    "bar",
 			TaskRef: &TaskRef{Name: "bar-task"},
@@ -2271,7 +2271,7 @@ func TestContextValid(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "valid string context variable for taskrun name",
+		name: "valid string context variable for PipelineRun name",
 		tasks: []PipelineTask{{
 			Name:    "bar",
 			TaskRef: &TaskRef{Name: "bar-task"},
@@ -2280,7 +2280,7 @@ func TestContextValid(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "valid string context variable for taskRun namespace",
+		name: "valid string context variable for PipelineRun namespace",
 		tasks: []PipelineTask{{
 			Name:    "bar",
 			TaskRef: &TaskRef{Name: "bar-task"},
@@ -2289,7 +2289,7 @@ func TestContextValid(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "valid string context variable for taskRun uid",
+		name: "valid string context variable for PipelineRun uid",
 		tasks: []PipelineTask{{
 			Name:    "bar",
 			TaskRef: &TaskRef{Name: "bar-task"},
@@ -2298,7 +2298,7 @@ func TestContextValid(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "valid array context variables for task and taskRun names",
+		name: "valid array context variables for Pipeline and PipelineRun names",
 		tasks: []PipelineTask{{
 			Name:    "bar",
 			TaskRef: &TaskRef{Name: "bar-task"},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

The Pipeline(Run) context variables validation tests have errors in the naming - mistakenly saying that they test Task(Run) context variables. In this change, we fix the names of the tests.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```