### PR TITLE
Exclude the third_party directory from PKGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MODULE   = $(shell env GO111MODULE=on $(GO) list -m)
 DATE    ?= $(shell date +%FT%T%z)
 VERSION ?= $(shell git describe --tags --always --dirty --match=v* 2> /dev/null || \
 			cat $(CURDIR)/.version 2> /dev/null || echo v0)
-PKGS     = $(or $(PKG),$(shell env GO111MODULE=on $(GO) list ./...))
+PKGS     = $(or $(PKG),$(shell env GO111MODULE=on $(GO) list ./... | grep -v 'github\.com\/tektoncd\/pipeline\/third_party\/'))
 TESTPKGS = $(shell env GO111MODULE=on $(GO) list -f \
 			'{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' \
 			$(PKGS))


### PR DESCRIPTION
# Changes

With Go 1.16 and earlier, `go list ./...` excluded anything under the `third_party` directory, but
that seems to have changed with Go 1.17. So until this change, `make fmt` would end up reformatting
`third_party/github.com/hashicorp/golang-lru/simplelru/lru_interface.go`.

To fix this, let's just exclude `github.com/tektoncd/pipeline/third_party/` from the `go list ./...`
call used to generate `PKGS`, which itself is then used in the `fmt` and `golint` targets.

I went with the very specific full path to make sure that we don't inadvertently ignore something we
could add in the future with `third_party` in the path outside of the root-level `third_party`
directory. Just to be super-extra-safe. =)

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
