### PR TITLE
Switch to YAML parsing in much of `taskrun_test.go`

### DIFF
--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/ptr"
 
 	"github.com/google/go-cmp/cmp"
@@ -45,11 +44,11 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/pkg/reconciler/volumeclaim"
-	"github.com/tektoncd/pipeline/pkg/workspace"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
 	eventstest "github.com/tektoncd/pipeline/test/events"
 	"github.com/tektoncd/pipeline/test/names"
+	"github.com/tektoncd/pipeline/test/parse"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -133,57 +132,6 @@ var (
 		},
 		Spec: v1beta1.TaskSpec{
 			Steps: []v1beta1.Step{simpleStep},
-		},
-	}
-	taskMultipleSteps = &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-multi-steps", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{
-				{
-					Container: corev1.Container{
-						Image:   "foo",
-						Name:    "z-step",
-						Command: []string{"/mycmd"},
-					},
-				},
-				{
-					Container: corev1.Container{
-						Image:   "foo",
-						Name:    "v-step",
-						Command: []string{"/mycmd"},
-					},
-				},
-				{
-					Container: corev1.Container{
-						Image:   "foo",
-						Name:    "x-step",
-						Command: []string{"/mycmd"},
-					},
-				},
-			},
-		},
-	}
-
-	taskMultipleStepsIgnoreError = &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-multi-steps-with-ignore-error", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{
-				{
-					Container: corev1.Container{
-						Image:   "foo",
-						Name:    "step-0",
-						Command: []string{"/mycmd"},
-					},
-					OnError: "continue",
-				},
-				{
-					Container: corev1.Container{
-						Image:   "foo",
-						Name:    "step-1",
-						Command: []string{"/mycmd"},
-					},
-				},
-			},
 		},
 	}
 
@@ -597,25 +545,25 @@ func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.
 }
 
 func TestReconcile_ExplicitDefaultSA(t *testing.T) {
-	taskRunSuccess := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       simpleTask.Name,
-				APIVersion: "a1",
-			},
-		},
-	}
-	taskRunWithSaSuccess := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-sa-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       saTask.Name,
-				APIVersion: "a1",
-			},
-			ServiceAccountName: "test-sa",
-		},
-	}
+	taskRunSuccess := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-success
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task
+`)
+	taskRunWithSaSuccess := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-sa-run-success
+  namespace: foo
+spec:
+  serviceAccountName: test-sa
+  taskRef:
+    apiVersion: a1
+    name: test-with-sa
+`)
 	taskruns := []*v1beta1.TaskRun{taskRunSuccess, taskRunWithSaSuccess}
 	defaultSAName := "pipelines"
 	d := test.Data{
@@ -716,31 +664,29 @@ func TestReconcile_ExplicitDefaultSA(t *testing.T) {
 // TestReconcile_CloudEvents runs reconcile with a cloud event sink configured
 // to ensure that events are sent in different cases
 func TestReconcile_CloudEvents(t *testing.T) {
-	task := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Image:   "foo",
-					Name:    "simple-step",
-					Command: []string{"/mycmd"},
-					Env: []corev1.EnvVar{{
-						Name:  "foo",
-						Value: "bar",
-					}},
-				},
-			}},
-		},
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-not-started", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: task.Name,
-			},
-		},
-	}
-	taskRun.ObjectMeta.SelfLink = "/test/taskrun1"
+	task := parse.MustParseTask(t, `
+metadata:
+  name: test-task
+  namespace: foo
+spec:
+  steps:
+  - command:
+    - /mycmd
+    env:
+    - name: foo
+      value: bar
+    image: foo
+    name: simple-step
+`)
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-not-started
+  namespace: foo
+  selfLink: /test/taskrun1
+spec:
+  taskRef:
+    name: test-task
+`)
 	d := test.Data{
 		Tasks:    []*v1beta1.Task{task},
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
@@ -811,245 +757,193 @@ func TestReconcile_CloudEvents(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
-	taskRunSuccess := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       simpleTask.Name,
-				APIVersion: "a1",
-			},
-		},
-	}
-	taskRunWithSaSuccess := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-sa-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       saTask.Name,
-				APIVersion: "a1",
-			},
-			ServiceAccountName: "test-sa",
-		},
-	}
-	taskRunSubstitution := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-substitution", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       templatedTask.Name,
-				APIVersion: "a1",
-			},
-			Params: []v1beta1.Param{
-				{
-					Name:  "myarg",
-					Value: *v1beta1.NewArrayOrString("foo"),
-				},
-				{
-					Name:  "myarghasdefault",
-					Value: *v1beta1.NewArrayOrString("bar"),
-				},
-				{
-					Name:  "configmapname",
-					Value: *v1beta1.NewArrayOrString("configbar"),
-				},
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Inputs: []v1beta1.TaskResourceBinding{{
-					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-						Name: "workspace",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: gitResource.Name,
-						},
-					},
-				}},
-				Outputs: []v1beta1.TaskResourceBinding{{
-					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-						Name: "myimage",
-						ResourceRef: &v1beta1.PipelineResourceRef{
-							Name: imageResource.Name,
-						},
-					},
-				}},
-			},
-		},
-	}
-	taskRunInputOutput := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-input-output", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: outputTask.Name,
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Inputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name:        gitResource.Name,
-							ResourceRef: &v1beta1.PipelineResourceRef{Name: gitResource.Name},
-						},
-						Paths: []string{"source-folder"},
-					},
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name:        anotherGitResource.Name,
-							ResourceRef: &v1beta1.PipelineResourceRef{Name: anotherGitResource.Name},
-						},
-						Paths: []string{"source-folder"},
-					},
-				},
-				Outputs: []v1beta1.TaskResourceBinding{{
-					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-						Name:        gitResource.Name,
-						ResourceRef: &v1beta1.PipelineResourceRef{Name: gitResource.Name},
-					},
-					Paths: []string{"output-folder"},
-				}},
-			},
-		},
-	}
-	taskRunInputOutput.OwnerReferences = []metav1.OwnerReference{{
-		Kind: "PipelineRun",
-		Name: "test",
-	}}
-	taskRunWithTaskSpec := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-taskspec", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
-				Name:  "myarg",
-				Value: *v1beta1.NewArrayOrString("foo"),
-			}},
-			Resources: &v1beta1.TaskRunResources{
-				Inputs: []v1beta1.TaskResourceBinding{{
-					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-						Name:        "workspace",
-						ResourceRef: &v1beta1.PipelineResourceRef{Name: gitResource.Name},
-					},
-				}},
-			},
-			TaskSpec: &v1beta1.TaskSpec{
-				Params: []v1beta1.ParamSpec{{
-					Name:    "myarg",
-					Type:    v1beta1.ParamTypeString,
-					Default: v1beta1.NewArrayOrString("mydefault"),
-				}},
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{{
-						ResourceDeclaration: v1beta1.ResourceDeclaration{
-							Name: "workspace",
-							Type: resourcev1alpha1.PipelineResourceTypeGit,
-						},
-					}},
-				},
-				Steps: []v1beta1.Step{{
-					Container: corev1.Container{
-						Image:   "myimage",
-						Name:    "mycontainer",
-						Command: []string{"/mycmd"},
-						Args:    []string{"--my-arg=$(inputs.params.myarg)"},
-					},
-				}},
-			},
-		},
-	}
+	taskRunSuccess := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-success
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task
+`)
+	taskRunWithSaSuccess := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-sa-run-success
+  namespace: foo
+spec:
+  serviceAccountName: test-sa
+  taskRef:
+    apiVersion: a1
+    name: test-with-sa
+`)
+	taskRunSubstitution := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-substitution
+  namespace: foo
+spec:
+  params:
+  - name: myarg
+    value: foo
+  - name: myarghasdefault
+    value: bar
+  - name: configmapname
+    value: configbar
+  resources:
+    inputs:
+    - name: workspace
+      resourceRef:
+        name: git-resource
+    outputs:
+    - name: myimage
+      resourceRef:
+        name: image-resource
+  taskRef:
+    apiVersion: a1
+    name: test-task-with-substitution
+`)
+	taskRunInputOutput := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-input-output
+  namespace: foo
+  ownerReferences:
+  - kind: PipelineRun
+    name: test
+spec:
+  resources:
+    inputs:
+    - name: git-resource
+      paths:
+      - source-folder
+      resourceRef:
+        name: git-resource
+    - name: another-git-resource
+      paths:
+      - source-folder
+      resourceRef:
+        name: another-git-resource
+    outputs:
+    - name: git-resource
+      paths:
+      - output-folder
+      resourceRef:
+        name: git-resource
+  taskRef:
+    name: test-output-task
+`)
+	taskRunWithTaskSpec := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-taskspec
+  namespace: foo
+spec:
+  params:
+  - name: myarg
+    value: foo
+  resources:
+    inputs:
+    - name: workspace
+      resourceRef:
+        name: git-resource
+  taskSpec:
+    params:
+    - default: mydefault
+      name: myarg
+      type: string
+    resources:
+      inputs:
+      - name: workspace
+        type: git
+    steps:
+    - args:
+      - --my-arg=$(inputs.params.myarg)
+      command:
+      - /mycmd
+      image: myimage
+      name: mycontainer
+`)
 
