### PR TITLE
Update taskrun code example links in the documentation 

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -38,9 +38,9 @@ weight: 300
 - [Code examples](#code-examples)
   - [Example `TaskRun` with a referenced `Task`](#example-taskrun-with-a-referenced-task)
   - [Example `TaskRun` with an embedded `Task`](#example-taskrun-with-an-embedded-task)
-  - [Reusing a `Task`](#reusing-a-task)
-  - [Using custom `ServiceAccount` credentials](#using-custom-serviceaccount-credentials)
-  - [Running Step Containers as a Non Root User](#running-step-containers-as-a-non-root-user)
+  - [Example of reusing a `Task`](#example-of-reusing-a-task)
+  - [Example of Using custom `ServiceAccount` credentials](#example-of-using-custom-serviceaccount-credentials)
+  - [Example of Running Step Containers as a Non Root User](#example-of-running-step-containers-as-a-non-root-user)
 <!-- /toc -->
 
 ## Overview
@@ -668,7 +668,8 @@ To better understand `TaskRuns`, study the following code examples:
 - [Example `TaskRun` with a referenced `Task`](#example-taskrun-with-a-referenced-task)
 - [Example `TaskRun` with an embedded `Task`](#example-taskrun-with-an-embedded-task)
 - [Example of reusing a `Task`](#example-of-reusing-a-task)
-- [Example of specifying a `ServiceAccount`](#example-of-specifying-a-service-account)
+- [Example of Using custom `ServiceAccount` credentials](#example-of-using-custom-serviceaccount-credentials)
+- [Example of Running Step Containers as a Non Root User](#example-of-running-step-containers-as-a-non-root-user)
 
 ### Example `TaskRun` with a referenced `Task`
 
@@ -780,7 +781,7 @@ spec:
               value: https://github.com/pivotal-nader-ziada/gohelloworld
 ```
 
-### Reusing a `Task`
+### Example of Reusing a `Task`
 
 The following example illustrates the reuse of the same `Task`. Below, you can see
 several `TaskRuns` that instantiate a `Task` named `dockerfile-build-and-push`. The
@@ -880,7 +881,7 @@ spec:
           name: cloud-builder-repo
 ```
 
-### Using custom `ServiceAccount` credentials
+### Example of Using custom `ServiceAccount` credentials
 
 The example below illustrates how to specify a `ServiceAccount` to access a private `git` repository:
 
@@ -942,7 +943,7 @@ data:
   known_hosts: Z2l0aHViLmNvbSBzc2g.....[example]
 ```
 
-### Running Step Containers as a Non Root User
+### Example of Running Step Containers as a Non Root User
 
 All steps that do not require to be run as a root user should make use of TaskRun features to
 designate the container for a step runs as a user without root permissions. As a best practice,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The link anchors to the code examples given in the documentation are broken. This is an attempt to fix them 
Also the unified the naming of the examples. 
Thank you!!
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
