### PR TITLE
Update a number of PipelineRun reconciler tests with parsed YAML

### DIFF
--- a/test/parse/yaml.go
+++ b/test/parse/yaml.go
@@ -64,6 +64,16 @@ kind: Task
 	return &task
 }
 
+// MustParseClusterTask takes YAML and parses it into a *v1beta1.ClusterTask
+func MustParseClusterTask(t *testing.T, yaml string) *v1beta1.ClusterTask {
+	var clusterTask v1beta1.ClusterTask
+	yaml = `apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+` + yaml
+	mustParseYAML(t, yaml, &clusterTask)
+	return &clusterTask
+}
+
 // MustParseAlphaTask takes YAML and parses it into a *v1alpha1.Task
 func MustParseAlphaTask(t *testing.T, yaml string) *v1alpha1.Task {
 	var task v1alpha1.Task


### PR DESCRIPTION
# Changes

This doesn't address all uses of explicitly declared structs in `pipelinerun_test.go`,
but it's progress. I decided that it made sense to do this incrementally, rather
than attempting a single Big Bang switching all of them over.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
