### PR TITLE
Update PR template to clarify release notes policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,8 @@ As the author of this PR, please check off the items in this checklist:
 - [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
 - [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
   functionality, content, code)
-- [ ] Release notes block below has been filled in or deleted (only if no user facing changes)
+- [ ] Release notes block below has been filled in
+(if there are no user facing changes, use release note "NONE")
 
 # Release Notes
 


### PR DESCRIPTION
# Changes
PRs must have a release notes block in their description. This commit updates the PR template
to clarify this requirement.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
NONE
```
