### PR TITLE
Fix git-init for Git 2.35.2

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -93,8 +93,16 @@ func Fetch(logger *zap.SugaredLogger, spec FetchSpec) error {
 		if err := os.Chdir(spec.Path); err != nil {
 			return fmt.Errorf("failed to change directory with path %s; err: %w", spec.Path, err)
 		}
-	} else if _, err := run(logger, "", "init"); err != nil {
-		return err
+		if _, err := run(logger, "", "config", "--add", "--global", "safe.directory", spec.Path); err != nil {
+			return err
+		}
+	} else {
+		if _, err := run(logger, "", "init"); err != nil {
+			return err
+		}
+		if _, err := run(logger, "", "config", "--add", "--global", "safe.directory", "/"); err != nil {
+			return err
+		}
 	}
 	if err := configSparseCheckout(logger, spec); err != nil {
 		return err


### PR DESCRIPTION
# Changes

https://github.blog/2022-04-12-git-security-vulnerability-announced/ was announced
and then fixed in Git 2.35.2. This ends up creating issues like https://github.com/actions/checkout/issues/760,
where the directory the git repo lives isn't owned by the same user performing the
git operations. This does appear to be affecting us - see https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/4750/pull-tekton-pipeline-integration-tests/1514143139193950210/
for example, which has the telltale error message of `fatal: unsafe repository ('/workspace/go/src/github.com/GoogleContainerTools/skaffold' is owned by someone else)`.

This is an attempt to fix that by having `git-init` call `git config --global --add safe.directory [repo dir]`
before fetching, etc.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Fixed git-init behavior to work with Git 2.35.2 changes.
```
