### PR TITLE
Avoid panic in PipelineRun reconciler for Runs with no owner refs

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1297,7 +1297,7 @@ func updatePipelineRunStatusFromRuns(logger *zap.SugaredLogger, pr *v1beta1.Pipe
 	for _, run := range runs {
 		// Only process Runs that are owned by this PipelineRun.
 		// This skips Runs that are indirectly created by the PipelineRun (e.g. by custom tasks).
-		if len(run.OwnerReferences) < 1 && run.OwnerReferences[0].UID != pr.ObjectMeta.UID {
+		if len(run.OwnerReferences) < 1 || run.OwnerReferences[0].UID != pr.ObjectMeta.UID {
 			logger.Debugf("Found a Run %s that is not owned by this PipelineRun", run.Name)
 			continue
 		}


### PR DESCRIPTION
# Changes

fixes #4729

We were checking `if len(run.OwnerReferences) < 1 && run.OwnerReferences[0].UID != pr.ObjectMeta.UID { ...` in `updatePipelineStatusFromRuns` instead of `if len(run.OwnerReferences) < 1 || run.OwnerReferences[0].UID != pr.ObjectMeta.UID { ...`. So if we came across a `Run` which for some reason had the appropriate labels signifying that it
belonged to the current `PipelineRun`, we would see that there were no `OwnerReferences` on that `Run`, and then try to check the value of `run.OwnerReferences[0].UID`...which obviously would panic. `updatePipelineStatusFromTaskRuns` did this correctly.

There wasn't a test for this scenario for `updatePipelineStatusFromTaskRuns`, so I added that along with a new `TestUpdatePipelineStatusFromRuns` covering this and other scenarios as well.

There's still an open question in my mind as to how a `Run` got created with the `tekton.dev/pipelineRun` label set for the `PipelineRun` we're reconciling but without any owner references. That's definitely a scenario we need to protect against, but I'd like to know how we got into that situation in the first place.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in or deleted (only if no user facing changes)

# Release Notes

```release-note
Fix panic when reconciling PipelineRun with indirectly-created custom tasks.
```