-	taskRunWithResourceSpecAndTaskSpec := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-resource-spec", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			Resources: &v1beta1.TaskRunResources{
-				Inputs: []v1beta1.TaskResourceBinding{{
-					PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-						Name: "workspace",
-						ResourceSpec: &resourcev1alpha1.PipelineResourceSpec{
-							Type: resourcev1alpha1.PipelineResourceTypeGit,
-							Params: []resourcev1alpha1.ResourceParam{{
-								Name:  "URL",
-								Value: "github.com/foo/bar.git",
-							}, {
-								Name:  "revision",
-								Value: "rel-can",
-							}},
-						},
-					},
-				}},
-			},
-			TaskSpec: &v1beta1.TaskSpec{
-				Resources: &v1beta1.TaskResources{
-					Inputs: []v1beta1.TaskResource{{
-						ResourceDeclaration: v1beta1.ResourceDeclaration{
-							Name: "workspace",
-							Type: resourcev1alpha1.PipelineResourceTypeGit,
-						},
-					}},
-				},
-				Steps: []v1beta1.Step{{
-					Container: corev1.Container{
-						Image:   "ubuntu",
-						Name:    "mystep",
-						Command: []string{"/mycmd"},
-					},
-				}},
-			},
-		},
-	}
+	taskRunWithResourceSpecAndTaskSpec := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-resource-spec
+  namespace: foo
+spec:
+  resources:
+    inputs:
+    - name: workspace
+      resourceSpec:
+        params:
+        - name: URL
+          value: github.com/foo/bar.git
+        - name: revision
+          value: rel-can
+        type: git
+  taskSpec:
+    resources:
+      inputs:
+      - name: workspace
+        type: git
+    steps:
+    - command:
+      - /mycmd
+      image: ubuntu
+      name: mystep
+`)
 
-	taskRunWithClusterTask := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-cluster-task", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: clustertask.Name,
-				Kind: v1beta1.ClusterTaskKind,
-			},
-		},
-	}
+	taskRunWithClusterTask := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-cluster-task
+  namespace: foo
+spec:
+  taskRef:
+    kind: ClusterTask
+    name: test-cluster-task
+`)
 
-	taskRunWithLabels := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-labels", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-	}
-	taskRunWithLabels.Labels = map[string]string{
-		"TaskRunLabel":           "TaskRunValue",
-		pipeline.TaskRunLabelKey: "WillNotBeUsed",
-	}
+	taskRunWithLabels := parse.MustParseTaskRun(t, `
+metadata:
+  labels:
+    TaskRunLabel: TaskRunValue
+    tekton.dev/taskRun: WillNotBeUsed
+  name: test-taskrun-with-labels
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+`)
 
-	taskRunWithAnnotations := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-annotations", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-	}
-	taskRunWithAnnotations.Annotations = map[string]string{"TaskRunAnnotation": "TaskRunValue"}
+	taskRunWithAnnotations := parse.MustParseTaskRun(t, `
+metadata:
+  annotations:
+    TaskRunAnnotation: TaskRunValue
+  name: test-taskrun-with-annotations
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+`)
 
-	taskRunWithPod := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-pod", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				PodName: "some-pod-abcdethat-no-longer-exists",
-			},
-		},
-	}
+	taskRunWithPod := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-pod
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+status:
+  podName: some-pod-abcdethat-no-longer-exists
+`)
 
-	taskRunWithCredentialsVariable := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-with-credentials-variable", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
-					Container: corev1.Container{
-						Image:   "myimage",
-						Name:    "mycontainer",
-						Command: []string{"/mycmd $(credentials.path)"},
-					},
-				}},
-			},
-		},
-	}
+	taskRunWithCredentialsVariable := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-with-credentials-variable
+  namespace: foo
+spec:
+  taskSpec:
+    steps:
+    - command:
+      - /mycmd $(credentials.path)
+      image: myimage
+      name: mycontainer
+`)
 
 	// Set up a fake registry to push an image to.
 	s := httptest.NewServer(registry.New())
@@ -1065,15 +959,15 @@ func TestReconcile(t *testing.T) {
 		t.Fatalf("failed to upload image with simple task: %s", err.Error())
 	}
 
