### PR TITLE
Add Go libraries compatibility policy

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -85,3 +85,10 @@ These changes must be approved by [more than half of the project OWNERS](OWNERS)
 
 Tekton Pipelines [maintains a list of features that have been deprecated](https://github.com/tektoncd/pipeline/tree/main/docs/deprecations.md)
 which includes the earliest date each feature will be removed.
+
+## Go libraries compatibility policy
+
+Tekton Pipelines may introduce breaking changes to its Go client libraries, as long as these changes
+do not impact users' yaml/json CRD definitions. For example, a change that renames a field of a CRD
+would need to follow the policy on [backwards incompatible changes](#backwards-incompatible-changes),
+but a change that renames the Go struct type for that field is allowed.


### PR DESCRIPTION
# Changes

This change proposes that breaking changes may be introduced to the Go client libraries,
as long as existing yaml/json CRD definitions remain unaffected.

Breaking changes to the Go client libraries do not affect the Dashboard team, as the Dashboard
team no longer uses these libraries. The CLI team has decided that the impact of such changes
on them is acceptable.

Closes #2748.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
