### PR TITLE
Fix TestReconcileOnCompletedTaskRun

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -1795,7 +1795,7 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 		Message: "Build succeeded",
 	}
 	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-taskrun-run-success"},
+		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef: &v1beta1.TaskRef{
 				Name: simpleTask.Name,
@@ -1806,6 +1806,9 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 				Conditions: duckv1beta1.Conditions{
 					*taskSt,
 				},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				StartTime: &metav1.Time{Time: now.Add(-15 * time.Second)},
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Brandon Lum <lumjjb@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Fix taskrun reconciler test `TestReconcileOnCompletedTaskRun` where it was not appropriately testing the reconciler due to missing namespace object metadata which resulted in the reconciler not running as it couldn't find the TaskRun object.

Fixing this bug in the test revealed another issue with the test where it did not set `StartTime` and so the condition was overwritten by the reconciler. This is also fixed in this PR. 

/kind bug

Before fixing namespace:

```
go test -v . -run TestReconcileOnCompletedTaskRun
=== RUN   TestReconcileOnCompletedTaskRun
    logger.go:130: 2022-03-21T13:28:13.560-0400	INFO	cache/cacheclient.go:42	CACHE CLIENT &{lru:0xc0002761e0 lock:{w:{state:0 sema:0} writerSem:0 readerSem:0 readerCount:0 readerWait:0}}
    logger.go:130: 2022-03-21T13:28:13.562-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-artifact-bucket" config was added or updated: &config.ArtifactBucket{Location:"", ServiceAccountSecretName:"", ServiceAccountSecretKey:"", ServiceAccountFieldName:"GOOGLE_APPLICATION_CREDENTIALS"}
    logger.go:130: 2022-03-21T13:28:13.562-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-artifact-pvc" config was added or updated: &config.ArtifactPVC{Size:"5Gi", StorageClassName:""}
    logger.go:130: 2022-03-21T13:28:13.562-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-defaults" config was added or updated: &config.Defaults{DefaultTimeoutMinutes:60, DefaultServiceAccount:"default", DefaultManagedByLabelValue:"tekton-pipelines", DefaultPodTemplate:(*pod.Template)(nil), DefaultCloudEventsSink:"", DefaultTaskRunWorkspaceBinding:""}
    logger.go:130: 2022-03-21T13:28:13.562-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-observability" config was added or updated: &config.Metrics{TaskrunLevel:"task", PipelinerunLevel:"pipeline", DurationTaskrunType:"histogram", DurationPipelinerunType:"histogram"}
    logger.go:130: 2022-03-21T13:28:13.562-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "feature-flags" config was added or updated: &config.FeatureFlags{DisableAffinityAssistant:false, DisableCredsInit:false, RunningInEnvWithInjectedSidecars:true, RequireGitSSHSecretKnownHosts:false, EnableTektonOCIBundles:false, EnableCustomTasks:false, ScopeWhenExpressionsToTask:true, EnableAPIFields:"stable", SendCloudEventsForRuns:false}
**<Look here>**    logger.go:130: 2022-03-21T13:28:13.662-0400	DEBUG	TestReconcileOnCompletedTaskRun	taskrun/reconciler.go:205	Resource "/test-taskrun-run-success" no longer exists
--- PASS: TestReconcileOnCompletedTaskRun (0.10s)
PASS
ok  	github.com/tektoncd/pipeline/pkg/reconciler/taskrun	0.909s
```

After fix:

```
=== RUN   TestReconcileOnCompletedTaskRun
    logger.go:130: 2022-03-21T13:42:07.424-0400	INFO	cache/cacheclient.go:42	CACHE CLIENT &{lru:0xc000490aa0 lock:{w:{state:0 sema:0} writerSem:0 readerSem:0 readerCount:0 readerWait:0}}
    logger.go:130: 2022-03-21T13:42:07.425-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-artifact-bucket" config was added or updated: &config.ArtifactBucket{Location:"", ServiceAccountSecretName:"", ServiceAccountSecretKey:"", ServiceAccountFieldName:"GOOGLE_APPLICATION_CREDENTIALS"}
    logger.go:130: 2022-03-21T13:42:07.425-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-artifact-pvc" config was added or updated: &config.ArtifactPVC{Size:"5Gi", StorageClassName:""}
    logger.go:130: 2022-03-21T13:42:07.425-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-defaults" config was added or updated: &config.Defaults{DefaultTimeoutMinutes:60, DefaultServiceAccount:"default", DefaultManagedByLabelValue:"tekton-pipelines", DefaultPodTemplate:(*pod.Template)(nil), DefaultCloudEventsSink:"", DefaultTaskRunWorkspaceBinding:""}
    logger.go:130: 2022-03-21T13:42:07.425-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "config-observability" config was added or updated: &config.Metrics{TaskrunLevel:"task", PipelinerunLevel:"pipeline", DurationTaskrunType:"histogram", DurationPipelinerunType:"histogram"}
    logger.go:130: 2022-03-21T13:42:07.425-0400	DEBUG	TestReconcileOnCompletedTaskRun.config-store	configmap/store.go:155	defaults/features/artifacts config "feature-flags" config was added or updated: &config.FeatureFlags{DisableAffinityAssistant:false, DisableCredsInit:false, RunningInEnvWithInjectedSidecars:true, RequireGitSSHSecretKnownHosts:false, EnableTektonOCIBundles:false, EnableCustomTasks:false, ScopeWhenExpressionsToTask:true, EnableAPIFields:"stable", SendCloudEventsForRuns:false}
**<Look here>**    logger.go:130: 2022-03-21T13:42:07.526-0400	INFO	TestReconcileOnCompletedTaskRun	taskrun/taskrun.go:118	taskrun done : test-taskrun-run-success
--- PASS: TestReconcileOnCompletedTaskRun (0.11s)
PASS
ok  	github.com/tektoncd/pipeline/pkg/reconciler/taskrun	1.072s
```


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes
```release-note
NONE
```