-	taskRunBundle := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-bundle", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:   simpleTypedTask.Name,
-				Bundle: ref,
-			},
-		},
-	}
+	taskRunBundle := parse.MustParseTaskRun(t, fmt.Sprintf(`
+metadata:
+  name: test-taskrun-bundle
+  namespace: foo
+spec:
+  taskRef:
+    bundle: %s
+    name: test-task
+`, ref))
 
 	taskruns := []*v1beta1.TaskRun{
 		taskRunSuccess, taskRunWithSaSuccess,
@@ -1353,14 +1247,14 @@ func TestReconcile(t *testing.T) {
 }
 
 func TestReconcile_SetsStartTime(t *testing.T) {
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+`)
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -1386,20 +1280,17 @@ func TestReconcile_SetsStartTime(t *testing.T) {
 
 func TestReconcile_DoesntChangeStartTime(t *testing.T) {
 	startTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				StartTime: &metav1.Time{Time: startTime},
-				PodName:   "the-pod",
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+status:
+  podName: the-pod
+`)
+	taskRun.Status.StartTime = &metav1.Time{Time: startTime}
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -1423,23 +1314,23 @@ func TestReconcile_DoesntChangeStartTime(t *testing.T) {
 }
 
 func TestReconcileInvalidTaskRuns(t *testing.T) {
-	noTaskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("notaskrun", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "notask",
-			},
-		},
-	}
-	withWrongRef := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("taskrun-with-wrong-ref", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "taskrun-with-wrong-ref",
-				Kind: v1beta1.ClusterTaskKind,
-			},
-		},
-	}
+	noTaskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: notaskrun
+  namespace: foo
+spec:
+  taskRef:
+    name: notask
+`)
+	withWrongRef := parse.MustParseTaskRun(t, `
+metadata:
+  name: taskrun-with-wrong-ref
+  namespace: foo
+spec:
+  taskRef:
+    kind: ClusterTask
+    name: taskrun-with-wrong-ref
+`)
 	taskRuns := []*v1beta1.TaskRun{noTaskRun, withWrongRef}
 	tasks := []*v1beta1.Task{simpleTask}
 
@@ -1520,14 +1411,14 @@ func TestReconcileInvalidTaskRuns(t *testing.T) {
 }
 
 func TestReconcileGetTaskError(t *testing.T) {
-	tr := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-	}
+	tr := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-success
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+`)
 	d := test.Data{
 		TaskRuns:          []*v1beta1.TaskRun{tr},
 		Tasks:             []*v1beta1.Task{simpleTask},
@@ -1570,29 +1461,22 @@ func TestReconcileGetTaskError(t *testing.T) {
 }
 
 func TestReconcileTaskRunWithPermanentError(t *testing.T) {
-	noTaskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("notaskrun", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "notask",
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:    apis.ConditionSucceeded,
-						Status:  corev1.ConditionFalse,
-						Reason:  podconvert.ReasonFailedResolution,
-						Message: "error when listing tasks for taskRun taskrun-failure: tasks.tekton.dev \"notask\" not found",
-					},
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				StartTime: &metav1.Time{Time: now},
-			},
-		},
-	}
+	noTaskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: notaskrun
+  namespace: foo
+spec:
+  taskRef:
+    name: notask
+status:
+  conditions:
+  - message: 'error when listing tasks for taskRun taskrun-failure: tasks.tekton.dev
+      "notask" not found'
+    reason: TaskRunResolutionFailed
+    status: "False"
+    type: Succeeded
+  startTime: "2022-01-01T00:00:00Z"
+`)
 
 	taskRuns := []*v1beta1.TaskRun{noTaskRun}
 	d := test.Data{
@@ -1635,19 +1519,16 @@ func TestReconcileTaskRunWithPermanentError(t *testing.T) {
 }
 
 func TestReconcilePodFetchError(t *testing.T) {
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "test-task",
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				PodName: "will-not-be-found",
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-success
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+status:
+  podName: will-not-be-found
+`)
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -1697,23 +1578,20 @@ func makePod(taskRun *v1beta1.TaskRun, task *v1beta1.Task) (*corev1.Pod, error) 
 
 func TestReconcilePodUpdateStatus(t *testing.T) {
 	const taskLabel = "test-task"
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: taskLabel,
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-success
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+status:
+  podName: test-taskrun-run-success-pod
+`)
 
 	pod, err := makePod(taskRun, simpleTask)
 	if err != nil {
 		t.Fatalf("MakePod: %v", err)
-	}
-	taskRun.Status = v1beta1.TaskRunStatus{
-		TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-			PodName: pod.Name,
-		},
 	}
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
@@ -1795,30 +1673,21 @@ func TestReconcilePodUpdateStatus(t *testing.T) {
 }
 
 func TestReconcileOnCompletedTaskRun(t *testing.T) {
-	taskSt := &apis.Condition{
-		Type:    apis.ConditionSucceeded,
-		Status:  corev1.ConditionTrue,
-		Reason:  "Build succeeded",
-		Message: "Build succeeded",
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-success", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					*taskSt,
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				StartTime: &metav1.Time{Time: now.Add(-15 * time.Second)},
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-success
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - message: Build succeeded
+    reason: Build succeeded
+    status: "True"
+    type: Succeeded
+  startTime: "2021-12-31T23:59:45Z"
+`)
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{
 			taskRun,
@@ -1838,36 +1707,30 @@ func TestReconcileOnCompletedTaskRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected completed TaskRun %s to exist but instead got error when getting it: %v", taskRun.Name, err)
 	}
