### PR TITLE
PullRequest PipelineResource expects root

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -3,6 +3,3 @@ baseImageOverrides:
   # git-init uses a base image that includes Git, and supports running either
   # as root or as user nonroot with UID 65532.
   github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/git-init-build-base:latest
-
-  # pullrequest-init supports running either as root or as user with UID 65532.
-  github.com/tektoncd/pipeline/cmd/pullrequest-init: gcr.io/distroless/static

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource.go
@@ -26,6 +26,7 @@ import (
 	resourcev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/names"
 	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/ptr"
 )
 
 const (
@@ -174,5 +175,9 @@ func (s *Resource) getSteps(mode string, sourcePath string) []pipelinev1beta1.St
 		Args:       args,
 		WorkingDir: pipeline.WorkspaceDir,
 		Env:        evs,
+		SecurityContext: &corev1.SecurityContext{
+			// The pullrequest pipeline resource only works when running as root.
+			RunAsUser: ptr.Int64(0),
+		},
 	}}}
 }

--- a/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
+++ b/pkg/apis/resource/v1alpha1/pullrequest/pull_request_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -102,6 +103,9 @@ type testcase struct {
 const workspace = "/workspace"
 
 func containerTestCases(mode string) []testcase {
+	securityContext := &corev1.SecurityContext{
+		RunAsUser: ptr.Int64(0),
+	}
 	return []testcase{{
 		in: &pullrequest.Resource{
 			Name:                  "nocreds",
@@ -110,12 +114,13 @@ func containerTestCases(mode string) []testcase {
 			InsecureSkipTLSVerify: false,
 		},
 		out: []v1beta1.Step{{Container: corev1.Container{
-			Name:       "pr-source-nocreds-9l9zj",
-			Image:      "override-with-pr:latest",
-			WorkingDir: pipeline.WorkspaceDir,
-			Command:    []string{"/ko-app/pullrequest-init"},
-			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode},
-			Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "nocreds"}},
+			Name:            "pr-source-nocreds-9l9zj",
+			Image:           "override-with-pr:latest",
+			WorkingDir:      pipeline.WorkspaceDir,
+			Command:         []string{"/ko-app/pullrequest-init"},
+			Args:            []string{"-url", "https://example.com", "-path", workspace, "-mode", mode},
+			Env:             []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "nocreds"}},
+			SecurityContext: securityContext,
 		}}},
 	}, {
 		in: &pullrequest.Resource{
@@ -149,6 +154,7 @@ func containerTestCases(mode string) []testcase {
 						},
 					},
 				}},
+			SecurityContext: securityContext,
 		}}},
 	}, {
 		in: &pullrequest.Resource{
@@ -158,12 +164,13 @@ func containerTestCases(mode string) []testcase {
 			InsecureSkipTLSVerify: true,
 		},
 		out: []v1beta1.Step{{Container: corev1.Container{
-			Name:       "pr-source-nocreds-mssqb",
-			Image:      "override-with-pr:latest",
-			WorkingDir: pipeline.WorkspaceDir,
-			Command:    []string{"/ko-app/pullrequest-init"},
-			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode, "-insecure-skip-tls-verify=true"},
-			Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "nocreds"}},
+			Name:            "pr-source-nocreds-mssqb",
+			Image:           "override-with-pr:latest",
+			WorkingDir:      pipeline.WorkspaceDir,
+			Command:         []string{"/ko-app/pullrequest-init"},
+			Args:            []string{"-url", "https://example.com", "-path", workspace, "-mode", mode, "-insecure-skip-tls-verify=true"},
+			Env:             []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "nocreds"}},
+			SecurityContext: securityContext,
 		}}},
 	}, {
 		in: &pullrequest.Resource{
@@ -173,12 +180,13 @@ func containerTestCases(mode string) []testcase {
 			DisableStrictJSONComments: true,
 		},
 		out: []v1beta1.Step{{Container: corev1.Container{
-			Name:       "pr-source-strict-json-comments-78c5n",
-			Image:      "override-with-pr:latest",
-			WorkingDir: pipeline.WorkspaceDir,
-			Command:    []string{"/ko-app/pullrequest-init"},
-			Args:       []string{"-url", "https://example.com", "-path", workspace, "-mode", mode, "-disable-strict-json-comments=true"},
-			Env:        []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "strict-json-comments"}},
+			Name:            "pr-source-strict-json-comments-78c5n",
+			Image:           "override-with-pr:latest",
+			WorkingDir:      pipeline.WorkspaceDir,
+			Command:         []string{"/ko-app/pullrequest-init"},
+			Args:            []string{"-url", "https://example.com", "-path", workspace, "-mode", mode, "-disable-strict-json-comments=true"},
+			Env:             []corev1.EnvVar{{Name: "TEKTON_RESOURCE_NAME", Value: "strict-json-comments"}},
+			SecurityContext: securityContext,
 		}}},
 	}}
 }

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -110,7 +110,6 @@ spec:
 
         # This matches values configured in .ko.yaml
         $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/git-init-build-base:latest
-        $(params.package)/cmd/pullrequest-init: gcr.io/distroless/static
       EOF
 
       cat ${PROJECT_ROOT}/.ko.yaml


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When a user replaces the pullrequest-init image with their own it's possible that the default UID of the container is not 0.

More generally, we've never tested PipelineResources as anything but the root user. Rather than attempt to improve a feature that's now deprecated by adding testing and support for non-root use-cases it makes more sense to simply encode this expectation in to their containers until they're removed.

This commit updates the pullrequest pipelineresource to explicitly set its container `runAsUser` to `0`. It also updates the pullrequest-init image to use our default base of distroless' static:nonroot.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
The pullrequest PipelineResource is updated to explicitly set its runAsUser to 0. PipelineResources aren't tested as anything other than the root user and this change makes that explicit.

The pullrequest-init base image also no longer uses the root user by default. It now defaults to using UID 65532.
```