### PR TITLE
WIP: remove pullrequest-init-build-base

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,7 +1,5 @@
 defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
-  # git-init uses a base image that supports running either as root or as user nonroot with UID 65532.
+  # git-init uses a base image that includes Git, and supports running either
+  # as root or as user nonroot with UID 65532.
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/git-init-build-base:latest
-
-  # PullRequest resource uses a distroless base image that supports running either as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/pullrequest-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/pullrequest-init-build-base:latest

--- a/images/pullrequest-init/Dockerfile
+++ b/images/pullrequest-init/Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:3.14 as source
-RUN addgroup -S -g 65532 nonroot && adduser -S -u 65532 nonroot -G nonroot
-
-FROM gcr.io/distroless/static:latest
-COPY --from=source /etc/passwd /etc/passwd
-COPY --from=source /etc/group /etc/group

--- a/tekton/build-push-ma-base-image.yaml
+++ b/tekton/build-push-ma-base-image.yaml
@@ -76,14 +76,6 @@ spec:
         --no-cache \
         $(workspaces.source.path)/images/git-init
 
-      #build multi-arch pullrequest-init build-base image
-      docker buildx build \
-        --platform "${PLATFORMS}" \
-        --tag ${IMAGE_REGISTRY}/${IMAGE_REGISTRY_PATH}/${PACKAGE}/pullrequest-init-build-base \
-        --push \
-        --no-cache \
-        $(workspaces.source.path)/images/pullrequest-init
-
     volumeMounts:
     - mountPath: /certs/client
       name: dind-certs

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -108,9 +108,8 @@ spec:
         $(params.package)/cmd/nop: ${COMBINED_BASE_IMAGE}
         $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
 
+        # This matches values configured in .ko.yaml
         $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/git-init-build-base:latest
-        # These match values configured in .ko.yaml
-        $(params.package)/cmd/pullrequest-init: ${CONTAINER_REGISTRY}/$(params.package)/pullrequest-init-build-base:latest
       EOF
 
       cat ${PROJECT_ROOT}/.ko.yaml


### PR DESCRIPTION
Testing a theory that `pullrequest-init` doesn't need to have a custom-built base image.

/hold

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [not yet] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [not yet] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
TODO
```