-	if d := cmp.Diff(taskSt, newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
+	if d := cmp.Diff(taskRun.Status.GetCondition(apis.ConditionSucceeded), newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
 	}
 }
 
 func TestReconcileOnCancelledTaskRun(t *testing.T) {
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-run-cancelled", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-			Status: v1beta1.TaskRunSpecStatusCancelled,
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionUnknown,
-					},
-				},
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-cancelled
+  namespace: foo
+spec:
+  status: TaskRunCancelled
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: test-taskrun-run-cancelled-pod
+`)
 	pod, err := makePod(taskRun, simpleTask)
 	if err != nil {
 		t.Fatalf("MakePod: %v", err)
 	}
-	taskRun.Status.PodName = pod.Name
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -1932,28 +1795,20 @@ func TestReconcileTimeouts(t *testing.T) {
 	testcases := []testCase{
 		{
 			name: "taskrun with timeout",
-			taskRun: &v1beta1.TaskRun{
-				ObjectMeta: objectMeta("test-taskrun-timeout", "foo"),
-				Spec: v1beta1.TaskRunSpec{
-					TaskRef: &v1beta1.TaskRef{
-						Name: simpleTask.Name,
-					},
-					Timeout: &metav1.Duration{Duration: 10 * time.Second},
-				},
-				Status: v1beta1.TaskRunStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{
-							apis.Condition{
-								Type:   apis.ConditionSucceeded,
-								Status: corev1.ConditionUnknown,
-							},
-						},
-					},
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-						StartTime: &metav1.Time{Time: now.Add(-15 * time.Second)},
-					},
-				},
-			},
+			taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-timeout
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: 10s
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  startTime: "2021-12-31T23:59:45Z"
+`),
 
 			expectedStatus: &apis.Condition{
 				Type:    apis.ConditionSucceeded,
@@ -1966,27 +1821,19 @@ func TestReconcileTimeouts(t *testing.T) {
 			},
 		}, {
 			name: "taskrun with default timeout",
-			taskRun: &v1beta1.TaskRun{
-				ObjectMeta: objectMeta("test-taskrun-default-timeout-60-minutes", "foo"),
-				Spec: v1beta1.TaskRunSpec{
-					TaskRef: &v1beta1.TaskRef{
-						Name: simpleTask.Name,
-					},
-				},
-				Status: v1beta1.TaskRunStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{
-							apis.Condition{
-								Type:   apis.ConditionSucceeded,
-								Status: corev1.ConditionUnknown,
-							},
-						},
-					},
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-						StartTime: &metav1.Time{Time: now.Add(-61 * time.Minute)},
-					},
-				},
-			},
+			taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-default-timeout-60-minutes
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  startTime: "2021-12-31T22:59:00Z"
+`),
 			expectedStatus: &apis.Condition{
 				Type:    apis.ConditionSucceeded,
 				Status:  corev1.ConditionFalse,
@@ -1998,28 +1845,20 @@ func TestReconcileTimeouts(t *testing.T) {
 			},
 		}, {
 			name: "task run with nil timeout uses default",
-			taskRun: &v1beta1.TaskRun{
-				ObjectMeta: objectMeta("test-taskrun-nil-timeout-default-60-minutes", "foo"),
-				Spec: v1beta1.TaskRunSpec{
-					TaskRef: &v1beta1.TaskRef{
-						Name: simpleTask.Name,
-					},
-					Timeout: nil,
-				},
-				Status: v1beta1.TaskRunStatus{
-					Status: duckv1beta1.Status{
-						Conditions: duckv1beta1.Conditions{
-							apis.Condition{
-								Type:   apis.ConditionSucceeded,
-								Status: corev1.ConditionUnknown,
-							},
-						},
-					},
-					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-						StartTime: &metav1.Time{Time: now.Add(-61 * time.Minute)},
-					},
-				},
-			},
+			taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-nil-timeout-default-60-minutes
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: null
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  startTime: "2021-12-31T22:59:00Z"
+`),
 
 			expectedStatus: &apis.Condition{
 				Type:    apis.ConditionSucceeded,
@@ -2066,52 +1905,44 @@ func TestExpandMountPath(t *testing.T) {
 	expectedMountPath := "/temppath/replaced"
 	expectedReplacedArgs := fmt.Sprintf("replacedArgs - %s", expectedMountPath)
 	// The task's Workspace has a parameter variable
-	simpleTask := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name:        "tr-workspace",
-				Description: "a test task workspace",
-				MountPath:   "/temppath/$(params.source-path)",
-				ReadOnly:    true,
-			}},
-			Params: []v1beta1.ParamSpec{
-				{
-					Name: "source-path",
-					Type: v1beta1.ParamTypeString,
-				},
-				{
-					Name: "source-path-two",
-					Type: v1beta1.ParamTypeString,
-				},
-			},
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Image:   "foo",
-					Name:    "simple-step",
-					Command: []string{"echo"},
-					Args:    []string{"replacedArgs - $(workspaces.tr-workspace.path)"},
-				},
-			}},
-		},
-	}
+	simpleTask := parse.MustParseTask(t, `
+metadata:
+  name: test-task
+  namespace: foo
+spec:
+  params:
+  - name: source-path
+    type: string
+  - name: source-path-two
+    type: string
+  steps:
+  - args:
+    - replacedArgs - $(workspaces.tr-workspace.path)
+    command:
+    - echo
+    image: foo
+    name: simple-step
+  workspaces:
+  - description: a test task workspace
+    mountPath: /temppath/$(params.source-path)
+    name: tr-workspace
+    readOnly: true
+`)
 
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-not-started", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-			Workspaces: []v1beta1.WorkspaceBinding{{
-				Name:     "tr-workspace",
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			}},
-			Params: []v1beta1.Param{{
-				Name:  "source-path",
-				Value: *v1beta1.NewArrayOrString("replaced"),
-			}},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-not-started
+  namespace: foo
+spec:
+  params:
+  - name: source-path
+    value: replaced
+  taskRef:
+    name: test-task
+  workspaces:
+  - emptyDir: {}
+    name: tr-workspace
+`)
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -2167,76 +1998,54 @@ func TestExpandMountPath(t *testing.T) {
 func TestExpandMountPath_DuplicatePaths(t *testing.T) {
 	expectedError := "workspace mount path \"/temppath/duplicate\" must be unique: workspaces[1].mountpath"
 	// The task has two workspaces, with different mount path strings.
-	simpleTask := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{
-				{
-					Name:        "tr-workspace",
-					Description: "a test task workspace",
-					MountPath:   "/temppath/$(params.source-path)",
-					ReadOnly:    true,
-				},
-				{
-					Name:        "tr-workspace-two",
-					Description: "a second task workspace",
-					MountPath:   "/temppath/$(params.source-path-two)",
-					ReadOnly:    true,
-				},
-			},
-			Params: []v1beta1.ParamSpec{
-				{
-					Name: "source-path",
-					Type: v1beta1.ParamTypeString,
-				},
-				{
-					Name: "source-path-two",
-					Type: v1beta1.ParamTypeString,
-				},
-			},
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Image:   "foo",
-					Name:    "simple-step",
-					Command: []string{"/mycmd"},
-					Env: []corev1.EnvVar{{
-						Name:  "foo",
-						Value: "bar",
-					}},
-				},
-			}},
-		},
-	}
+	simpleTask := parse.MustParseTask(t, `
+metadata:
+  name: test-task
+  namespace: foo
+spec:
+  params:
+  - name: source-path
+    type: string
+  - name: source-path-two
+    type: string
+  steps:
+  - command:
+    - /mycmd
+    env:
+    - name: foo
+      value: bar
+    image: foo
+    name: simple-step
+  workspaces:
+  - description: a test task workspace
+    mountPath: /temppath/$(params.source-path)
+    name: tr-workspace
+    readOnly: true
+  - description: a second task workspace
+    mountPath: /temppath/$(params.source-path-two)
+    name: tr-workspace-two
+    readOnly: true
+`)
 
 	// The parameter values will cause the two Workspaces to have duplicate mount path values after the parameters are expanded.
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-not-started", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-			Workspaces: []v1beta1.WorkspaceBinding{
-				{
-					Name:     "tr-workspace",
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-				{
-					Name:     "tr-workspace-two",
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
-			Params: []v1beta1.Param{
-				{
-					Name:  "source-path",
-					Value: *v1beta1.NewArrayOrString("duplicate"),
-				},
-				{
-					Name:  "source-path-two",
-					Value: *v1beta1.NewArrayOrString("duplicate"),
-				},
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-not-started
+  namespace: foo
+spec:
+  params:
+  - name: source-path
+    value: duplicate
+  - name: source-path-two
+    value: duplicate
+  taskRef:
+    name: test-task
+  workspaces:
+  - emptyDir: {}
+    name: tr-workspace
+  - emptyDir: {}
+    name: tr-workspace-two
+`)
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -2282,27 +2091,18 @@ func TestExpandMountPath_DuplicatePaths(t *testing.T) {
 }
 
 func TestHandlePodCreationError(t *testing.T) {
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-taskrun-pod-creation-failed"},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: simpleTask.Name,
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionUnknown,
-					},
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				StartTime: &metav1.Time{Time: now},
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-pod-creation-failed
+spec:
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  startTime: "2022-01-01T00:00:00Z"
+`)
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 		Tasks:    []*v1beta1.Task{simpleTask},
@@ -2368,256 +2168,141 @@ func TestHandlePodCreationError(t *testing.T) {
 
 func TestReconcileCloudEvents(t *testing.T) {
 
-	taskRunWithNoCEResources := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-no-ce-resources", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       simpleTask.Name,
-				APIVersion: "a1",
-			},
-		},
-	}
-	taskRunWithTwoCEResourcesNoInit := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-two-ce-resources-no-init", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: twoOutputsTask.Name,
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: cloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: cloudEventResource.Name,
-							},
-						},
-					},
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: anotherCloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: anotherCloudEventResource.Name,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	taskRunWithTwoCEResourcesInit := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-two-ce-resources-init", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: twoOutputsTask.Name,
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: cloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: cloudEventResource.Name,
-							},
-						},
-					},
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: anotherCloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: anotherCloudEventResource.Name,
-							},
-						},
-					},
-				},
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				CloudEvents: []v1beta1.CloudEventDelivery{
-					{
-						Target: cloudEventTarget1,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-						},
-					},
-					{
-						Target: cloudEventTarget2,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-						},
-					},
-				},
-			},
-		},
-	}
-	taskRunWithCESucceded := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-ce-succeeded", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: twoOutputsTask.Name,
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: cloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: cloudEventResource.Name,
-							},
-						},
-					},
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: anotherCloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: anotherCloudEventResource.Name,
-							},
-						},
-					},
-				},
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				CloudEvents: []v1beta1.CloudEventDelivery{
-					{
-						Target: cloudEventTarget1,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-						},
-					},
-					{
-						Target: cloudEventTarget2,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-						},
-					},
-				},
-			},
-		},
-	}
-	taskRunWithCESucceded.ObjectMeta.SelfLink = "/task/1234"
-	taskRunWithCEFailed := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-ce-failed", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: twoOutputsTask.Name,
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: cloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: cloudEventResource.Name,
-							},
-						},
-					},
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: anotherCloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: anotherCloudEventResource.Name,
-							},
-						},
-					},
-				},
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionFalse,
-					},
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				CloudEvents: []v1beta1.CloudEventDelivery{
-					{
-						Target: cloudEventTarget1,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-						},
-					},
-					{
-						Target: cloudEventTarget2,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-						},
-					},
-				},
-			},
-		},
-	}
-	taskRunWithCEFailed.ObjectMeta.SelfLink = "/task/1234"
-	taskRunWithCESuccededOneAttempt := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-ce-succeeded-one-attempt", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: twoOutputsTask.Name,
-			},
-			Resources: &v1beta1.TaskRunResources{
-				Outputs: []v1beta1.TaskResourceBinding{
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: cloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: cloudEventResource.Name,
-							},
-						},
-					},
-					{
-						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-							Name: anotherCloudEventResource.Name,
-							ResourceRef: &resourcev1alpha1.PipelineResourceRef{
-								Name: anotherCloudEventResource.Name,
-							},
-						},
-					},
-				},
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				CloudEvents: []v1beta1.CloudEventDelivery{
-					{
-						Target: cloudEventTarget1,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition:  v1beta1.CloudEventConditionUnknown,
-							RetryCount: 1,
-						},
-					},
-					{
-						Target: cloudEventTarget2,
-						Status: v1beta1.CloudEventDeliveryState{
-							Condition: v1beta1.CloudEventConditionUnknown,
-							Error:     "fakemessage",
-						},
-					},
-				},
-			},
-		},
-	}
-	taskRunWithCESuccededOneAttempt.ObjectMeta.SelfLink = "/task/1234"
+	taskRunWithNoCEResources := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-no-ce-resources
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task
+`)
+	taskRunWithTwoCEResourcesNoInit := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-two-ce-resources-no-init
+  namespace: foo
+spec:
+  resources:
+    outputs:
+    - name: cloud-event-resource
+      resourceRef:
+        name: cloud-event-resource
+    - name: another-cloud-event-resource
+      resourceRef:
+        name: another-cloud-event-resource
+  taskRef:
+    name: test-two-output-task
+`)
+	taskRunWithTwoCEResourcesInit := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-two-ce-resources-init
+  namespace: foo
+spec:
+  resources:
+    outputs:
+    - name: cloud-event-resource
+      resourceRef:
+        name: cloud-event-resource
+    - name: another-cloud-event-resource
+      resourceRef:
+        name: another-cloud-event-resource
+  taskRef:
+    name: test-two-output-task
+status:
+  cloudEvents:
+  - status:
+      condition: Unknown
+    target: https://foo
+  - status:
+      condition: Unknown
+    target: https://bar
+`)
+	taskRunWithCESucceded := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-ce-succeeded
+  namespace: foo
+  selfLink: /task/1234
+spec:
+  resources:
+    outputs:
+    - name: cloud-event-resource
+      resourceRef:
+        name: cloud-event-resource
+    - name: another-cloud-event-resource
+      resourceRef:
+        name: another-cloud-event-resource
+  taskRef:
+    name: test-two-output-task
+status:
+  cloudEvents:
+  - status:
+      condition: Unknown
+    target: https://foo
+  - status:
+      condition: Unknown
+    target: https://bar
+  conditions:
+  - status: "True"
+    type: Succeeded
+`)
+	taskRunWithCEFailed := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-ce-failed
+  namespace: foo
+  selfLink: /task/1234
+spec:
+  resources:
+    outputs:
+    - name: cloud-event-resource
+      resourceRef:
+        name: cloud-event-resource
+    - name: another-cloud-event-resource
+      resourceRef:
+        name: another-cloud-event-resource
+  taskRef:
+    name: test-two-output-task
+status:
+  cloudEvents:
+  - status:
+      condition: Unknown
+    target: https://foo
+  - status:
+      condition: Unknown
+    target: https://bar
+  conditions:
+  - status: "False"
+    type: Succeeded
+`)
+	taskRunWithCESuccededOneAttempt := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-ce-succeeded-one-attempt
+  namespace: foo
+  selfLink: /task/1234
+spec:
+  resources:
+    outputs:
+    - name: cloud-event-resource
+      resourceRef:
+        name: cloud-event-resource
+    - name: another-cloud-event-resource
+      resourceRef:
+        name: another-cloud-event-resource
+  taskRef:
+    name: test-two-output-task
+status:
+  cloudEvents:
+  - status:
+      condition: Unknown
+      retryCount: 1
+    target: https://foo
+  - status:
+      condition: Unknown
+      message: fakemessage
+    target: https://bar
+  conditions:
+  - status: "True"
+    type: Succeeded
+`)
 	taskruns := []*v1beta1.TaskRun{
 		taskRunWithNoCEResources, taskRunWithTwoCEResourcesNoInit,
 		taskRunWithTwoCEResourcesInit, taskRunWithCESucceded, taskRunWithCEFailed,
@@ -2771,26 +2456,20 @@ func TestReconcileCloudEvents(t *testing.T) {
 
 func TestReconcile_Single_SidecarState(t *testing.T) {
 	runningState := corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now}}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-taskrun-sidecars"},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: taskSidecar.Name,
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Sidecars: []v1beta1.SidecarState{{
-					Name:          "sidecar",
-					ImageID:       "image-id",
-					ContainerName: "sidecar-sidecar",
-					ContainerState: corev1.ContainerState{
-						Running: &runningState,
-					},
-				}},
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-sidecars
+spec:
+  taskRef:
+    name: test-task-sidecar
+status:
+  sidecars:
+  - container: sidecar-sidecar
+    imageID: image-id
+    name: sidecar
+    running:
+      startedAt: "2022-01-01T00:00:00Z"
+`)
 
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
@@ -2827,36 +2506,25 @@ func TestReconcile_Single_SidecarState(t *testing.T) {
 func TestReconcile_Multiple_SidecarStates(t *testing.T) {
 	runningState := corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now}}
 	waitingState := corev1.ContainerStateWaiting{Reason: "PodInitializing"}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-taskrun-sidecars"},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: taskMultipleSidecars.Name,
