### PR TITLE
test: use `t.TempDir` to create temporary test directory

### DIFF
--- a/cmd/entrypoint/post_writer_test.go
+++ b/cmd/entrypoint/post_writer_test.go
@@ -8,11 +8,7 @@ import (
 )
 
 func TestRealPostWriter_WriteFileContent(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "post-writer")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 	tests := []struct {
 		name, file, content string
 	}{{

--- a/cmd/entrypoint/subcommands/cp_test.go
+++ b/cmd/entrypoint/subcommands/cp_test.go
@@ -25,15 +25,11 @@ import (
 )
 
 func TestCp(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "cp-test-*")
-	if err != nil {
-		t.Fatalf("error creating temp directory: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	src := filepath.Join(tmp, "foo.txt")
 	dst := filepath.Join(tmp, "bar.txt")
 
-	if err = ioutil.WriteFile(src, []byte("hello world"), 0700); err != nil {
+	if err := ioutil.WriteFile(src, []byte("hello world"), 0700); err != nil {
 		t.Fatalf("error writing source file: %v", err)
 	}
 
@@ -61,14 +57,10 @@ func TestCp(t *testing.T) {
 }
 
 func TestCpMissingFile(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "cp-test-*")
-	if err != nil {
-		t.Fatalf("error creating temp directory: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	src := filepath.Join(tmp, "doesnt-exist.txt")
 	dst := filepath.Join(tmp, "bar.txt")
-	err = cp(src, dst)
+	err := cp(src, dst)
 	if err == nil {
 		t.Errorf("unexpected success copying missing file")
 	}

--- a/cmd/entrypoint/subcommands/decode_script_test.go
+++ b/cmd/entrypoint/subcommands/decode_script_test.go
@@ -33,21 +33,18 @@ echo "Hello World!"
 	mode := os.FileMode(0600)
 	expectedPermissions := os.FileMode(0600)
 
-	tmp, err := ioutil.TempDir("", "decode-script-test-*")
-	if err != nil {
-		t.Fatalf("error creating temp file: %v", err)
-	}
+	tmp := t.TempDir()
 	src := filepath.Join(tmp, "script.txt")
 	defer func() {
 		if err := os.Remove(src); err != nil {
 			t.Errorf("temporary script file %q was not cleaned up: %v", src, err)
 		}
 	}()
-	if err = ioutil.WriteFile(src, []byte(encoded), mode); err != nil {
+	if err := ioutil.WriteFile(src, []byte(encoded), mode); err != nil {
 		t.Fatalf("error writing encoded script: %v", err)
 	}
 
-	if err = decodeScript(src); err != nil {
+	if err := decodeScript(src); err != nil {
 		t.Errorf("unexpected error decoding script: %v", err)
 	}
 

--- a/cmd/entrypoint/subcommands/step_init_test.go
+++ b/cmd/entrypoint/subcommands/step_init_test.go
@@ -1,18 +1,13 @@
 package subcommands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestStepInit(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "step-init-*")
-	if err != nil {
-		t.Fatalf("error creating temp directory: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	// Override tektonRoot for testing.
 	tektonRoot = tmp

--- a/cmd/entrypoint/subcommands/subcommands_test.go
+++ b/cmd/entrypoint/subcommands/subcommands_test.go
@@ -1,7 +1,6 @@
 package subcommands
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,11 +11,7 @@ const helloWorldBase64 = "aGVsbG8gd29ybGQK"
 // TestProcessSuccessfulSubcommands checks that input args matching the format
 // expected by subcommands results in successfully running those subcommands.
 func TestProcessSuccessfulSubcommands(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "cp-test-*")
-	if err != nil {
-		t.Fatalf("error creating temp directory: %v", err)
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	src := filepath.Join(tmp, "foo.txt")
 	dst := filepath.Join(tmp, "bar.txt")
 

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestFlagHandling(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -71,7 +71,7 @@ func TestFlagHandling(t *testing.T) {
 }
 
 func TestFlagHandlingTwice(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	fooDir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
@@ -121,7 +121,7 @@ func TestFlagHandlingTwice(t *testing.T) {
 }
 
 func TestFlagHandlingMissingFiles(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("not-found")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -135,7 +135,7 @@ func TestFlagHandlingMissingFiles(t *testing.T) {
 }
 
 func TestFlagHandlingURLCollision(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -224,7 +224,7 @@ func TestMatchingAnnotations(t *testing.T) {
 }
 
 func TestMultipleFlagHandling(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	fooDir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
@@ -301,7 +301,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 // TestNoAuthProvided confirms that providing zero secrets results in no docker
 // credential file being written to disk.
 func TestNoAuthProvided(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	fooDir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestBasicFlagHandling(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -85,7 +85,7 @@ func TestBasicFlagHandling(t *testing.T) {
 }
 
 func TestBasicFlagHandlingTwice(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	fooDir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
@@ -152,7 +152,7 @@ https://bleh:belch@gitlab.com
 }
 
 func TestBasicFlagHandlingMissingFiles(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("not-found")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -166,7 +166,7 @@ func TestBasicFlagHandlingMissingFiles(t *testing.T) {
 }
 
 func TestBasicFlagHandlingURLCollision(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -188,7 +188,7 @@ func TestBasicFlagHandlingURLCollision(t *testing.T) {
 }
 
 func TestSSHFlagHandling(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -249,7 +249,7 @@ func TestSSHFlagHandling(t *testing.T) {
 }
 
 func TestSSHFlagHandlingThrice(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	fooDir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(fooDir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", fooDir, err)
@@ -361,7 +361,7 @@ ssh-rsa cccc`
 }
 
 func TestSSHFlagHandlingMissingFiles(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("not-found")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)
@@ -451,7 +451,7 @@ func TestMatchingAnnotations(t *testing.T) {
 }
 
 func TestBasicBackslashInUsername(t *testing.T) {
-	credentials.VolumePath, _ = ioutil.TempDir("", "")
+	credentials.VolumePath = t.TempDir()
 	dir := credentials.VolumeName("foo")
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		t.Fatalf("os.MkdirAll(%s) = %v", dir, err)

--- a/pkg/credentials/initialize_test.go
+++ b/pkg/credentials/initialize_test.go
@@ -10,8 +10,7 @@ import (
 const credContents string = "hello, world!"
 
 func TestTryCopyCredDir(t *testing.T) {
-	dir, cleanup := createTempDir(t)
-	defer cleanup()
+	dir := t.TempDir()
 
 	fakeCredDir := filepath.Join(dir, ".docker")
 	err := os.Mkdir(fakeCredDir, 0700)
@@ -39,8 +38,7 @@ func TestTryCopyCredDir(t *testing.T) {
 }
 
 func TestTryCopyCredFile(t *testing.T) {
-	dir, cleanup := createTempDir(t)
-	defer cleanup()
+	dir := t.TempDir()
 	fakeCredFile := writeFakeCred(t, dir, ".git-credentials", credContents)
 	destination := filepath.Join(dir, ".git-credentials-copy")
 
@@ -60,8 +58,7 @@ func TestTryCopyCredFile(t *testing.T) {
 }
 
 func TestTryCopyCredFileMissing(t *testing.T) {
-	dir, cleanup := createTempDir(t)
-	defer cleanup()
+	dir := t.TempDir()
 	fakeCredFile := filepath.Join(dir, "foo")
 	destination := filepath.Join(dir, "foo-copy")
 
@@ -87,16 +84,4 @@ func writeFakeCred(t *testing.T, dir, name, contents string) string {
 	_, _ = cred.Write([]byte(credContents))
 	_ = cred.Close()
 	return path
-}
-
-func createTempDir(t *testing.T) (string, func()) {
-	dir, err := ioutil.TempDir("", "cred-test-fs-")
-	if err != nil {
-		t.Fatalf("unexpected error creating temp directory: %v", err)
-	}
-	return dir, func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("unexpected error cleaning up temp directory: %v", err)
-		}
-	}
 }

--- a/pkg/pullrequest/api_test.go
+++ b/pkg/pullrequest/api_test.go
@@ -18,8 +18,6 @@ package pullrequest
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/go-multierror"
@@ -95,11 +93,6 @@ func TestDownload(t *testing.T) {
 	ctx := context.Background()
 	h, data := newHandler(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
 	got, err := h.Download(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -122,11 +115,7 @@ func TestUploadFromDisk(t *testing.T) {
 	ctx := context.Background()
 	h, _ := newHandler(t)
 
-	dir, err := ioutil.TempDir("", t.Name())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	r, err := h.Download(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -72,11 +72,7 @@ func TestToDisk(t *testing.T) {
 		}},
 	}
 
-	d, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	if err := ToDisk(rsrc, d); err != nil {
 		t.Error(err)
 	}
@@ -84,9 +80,7 @@ func TestToDisk(t *testing.T) {
 	// Base PR
 	pr := &scm.PullRequest{}
 	readAndUnmarshal(t, filepath.Join(d, "pr.json"), pr)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	if d := cmp.Diff(pr, rsrc.PR); d != "" {
 		t.Errorf("PullRequest %s", diff.PrintWantGot(d))
 	}
@@ -202,11 +196,7 @@ func TestToDisk(t *testing.T) {
 }
 
 func TestFromDiskWithoutComments(t *testing.T) {
-	d, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// Write some refs
 	base := scm.PullRequestBranch{
@@ -248,11 +238,7 @@ func TestFromDiskWithoutComments(t *testing.T) {
 }
 
 func TestFromDisk(t *testing.T) {
-	d, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// Write some refs
 	base := scm.PullRequestBranch{
@@ -509,11 +495,7 @@ func TestCommentsFromDisk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(d)
+			d := t.TempDir()
 			if err := os.MkdirAll(filepath.Join(d, "comments"), 0750); err != nil {
 				t.Fatal(err)
 			}
@@ -596,11 +578,7 @@ func TestLabelsToDisk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating temp dir: %s", err)
-			}
-			defer os.RemoveAll(d)
+			d := t.TempDir()
 			if err := labelsToDisk(d, tt.args.labels); err != nil {
 				t.Errorf("labelsToDisk() error = %v", err)
 			}
@@ -664,11 +642,7 @@ func TestStatusToDisk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating temp dir: %s", err)
-			}
-			defer os.RemoveAll(d)
+			d := t.TempDir()
 			if err := statusToDisk(d, tt.args.statuses); err != nil {
 				t.Errorf("statusToDisk() error = %v", err)
 			}
@@ -733,11 +707,7 @@ func TestLabelsFromDisk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "")
-			if err != nil {
-				t.Fatalf("Error creating temp dir: %s", err)
-			}
-			defer os.RemoveAll(d)
+			d := t.TempDir()
 
 			for _, l := range tt.args.fileNames {
 				if err := ioutil.WriteFile(filepath.Join(d, l), []byte{}, 0700); err != nil {
@@ -770,11 +740,7 @@ func TestLabelsFromDisk(t *testing.T) {
 }
 
 func TestFromDiskPRShaWithNullHeadAndBase(t *testing.T) {
-	d, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	expectedSha := "1a2s3d4f5g6g6h7j8k9l"
 	// Write some refs


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

A testing cleanup. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```