### PR TITLE
TEP-0090: Matrix - Context Variables

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -8,6 +8,8 @@ weight: 11
 # Matrix
 
 - [Overview](#overview)
+- [Configuring a Matrix](#configuring-a-matrix)
+  - [Context Variables](#context-variables)
 
 ## Overview
 
@@ -19,3 +21,17 @@ Tekton.
 >
 > :warning: This feature is in a preview mode. 
 > It is still in a very early stage of development and is not yet fully functional.
+
+## Configuring a Matrix
+
+A `Matrix` supports the following features:
+* [Context Variables](#context-variables)
+
+### Context Variables
+
+Similarly to the `Parameters` in the `Params` field, the `Parameters` in the `Matrix` field will accept 
+[context variables](variables.md) that will be substituted, including:
+
+* `PipelineRun` name, namespace and uid
+* `Pipeline` name
+* `PipelineTask` retries

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -181,7 +181,7 @@ func validatePipelineContextVariables(tasks []PipelineTask) *apis.FieldError {
 	)
 	var paramValues []string
 	for _, task := range tasks {
-		for _, param := range task.Params {
+		for _, param := range append(task.Params, task.Matrix...) {
 			paramValues = append(paramValues, param.Value.StringVal)
 			paramValues = append(paramValues, param.Value.ArrayVal...)
 		}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -2269,6 +2269,9 @@ func TestContextValid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipeline.name)"},
 			}},
+			Matrix: []Param{{
+				Name: "a-param-mat", Value: ArrayOrString{ArrayVal: []string{"$(context.pipeline.name)"}},
+			}},
 		}},
 	}, {
 		name: "valid string context variable for PipelineRun name",
@@ -2277,6 +2280,9 @@ func TestContextValid(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineRun.name)"},
+			}},
+			Matrix: []Param{{
+				Name: "a-param-mat", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineRun.name)"}},
 			}},
 		}},
 	}, {
@@ -2287,6 +2293,9 @@ func TestContextValid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineRun.namespace)"},
 			}},
+			Matrix: []Param{{
+				Name: "a-param-mat", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineRun.namespace)"}},
+			}},
 		}},
 	}, {
 		name: "valid string context variable for PipelineRun uid",
@@ -2295,6 +2304,9 @@ func TestContextValid(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineRun.uid)"},
+			}},
+			Matrix: []Param{{
+				Name: "a-param-mat", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineRun.uid)"}},
 			}},
 		}},
 	}, {
@@ -2305,6 +2317,9 @@ func TestContextValid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{ArrayVal: []string{"$(context.pipeline.name)", "and", "$(context.pipelineRun.name)"}},
 			}},
+			Matrix: []Param{{
+				Name: "a-param-mat", Value: ArrayOrString{ArrayVal: []string{"$(context.pipeline.name)", "and", "$(context.pipelineRun.name)"}},
+			}},
 		}},
 	}, {
 		name: "valid string context variable for PipelineTask retries",
@@ -2312,6 +2327,9 @@ func TestContextValid(t *testing.T) {
 			Name:    "bar",
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
+				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineTask.retries)"},
+			}},
+			Matrix: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineTask.retries)"},
 			}},
 		}},
@@ -2322,6 +2340,9 @@ func TestContextValid(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineTask.retries)"}},
+			}},
+			Matrix: []Param{{
+				Name: "a-param-mat", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineTask.retries)"}},
 			}},
 		}},
 	}}
@@ -2347,11 +2368,17 @@ func TestContextInvalid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipeline.missing)"},
 			}},
+			Matrix: []Param{{
+				Name: "a-param-foo", Value: ArrayOrString{ArrayVal: []string{"$(context.pipeline.missing-foo)"}},
+			}},
 		}},
-		expectedError: apis.FieldError{
+		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
 			Message: `non-existent variable in "$(context.pipeline.missing)"`,
 			Paths:   []string{"value"},
-		},
+		}).Also(&apis.FieldError{
+			Message: `non-existent variable in "$(context.pipeline.missing-foo)"`,
+			Paths:   []string{"value"},
+		}),
 	}, {
 		name: "invalid string context variable for pipelineRun",
 		tasks: []PipelineTask{{
@@ -2360,11 +2387,17 @@ func TestContextInvalid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineRun.missing)"},
 			}},
+			Matrix: []Param{{
+				Name: "a-param-foo", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineRun.missing-foo)"}},
+			}},
 		}},
-		expectedError: apis.FieldError{
+		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
 			Message: `non-existent variable in "$(context.pipelineRun.missing)"`,
 			Paths:   []string{"value"},
-		},
+		}).Also(&apis.FieldError{
+			Message: `non-existent variable in "$(context.pipelineRun.missing-foo)"`,
+			Paths:   []string{"value"},
+		}),
 	}, {
 		name: "invalid string context variable for pipelineTask",
 		tasks: []PipelineTask{{
@@ -2373,11 +2406,17 @@ func TestContextInvalid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{StringVal: "$(context.pipelineTask.missing)"},
 			}},
+			Matrix: []Param{{
+				Name: "a-param-foo", Value: ArrayOrString{ArrayVal: []string{"$(context.pipelineTask.missing-foo)"}},
+			}},
 		}},