-			},
-		},
-		Status: v1beta1.TaskRunStatus{
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				Sidecars: []v1beta1.SidecarState{
-					{
-						Name:          "sidecar1",
-						ImageID:       "image-id",
-						ContainerName: "sidecar-sidecar1",
-						ContainerState: corev1.ContainerState{
-							Running: &runningState,
-						},
-					},
-					{
-						Name:          "sidecar2",
-						ImageID:       "image-id",
-						ContainerName: "sidecar-sidecar2",
-						ContainerState: corev1.ContainerState{
-							Waiting: &waitingState,
-						},
-					},
-				},
-			},
-		},
-	}
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-sidecars
+spec:
+  taskRef:
+    name: test-task-sidecar
+status:
+  sidecars:
+  - container: sidecar-sidecar1
+    imageID: image-id
+    name: sidecar1
+    running:
+      startedAt: "2022-01-01T00:00:00Z"
+  - container: sidecar-sidecar2
+    imageID: image-id
+    name: sidecar2
+    waiting:
+      reason: PodInitializing
+`)
 
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
@@ -2905,25 +2573,25 @@ func TestReconcile_Multiple_SidecarStates(t *testing.T) {
 // TestReconcileWorkspaceMissing tests a reconcile of a TaskRun that does
 // not include a Workspace that the Task is expecting.
 func TestReconcileWorkspaceMissing(t *testing.T) {
-	taskWithWorkspace := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-with-workspace", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name:        "ws1",
-				Description: "a test task workspace",
-				ReadOnly:    true,
-			}},
-		},
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-missing-workspace", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       taskWithWorkspace.Name,
-				APIVersion: "a1",
-			},
-		},
-	}
+	taskWithWorkspace := parse.MustParseTask(t, `
+metadata:
+  name: test-task-with-workspace
+  namespace: foo
+spec:
+  workspaces:
+  - description: a test task workspace
+    name: ws1
+    readOnly: true
+`)
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-missing-workspace
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-with-workspace
+`)
 	d := test.Data{
 		Tasks:             []*v1beta1.Task{taskWithWorkspace},
 		TaskRuns:          []*v1beta1.TaskRun{taskRun},
@@ -2961,32 +2629,30 @@ func TestReconcileWorkspaceMissing(t *testing.T) {
 // TestReconcileValidDefaultWorkspace tests a reconcile of a TaskRun that does
 // not include a Workspace that the Task is expecting and it uses the default Workspace instead.
 func TestReconcileValidDefaultWorkspace(t *testing.T) {
-	taskWithWorkspace := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-with-workspace", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name:        "ws1",
-				Description: "a test task workspace",
-				ReadOnly:    true,
-			}},
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Image:   "foo",
-					Name:    "simple-step",
-					Command: []string{"/mycmd"},
-				},
-			}},
-		},
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-default-workspace", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       taskWithWorkspace.Name,
-				APIVersion: "a1",
-			},
-		},
-	}
+	taskWithWorkspace := parse.MustParseTask(t, `
+metadata:
+  name: test-task-with-workspace
+  namespace: foo
+spec:
+  steps:
+  - command:
+    - /mycmd
+    image: foo
+    name: simple-step
+  workspaces:
+  - description: a test task workspace
+    name: ws1
+    readOnly: true
+`)
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-default-workspace
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-with-workspace
+`)
 	d := test.Data{
 		Tasks:             []*v1beta1.Task{taskWithWorkspace},
 		TaskRuns:          []*v1beta1.TaskRun{taskRun},
@@ -3028,32 +2694,30 @@ func TestReconcileValidDefaultWorkspace(t *testing.T) {
 // not include a Workspace that the Task is expecting, and gets an error updating
 // the TaskRun with an invalid default workspace.
 func TestReconcileInvalidDefaultWorkspace(t *testing.T) {
-	taskWithWorkspace := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-with-workspace", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name:        "ws1",
-				Description: "a test task workspace",
-				ReadOnly:    true,
-			}},
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Image:   "foo",
-					Name:    "simple-step",
-					Command: []string{"/mycmd"},
-				},
-			}},
-		},
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-default-workspace", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       taskWithWorkspace.Name,
-				APIVersion: "a1",
-			},
-		},
-	}
+	taskWithWorkspace := parse.MustParseTask(t, `
+metadata:
+  name: test-task-with-workspace
+  namespace: foo
+spec:
+  steps:
+  - command:
+    - /mycmd
+    image: foo
+    name: simple-step
+  workspaces:
+  - description: a test task workspace
+    name: ws1
+    readOnly: true
+`)
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-default-workspace
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-with-workspace
+`)
 	d := test.Data{
 		Tasks:             []*v1beta1.Task{taskWithWorkspace},
 		TaskRuns:          []*v1beta1.TaskRun{taskRun},
@@ -3092,35 +2756,29 @@ func TestReconcileInvalidDefaultWorkspace(t *testing.T) {
 // injected in place of the omitted optional workspace.
 func TestReconcileValidDefaultWorkspaceOmittedOptionalWorkspace(t *testing.T) {
 	optionalWorkspaceMountPath := "/foo/bar/baz"
-	taskWithOptionalWorkspace := &v1beta1.Task{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-task-with-optional-workspace",
-			Namespace: "default",
-		},
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name:      "optional-ws",
-				MountPath: optionalWorkspaceMountPath,
-				Optional:  true,
-			}},
-			Steps: []v1beta1.Step{{Container: corev1.Container{
-				Name:    "simple-step",
-				Image:   "foo",
-				Command: []string{"/mycmd"},
-			}}},
-		},
-	}
-	taskRunOmittingWorkspace := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-taskrun",
-			Namespace: "default",
-		},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "test-task-with-optional-workspace",
-			},
-		},
-	}
+	taskWithOptionalWorkspace := parse.MustParseTask(t, `
+metadata:
+  name: test-task-with-optional-workspace
+  namespace: default
+spec:
+  steps:
+  - command:
+    - /mycmd
+    image: foo
+    name: simple-step
+  workspaces:
+  - mountPath: /foo/bar/baz
+    name: optional-ws
+    optional: true
+`)
+	taskRunOmittingWorkspace := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun
+  namespace: default
+spec:
+  taskRef:
+    name: test-task-with-optional-workspace
+`)
 
 	d := test.Data{
 		Tasks:    []*v1beta1.Task{taskWithOptionalWorkspace},
@@ -3178,38 +2836,30 @@ func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 	}{{
 		desc: "Fail ResolveTaskResources",
 		d: test.Data{
-			Tasks: []*v1beta1.Task{{
-				ObjectMeta: objectMeta("test-task-missing-resource", "foo"),
-				Spec: v1beta1.TaskSpec{
-					Resources: &v1beta1.TaskResources{
-						Inputs: []v1beta1.TaskResource{{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "workspace",
-								Type: resourcev1alpha1.PipelineResourceTypeGit,
-							},
-						}},
-					},
-				},
-			}},
-			TaskRuns: []*v1beta1.TaskRun{{
-				ObjectMeta: objectMeta("test-taskrun-missing-resource", "foo"),
-				Spec: v1beta1.TaskRunSpec{
-					TaskRef: &v1beta1.TaskRef{
-						Name:       "test-task-missing-resource",
-						APIVersion: "a1",
-					},
-					Resources: &v1beta1.TaskRunResources{
-						Inputs: []v1beta1.TaskResourceBinding{{
-							PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-								Name: "workspace",
-								ResourceRef: &v1beta1.PipelineResourceRef{
-									Name: "git",
-								},
-							},
-						}},
-					},
-				},
-			}},
+			Tasks: []*v1beta1.Task{parse.MustParseTask(t, `
+metadata:
+  name: test-task-missing-resource
+  namespace: foo
+spec:
+  resources:
+    inputs:
+    - name: workspace
+      type: git
+`)},
+			TaskRuns: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-missing-resource
+  namespace: foo
+spec:
+  resources:
+    inputs:
+    - name: workspace
+      resourceRef:
+        name: git
+  taskRef:
+    apiVersion: a1
+    name: test-task-missing-resource
+`)},
 			ClusterTasks:      nil,
 			PipelineResources: nil,
 		},
