### PR TITLE
Git PipelineResource requires root

### DIFF
--- a/pkg/apis/resource/v1alpha1/git/git_resource.go
+++ b/pkg/apis/resource/v1alpha1/git/git_resource.go
@@ -26,6 +26,7 @@ import (
 	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/ptr"
 )
 
 var (
@@ -195,6 +196,10 @@ func (s *Resource) GetInputTaskModifier(_ *v1beta1.TaskSpec, path string) (v1bet
 			WorkingDir: pipeline.WorkspaceDir,
 			// This is used to populate the ResourceResult status.
 			Env: env,
+			SecurityContext: &corev1.SecurityContext{
+				// The git pipeline resource only works when running as root.
+				RunAsUser: ptr.Int64(0),
+			},
 		},
 	}
 

--- a/pkg/apis/resource/v1alpha1/git/git_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/git/git_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -542,7 +543,7 @@ func TestGitResource_Replacements(t *testing.T) {
 
 func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 	names.TestingSeed()
-
+	securityContext := &corev1.SecurityContext{RunAsUser: ptr.Int64(0)}
 	for _, tc := range []struct {
 		desc        string
 		gitResource *git.Resource
@@ -583,6 +584,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "Without submodules",
@@ -621,6 +623,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "With more depth",
@@ -660,6 +663,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "Without sslVerify",
@@ -699,6 +703,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "Without httpProxy",
@@ -736,6 +741,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "Without httpsProxy",
@@ -773,6 +779,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTP_PROXY", Value: "http-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "Without noProxy",
@@ -810,6 +817,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTP_PROXY", Value: "http-proxy.git.com"},
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "With Refspec",
@@ -850,6 +858,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}, {
 		desc: "Without Refspec and without revision",
@@ -886,6 +895,7 @@ func TestGitResource_GetDownloadTaskModifier(t *testing.T) {
 				{Name: "HTTPS_PROXY", Value: "https-proxy.git.com"},
 				{Name: "NO_PROXY", Value: "no-proxy.git.com"},
 			},
+			SecurityContext: securityContext,
 		},
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/pkg/reconciler/taskrun/resources/input_resource_test.go
+++ b/pkg/reconciler/taskrun/resources/input_resource_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
+	"knative.dev/pkg/ptr"
 )
 
 var (
@@ -99,6 +100,9 @@ var (
 			Type:     "git",
 			Optional: true,
 		}},
+	}
+	gitResourceSecurityContext = &corev1.SecurityContext{
+		RunAsUser: ptr.Int64(0),
 	}
 )
 
@@ -369,6 +373,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: gitInputs,
@@ -410,6 +415,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: gitInputs,
@@ -458,6 +464,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}, {Container: corev1.Container{
 				Name:       "git-source-the-git-with-branch-9l9zj",
 				Image:      "override-with-git:latest",
@@ -468,6 +475,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: multipleGitInputs,
@@ -509,6 +517,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: gitInputs,
@@ -550,6 +559,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: gitInputs,
@@ -640,6 +650,7 @@ func TestAddInputResourceToTask(t *testing.T) {
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-sslVerify-false"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: gitInputs,
@@ -964,6 +975,7 @@ gsutil cp gs://fake-bucket/rules.zip /workspace/gcs-dir
 					{Name: "TEKTON_RESOURCE_NAME", Value: "the-git-with-branch"},
 					{Name: "HOME", Value: pipeline.HomeDir},
 				},
+				SecurityContext: gitResourceSecurityContext,
 			}}},
 			Resources: &v1beta1.TaskResources{
 				Inputs: optionalGitInputs,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR makes explicit an assumption that the Git PipelineResource makes about how it's run. When a user replaces the git-init image with their own it's possible that the default UID of the container is not 0. Git PipelineResources expect to run as root and when they don't a confusing error is emitted (Permission denied while running git).

This commit updates the git pipelineresource to explicitly set its container `runAsUser` to `0`.

Fixes https://github.com/tektoncd/pipeline/issues/4711

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
The git pipelineresource is updated to explicitly set its `runAsUser` to 0 since it requires root.
```