-		expectedError: apis.FieldError{
+		expectedError: *apis.ErrGeneric("").Also(&apis.FieldError{
 			Message: `non-existent variable in "$(context.pipelineTask.missing)"`,
 			Paths:   []string{"value"},
-		},
+		}).Also(&apis.FieldError{
+			Message: `non-existent variable in "$(context.pipelineTask.missing-foo)"`,
+			Paths:   []string{"value"},
+		}),
 	}, {
 		name: "invalid array context variables for pipeline, pipelineTask and pipelineRun",
 		tasks: []PipelineTask{{
@@ -2386,10 +2425,16 @@ func TestContextInvalid(t *testing.T) {
 			Params: []Param{{
 				Name: "a-param", Value: ArrayOrString{ArrayVal: []string{"$(context.pipeline.missing)", "$(context.pipelineTask.missing)", "$(context.pipelineRun.missing)"}},
 			}},
+			Matrix: []Param{{
+				Name: "a-param", Value: ArrayOrString{ArrayVal: []string{"$(context.pipeline.missing-foo)", "$(context.pipelineTask.missing-foo)", "$(context.pipelineRun.missing-foo)"}},
+			}},
 		}},
 		expectedError: *apis.ErrGeneric(`non-existent variable in "$(context.pipeline.missing)"`, "value").
 			Also(apis.ErrGeneric(`non-existent variable in "$(context.pipelineRun.missing)"`, "value")).
-			Also(apis.ErrGeneric(`non-existent variable in "$(context.pipelineTask.missing)"`, "value")),
+			Also(apis.ErrGeneric(`non-existent variable in "$(context.pipelineTask.missing)"`, "value")).
+			Also(apis.ErrGeneric(`non-existent variable in "$(context.pipeline.missing-foo)"`, "value")).
+			Also(apis.ErrGeneric(`non-existent variable in "$(context.pipelineRun.missing-foo)"`, "value")).
+			Also(apis.ErrGeneric(`non-existent variable in "$(context.pipelineTask.missing-foo)"`, "value")),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -92,6 +92,7 @@ func ApplyPipelineTaskContexts(pt *v1beta1.PipelineTask) *v1beta1.PipelineTask {
 		"context.pipelineTask.retries": strconv.Itoa(pt.Retries),
 	}
 	pt.Params = replaceParamValues(pt.Params, replacements, map[string][]string{})
+	pt.Matrix = replaceParamValues(pt.Matrix, replacements, map[string][]string{})
 	return pt
 }
 
@@ -148,6 +149,7 @@ func ApplyReplacements(p *v1beta1.PipelineSpec, replacements map[string]string, 
 
 	for i := range p.Tasks {
 		p.Tasks[i].Params = replaceParamValues(p.Tasks[i].Params, replacements, arrayReplacements)
+		p.Tasks[i].Matrix = replaceParamValues(p.Tasks[i].Matrix, replacements, arrayReplacements)
 		for j := range p.Tasks[i].Workspaces {
 			p.Tasks[i].Workspaces[j].SubPath = substitution.ApplyReplacements(p.Tasks[i].Workspaces[j].SubPath, replacements)
 		}
@@ -160,6 +162,7 @@ func ApplyReplacements(p *v1beta1.PipelineSpec, replacements map[string]string, 
 
 	for i := range p.Finally {
 		p.Finally[i].Params = replaceParamValues(p.Finally[i].Params, replacements, arrayReplacements)
+		p.Finally[i].Matrix = replaceParamValues(p.Finally[i].Matrix, replacements, arrayReplacements)
 		p.Finally[i].WhenExpressions = p.Finally[i].WhenExpressions.ReplaceWhenExpressionsVariables(replacements, arrayReplacements)
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -656,11 +656,15 @@ func TestContext(t *testing.T) {
 				Spec: v1beta1.PipelineSpec{
 					Tasks: []v1beta1.PipelineTask{{
 						Params: []v1beta1.Param{tc.original},
+						Matrix: []v1beta1.Param{tc.original},
 					}},
 				},
 			}
 			got := ApplyContexts(&orig.Spec, orig.Name, tc.pr)
 			if d := cmp.Diff(tc.expected, got.Tasks[0].Params[0]); d != "" {
+				t.Errorf(diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(tc.expected, got.Tasks[0].Matrix[0]); d != "" {
 				t.Errorf(diff.PrintWantGot(d))
 			}
 		})
@@ -680,10 +684,18 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				Name:  "retries",
 				Value: *v1beta1.NewArrayOrString("$(context.pipelineTask.retries)"),
 			}},
+			Matrix: []v1beta1.Param{{
+				Name:  "retries",
+				Value: *v1beta1.NewArrayOrString("$(context.pipelineTask.retries)"),
+			}},
 		},
 		want: v1beta1.PipelineTask{
 			Retries: 5,
 			Params: []v1beta1.Param{{
+				Name:  "retries",
+				Value: *v1beta1.NewArrayOrString("5"),
+			}},
+			Matrix: []v1beta1.Param{{
 				Name:  "retries",
 				Value: *v1beta1.NewArrayOrString("5"),
 			}},
@@ -695,9 +707,17 @@ func TestApplyPipelineTaskContexts(t *testing.T) {
 				Name:  "retries",
 				Value: *v1beta1.NewArrayOrString("$(context.pipelineTask.retries)"),
 			}},
+			Matrix: []v1beta1.Param{{
+				Name:  "retries",
+				Value: *v1beta1.NewArrayOrString("$(context.pipelineTask.retries)"),
+			}},
 		},
 		want: v1beta1.PipelineTask{
 			Params: []v1beta1.Param{{
+				Name:  "retries",
+				Value: *v1beta1.NewArrayOrString("0"),
+			}},
+			Matrix: []v1beta1.Param{{
 				Name:  "retries",
 				Value: *v1beta1.NewArrayOrString("0"),
 			}},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In this change, we add support for context variables in `Matrix`, including `PipelineRun` name, `Pipeline` name, `PipelineRun` namespace, `PipelineRun` uid, and `PipelineTask` retries. This change also includes validation for context variables.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
`Parameters` in `Matrix` support `Context Variables`. Note that `Matrix` is not yet fully functional.
```