@@ -3222,28 +2872,25 @@ func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 	}, {
 		desc: "Fail ValidateResolvedTaskResources",
 		d: test.Data{
-			Tasks: []*v1beta1.Task{{
-				ObjectMeta: objectMeta("test-task-missing-resource", "foo"),
-				Spec: v1beta1.TaskSpec{
-					Resources: &v1beta1.TaskResources{
-						Inputs: []v1beta1.TaskResource{{
-							ResourceDeclaration: v1beta1.ResourceDeclaration{
-								Name: "workspace",
-								Type: resourcev1alpha1.PipelineResourceTypeGit,
-							},
-						}},
-					},
-				},
-			}},
-			TaskRuns: []*v1beta1.TaskRun{{
-				ObjectMeta: objectMeta("test-taskrun-missing-resource", "foo"),
-				Spec: v1beta1.TaskRunSpec{
-					TaskRef: &v1beta1.TaskRef{
-						Name:       "test-task-missing-resource",
-						APIVersion: "a1",
-					},
-				},
-			}},
+			Tasks: []*v1beta1.Task{parse.MustParseTask(t, `
+metadata:
+  name: test-task-missing-resource
+  namespace: foo
+spec:
+  resources:
+    inputs:
+    - name: workspace
+      type: git
+`)},
+			TaskRuns: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-missing-resource
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-missing-resource
+`)},
 			ClusterTasks:      nil,
 			PipelineResources: nil,
 		},
@@ -3256,38 +2903,36 @@ func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 	}, {
 		desc: "Fail ValidateTaskSpecRequestResources",
 		d: test.Data{
-			Tasks: []*v1beta1.Task{{
-				ObjectMeta: objectMeta("test-task-invalid-taskspec-resource", "foo"),
-				Spec: v1beta1.TaskSpec{
-					Workspaces: []v1beta1.WorkspaceDeclaration{{
-						Name:        "ws1",
-						Description: "a test task workspace",
-						ReadOnly:    true,
-					}},
-					Steps: []v1beta1.Step{{Container: corev1.Container{
-						Image:   "image",
-						Command: []string{"cmd"},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("8"),
-								corev1.ResourceMemory: resource.MustParse("8Gi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("8"),
-								corev1.ResourceMemory: resource.MustParse("4Gi"),
-							},
-						},
-					}}}},
-			}},
-			TaskRuns: []*v1beta1.TaskRun{{
-				ObjectMeta: objectMeta("test-taskrun-invalid-taskspec-resource", "foo"),
-				Spec: v1beta1.TaskRunSpec{
-					TaskRef: &v1beta1.TaskRef{
-						Name:       "test-task-invalid-taskspec-resource",
-						APIVersion: "a1",
-					},
-				},
-			}},
+			Tasks: []*v1beta1.Task{parse.MustParseTask(t, `
+metadata:
+  name: test-task-invalid-taskspec-resource
+  namespace: foo
+spec:
+  steps:
+  - command:
+    - cmd
+    image: image
+    resources:
+      limits:
+        cpu: "8"
+        memory: 4Gi
+      requests:
+        cpu: "8"
+        memory: 8Gi
+  workspaces:
+  - description: a test task workspace
+    name: ws1
+    readOnly: true
+`)},
+			TaskRuns: []*v1beta1.TaskRun{parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-invalid-taskspec-resource
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-invalid-taskspec-resource
+`)},
 			ClusterTasks:      nil,
 			PipelineResources: nil,
 		},
