### PR TITLE
[V1] Add new API versions to /config

### DIFF
--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -61,6 +61,24 @@ spec:
         # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
         # See issue: https://github.com/knative/serving/issues/912
         x-kubernetes-preserve-unknown-fields: true
+  - name: v1
+    served: false
+    storage: false
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Pipeline
     plural: pipelines

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -87,6 +87,37 @@ spec:
     # starts to increment
     subresources:
       status: {}
+  - name: v1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      jsonPath: .status.completionTime
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: PipelineRun
     plural: pipelineruns

--- a/config/300-run.yaml
+++ b/config/300-run.yaml
@@ -56,6 +56,37 @@ spec:
     # starts to increment
     subresources:
       status: {}
+  - name: v1beta1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      jsonPath: .status.completionTime
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: Run
     plural: runs

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -61,6 +61,24 @@ spec:
     # starts to increment
     subresources:
       status: {}
+  - name: v1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: Task
     plural: tasks

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -87,6 +87,37 @@ spec:
     # starts to increment
     subresources:
       status: {}
+  - name: v1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      jsonPath: .status.completionTime
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: TaskRun
     plural: taskruns


### PR DESCRIPTION
# Changes

This commit adds v1 API versions to the Task, TaskRun, Pipeline, and PipelineRun CRDs,
and adds the v1beta1 version to the Run CRD. These versions will not be served to users
(served = false) and will not be stored in etcd (storage = false). Tekton devs can experiment
with the new CRD versions by locally changing "served" to true.

This follows the first step of the plan laid out in the doc "How to add a new APIVersion for your CRD"
(https://docs.google.com/document/d/1omfO0O4yoUuM1Fk2E6wjfdVNK6XFSmxI3pb13xQ3rys). Go structs and
conversion webhooks will be added in future commits.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```