### PR TITLE
TEP-0090: `Matrix` - `Results`

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -11,6 +11,9 @@ weight: 11
 - [Configuring a Matrix](#configuring-a-matrix)
   - [Parameters](#parameters)
   - [Context Variables](#context-variables)
+  - [Results](#results)
+    - [Specifying Results in a Matrix](#specifying-results-in-a-matrix)
+    - [Results from fanned out PipelineTasks](#results-from-fanned-out-pipelinetasks)
 
 ## Overview
 
@@ -88,3 +91,17 @@ Similarly to the `Parameters` in the `Params` field, the `Parameters` in the `Ma
 * `PipelineRun` name, namespace and uid
 * `Pipeline` name
 * `PipelineTask` retries
+
+### Results
+
+#### Specifying Results in a Matrix
+
+Consuming `Results` from previous `TaskRuns` or `Runs` in a `Matrix`, which would dynamically generate 
+`TaskRuns` or `Runs` from the fanned out `PipelineTask`, is not yet supported. This dynamic fan out of
+`PipelineTasks` through consuming `Results` will be supported soon. 
+
+#### Results from fanned out PipelineTasks
+
+Consuming `Results` from fanned out `PipelineTasks` will not be in the supported in the initial iteration
+of `Matrix`. Supporting consuming `Results` from fanned out `PipelineTasks` will be revisited after array
+and object `Results` are supported. 

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -192,6 +192,10 @@ func validateParametersInTaskMatrix(matrix []Param) (errs *apis.FieldError) {
 		if param.Value.Type != ParamTypeArray {
 			errs = errs.Also(apis.ErrInvalidValue("parameters of type array only are allowed in matrix", "").ViaFieldKey("matrix", param.Name))
 		}
+		// results are not yet allowed in parameters in a matrix - dynamic fanning out will be supported in future milestone
+		if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok && LooksLikeContainsResultRefs(expressions) {
+			return errs.Also(apis.ErrInvalidValue("result references are not allowed in parameters in a matrix", "value").ViaFieldKey("matrix", param.Name))
+		}
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -298,6 +298,15 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 	return errs
 }
 
+func (pt *PipelineTask) validateResultsFromMatrixedPipelineTasksNotConsumed(matrixedPipelineTasks sets.String) (errs *apis.FieldError) {
+	for _, ref := range PipelineTaskResultRefs(pt) {
+		if matrixedPipelineTasks.Has(ref.PipelineTask) {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("consuming results from matrixed task %s is not allowed", ref.PipelineTask), ""))
+		}
+	}
+	return errs
+}
+
 func (pt *PipelineTask) validateExecutionStatusVariablesDisallowed() (errs *apis.FieldError) {
 	for _, param := range pt.Params {
 		if expressions, ok := GetVarSubstitutionExpressionsForParam(param); ok {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -703,6 +703,18 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 				Name: "barfoo", Value: ArrayOrString{Type: ParamTypeArray, ArrayVal: []string{"bar", "foo"}},
 			}},
 		},
+	}, {
+		name: "parameters in matrix contain results references",
+		pt: &PipelineTask{
+			Name: "task",
+			Matrix: []Param{{
+				Name: "a-param", Value: ArrayOrString{Type: ParamTypeArray, ArrayVal: []string{"$(tasks.foo-task.results.a-result)"}},
+			}},
+		},
+		wantErrs: &apis.FieldError{
+			Message: "invalid value: result references are not allowed in parameters in a matrix",
+			Paths:   []string{"matrix[a-param].value"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In this change, we add validation that dynamic fan out of `PipelineTasks` through consuming `Results` in `Matrix` is not yet supported. We plan to support dynamic fan out after gathering feedback on static fan out only.

In this change, we also add validation that `Results` from fanned out `PipelineTasks` are not consumed. We plan to revisit this after array and object `Results` are supported.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
-  Consuming `Results` in `Matrix` is invalid - will be supported soon to allow dynamic fan out.
-  Consuming `Results` from fanned out `PipelineTasks` is invalid - will be revisited soon after array and object `Results` are supported. 
```