@@ -3339,52 +2984,37 @@ func TestReconcileTaskResourceResolutionAndValidation(t *testing.T) {
 // Affinity Assistant is validated and that the validation fails for a TaskRun that is incompatible with
 // Affinity Assistant; e.g. using more than one PVC-backed workspace.
 func TestReconcileWithWorkspacesIncompatibleWithAffinityAssistant(t *testing.T) {
-	taskWithTwoWorkspaces := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-two-workspaces", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{
-				{
-					Name:        "ws1",
-					Description: "task workspace",
-					ReadOnly:    true,
-				},
-				{
-					Name:        "ws2",
-					Description: "another workspace",
-					ReadOnly:    false,
-				},
-			},
-		},
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("taskrun-with-two-workspaces", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       taskWithTwoWorkspaces.Name,
-				APIVersion: "a1",
-			},
-			Workspaces: []v1beta1.WorkspaceBinding{
-				{
-					Name: "ws1",
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: "pvc1",
-					},
-				},
-				{
-					Name: "ws2",
-					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "pvc2",
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{},
-					},
-				},
-			},
-		},
-	}
-
-	// associate the TaskRun with a dummy Affinity Assistant
-	taskRun.Annotations[workspace.AnnotationAffinityAssistantName] = "dummy-affinity-assistant"
+	taskWithTwoWorkspaces := parse.MustParseTask(t, `
+metadata:
+  name: test-task-two-workspaces
+  namespace: foo
+spec:
+  workspaces:
+  - description: task workspace
+    name: ws1
+    readOnly: true
+  - description: another workspace
+    name: ws2
+`)
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  annotations:
+    pipeline.tekton.dev/affinity-assistant: dummy-affinity-assistant
+  name: taskrun-with-two-workspaces
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-two-workspaces
+  workspaces:
+  - name: ws1
+    persistentVolumeClaim:
+      claimName: pvc1
+  - name: ws2
+    volumeClaimTemplate:
+      metadata:
+        name: pvc2
+`)
 
 	d := test.Data{
 		Tasks:             []*v1beta1.Task{taskWithTwoWorkspaces},
@@ -3422,45 +3052,36 @@ func TestReconcileWithWorkspacesIncompatibleWithAffinityAssistant(t *testing.T) 
 // TestReconcileWorkspaceWithVolumeClaimTemplate tests a reconcile of a TaskRun that has
 // a Workspace with VolumeClaimTemplate and check that it is translated to a created PersistentVolumeClaim.
 func TestReconcileWorkspaceWithVolumeClaimTemplate(t *testing.T) {
-	workspaceName := "ws1"
-	claimName := "mypvc"
-	taskWithWorkspace := &v1beta1.Task{
-		ObjectMeta: objectMeta("test-task-with-workspace", "foo"),
-		Spec: v1beta1.TaskSpec{
-			Workspaces: []v1beta1.WorkspaceDeclaration{{
-				Name:        workspaceName,
-				Description: "a test task workspace",
-				ReadOnly:    true,
-			}},
-			Steps: []v1beta1.Step{{
-				Container: corev1.Container{
-					Image:   "foo",
-					Name:    "simple-step",
-					Command: []string{"/mycmd"},
-				},
-			}},
-		},
-	}
-	taskRun := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun-missing-workspace", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name:       taskWithWorkspace.Name,
-				APIVersion: "a1",
-			},
-			Workspaces: []v1beta1.WorkspaceBinding{
-				{
-					Name: workspaceName,
-					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: claimName,
-						},
-						Spec: corev1.PersistentVolumeClaimSpec{},
-					},
-				},
-			},
-		},
-	}
+	taskWithWorkspace := parse.MustParseTask(t, `
+metadata:
+  name: test-task-with-workspace
+  namespace: foo
+spec:
+  steps:
+  - command:
+    - /mycmd
+    image: foo
+    name: simple-step
+  workspaces:
+  - description: a test task workspace
+    name: ws1
+    readOnly: true
+`)
+	taskRun := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-missing-workspace
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: a1
+    name: test-task-with-workspace
+  workspaces:
+  - name: ws1
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+        name: mypvc
+`)
 	d := test.Data{
 		Tasks:             []*v1beta1.Task{taskWithWorkspace},
 		TaskRuns:          []*v1beta1.TaskRun{taskRun},
@@ -3500,10 +3121,6 @@ func TestReconcileWorkspaceWithVolumeClaimTemplate(t *testing.T) {
 }
 
 func TestFailTaskRun(t *testing.T) {
-	runningState := corev1.ContainerStateRunning{StartedAt: metav1.Time{Time: now}}
-	terminatedState := corev1.ContainerStateTerminated{StartedAt: metav1.Time{Time: now}, FinishedAt: metav1.Time{Time: now}, Reason: "Completed"}
-	terminatedWithErrorState := corev1.ContainerStateTerminated{StartedAt: metav1.Time{Time: now}, FinishedAt: metav1.Time{Time: now}, Reason: "Completed", ExitCode: 12}
-	waitingState := corev1.ContainerStateWaiting{Reason: "PodInitializing"}
 	testCases := []struct {
 		name               string
 		taskRun            *v1beta1.TaskRun
@@ -3514,25 +3131,19 @@ func TestFailTaskRun(t *testing.T) {
 		expectedStepStates []v1beta1.StepState
 	}{{
 		name: "no-pod-scheduled",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-failed", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: simpleTask.Name,
-				},
-				Status: v1beta1.TaskRunSpecStatusCancelled,
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionUnknown,
-						},
-					},
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-failed
+  namespace: foo
+spec:
+  status: TaskRunCancelled
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+`),
 		reason:  "some reason",
 		message: "some message",
 		expectedStatus: apis.Condition{
@@ -3543,28 +3154,20 @@ func TestFailTaskRun(t *testing.T) {
 		},
 	}, {
 		name: "pod-scheduled",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-failed", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: simpleTask.Name,
-				},
-				Status: v1beta1.TaskRunSpecStatusCancelled,
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionUnknown,
-						},
-					},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName: "foo-is-bar",
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-failed
+  namespace: foo
+spec:
+  status: TaskRunCancelled
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+`),
 		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "foo-is-bar",
@@ -3579,33 +3182,23 @@ func TestFailTaskRun(t *testing.T) {
 		},
 	}, {
 		name: "step-status-update-cancel",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-cancel", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: simpleTask.Name,
-				},
-				Status: v1beta1.TaskRunSpecStatusCancelled,
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionUnknown,
-						},
-					},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName: "foo-is-bar",
-					Steps: []v1beta1.StepState{{
-						ContainerState: corev1.ContainerState{
-							Running: &runningState,
-						},
-					}},
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-cancel
+  namespace: foo
+spec:
+  status: TaskRunCancelled
+  taskRef:
+    name: test-task
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+`),
 		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "foo-is-bar",
@@ -3630,33 +3223,23 @@ func TestFailTaskRun(t *testing.T) {
 		},
 	}, {
 		name: "step-status-update-timeout",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-timeout", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: simpleTask.Name,
-				},
-				Timeout: &metav1.Duration{Duration: 10 * time.Second},
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionUnknown,
-						},
-					},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName: "foo-is-bar",
-					Steps: []v1beta1.StepState{{
-						ContainerState: corev1.ContainerState{
-							Running: &runningState,
-						},
-					}},
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-timeout
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task
+  timeout: 10s
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+`),
 		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "foo-is-bar",
