### PR TITLE
Add example for PipelineRun namespace context variable

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -903,6 +903,8 @@ performed by the Tekton Controller when a PipelineRun is executed.
 See the [complete list of variable substitutions for Pipelines](./variables.md#variables-available-in-a-pipeline)
 and the [list of fields that accept substitutions](./variables.md#fields-that-accept-variable-substitutions).
 
+For an end-to-end example, see [using context variables](../examples/v1beta1/pipelineruns/using_context_variables.yaml).
+
 ### Using the `retries` and `retry-count` variable substitutions
 
 Tekton supports variable substitution for the [`retries`](#using-the-retries-field)

--- a/examples/v1beta1/pipelineruns/using_context_variables.yaml
+++ b/examples/v1beta1/pipelineruns/using_context_variables.yaml
@@ -15,6 +15,8 @@ spec:
         value: "$(context.pipeline.name)"
       - name: pipelineRun-name
         value: "$(context.pipelineRun.name)"
+      - name: pipelineRun-namespace
+        value: "$(context.pipelineRun.namespace)"
       - name: pipelineTask-retries
         value: "$(context.pipelineTask.retries)"
       taskSpec:
@@ -22,6 +24,7 @@ spec:
         - name: pipeline-uid
         - name: pipeline-name
         - name: pipelineRun-name
+        - name: pipelineRun-namespace
         - name: pipelineTask-retries
         steps:
         - image: ubuntu
@@ -36,6 +39,7 @@ spec:
             echo "TaskRun name: $(context.taskRun.name)"
             echo "Pipeline name from params: $(params.pipeline-name)"
             echo "PipelineRun name from params: $(params.pipelineRun-name)"
+            echo "PipelineRun namespace from params: $(params.pipelineRun-namespace)"
         - image: ubuntu
           name: print-retries
           script: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In https://github.com/tektoncd/pipeline/issues/4540, users are having issues using `context.pipelineRun.namespace`. This variable needs to be passed via `Parameters` to reach the `Task`.

In this change, we add an example of using `context.pipelineRun.namespace` and add a reference to the example in the documentation.

/kind documentation

/closes https://github.com/tektoncd/pipeline/issues/4540

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```