### PR TITLE
Switch ApplyTaskResultsToPipelineResults to not use status maps

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -577,7 +577,8 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	pr.Status.Runs = pipelineRunFacts.State.GetRunsStatus(pr)
 	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks()
 	if after.Status == corev1.ConditionTrue {
-		pr.Status.PipelineResults = resources.ApplyTaskResultsToPipelineResults(pipelineSpec.Results, pr.Status.TaskRuns, pr.Status.Runs)
+		pr.Status.PipelineResults = resources.ApplyTaskResultsToPipelineResults(pipelineSpec.Results,
+			pipelineRunFacts.State.GetTaskRunsResults(), pipelineRunFacts.State.GetRunsResults())
 	}
 
 	logger.Infof("PipelineRun %s status is being set to %s", pr.Name, after)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2309,6 +2309,202 @@ spec:
 	}
 }
 
+func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
+	state := PipelineRunState{{
+		TaskRunName: "successful-task-with-results",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "successful-task-with-results-1",
+		},
+		TaskRun: &v1beta1.TaskRun{
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}}},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskRunResults: []v1beta1.TaskRunResult{{
+						Name:  "foo",
+						Value: "oof",
+					}, {
+						Name:  "bar",
+						Value: "rab",
+					}},
+				},
+			},
+		},
+	}, {
+		TaskRunName: "successful-task-without-results",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "successful-task-without-results-1",
+		},
+		TaskRun: &v1beta1.TaskRun{
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}}},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{},
+			},
+		},
+	}, {
+		TaskRunName: "failed-task",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "failed-task-1",
+		},
+		TaskRun: &v1beta1.TaskRun{
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
+				}}},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskRunResults: []v1beta1.TaskRunResult{{
+						Name:  "fail-foo",
+						Value: "fail-oof",
+					}},
+				},
+			},
+		},
+	}, {
+		TaskRunName: "incomplete-task",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "incomplete-task-1",
+		},
+		TaskRun: &v1beta1.TaskRun{
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+				}}},
+				TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+					TaskRunResults: []v1beta1.TaskRunResult{{
+						Name:  "unknown-foo",
+						Value: "unknown-oof",
+					}},
+				},
+			},
+		},
+	}, {
+		TaskRunName: "nil-taskrun",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "nil-taskrun-1",
+		},
+	}, {
+		RunName:    "successful-run-with-results",
+		CustomTask: true,
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "successful-run-with-results-1",
+		},
+		Run: &v1alpha1.Run{
+			Status: v1alpha1.RunStatus{
+				Status: duckv1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}}},
+				RunStatusFields: v1alpha1.RunStatusFields{
+					Results: []v1alpha1.RunResult{{
+						Name:  "foo",
+						Value: "oof",
+					}, {
+						Name:  "bar",
+						Value: "rab",
+					}},
+				},
+			},
+		},
+	}, {
+		RunName:    "successful-run-without-results",
+		CustomTask: true,
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "successful-run-without-results-1",
+		},
+		Run: &v1alpha1.Run{
+			Status: v1alpha1.RunStatus{
+				Status: duckv1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+				}}},
+				RunStatusFields: v1alpha1.RunStatusFields{},
+			},
+		},
+	}, {
+		RunName: "failed-run",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "failed-run-1",
+		},
+		Run: &v1alpha1.Run{
+			Status: v1alpha1.RunStatus{
+				Status: duckv1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionFalse,
+				}}},
+				RunStatusFields: v1alpha1.RunStatusFields{
+					Results: []v1alpha1.RunResult{{
+						Name:  "fail-foo",
+						Value: "fail-oof",
+					}},
+				},
+			},
+		},
+	}, {
+		RunName: "incomplete-run",
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "incomplete-run-1",
+		},
+		Run: &v1alpha1.Run{
+			Status: v1alpha1.RunStatus{
+				Status: duckv1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionUnknown,
+				}}},
+				RunStatusFields: v1alpha1.RunStatusFields{
+					Results: []v1alpha1.RunResult{{
+						Name:  "unknown-foo",
+						Value: "unknown-oof",
+					}},
+				},
+			},
+		},
+	}, {
+		RunName:    "nil-run",
+		CustomTask: true,
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "nil-run-1",
+		},
+	}}
+
+	expectedTaskResults := map[string][]v1beta1.TaskRunResult{
+		"successful-task-with-results-1": {{
+			Name:  "foo",
+			Value: "oof",
+		}, {
+			Name:  "bar",
+			Value: "rab",
+		}},
+		"successful-task-without-results-1": nil,
+	}
+	expectedRunResults := map[string][]v1alpha1.RunResult{
+		"successful-run-with-results-1": {{
+			Name:  "foo",
+			Value: "oof",
+		}, {
+			Name:  "bar",
+			Value: "rab",
+		}},
+		"successful-run-without-results-1": nil,
+	}
+
+	actualTaskResults := state.GetTaskRunsResults()
+	if d := cmp.Diff(expectedTaskResults, actualTaskResults); d != "" {
+		t.Errorf("Didn't get expected TaskRun results map: %s", diff.PrintWantGot(d))
+	}
+
+	actualRunResults := state.GetRunsResults()
+	if d := cmp.Diff(expectedRunResults, actualRunResults); d != "" {
+		t.Errorf("Didn't get expected Run results map: %s", diff.PrintWantGot(d))
+	}
+}
+
 // conditionCheckFromTaskRun takes a pointer to a TaskRun and wraps it into a ConditionCheck
 func conditionCheckFromTaskRun(tr *v1beta1.TaskRun) *v1beta1.ConditionCheck {
 	cc := v1beta1.ConditionCheck(*tr)


### PR DESCRIPTION
# Changes

This comes out of discussions on #4739 - with the new minimal embedded status
changes which will be introduced in that PR, we can see that we're currently
using the output of `pipelineRunFacts.State.GetTaskRunsStatus(pr)` and
`pipelineRunFacts.State.GetRunsStatus(pr)` for two separate purposes:

* To set `pr.Status.TaskRuns` and `pr.Status.Runs` with the full embedded status
* To pass to `resources.ApplyTaskResultsToPipelineResults` for populating results

It's understandable why `ApplyTaskResultsToPipelineResults` is using
the maps from `pr.Status.[TaskRuns|Runs]`, since those maps do contain everything
needed for propagating results up from the tasks to the pipeline run, but if you
look at the current implementation, you can see that it's shuffling the maps
around into a different form that's more suited for what it's doing than the
original form.

So this PR reworks `ApplyTaskResultsToPipelineResults` to instead take maps in
the form the current implementation uses internally, with new functions on
`PipelineRunState` to get these new maps without needing to use the `pr.Status.[TaskRuns|Runs]`
form as an intermediary. This makes the pre-minimal-embedded-status
implementation cleaner, and is particularly helpful in that regard once we do
have minimal embedded status in place.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