@@ -3681,45 +3264,30 @@ func TestFailTaskRun(t *testing.T) {
 		},
 	}, {
 		name: "step-status-update-multiple-steps",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-timeout-multiple-steps", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: taskMultipleSteps.Name,
-				},
-				Timeout: &metav1.Duration{Duration: 10 * time.Second},
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionUnknown,
-						},
-					},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName: "foo-is-bar",
-					Steps: []v1beta1.StepState{
-						{
-							ContainerState: corev1.ContainerState{
-								Terminated: &terminatedState,
-							},
-						},
-						{
-							ContainerState: corev1.ContainerState{
-								Running: &runningState,
-							},
-						},
-						{
-							ContainerState: corev1.ContainerState{
-								Running: &runningState,
-							},
-						},
-					},
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-timeout-multiple-steps
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task-multi-steps
+  timeout: 10s
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - terminated:
+      exitCode: 0
+      finishedAt: "2022-01-01T00:00:00Z"
+      reason: Completed
+      startedAt: "2022-01-01T00:00:00Z"
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+`),
 		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "foo-is-bar",
@@ -3760,45 +3328,27 @@ func TestFailTaskRun(t *testing.T) {
 		},
 	}, {
 		name: "step-status-update-multiple-steps-waiting-state",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-timeout-multiple-steps-waiting", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: taskMultipleSteps.Name,
-				},
-				Timeout: &metav1.Duration{Duration: 10 * time.Second},
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionUnknown,
-						},
-					},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName: "foo-is-bar",
-					Steps: []v1beta1.StepState{
-						{
-							ContainerState: corev1.ContainerState{
-								Waiting: &waitingState,
-							},
-						},
-						{
-							ContainerState: corev1.ContainerState{
-								Waiting: &waitingState,
-							},
-						},
-						{
-							ContainerState: corev1.ContainerState{
-								Waiting: &waitingState,
-							},
-						},
-					},
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-timeout-multiple-steps-waiting
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task-multi-steps
+  timeout: 10s
+status:
+  conditions:
+  - status: Unknown
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - waiting:
+      reason: PodInitializing
+  - waiting:
+      reason: PodInitializing
+  - waiting:
+      reason: PodInitializing
+`),
 		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "foo-is-bar",
@@ -3839,39 +3389,27 @@ func TestFailTaskRun(t *testing.T) {
 		},
 	}, {
 		name: "step-status-update-with-multiple-steps-and-some-continue-on-error",
-		taskRun: &v1beta1.TaskRun{
-			ObjectMeta: objectMeta("test-taskrun-run-ignore-step-error", "foo"),
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{
-					Name: taskMultipleStepsIgnoreError.Name,
-				},
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{
-						apis.Condition{
-							Type:   apis.ConditionSucceeded,
-							Status: corev1.ConditionTrue,
-						},
-					},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName: "foo-is-bar",
-					Steps: []v1beta1.StepState{
-						{
-							ContainerState: corev1.ContainerState{
-								Terminated: &terminatedWithErrorState,
-							},
-						},
-						{
-							ContainerState: corev1.ContainerState{
-								Running: &runningState,
-							},
-						},
-					},
-				},
-			},
-		},
+		taskRun: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun-run-ignore-step-error
+  namespace: foo
+spec:
+  taskRef:
+    name: test-task-multi-steps-with-ignore-error
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  podName: foo-is-bar
+  steps:
+  - terminated:
+      exitCode: 12
+      finishedAt: "2022-01-01T00:00:00Z"
+      reason: Completed
+      startedAt: "2022-01-01T00:00:00Z"
+  - running:
+      startedAt: "2022-01-01T00:00:00Z"
+`),
 		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "foo",
 			Name:      "foo-is-bar",
@@ -3949,20 +3487,17 @@ func TestFailTaskRun(t *testing.T) {
 }
 
 func Test_storeTaskSpec(t *testing.T) {
-	labels := map[string]string{"lbl1": "value1"}
-	annotations := map[string]string{"io.annotation": "value"}
-	tr := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        "foo",
-			Labels:      labels,
-			Annotations: annotations,
-		},
-		Spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
-				Name: "foo-task",
-			},
-		},
-	}
+	tr := parse.MustParseTaskRun(t, `
+metadata:
+  annotations:
+    io.annotation: value
+  labels:
+    lbl1: value1
+  name: foo
+spec:
+  taskRef:
+    name: foo-task
+`)
 
 	ts := v1beta1.TaskSpec{
 		Description: "foo-task",
@@ -4084,21 +3619,20 @@ func TestWillOverwritePodAffinity(t *testing.T) {
 }
 
 func TestPodAdoption(t *testing.T) {
-	tr := &v1beta1.TaskRun{
-		ObjectMeta: objectMeta("test-taskrun", "foo"),
-		Spec: v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
-					Container: corev1.Container{
-						Image:   "myimage",
-						Name:    "mycontainer",
-						Command: []string{"/mycmd"},
-					},
-				}},
-			},
-		},
-	}
-	tr.ObjectMeta.Labels = map[string]string{"mylabel": "myvalue"}
+	tr := parse.MustParseTaskRun(t, `
+metadata:
+  labels:
+    mylabel: myvalue
+  name: test-taskrun
+  namespace: foo
+spec:
+  taskSpec:
+    steps:
+    - command:
+      - /mycmd
+      image: myimage
+      name: mycontainer
+`)
 
 	d := test.Data{
 		TaskRuns: []*v1beta1.TaskRun{tr},
@@ -4165,34 +3699,20 @@ func TestPodAdoption(t *testing.T) {
 }
 
 func TestStopSidecars_ClientGetPodForTaskSpecWithSidecars(t *testing.T) {
-	startTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
-	tr := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-taskrun",
-			Namespace: "foo",
-		},
-		Status: v1beta1.TaskRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					},
-				},
-			},
-			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-				PodName:   "test-taskrun-pod",
-				StartTime: &metav1.Time{Time: startTime},
-				Sidecars: []v1beta1.SidecarState{{
-					ContainerState: corev1.ContainerState{
-						Running: &corev1.ContainerStateRunning{
-							StartedAt: metav1.Time{startTime},
-						},
-					},
-				}},
-			},
-		},
-	}
+	tr := parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun
+  namespace: foo
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  podName: test-taskrun-pod
+  sidecars:
+  - running:
+      startedAt: "2000-01-01T01:01:01Z"
+  startTime: "2000-01-01T01:01:01Z"
+`)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -4231,60 +3751,40 @@ func TestStopSidecars_ClientGetPodForTaskSpecWithSidecars(t *testing.T) {
 }
 
 func TestStopSidecars_NoClientGetPodForTaskSpecWithoutRunningSidecars(t *testing.T) {
-	startTime := time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)
-
 	for _, tc := range []struct {
 		desc string
 		tr   *v1beta1.TaskRun
 	}{{
 		desc: "no sidecars",
-		tr: &v1beta1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun",
-				Namespace: "foo",
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName:   "test-taskrun-pod",
-					StartTime: &metav1.Time{Time: startTime},
-					Sidecars:  []v1beta1.SidecarState{},
-				},
-			},
-		},
+		tr: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun
+  namespace: foo
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  podName: test-taskrun-pod
+  startTime: "2000-01-01T01:01:01Z"
+`),
 	}, {
 		desc: "sidecars are terminated",
-		tr: &v1beta1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-taskrun",
-				Namespace: "foo",
-			},
-			Status: v1beta1.TaskRunStatus{
-				Status: duckv1beta1.Status{
-					Conditions: duckv1beta1.Conditions{apis.Condition{
-						Type:   apis.ConditionSucceeded,
-						Status: corev1.ConditionTrue,
-					}},
-				},
-				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
-					PodName:   "test-taskrun-pod",
-					StartTime: &metav1.Time{Time: startTime},
-					Sidecars: []v1beta1.SidecarState{{
-						ContainerState: corev1.ContainerState{
-							Terminated: &corev1.ContainerStateTerminated{
-								StartedAt:  metav1.Time{startTime},
-								FinishedAt: metav1.Time{startTime},
-							},
-						},
-					}},
-				},
-			},
-		},
+		tr: parse.MustParseTaskRun(t, `
+metadata:
+  name: test-taskrun
+  namespace: foo
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  podName: test-taskrun-pod
+  sidecars:
+  - terminated:
+      exitCode: 0
+      finishedAt: "2000-01-01T01:01:01Z"
+      startedAt: "2000-01-01T01:01:01Z"
+  startTime: "2000-01-01T01:01:01Z"
+`),
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
 			d := test.Data{


### PR DESCRIPTION
# Changes

This doesn't switch everything - the "global" tasks and other resources are left
as is, for example. But it does move most of the explicit `Task` and `TaskRun`
structs to parsed YAML instead.

Tangentially related to #4610. =)

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
