### PR TITLE
[TEP-0100] Implementation for embedded TaskRun and Run statuses in PipelineRuns

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -389,7 +389,7 @@ features](#alpha-features) to be used.
 - `embedded-status`: set this flag to "full" to enable full embedding of `TaskRun` and `Run` statuses in the 
  `PipelineRun` status. Set it to "minimal" to populate the `ChildReferences` field in the `PipelineRun` status with
   name, kind, and API version information for each `TaskRun` and `Run` in the `PipelineRun` instead. Set it to "both" to 
-  do both. For more information, see [Configuring usage of `TaskRun` and `Run` embedded statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses). **NOTE**: This functionality is not yet active.
+  do both. For more information, see [Configuring usage of `TaskRun` and `Run` embedded statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses).
 
 For example:
 

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/test/diff"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
@@ -32,12 +38,15 @@ import (
 
 func TestCancelPipelineRun(t *testing.T) {
 	testCases := []struct {
-		name        string
-		pipelineRun *v1beta1.PipelineRun
-		taskRuns    []*v1beta1.TaskRun
-		runs        []*v1alpha1.Run
+		name           string
+		embeddedStatus string
+		pipelineRun    *v1beta1.PipelineRun
+		taskRuns       []*v1beta1.TaskRun
+		runs           []*v1alpha1.Run
+		wantErr        bool
 	}{{
-		name: "no-resolved-taskrun",
+		name:           "no-resolved-taskrun",
+		embeddedStatus: config.DefaultEmbeddedStatus,
 		pipelineRun: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
 			Spec: v1beta1.PipelineRunSpec{
@@ -45,7 +54,8 @@ func TestCancelPipelineRun(t *testing.T) {
 			},
 		},
 	}, {
-		name: "one-taskrun",
+		name:           "one-taskrun",
+		embeddedStatus: config.DefaultEmbeddedStatus,
 		pipelineRun: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
 			Spec: v1beta1.PipelineRunSpec{
@@ -61,7 +71,8 @@ func TestCancelPipelineRun(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
 		},
 	}, {
-		name: "multiple-taskruns",
+		name:           "multiple-taskruns",
+		embeddedStatus: config.DefaultEmbeddedStatus,
 		pipelineRun: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
 			Spec: v1beta1.PipelineRunSpec{
@@ -79,7 +90,8 @@ func TestCancelPipelineRun(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
 		},
 	}, {
-		name: "multiple-runs",
+		name:           "multiple-runs",
+		embeddedStatus: config.DefaultEmbeddedStatus,
 		pipelineRun: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
 			Spec: v1beta1.PipelineRunSpec{
@@ -97,55 +109,315 @@ func TestCancelPipelineRun(t *testing.T) {
 			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
 		},
 	}, {
-		name: "deprecated-state",
+		name:           "deprecated-state",
+		embeddedStatus: config.DefaultEmbeddedStatus,
 		pipelineRun: &v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
 			Spec: v1beta1.PipelineRunSpec{
 				Status: v1beta1.PipelineRunSpecStatusCancelledDeprecated,
 			},
 		},
+	}, {
+		name:           "child-references-with-both",
+		embeddedStatus: config.BothEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
+			Spec: v1beta1.PipelineRunSpec{
+				Status: v1beta1.PipelineRunSpecStatusCancelled,
+			},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t1",
+						PipelineTaskName: "task-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t2",
+						PipelineTaskName: "task-2",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r1",
+						PipelineTaskName: "run-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r2",
+						PipelineTaskName: "run-2",
+					},
+				},
+			}},
+		},
+		taskRuns: []*v1beta1.TaskRun{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
+		},
+		runs: []*v1alpha1.Run{
+			{ObjectMeta: metav1.ObjectMeta{Name: "r1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "r2"}},
+		},
+	}, {
+		name:           "child-references-with-minimal",
+		embeddedStatus: config.MinimalEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
+			Spec: v1beta1.PipelineRunSpec{
+				Status: v1beta1.PipelineRunSpecStatusCancelled,
+			},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t1",
+						PipelineTaskName: "task-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t2",
+						PipelineTaskName: "task-2",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r1",
+						PipelineTaskName: "run-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r2",
+						PipelineTaskName: "run-2",
+					},
+				},
+			}},
+		},
+		taskRuns: []*v1beta1.TaskRun{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
+		},
+		runs: []*v1alpha1.Run{
+			{ObjectMeta: metav1.ObjectMeta{Name: "r1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "r2"}},
+		},
+	}, {
+		name:           "unknown-kind-on-child-references",
+		embeddedStatus: config.MinimalEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-cancelled"},
+			Spec: v1beta1.PipelineRunSpec{
+				Status: v1beta1.PipelineRunSpecStatusCancelled,
+			},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{{
+					TypeMeta:         runtime.TypeMeta{Kind: "InvalidKind"},
+					Name:             "t1",
+					PipelineTaskName: "task-1",
+				}},
+			}},
+		},
+		wantErr: true,
 	}}
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+
 			d := test.Data{
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pipelineRun},
 				TaskRuns:     tc.taskRuns,
 				Runs:         tc.runs,
 			}
 			ctx, _ := ttesting.SetupFakeContext(t)
