### PR TITLE
TEP-0090: `Matrix` - `Parameters`

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -9,6 +9,7 @@ weight: 11
 
 - [Overview](#overview)
 - [Configuring a Matrix](#configuring-a-matrix)
+  - [Parameters](#parameters)
   - [Context Variables](#context-variables)
 
 ## Overview
@@ -25,7 +26,59 @@ Tekton.
 ## Configuring a Matrix
 
 A `Matrix` supports the following features:
+* [Parameters](#parameters)
 * [Context Variables](#context-variables)
+
+### Parameters
+
+The `Matrix` will take `Parameters` of type `"array"` only, which will be supplied to the
+`PipelineTask` by substituting `Parameters` of type `"string"` in the underlying `Task`.
+The names of the `Parameters` in the `Matrix` must match the names of the `Parameters`
+in the underlying `Task` that they will be substituting.
+
+In the example below, the *test* `Task` takes *browser* and *platform* `Parameters` of type
+`"string"`. A `Pipeline` used to fan out the `Task` using `Matrix` would have two `Parameters`
+of type `"array"`, and it would execute nine `TaskRuns`:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: platform-browser-tests
+spec:
+  params:
+    - name: platforms
+      type: array
+      default:
+        - linux
+        - mac
+        - windows
+    - name: browsers
+      type: array
+      default:
+        - chrome
+        - safari
+        - firefox    
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    ...
+  - name: test
+    matrix:
+      - name: platform
+        value: $(params.platforms)
+      - name: browser
+        value: $(params.browsers)
+    taskRef:
+      name: browser-test
+  ...
+```
+
+A `Parameter` can be passed to either the `matrix` or `params` field, not both. 
+
+For further details on specifying `Parameters` in the `Pipeline` and passing them to
+`PipelineTasks`, see [documentation](pipelines.md#specifying-parameters).
 
 ### Context Variables
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -293,6 +293,8 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 		// when the enable-api-fields feature gate is anything but "alpha".
 		errs = errs.Also(ValidateEnabledAPIFields(ctx, "matrix", config.AlphaAPIFields))
 	}
+	errs = errs.Also(validateParameterInOneOfMatrixOrParams(pt.Matrix, pt.Params))
+	errs = errs.Also(validateParametersInTaskMatrix(pt.Matrix))
 	return errs
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -162,6 +162,7 @@ func validatePipelineParameterVariables(tasks []PipelineTask, params []ParamSpec
 func validatePipelineParametersVariables(tasks []PipelineTask, prefix string, paramNames sets.String, arrayParamNames sets.String) (errs *apis.FieldError) {
 	for idx, task := range tasks {
 		errs = errs.Also(validatePipelineParametersVariablesInTaskParameters(task.Params, prefix, paramNames, arrayParamNames).ViaIndex(idx))
+		errs = errs.Also(validatePipelineParametersVariablesInMatrixParameters(task.Matrix, prefix, paramNames, arrayParamNames).ViaIndex(idx))
 		errs = errs.Also(task.WhenExpressions.validatePipelineParametersVariables(prefix, paramNames, arrayParamNames).ViaIndex(idx))
 	}
 	return errs


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In this change, we add validation for `Parameters` including:
- `Parameter` must be of type `Array`
- `Parameter` must be in one of `matrix` or `params`, not both
- `Parameter` in `Matrix` must exist in `Parameters` declarations in `Pipeline`

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
`Parameters` in `Matrix`:
- must be of type `Array`
- must not be in `Params` field as well
- must be declared in the `Parameters` in `Pipeline` specification

Note that `Matrix` is not yet fully functional.
```