### PR TITLE
Implement function to ignore possible variables inside quotes on a task input

### DIFF
--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -52,7 +52,7 @@ func ValidateVariableP(value, prefix string, vars sets.String) *apis.FieldError 
 			v = strings.TrimSuffix(v, "[*]")
 			if !vars.Has(v) {
 				return &apis.FieldError{
-					Message: fmt.Sprintf("non-existent variable in %q", value),
+					Message: fmt.Sprintf("non-existent variable %q in %q", v, value),
 					// Empty path is required to make the `ViaField`, … work
 					Paths: []string{""},
 				}
@@ -149,6 +149,7 @@ func extractExpressionFromString(s, prefix string) (string, bool) {
 func extractVariablesFromString(s, prefix string) ([]string, bool) {
 	pattern := fmt.Sprintf(braceMatchingRegex, prefix, parameterSubstitution)
 	re := regexp.MustCompile(pattern)
+	s = replaceContentInsideQuotes(s)
 	matches := re.FindAllStringSubmatch(s, -1)
 	if len(matches) == 0 {
 		return []string{}, false
@@ -162,6 +163,12 @@ func extractVariablesFromString(s, prefix string) ([]string, bool) {
 		vars[i] = strings.SplitN(groups["var"], ".", 2)[0]
 	}
 	return vars, true
+}
+
+func replaceContentInsideQuotes(value string) string {
+	// match every string inside double and/or single quotes.
+	re := regexp.MustCompile(`"[^"]*"|'[^']*'`)
+	return re.ReplaceAllString(value, "")
 }
 
 func matchGroups(matches []string, pattern *regexp.Regexp) map[string]string {

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -116,6 +116,36 @@ func TestValidateVariables(t *testing.T) {
 	}
 }
 
+func  TestValidateVariableP(t *testing.T){
+	type args struct {
+		input        string
+		prefix       string
+		vars         sets.String
+	}
+	for _, tc := range []struct {
+		name          string
+		args          args
+		expectedError *apis.FieldError
+	}{{
+		name: "valid variable",
+		args: args{
+			input:        "echo {\"key\": \"$(params.a)\"}",
+			prefix:       "params",
+			vars:         sets.NewString(),
+		},
+		expectedError: nil,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := substitution.ValidateVariableP(tc.args.input, tc.args.prefix, tc.args.vars) 
+		
+			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("ValidateVariableP() error did not match expected error %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+
+}
+
 func TestApplyReplacements(t *testing.T) {
 	type args struct {
 		input        string

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -116,28 +116,51 @@ func TestValidateVariables(t *testing.T) {
 	}
 }
 
-func  TestValidateVariableP(t *testing.T){
+func TestValidateVariableP(t *testing.T) {
 	type args struct {
-		input        string
-		prefix       string
-		vars         sets.String
+		input  string
+		prefix string
+		vars   sets.String
 	}
 	for _, tc := range []struct {
 		name          string
 		args          args
 		expectedError *apis.FieldError
-	}{{
-		name: "valid variable",
-		args: args{
-			input:        "echo {\"key\": \"$(params.a)\"}",
-			prefix:       "params",
-			vars:         sets.NewString(),
+	}{
+		{
+			name: "valid input with double quotes",
+			args: args{
+				input:  "echo {\"key\": \"$(params.a)\"}",
+				prefix: "params",
+				vars:   sets.NewString(),
+			},
+			expectedError: nil,
 		},
-		expectedError: nil,
-	}} {
+		{
+			name: "valid input with single quotes",
+			args: args{
+				input:  "echo {'key': '$(params.a)'}",
+				prefix: "params",
+				vars:   sets.NewString(),
+			},
+			expectedError: nil,
+		},
+		{
+			name: "expected non-existent variable",
+			args: args{
+				input:  "echo {\"key\": $(params.a)}",
+				prefix: "params",
+				vars:   sets.NewString(),
+			},
+			expectedError: &apis.FieldError{
+				Message: `non-existent variable "a" in "echo {\"key\": $(params.a)}"`,
+				Paths:   []string{""},
+			},
+		},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := substitution.ValidateVariableP(tc.args.input, tc.args.prefix, tc.args.vars) 
-		
+			got := substitution.ValidateVariableP(tc.args.input, tc.args.prefix, tc.args.vars)
+
 			if d := cmp.Diff(got, tc.expectedError, cmp.AllowUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("ValidateVariableP() error did not match expected error %s", diff.PrintWantGot(d))
 			}


### PR DESCRIPTION
# Changes

<!-- 

As per requested on #4690. When a user tries to pass something that can be interpreted as a variable on a task input it will break.

So I Include a regex to match content inside quotes on a task input, and remove it only for variable interpretation, to avoid extract undesirable variables from it.


/kind feature

-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
```release-note
NONE
```
-->