+			cfg := config.NewStore(logtesting.TestLogger(t))
+			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
+			ctx = cfg.ToContext(ctx)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			c, _ := test.SeedTestData(t, ctx, d)
-			if err := cancelPipelineRun(ctx, logtesting.TestLogger(t), tc.pipelineRun, c.Pipeline); err != nil {
-				t.Fatal(err)
-			}
-			// This PipelineRun should still be complete and false, and the status should reflect that
-			cond := tc.pipelineRun.Status.GetCondition(apis.ConditionSucceeded)
-			if cond.IsTrue() {
-				t.Errorf("Expected PipelineRun status to be complete and false, but was %v", cond)
-			}
-			if tc.taskRuns != nil {
-				l, err := c.Pipeline.TektonV1beta1().TaskRuns("").List(ctx, metav1.ListOptions{})
+
+			err := cancelPipelineRun(ctx, logtesting.TestLogger(t), tc.pipelineRun, c.Pipeline)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected an error, but did not get one")
+				}
+			} else {
 				if err != nil {
 					t.Fatal(err)
 				}
-				for _, tr := range l.Items {
-					if tr.Spec.Status != v1beta1.TaskRunSpecStatusCancelled {
-						t.Errorf("expected task %q to be marked as cancelled, was %q", tr.Name, tr.Spec.Status)
+				// This PipelineRun should still be complete and false, and the status should reflect that
+				cond := tc.pipelineRun.Status.GetCondition(apis.ConditionSucceeded)
+				if cond.IsTrue() {
+					t.Errorf("Expected PipelineRun status to be complete and false, but was %v", cond)
+				}
+				if tc.taskRuns != nil {
+					for _, expectedTR := range tc.taskRuns {
+						tr, err := c.Pipeline.TektonV1beta1().TaskRuns("").Get(ctx, expectedTR.Name, metav1.GetOptions{})
+						if err != nil {
+							t.Fatalf("couldn't get expected TaskRun %s, got error %s", expectedTR.Name, err)
+						}
+						if tr.Spec.Status != v1beta1.TaskRunSpecStatusCancelled {
+							t.Errorf("expected task %q to be marked as cancelled, was %q", tr.Name, tr.Spec.Status)
+						}
+					}
+				}
+				if tc.runs != nil {
+					for _, expectedRun := range tc.runs {
+						r, err := c.Pipeline.TektonV1alpha1().Runs("").Get(ctx, expectedRun.Name, metav1.GetOptions{})
+						if err != nil {
+							t.Fatalf("couldn't get expected Run %s, got error %s", expectedRun.Name, err)
+						}
+						if r.Spec.Status != v1alpha1.RunSpecStatusCancelled {
+							t.Errorf("expected task %q to be marked as cancelled, was %q", r.Name, r.Spec.Status)
+						}
 					}
 				}
 			}
-			if tc.runs != nil {
-				l, err := c.Pipeline.TektonV1alpha1().Runs("").List(ctx, metav1.ListOptions{})
-				if err != nil {
-					t.Fatal(err)
+		})
+	}
+}
+
+func TestGetChildObjectsFromPRStatus(t *testing.T) {
+	testCases := []struct {
+		name             string
+		embeddedStatus   string
+		prStatus         v1beta1.PipelineRunStatus
+		expectedTRNames  []string
+		expectedRunNames []string
+		hasError         bool
+	}{
+		{
+			name:           "single taskrun, default embedded",
+			embeddedStatus: config.DefaultEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+			}},
+			expectedTRNames:  []string{"t1"},
+			expectedRunNames: nil,
+			hasError:         false,
+		}, {
+			name:           "single run, default embedded",
+			embeddedStatus: config.DefaultEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				Runs: map[string]*v1beta1.PipelineRunRunStatus{
+					"r1": {PipelineTaskName: "run-1"},
+				},
+			}},
+			expectedTRNames:  nil,
+			expectedRunNames: []string{"r1"},
+			hasError:         false,
+		}, {
+			name:           "taskrun and run, default embedded",
+			embeddedStatus: config.DefaultEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+				Runs: map[string]*v1beta1.PipelineRunRunStatus{
+					"r1": {PipelineTaskName: "run-1"},
+				},
+			}},
+			expectedTRNames:  []string{"t1"},
+			expectedRunNames: []string{"r1"},
+			hasError:         false,
+		}, {
+			name:           "full embedded",
+			embeddedStatus: config.FullEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+				ChildReferences: []v1beta1.ChildStatusReference{{
+					TypeMeta: runtime.TypeMeta{
+						APIVersion: "v1alpha1",
+						Kind:       "Run",
+					},
+					Name:             "r1",
+					PipelineTaskName: "run-1",
+				}},
+			}},
+			expectedTRNames:  []string{"t1"},
+			expectedRunNames: nil,
+			hasError:         false,
+		}, {
+			name:           "both embedded",
+			embeddedStatus: config.BothEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+				ChildReferences: []v1beta1.ChildStatusReference{{
+					TypeMeta: runtime.TypeMeta{
+						APIVersion: "v1alpha1",
+						Kind:       "Run",
+					},
+					Name:             "r1",
+					PipelineTaskName: "run-1",
+				}},
+			}},
+			expectedTRNames:  nil,
+			expectedRunNames: []string{"r1"},
+			hasError:         false,
+		}, {
+			name:           "minimal embedded",
+			embeddedStatus: config.MinimalEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+				ChildReferences: []v1beta1.ChildStatusReference{{
+					TypeMeta: runtime.TypeMeta{
+						APIVersion: "v1alpha1",
+						Kind:       "Run",
+					},
+					Name:             "r1",
+					PipelineTaskName: "run-1",
+				}},
+			}},
+			expectedTRNames:  nil,
+			expectedRunNames: []string{"r1"},
+			hasError:         false,
+		}, {
+			name:           "unknown kind",
+			embeddedStatus: config.MinimalEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{{
+					TypeMeta: runtime.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "UnknownKind",
+					},
+					Name:             "u1",
+					PipelineTaskName: "unknown-1",
+				}},
+			}},
+			expectedTRNames:  nil,
+			expectedRunNames: nil,
+			hasError:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, _ := ttesting.SetupFakeContext(t)
+			cfg := config.NewStore(logtesting.TestLogger(t))
+			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
+			ctx = cfg.ToContext(ctx)
+
+			trNames, runNames, err := getChildObjectsFromPRStatus(ctx, tc.prStatus)
+
+			if tc.hasError {
+				if err == nil {
+					t.Error("expected to see an error, but did not")
 				}
-				for _, r := range l.Items {
-					if r.Spec.Status != v1alpha1.RunSpecStatusCancelled {
-						t.Errorf("expected Run %q to be marked as cancelled, was %q", r.Name, r.Spec.Status)
-					}
-				}
+			} else if err != nil {
+				t.Errorf("did not expect to see an error, but saw %v", err)
+			}
+
+			if d := cmp.Diff(tc.expectedTRNames, trNames); d != "" {
+				t.Errorf("expected to see TaskRun names %v. Diff %s", tc.expectedTRNames, diff.PrintWantGot(d))
+			}
+			if d := cmp.Diff(tc.expectedRunNames, runNames); d != "" {
+				t.Errorf("expected to see Run names %v. Diff %s", tc.expectedRunNames, diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -573,8 +573,17 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	// Read the condition the way it was set by the Mark* helpers
 	after = pr.Status.GetCondition(apis.ConditionSucceeded)
 	pr.Status.StartTime = pipelineRunFacts.State.AdjustStartTime(pr.Status.StartTime)
-	pr.Status.TaskRuns = pipelineRunFacts.State.GetTaskRunsStatus(pr)
-	pr.Status.Runs = pipelineRunFacts.State.GetRunsStatus(pr)
+
+	if cfg.FeatureFlags.EmbeddedStatus == config.FullEmbeddedStatus || cfg.FeatureFlags.EmbeddedStatus == config.BothEmbeddedStatus {
+		pr.Status.TaskRuns = pipelineRunFacts.State.GetTaskRunsStatus(pr)
+		pr.Status.Runs = pipelineRunFacts.State.GetRunsStatus(pr)
+	}
+
+	if cfg.FeatureFlags.EmbeddedStatus == config.MinimalEmbeddedStatus || cfg.FeatureFlags.EmbeddedStatus == config.BothEmbeddedStatus {
+		pr.Status.ChildReferences = pipelineRunFacts.State.GetChildReferences(v1beta1.SchemeGroupVersion.String(),
+			v1alpha1.SchemeGroupVersion.String())
+	}
+
 	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks()
 	if after.Status == corev1.ConditionTrue {
 		pr.Status.PipelineResults = resources.ApplyTaskResultsToPipelineResults(pipelineSpec.Results,
@@ -697,6 +706,8 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 	return nil
 }
 
+// updateTaskRunsStatusDirectly is used with "full" or "both" set as the value for the "embedded-status" feature flag.
+// When the "full" and "both" options are removed, updateTaskRunsStatusDirectly can be removed.
 func (c *Reconciler) updateTaskRunsStatusDirectly(pr *v1beta1.PipelineRun) error {
 	for taskRunName := range pr.Status.TaskRuns {
 		// TODO(dibyom): Add conditionCheck statuses here
@@ -714,6 +725,8 @@ func (c *Reconciler) updateTaskRunsStatusDirectly(pr *v1beta1.PipelineRun) error
 	return nil
 }
 
+// updateRunsStatusDirectly is used with "full" or "both" set as the value for the "embedded-status" feature flag.
+// When the "full" and "both" options are removed, updateRunsStatusDirectly can be removed.
 func (c *Reconciler) updateRunsStatusDirectly(pr *v1beta1.PipelineRun) error {
 	for runName := range pr.Status.Runs {
 		prRunStatus := pr.Status.Runs[runName]
@@ -1184,16 +1197,96 @@ func (c *Reconciler) updatePipelineRunStatusFromInformer(ctx context.Context, pr
 		logger.Errorf("could not list TaskRuns %#v", err)
 		return err
 	}
-	updatePipelineRunStatusFromTaskRuns(logger, pr, taskRuns)
-
 	runs, err := c.runLister.Runs(pr.Namespace).List(k8slabels.SelectorFromSet(pipelineRunLabels))
 	if err != nil {
 		logger.Errorf("could not list Runs %#v", err)
 		return err
 	}
-	updatePipelineRunStatusFromRuns(logger, pr, runs)
 
-	return nil
+	return updatePipelineRunStatusFromChildObjects(ctx, logger, pr, taskRuns, runs)
+}
+
+func updatePipelineRunStatusFromChildObjects(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, taskRuns []*v1beta1.TaskRun, runs []*v1alpha1.Run) error {
+	cfg := config.FromContextOrDefaults(ctx)
+	fullEmbedded := cfg.FeatureFlags.EmbeddedStatus == config.FullEmbeddedStatus || cfg.FeatureFlags.EmbeddedStatus == config.BothEmbeddedStatus
+	minimalEmbedded := cfg.FeatureFlags.EmbeddedStatus == config.MinimalEmbeddedStatus || cfg.FeatureFlags.EmbeddedStatus == config.BothEmbeddedStatus
+
+	if minimalEmbedded {
+		updatePipelineRunStatusFromChildRefs(logger, pr, taskRuns, runs)
+	}
+	if fullEmbedded {
+		updatePipelineRunStatusFromTaskRuns(logger, pr, taskRuns)
+		updatePipelineRunStatusFromRuns(logger, pr, runs)
+	}
+
+	return validateChildObjectsInPipelineRunStatus(ctx, pr.Status)
+}
+
+func validateChildObjectsInPipelineRunStatus(ctx context.Context, prs v1beta1.PipelineRunStatus) error {
+	cfg := config.FromContextOrDefaults(ctx)
+
+	var err error
+
+	// Verify that we don't populate child references for "full"
+	if cfg.FeatureFlags.EmbeddedStatus == config.FullEmbeddedStatus && len(prs.ChildReferences) > 0 {
+		return fmt.Errorf("expected no ChildReferences with embedded-status=full, but found %d", len(prs.ChildReferences))
+	}
+
+	// Verify that we don't populate TaskRun statuses for "minimal"
+	if cfg.FeatureFlags.EmbeddedStatus == config.MinimalEmbeddedStatus {
+		// Verify that we don't populate TaskRun statuses for "minimal"
+		if len(prs.TaskRuns) > 0 {
+			err = multierror.Append(err, fmt.Errorf("expected no TaskRun statuses with embedded-status=minimal, but found %d", len(prs.TaskRuns)))
+		}
+		// Verify that we don't populate Run statuses for "minimal"
+		if len(prs.Runs) > 0 {
+			err = multierror.Append(err, fmt.Errorf("expected no Run statuses with embedded-status=minimal, but found %d", len(prs.Runs)))
+		}
+		for _, cr := range prs.ChildReferences {
+			switch cr.Kind {
+			case "TaskRun", "Run":
+				continue
+			default:
+				err = multierror.Append(err, fmt.Errorf("child with name %s has unknown kind %s", cr.Name, cr.Kind))
+			}
+		}
+	}
+
+	// Verify that the TaskRun and Run statuses match the ChildReferences for "both"
+	if cfg.FeatureFlags.EmbeddedStatus == config.BothEmbeddedStatus {
+		if len(prs.ChildReferences) != len(prs.TaskRuns)+len(prs.Runs) {
+			err = multierror.Append(err, fmt.Errorf("expected the same number of ChildReferences as the number of combined TaskRun and Run statuses (%d), but found %d",
+				len(prs.TaskRuns)+len(prs.Runs),
+				len(prs.ChildReferences)))
+		}
+
+		for _, cr := range prs.ChildReferences {
+			switch cr.Kind {
+			case "TaskRun":
+				tr, ok := prs.TaskRuns[cr.Name]
+				if !ok {
+					err = multierror.Append(err, fmt.Errorf("embedded-status is 'both', and child TaskRun with name %s found in ChildReferences only", cr.Name))
+				} else if cr.PipelineTaskName != tr.PipelineTaskName {
+					err = multierror.Append(err,
+						fmt.Errorf("child TaskRun with name %s has PipelineTask name %s in ChildReferences and %s in TaskRuns",
+							cr.Name, cr.PipelineTaskName, tr.PipelineTaskName))
+				}
+			case "Run":
+				r, ok := prs.Runs[cr.Name]
+				if !ok {
+					err = multierror.Append(err, fmt.Errorf("embedded-status is 'both', and child Run with name %s found in ChildReferences only", cr.Name))
+				} else if cr.PipelineTaskName != r.PipelineTaskName {
+					err = multierror.Append(err,
+						fmt.Errorf("child Run with name %s has PipelineTask name %s in ChildReferences and %s in Runs",
+							cr.Name, cr.PipelineTaskName, r.PipelineTaskName))
+				}
+			default:
+				err = multierror.Append(err, fmt.Errorf("child with name %s has unknown kind %s", cr.Name, cr.Kind))
+			}
+		}
+	}
+
+	return err
 }
 
 // filterTaskRunsForPipelineRun returns TaskRuns owned by the PipelineRun and their condition checks
@@ -1243,41 +1336,25 @@ func filterRunsForPipelineRun(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun
 	return runsToInclude
 }
 
+// updatePipelineRunStatusFromTaskRuns takes a PipelineRun and a list of TaskRuns within that PipelineRun, and updates
+// the PipelineRun's .Status.TaskRuns, including ensuring that any (deprecated) condition checks are represented.
 func updatePipelineRunStatusFromTaskRuns(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, trs []*v1beta1.TaskRun) {
 	// If no TaskRun was found, nothing to be done. We never remove taskruns from the status
-	if trs == nil || len(trs) == 0 {
+	if len(trs) == 0 {
 		return
 	}
-	// Store a list of Condition TaskRuns for each PipelineTask (by name)
-	conditionTaskRuns := make(map[string][]*v1beta1.TaskRun)
-	// Map PipelineTask names to TaskRun names that were already in the status
-	taskRunByPipelineTask := make(map[string]string)
-	if pr.Status.TaskRuns != nil {
-		for taskRunName, pipelineRunTaskRunStatus := range pr.Status.TaskRuns {
-			taskRunByPipelineTask[pipelineRunTaskRunStatus.PipelineTaskName] = taskRunName
-		}
-	} else {
+
+	if pr.Status.TaskRuns == nil {
 		pr.Status.TaskRuns = make(map[string]*v1beta1.PipelineRunTaskRunStatus)
 	}
+
+	taskRuns, conditionTaskRuns := filterTaskRunsForPipelineRun(logger, pr, trs)
+
 	// Loop over all the TaskRuns associated to Tasks
-	for _, taskrun := range trs {
-		// Only process TaskRuns that are owned by this PipelineRun.
-		// This skips TaskRuns that are indirectly created by the PipelineRun (e.g. by custom tasks).
-		if len(taskrun.OwnerReferences) < 1 || taskrun.OwnerReferences[0].UID != pr.ObjectMeta.UID {
-			logger.Debugf("Found a TaskRun %s that is not owned by this PipelineRun", taskrun.Name)
-			continue
-		}
+	for _, taskrun := range taskRuns {
 		lbls := taskrun.GetLabels()
 		pipelineTaskName := lbls[pipeline.PipelineTaskLabelKey]
-		if _, ok := lbls[pipeline.ConditionCheckKey]; ok {
-			// Save condition for looping over them after this
-			if _, ok := conditionTaskRuns[pipelineTaskName]; !ok {
-				// If it's the first condition taskrun, initialise the slice
-				conditionTaskRuns[pipelineTaskName] = []*v1beta1.TaskRun{}
-			}
-			conditionTaskRuns[pipelineTaskName] = append(conditionTaskRuns[pipelineTaskName], taskrun)
-			continue
-		}
+
 		if _, ok := pr.Status.TaskRuns[taskrun.Name]; !ok {
 			// This taskrun was missing from the status.
 			// Add it without conditions, which are handled in the next loop
@@ -1287,49 +1364,30 @@ func updatePipelineRunStatusFromTaskRuns(logger *zap.SugaredLogger, pr *v1beta1.
 				Status:           &taskrun.Status,
 				ConditionChecks:  nil,
 			}
-			// Since this was recovered now, add it to the map, or it might be overwritten
-			taskRunByPipelineTask[pipelineTaskName] = taskrun.Name
 		}
 	}
 	// Then loop by pipelinetask name over all the TaskRuns associated to Conditions
 	for pipelineTaskName, actualConditionTaskRuns := range conditionTaskRuns {
-		taskRunName, ok := taskRunByPipelineTask[pipelineTaskName]
-		if !ok {
-			// The pipelineTask associated to the conditions was not found in the pipelinerun
-			// status. This means that the conditions were orphaned, and never added to the
-			// status. In this case we need to generate a new TaskRun name, that will be used
-			// to run the TaskRun if the conditions are passed.
-			taskRunName = resources.GetTaskRunName(pr.Status.TaskRuns, pr.Status.ChildReferences, pipelineTaskName, pr.Name)
+		// GetTaskRunName will look in first ChildReferences and then TaskRuns to see if there's already a TaskRun name
+		// for this pipelineTaskName, and if not, it will generate one.
+		taskRunName := resources.GetTaskRunName(pr.Status.TaskRuns, pr.Status.ChildReferences, pipelineTaskName, pr.Name)
+
+		if _, ok := pr.Status.TaskRuns[taskRunName]; !ok {
 			pr.Status.TaskRuns[taskRunName] = &v1beta1.PipelineRunTaskRunStatus{
 				PipelineTaskName: pipelineTaskName,
 				Status:           nil,
 				ConditionChecks:  nil,
 			}
 		}
-		// Build the map of condition checks for the taskrun
-		// If there were no other condition, initialise the map
-		conditionChecks := pr.Status.TaskRuns[taskRunName].ConditionChecks
-		if conditionChecks == nil {
-			conditionChecks = make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
-		}
-		for i, foundTaskRun := range actualConditionTaskRuns {
-			lbls := foundTaskRun.GetLabels()
-			if _, ok := conditionChecks[foundTaskRun.Name]; !ok {
-				// The condition check was not found, so we need to add it
-				// We only add the condition name, the status can now be gathered by the
-				// normal reconcile process
-				if conditionName, ok := lbls[pipeline.ConditionNameKey]; ok {
-					conditionChecks[foundTaskRun.Name] = &v1beta1.PipelineRunConditionCheckStatus{
-						ConditionName: fmt.Sprintf("%s-%s", conditionName, strconv.Itoa(i)),
-					}
-				} else {
-					// The condition name label is missing, so we cannot recover this
-					logger.Warnf("found an orphaned condition taskrun %#v with missing %s label",
-						foundTaskRun, pipeline.ConditionNameKey)
-				}
+
+		// Add any new condition checks which we've found but weren't already present to the status's condition checks map
+		for k, v := range getNewConditionChecksForTaskRun(logger, pr.Status.TaskRuns[taskRunName].ConditionChecks, actualConditionTaskRuns) {
+			if pr.Status.TaskRuns[taskRunName].ConditionChecks == nil {
+				pr.Status.TaskRuns[taskRunName].ConditionChecks = make(map[string]*v1beta1.PipelineRunConditionCheckStatus)
 			}
+
+			pr.Status.TaskRuns[taskRunName].ConditionChecks[k] = v
 		}
-		pr.Status.TaskRuns[taskRunName].ConditionChecks = conditionChecks
 	}
 }
 
@@ -1367,20 +1425,15 @@ func getNewConditionChecksForTaskRun(logger *zap.SugaredLogger, existingChecks m
 
 func updatePipelineRunStatusFromRuns(logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, runs []*v1alpha1.Run) {
 	// If no Run was found, nothing to be done. We never remove runs from the status
-	if runs == nil || len(runs) == 0 {
+	if len(runs) == 0 {
 		return
 	}
 	if pr.Status.Runs == nil {
 		pr.Status.Runs = make(map[string]*v1beta1.PipelineRunRunStatus)
 	}
+
 	// Loop over all the Runs associated to Tasks
-	for _, run := range runs {
-		// Only process Runs that are owned by this PipelineRun.
-		// This skips Runs that are indirectly created by the PipelineRun (e.g. by custom tasks).
-		if len(run.OwnerReferences) < 1 || run.OwnerReferences[0].UID != pr.ObjectMeta.UID {
-			logger.Debugf("Found a Run %s that is not owned by this PipelineRun", run.Name)
-			continue
-		}
+	for _, run := range filterRunsForPipelineRun(logger, pr, runs) {
 		lbls := run.GetLabels()
 		pipelineTaskName := lbls[pipeline.PipelineTaskLabelKey]
 		if _, ok := pr.Status.Runs[run.Name]; !ok {

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+
 	"github.com/tektoncd/pipeline/test/parse"
 
 	"github.com/google/go-cmp/cmp"
@@ -50,7 +52,6 @@ const (
 var supportedFeatureGates = map[string]string{
 	"enable-custom-tasks": "true",
 	"enable-api-fields":   "alpha",
-	"embedded-status":     "full",
 }
 
 func TestCustomTask(t *testing.T) {
@@ -60,6 +61,9 @@ func TestCustomTask(t *testing.T) {
 	c, namespace := setup(ctx, t, requireAnyGate(supportedFeatureGates))
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	embeddedStatusValue := GetEmbeddedStatus(ctx, t, c.KubeClient)
+
 	customTaskRawSpec := []byte(`{"field1":123,"field2":"value"}`)
 	metadataLabel := map[string]string{"test-label": "test"}
 	// Create a PipelineRun that runs a Custom Task.
@@ -122,11 +126,26 @@ spec:
 	}
 
 	// Get the Run name.
-	if len(pr.Status.Runs) != 2 {
-		t.Fatalf("PipelineRun had unexpected .status.runs; got %d, want 2", len(pr.Status.Runs))
+	var runNames []string
+	if embeddedStatusValue != config.MinimalEmbeddedStatus {
+		if len(pr.Status.Runs) != 2 {
+			t.Fatalf("PipelineRun had unexpected .status.runs; got %d, want 2", len(pr.Status.Runs))
+		}
+		for rn := range pr.Status.Runs {
+			runNames = append(runNames, rn)
+		}
 	}
-
-	for runName := range pr.Status.Runs {
+	if embeddedStatusValue != config.FullEmbeddedStatus {
+		for _, cr := range pr.Status.ChildReferences {
+			if cr.Kind == "Run" {
+				runNames = append(runNames, cr.Name)
+			}
+		}
+		if len(runNames) != 2 {
+			t.Fatalf("PipelineRun had unexpected number of Runs in .status.childReferences; got %d, want 2", len(runNames))
+		}
+	}
+	for _, runName := range runNames {
 		// Get the Run.
 		r, err := c.RunClient.Get(ctx, runName, metav1.GetOptions{})
 		if err != nil {
@@ -186,13 +205,26 @@ spec:
 	}
 
 	// Get the TaskRun name.
-	if len(pr.Status.TaskRuns) != 1 {
-		t.Fatalf("PipelineRun had unexpected .status.taskRuns; got %d, want 1", len(pr.Status.TaskRuns))
-	}
 	var taskRunName string
-	for k := range pr.Status.TaskRuns {
-		taskRunName = k
-		break
+
+	if embeddedStatusValue != config.MinimalEmbeddedStatus {
+		if len(pr.Status.TaskRuns) != 1 {
+			t.Fatalf("PipelineRun had unexpected .status.taskRuns; got %d, want 1", len(pr.Status.TaskRuns))
+		}
+		for k := range pr.Status.TaskRuns {
+			taskRunName = k
+			break
+		}
+	}
+	if embeddedStatusValue != config.FullEmbeddedStatus {
+		for _, cr := range pr.Status.ChildReferences {
+			if cr.Kind == "TaskRun" {
+				taskRunName = cr.Name
+			}
+		}
+		if taskRunName == "" {
+			t.Fatal("PipelineRun does not have expected TaskRun in .status.childReferences")
+		}
 	}
 
 	// Get the TaskRun.
@@ -257,6 +289,9 @@ func TestPipelineRunCustomTaskTimeout(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(context.Background(), t, c, namespace) }, t.Logf)
 	defer tearDown(context.Background(), t, c, namespace)
+
+	embeddedStatusValue := GetEmbeddedStatus(ctx, t, c.KubeClient)
+
 	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -295,36 +330,47 @@ spec:
 	}
 
 	// Get the Run name.
-	if len(pr.Status.Runs) != 1 {
-		t.Fatalf("PipelineRun had unexpected .status.runs; got %d, want 1", len(pr.Status.Runs))
+	runName := ""
+
+	if embeddedStatusValue != config.MinimalEmbeddedStatus {
+		if len(pr.Status.Runs) != 1 {
+			t.Fatalf("PipelineRun had unexpected .status.runs; got %d, want 1", len(pr.Status.Runs))
+		}
+		for rn := range pr.Status.Runs {
+			runName = rn
+		}
+	}
+	if embeddedStatusValue != config.FullEmbeddedStatus {
+		if len(pr.Status.ChildReferences) != 1 {
+			t.Fatalf("PipelineRun had unexpected .status.childReferences; got %d, want 1", len(pr.Status.ChildReferences))
+		}
+		runName = pr.Status.ChildReferences[0].Name
 	}
 
-	for runName := range pr.Status.Runs {
-		// Get the Run.
-		r, err := c.RunClient.Get(ctx, runName, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Failed to get Run %q: %v", runName, err)
-		}
-		if r.IsDone() {
-			t.Fatalf("Run unexpectedly done: %v", r.Status.GetCondition(apis.ConditionSucceeded))
-		}
+	// Get the Run.
+	r, err := c.RunClient.Get(ctx, runName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get Run %q: %v", runName, err)
+	}
+	if r.IsDone() {
+		t.Fatalf("Run unexpectedly done: %v", r.Status.GetCondition(apis.ConditionSucceeded))
+	}
 
-		// Simulate a Custom Task controller updating the Run to be started/running,
-		// because, a run that has not started cannot timeout.
-		r.Status = v1alpha1.RunStatus{
-			RunStatusFields: v1alpha1.RunStatusFields{
-				StartTime: &metav1.Time{Time: time.Now()},
-			},
-			Status: duckv1.Status{
-				Conditions: []apis.Condition{{
-					Type:   apis.ConditionSucceeded,
-					Status: corev1.ConditionUnknown,
-				}},
-			},
-		}
-		if _, err := c.RunClient.UpdateStatus(ctx, r, metav1.UpdateOptions{}); err != nil {
-			t.Fatalf("Failed to update Run to successful: %v", err)
-		}
+	// Simulate a Custom Task controller updating the Run to be started/running,
+	// because, a run that has not started cannot timeout.
+	r.Status = v1alpha1.RunStatus{
+		RunStatusFields: v1alpha1.RunStatusFields{
+			StartTime: &metav1.Time{Time: time.Now()},
+		},
+		Status: duckv1.Status{
+			Conditions: []apis.Condition{{
+				Type:   apis.ConditionSucceeded,
+				Status: corev1.ConditionUnknown,
+			}},
+		},
+	}
+	if _, err := c.RunClient.UpdateStatus(ctx, r, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update Run to successful: %v", err)
 	}
 
 	t.Logf("Waiting for PipelineRun %s in namespace %s to be timed out", pipelineRun.Name, namespace)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+
 	"github.com/tektoncd/pipeline/test/parse"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +45,8 @@ func TestTaskRunRetry(t *testing.T) {
 	c, namespace := setup(ctx, t)
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	embeddedStatus := GetEmbeddedStatus(ctx, t, c.KubeClient)
 
 	// Create a PipelineRun with a single TaskRun that can only fail,
 	// configured to retry 5 times.
@@ -75,12 +79,32 @@ spec:
 		t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRunName, err)
 	}
 
-	// PipelineRunStatus should have 1 TaskRun status, and it should be failed.
-	if len(pr.Status.TaskRuns) != 1 {
-		t.Errorf("Got %d TaskRun statuses, wanted %d", len(pr.Status.TaskRuns), numRetries)
+	if embeddedStatus == config.FullEmbeddedStatus || embeddedStatus == config.BothEmbeddedStatus {
+		// PipelineRunStatus should have 1 TaskRun status, and it should be failed.
+		if len(pr.Status.TaskRuns) != 1 {
+			t.Errorf("Got %d TaskRun statuses, wanted %d", len(pr.Status.TaskRuns), numRetries)
+		}
+		for taskRunName, trs := range pr.Status.TaskRuns {
+			if !isFailed(t, taskRunName, trs.Status.Conditions) {
+				t.Errorf("TaskRun status %q is not failed", taskRunName)
+			}
+		}
 	}
-	for taskRunName, trs := range pr.Status.TaskRuns {
-		if !isFailed(t, taskRunName, trs.Status.Conditions) {
+	if embeddedStatus == config.MinimalEmbeddedStatus || embeddedStatus == config.BothEmbeddedStatus {
+		// PipelineRunStatus should have 1 child reference, and the TaskRun it refers to should be failed.
+		if len(pr.Status.ChildReferences) != 1 {
+			t.Fatalf("Got %d child references, wanted %d", len(pr.Status.ChildReferences), numRetries)
+		}
+		if pr.Status.ChildReferences[0].Kind != "TaskRun" {
+			t.Errorf("Got a child reference of kind %s, but expected TaskRun", pr.Status.ChildReferences[0].Kind)
+		}
+		taskRunName := pr.Status.ChildReferences[0].Name
+
+		tr, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get TaskRun %q: %v", taskRunName, err)
+		}
+		if !isFailed(t, taskRunName, tr.Status.Conditions) {
 			t.Errorf("TaskRun status %q is not failed", taskRunName)
 		}
 	}

--- a/test/v1alpha1/retry_test.go
+++ b/test/v1alpha1/retry_test.go
@@ -25,6 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/tektoncd/pipeline/test"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+
 	"github.com/tektoncd/pipeline/test/parse"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +47,8 @@ func TestTaskRunRetry(t *testing.T) {
 	c, namespace := setup(ctx, t)
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	embeddedStatus := test.GetEmbeddedStatus(ctx, t, c.KubeClient)
 
 	// Create a PipelineRun with a single TaskRun that can only fail,
 	// configured to retry 5 times.
@@ -75,12 +81,32 @@ spec:
 		t.Fatalf("Failed to get PipelineRun %q: %v", pipelineRunName, err)
 	}
 
-	// PipelineRunStatus should have 1 TaskRun status, and it should be failed.
-	if len(pr.Status.TaskRuns) != 1 {
-		t.Errorf("Got %d TaskRun statuses, wanted %d", len(pr.Status.TaskRuns), numRetries)
+	if embeddedStatus == config.FullEmbeddedStatus || embeddedStatus == config.BothEmbeddedStatus {
+		// PipelineRunStatus should have 1 TaskRun status, and it should be failed.
+		if len(pr.Status.TaskRuns) != 1 {
+			t.Errorf("Got %d TaskRun statuses, wanted %d", len(pr.Status.TaskRuns), numRetries)
+		}
+		for taskRunName, trs := range pr.Status.TaskRuns {
+			if !isFailed(t, taskRunName, trs.Status.Conditions) {
+				t.Errorf("TaskRun status %q is not failed", taskRunName)
+			}
+		}
 	}
-	for taskRunName, trs := range pr.Status.TaskRuns {
-		if !isFailed(t, taskRunName, trs.Status.Conditions) {
+	if embeddedStatus == config.MinimalEmbeddedStatus || embeddedStatus == config.BothEmbeddedStatus {
+		// PipelineRunStatus should have 1 child reference, and the TaskRun it refers to should be failed.
+		if len(pr.Status.ChildReferences) != 1 {
+			t.Fatalf("Got %d child references, wanted %d", len(pr.Status.ChildReferences), numRetries)
+		}
+		if pr.Status.ChildReferences[0].Kind != "TaskRun" {
+			t.Errorf("Got a child reference of kind %s, but expected TaskRun", pr.Status.ChildReferences[0].Kind)
+		}
+		taskRunName := pr.Status.ChildReferences[0].Name
+
+		tr, err := c.TaskRunClient.Get(ctx, taskRunName, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("Failed to get TaskRun %q: %v", taskRunName, err)
+		}
+		if !isFailed(t, taskRunName, tr.Status.Conditions) {
 			t.Errorf("TaskRun status %q is not failed", taskRunName)
 		}
 	}


### PR DESCRIPTION
# Changes

See:
* https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md
* https://github.com/tektoncd/pipeline/pull/4705
* https://github.com/tektoncd/pipeline/pull/4734
* https://github.com/tektoncd/pipeline/pull/4753
* https://github.com/tektoncd/pipeline/pull/4757
* https://github.com/tektoncd/pipeline/pull/4760
* https://github.com/tektoncd/pipeline/issues/3140

This implements TEP-0100, allowing for choosing between the original full embedded `TaskRun` and
`Run` statuses in `PipelineRun` statuses, minimal child references to the underlying `TaskRun` and
`Run`s, or both, building on top of all the other PRs referenced above.

/kind tep
/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Added implementation for minimal `TaskRun` and `Run` statuses within `PipelineRun` statuses. 
```
