### PR TITLE
[TEP-0100] Add functionality to be used in supporting minimal embedded status

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1252,7 +1252,7 @@ func updatePipelineRunStatusFromTaskRuns(logger *zap.SugaredLogger, pr *v1beta1.
 			// status. This means that the conditions were orphaned, and never added to the
 			// status. In this case we need to generate a new TaskRun name, that will be used
 			// to run the TaskRun if the conditions are passed.
-			taskRunName = resources.GetTaskRunName(pr.Status.TaskRuns, pipelineTaskName, pr.Name)
+			taskRunName = resources.GetTaskRunName(pr.Status.TaskRuns, pr.Status.ChildReferences, pipelineTaskName, pr.Name)
 			pr.Status.TaskRuns[taskRunName] = &v1beta1.PipelineRunTaskRunStatus{
 				PipelineTaskName: pipelineTaskName,
 				Status:           nil,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -502,14 +502,14 @@ func ResolvePipelineRunTask(
 	}
 	rprt.CustomTask = isCustomTask(ctx, rprt)
 	if rprt.IsCustomTask() {
-		rprt.RunName = getRunName(pipelineRun.Status.Runs, task.Name, pipelineRun.Name)
+		rprt.RunName = getRunName(pipelineRun.Status.Runs, pipelineRun.Status.ChildReferences, task.Name, pipelineRun.Name)
 		run, err := getRun(rprt.RunName)
 		if err != nil && !errors.IsNotFound(err) {
 			return nil, fmt.Errorf("error retrieving Run %s: %w", rprt.RunName, err)
 		}
 		rprt.Run = run
 	} else {
-		rprt.TaskRunName = GetTaskRunName(pipelineRun.Status.TaskRuns, task.Name, pipelineRun.Name)
+		rprt.TaskRunName = GetTaskRunName(pipelineRun.Status.TaskRuns, pipelineRun.Status.ChildReferences, task.Name, pipelineRun.Name)
 
 		// Find the Task that this PipelineTask is using
 		var (
@@ -560,7 +560,7 @@ func ResolvePipelineRunTask(
 
 		// Get all conditions that this pipelineTask will be using, if any
 		if len(task.Conditions) > 0 {
-			rcc, err := resolveConditionChecks(&task, pipelineRun.Status.TaskRuns, rprt.TaskRunName, getTaskRun, getCondition, providedResources)
+			rcc, err := resolveConditionChecks(&task, pipelineRun.Status.TaskRuns, pipelineRun.Status.ChildReferences, rprt.TaskRunName, getTaskRun, getCondition, providedResources)
 			if err != nil {
 				return nil, err
 			}
@@ -571,7 +571,16 @@ func ResolvePipelineRunTask(
 }
 
 // getConditionCheckName should return a unique name for a `ConditionCheck` if one has not already been defined, and the existing one otherwise.
-func getConditionCheckName(taskRunStatus map[string]*v1beta1.PipelineRunTaskRunStatus, trName, conditionRegisterName string) string {
+func getConditionCheckName(taskRunStatus map[string]*v1beta1.PipelineRunTaskRunStatus, childRefs []v1beta1.ChildStatusReference, trName, conditionRegisterName string) string {
+	for _, cr := range childRefs {
+		if cr.Name == trName {
+			for _, cc := range cr.ConditionChecks {
+				if cc.ConditionName == conditionRegisterName {
+					return cc.ConditionCheckName
+				}
+			}
+		}
+	}
 	trStatus, ok := taskRunStatus[trName]
 	if ok && trStatus.ConditionChecks != nil {
 		for k, v := range trStatus.ConditionChecks {
@@ -585,7 +594,13 @@ func getConditionCheckName(taskRunStatus map[string]*v1beta1.PipelineRunTaskRunS
 }
 
 // GetTaskRunName should return a unique name for a `TaskRun` if one has not already been defined, and the existing one otherwise.
-func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus, ptName, prName string) string {
+func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus, childRefs []v1beta1.ChildStatusReference, ptName, prName string) string {
+	for _, cr := range childRefs {
+		if cr.Kind == "TaskRun" && cr.PipelineTaskName == ptName {
+			return cr.Name
+		}
+	}
+
 	for k, v := range taskRunsStatus {
 		if v.PipelineTaskName == ptName {
 			return k
@@ -597,16 +612,23 @@ func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus,
 
 // getRunName should return a unique name for a `Run` if one has not already
 // been defined, and the existing one otherwise.
-func getRunName(runsStatus map[string]*v1beta1.PipelineRunRunStatus, ptName, prName string) string {
+func getRunName(runsStatus map[string]*v1beta1.PipelineRunRunStatus, childRefs []v1beta1.ChildStatusReference, ptName, prName string) string {
+	for _, cr := range childRefs {
+		if cr.Kind == "Run" && cr.PipelineTaskName == ptName {
+			return cr.Name
+		}
+	}
+
 	for k, v := range runsStatus {
 		if v.PipelineTaskName == ptName {
 			return k
 		}
 	}
+
 	return kmeta.ChildName(prName, fmt.Sprintf("-%s", ptName))
 }
 
-func resolveConditionChecks(pt *v1beta1.PipelineTask, taskRunStatus map[string]*v1beta1.PipelineRunTaskRunStatus, taskRunName string, getTaskRun resources.GetTaskRun, getCondition GetCondition, providedResources map[string]*resourcev1alpha1.PipelineResource) ([]*ResolvedConditionCheck, error) {
+func resolveConditionChecks(pt *v1beta1.PipelineTask, taskRunStatus map[string]*v1beta1.PipelineRunTaskRunStatus, childRefs []v1beta1.ChildStatusReference, taskRunName string, getTaskRun resources.GetTaskRun, getCondition GetCondition, providedResources map[string]*resourcev1alpha1.PipelineResource) ([]*ResolvedConditionCheck, error) {
 	rccs := []*ResolvedConditionCheck{}
 	for i := range pt.Conditions {
 		ptc := pt.Conditions[i]
@@ -619,7 +641,7 @@ func resolveConditionChecks(pt *v1beta1.PipelineTask, taskRunStatus map[string]*
 				Msg:  err.Error(),
 			}
 		}
-		conditionCheckName := getConditionCheckName(taskRunStatus, taskRunName, crName)
+		conditionCheckName := getConditionCheckName(taskRunStatus, childRefs, taskRunName, crName)
 		// TODO(#3133): Also handle Custom Task Runs (getRun here)
 		cctr, err := getTaskRun(conditionCheckName)
 		if err != nil {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -3444,6 +3444,11 @@ func TestGetTaskRunName(t *testing.T) {
 			PipelineTaskName: "task1",
 		},
 	}
+	childRefs := []v1beta1.ChildStatusReference{{
+		TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+		Name:             "taskrun-for-task1",
+		PipelineTaskName: "task1",
+	}}
 
 	for _, tc := range []struct {
 		name       string
@@ -3478,8 +3483,12 @@ func TestGetTaskRunName(t *testing.T) {
 			if tc.prName != "" {
 				testPrName = tc.prName
 			}
-			gotTrName := GetTaskRunName(taskRunsStatus, tc.ptName, testPrName)
-			if d := cmp.Diff(tc.wantTrName, gotTrName); d != "" {
+			trNameFromTRStatus := GetTaskRunName(taskRunsStatus, nil, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, trNameFromTRStatus); d != "" {
+				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
+			}
+			trNameFromChildRefs := GetTaskRunName(nil, childRefs, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, trNameFromChildRefs); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
 			}
 		})
@@ -3493,6 +3502,11 @@ func TestGetRunName(t *testing.T) {
 			PipelineTaskName: "task1",
 		},
 	}
+	childRefs := []v1beta1.ChildStatusReference{{
+		TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+		Name:             "run-for-task1",
+		PipelineTaskName: "task1",
+	}}
 
 	for _, tc := range []struct {
 		name       string
@@ -3527,8 +3541,16 @@ func TestGetRunName(t *testing.T) {
 			if tc.prName != "" {
 				testPrName = tc.prName
 			}
-			gotTrName := getRunName(runsStatus, tc.ptName, testPrName)
-			if d := cmp.Diff(tc.wantTrName, gotTrName); d != "" {
+			rnFromRunsStatus := getRunName(runsStatus, nil, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, rnFromRunsStatus); d != "" {
+				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
+			}
+			rnFromChildRefs := getRunName(nil, childRefs, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, rnFromChildRefs); d != "" {
+				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
+			}
+			rnFromBoth := getRunName(runsStatus, childRefs, tc.ptName, testPrName)
+			if d := cmp.Diff(tc.wantTrName, rnFromBoth); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/apis"
@@ -254,6 +255,73 @@ func (state PipelineRunState) GetRunsResults() map[string][]v1alpha1.RunResult {
 	}
 
 	return results
+}
+
+// GetChildReferences returns a slice of references, including version, kind, name, and pipeline task name, for all
+// TaskRuns and Runs in the state.
+func (state PipelineRunState) GetChildReferences(taskRunVersion string, runVersion string) []v1beta1.ChildStatusReference {
+	var childRefs []v1beta1.ChildStatusReference
+
+	for _, rprt := range state {
+		// If this is for a TaskRun, but there isn't yet a specified TaskRun and we haven't resolved condition checks yet,
+		// skip this entry.
+		if !rprt.CustomTask && rprt.TaskRun == nil && rprt.ResolvedConditionChecks == nil {
+			continue
+		}
+
+		var childAPIVersion string
+		var childTaskKind string
+		var childName string
+		var childConditions []*v1beta1.PipelineRunChildConditionCheckStatus
+
+		if rprt.CustomTask {
+			childName = rprt.RunName
+			childTaskKind = "Run"
+
+			if rprt.Run != nil {
+				childAPIVersion = rprt.Run.APIVersion
+			} else {
+				childAPIVersion = runVersion
+			}
+		} else {
+			childName = rprt.TaskRunName
+			childTaskKind = "TaskRun"
+
+			if rprt.TaskRun != nil {
+				childAPIVersion = rprt.TaskRun.APIVersion
+			} else {
+				childAPIVersion = taskRunVersion
+			}
+			if len(rprt.ResolvedConditionChecks) > 0 {
+				for _, c := range rprt.ResolvedConditionChecks {
+					condCheck := &v1beta1.PipelineRunChildConditionCheckStatus{
+						PipelineRunConditionCheckStatus: v1beta1.PipelineRunConditionCheckStatus{
+							ConditionName: c.ConditionRegisterName,
+						},
+						ConditionCheckName: c.ConditionCheckName,
+					}
+					if c.ConditionCheck != nil {
+						condCheck.Status = c.NewConditionCheckStatus()
+					}
+
+					childConditions = append(childConditions, condCheck)
+				}
+			}
+		}
+
+		childRefs = append(childRefs, v1beta1.ChildStatusReference{
+			TypeMeta: runtime.TypeMeta{
+				APIVersion: childAPIVersion,
+				Kind:       childTaskKind,
+			},
+			Name:             childName,
+			PipelineTaskName: rprt.PipelineTask.Name,
+			WhenExpressions:  rprt.PipelineTask.WhenExpressions,
+			ConditionChecks:  childConditions,
+		})
+
+	}
+	return childRefs
 }
 
 // getNextTasks returns a list of tasks which should be executed next i.e.

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -34,6 +34,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -2143,100 +2144,17 @@ status:
 // from several TaskRun with Conditions associated to the PipelineRun
 func TestUpdateTaskRunStateWithConditionChecks(t *testing.T) {
 	taskrunName := "task-run"
-	successConditionCheckName := "success-condition"
-	failingConditionCheckName := "fail-condition"
-
-	successCondition := parse.MustParseCondition(t, `
-metadata:
-  name: cond-1
-  namespace: foo
-`)
-
-	failingCondition := parse.MustParseCondition(t, `
-metadata:
-  name: cond-2
-  namespace: foo
-`)
 
 	pipelineTask := v1beta1.PipelineTask{
 		TaskRef: &v1beta1.TaskRef{Name: "unit-test-task"},
 		Conditions: []v1beta1.PipelineTaskCondition{{
-			ConditionRef: successCondition.Name,
+			ConditionRef: "success-condition",
 		}, {
-			ConditionRef: failingCondition.Name,
+			ConditionRef: "fail-condition",
 		}},
 	}
 
-	successConditionCheck := parse.MustParseTaskRun(t, fmt.Sprintf(`
-metadata:
-  name: %s
-  namespace: foo
-spec:
-status:
-  conditions:
-    - type: Succeeded
-      status: "True"
-  steps:
-    - container:
-      terminated:
-        exitCode: 0
-`, successConditionCheckName))
-
-	failingConditionCheck := parse.MustParseTaskRun(t, fmt.Sprintf(`
-metadata:
-  name: %s
-  namespace: foo
-spec:
-status:
-  conditions:
-    - type: Succeeded
-      status: "False"
-  steps:
-    - container:
-      terminated:
-        exitCode: 127
-`, failingConditionCheckName))
-
-	successrcc := ResolvedConditionCheck{
-		ConditionRegisterName: successCondition.Name + "-0",
-		ConditionCheckName:    successConditionCheckName,
-		Condition:             successCondition,
-		ConditionCheck:        conditionCheckFromTaskRun(successConditionCheck),
-	}
-	failingrcc := ResolvedConditionCheck{
-		ConditionRegisterName: failingCondition.Name + "-0",
-		ConditionCheckName:    failingConditionCheckName,
-		Condition:             failingCondition,
-		ConditionCheck:        conditionCheckFromTaskRun(failingConditionCheck),
-	}
-
-	successConditionCheckStatus := &v1beta1.PipelineRunConditionCheckStatus{
-		ConditionName: successrcc.ConditionRegisterName,
-		Status: &v1beta1.ConditionCheckStatus{
-			ConditionCheckStatusFields: v1beta1.ConditionCheckStatusFields{
-				Check: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
-				},
-			},
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue}},
-			},
-		},
-	}
-
-	failingConditionCheckStatus := &v1beta1.PipelineRunConditionCheckStatus{
-		ConditionName: failingrcc.ConditionRegisterName,
-		Status: &v1beta1.ConditionCheckStatus{
-			ConditionCheckStatusFields: v1beta1.ConditionCheckStatusFields{
-				Check: corev1.ContainerState{
-					Terminated: &corev1.ContainerStateTerminated{ExitCode: 127},
-				},
-			},
-			Status: duckv1beta1.Status{
-				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}},
-			},
-		},
-	}
+	successrcc, successConditionCheckStatus, failingrcc, failingConditionCheckStatus := getConditionCheckStatusData(t)
 
 	failedTaskRunStatus := v1beta1.TaskRunStatus{
 		Status: duckv1beta1.Status{
@@ -2505,8 +2423,316 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 	}
 }
 
+func TestPipelineRunState_GetChildReferences(t *testing.T) {
+	successrcc, successConditionCheckStatus, failingrcc, failingConditionCheckStatus := getConditionCheckStatusData(t)
+
+	testCases := []struct {
+		name      string
+		state     PipelineRunState
+		childRefs []v1beta1.ChildStatusReference
+	}{
+		{
+			name:      "no-tasks",
+			state:     PipelineRunState{},
+			childRefs: nil,
+		},
+		{
+			name: "unresolved-task",
+			state: PipelineRunState{{
+				TaskRunName: "unresolved-task-run",
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "unresolved-task-1",
+					TaskRef: &v1beta1.TaskRef{
+						Name:       "unresolved-task",
+						Kind:       "Task",
+						APIVersion: "v1beta1",
+					},
+				},
+			}},
+			childRefs: nil,
+		},
+		{
+			name: "unresolved-custom-task",
+			state: PipelineRunState{{
+				RunName:    "unresolved-custom-task-run",
+				CustomTask: true,
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "unresolved-custom-task-1",
+					TaskRef: &v1beta1.TaskRef{
+						APIVersion: "example.dev/v0",
+						Kind:       "Example",
+						Name:       "unresolved-custom-task",
+					},
+				},
+			}},
+			childRefs: []v1beta1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1alpha1",
+					Kind:       "Run",
+				},
+				Name:             "unresolved-custom-task-run",
+				PipelineTaskName: "unresolved-custom-task-1",
+			}},
+		},
+		{
+			name: "single-task",
+			state: PipelineRunState{{
+				TaskRunName: "single-task-run",
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "single-task-1",
+					TaskRef: &v1beta1.TaskRef{
+						Name:       "single-task",
+						Kind:       "Task",
+						APIVersion: "v1beta1",
+					},
+					WhenExpressions: []v1beta1.WhenExpression{{
+						Input:    "foo",
+						Operator: selection.In,
+						Values:   []string{"foo", "bar"},
+					}},
+				},
+				TaskRun: &v1beta1.TaskRun{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "single-task-run"},
+				},
+			}},
+			childRefs: []v1beta1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "single-task-run",
+				PipelineTaskName: "single-task-1",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"foo", "bar"},
+				}},
+			}},
+		},
+		{
+			name: "task-with-condition-check",
+			state: PipelineRunState{{
+				TaskRunName: "task-with-condition-check-run",
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "task-with-condition-check-1",
+					TaskRef: &v1beta1.TaskRef{
+						Name:       "task-with-condition-check",
+						Kind:       "Task",
+						APIVersion: "v1beta1",
+					},
+				},
+				ResolvedConditionChecks: TaskConditionCheckState{&successrcc, &failingrcc},
+			}},
+			childRefs: []v1beta1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "task-with-condition-check-run",
+				PipelineTaskName: "task-with-condition-check-1",
+				ConditionChecks: []*v1beta1.PipelineRunChildConditionCheckStatus{
+					{
+						PipelineRunConditionCheckStatus: *successConditionCheckStatus,
+						ConditionCheckName:              successrcc.ConditionCheck.Name,
+					},
+					{
+						PipelineRunConditionCheckStatus: *failingConditionCheckStatus,
+						ConditionCheckName:              failingrcc.ConditionCheck.Name,
+					},
+				},
+			}},
+		},
+		{
+			name: "single-custom-task",
+			state: PipelineRunState{{
+				RunName:    "single-custom-task-run",
+				CustomTask: true,
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "single-custom-task-1",
+					TaskRef: &v1beta1.TaskRef{
+						APIVersion: "example.dev/v0",
+						Kind:       "Example",
+						Name:       "single-custom-task",
+					},
+					WhenExpressions: []v1beta1.WhenExpression{{
+						Input:    "foo",
+						Operator: selection.In,
+						Values:   []string{"foo", "bar"},
+					}},
+				},
+				Run: &v1alpha1.Run{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1alpha1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
+				},
+			}},
+			childRefs: []v1beta1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1alpha1",
+					Kind:       "Run",
+				},
+				Name:             "single-custom-task-run",
+				PipelineTaskName: "single-custom-task-1",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"foo", "bar"},
+				}},
+			}},
+		},
+		{
+			name: "task-and-custom-task",
+			state: PipelineRunState{{
+				TaskRunName: "single-task-run",
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "single-task-1",
+					TaskRef: &v1beta1.TaskRef{
+						Name:       "single-task",
+						Kind:       "Task",
+						APIVersion: "v1beta1",
+					},
+				},
+				TaskRun: &v1beta1.TaskRun{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "single-task-run"},
+				},
+			}, {
+				RunName:    "single-custom-task-run",
+				CustomTask: true,
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "single-custom-task-1",
+					TaskRef: &v1beta1.TaskRef{
+						APIVersion: "example.dev/v0",
+						Kind:       "Example",
+						Name:       "single-custom-task",
+					},
+				},
+				Run: &v1alpha1.Run{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1alpha1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "single-custom-task-run"},
+				},
+			}},
+			childRefs: []v1beta1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "single-task-run",
+				PipelineTaskName: "single-task-1",
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1alpha1",
+					Kind:       "Run",
+				},
+				Name:             "single-custom-task-run",
+				PipelineTaskName: "single-custom-task-1",
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			childRefs := tc.state.GetChildReferences(v1beta1.SchemeGroupVersion.String(), v1alpha1.SchemeGroupVersion.String())
+			if d := cmp.Diff(tc.childRefs, childRefs); d != "" {
+				t.Errorf("Didn't get expected child references for %s: %s", tc.name, diff.PrintWantGot(d))
+			}
+
+		})
+	}
+}
+
 // conditionCheckFromTaskRun takes a pointer to a TaskRun and wraps it into a ConditionCheck
 func conditionCheckFromTaskRun(tr *v1beta1.TaskRun) *v1beta1.ConditionCheck {
 	cc := v1beta1.ConditionCheck(*tr)
 	return &cc
+}
+
+func getConditionCheckStatusData(t *testing.T) (ResolvedConditionCheck, *v1beta1.PipelineRunConditionCheckStatus, ResolvedConditionCheck, *v1beta1.PipelineRunConditionCheckStatus) {
+	successConditionCheckName := "success-condition"
+	failingConditionCheckName := "fail-condition"
+
+	successCondition := parse.MustParseCondition(t, `
+metadata:
+  name: cond-1
+  namespace: foo
+`)
+
+	failingCondition := parse.MustParseCondition(t, `
+metadata:
+  name: cond-2
+  namespace: foo
+`)
+
+	successConditionCheck := parse.MustParseTaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+status:
+  conditions:
+    - type: Succeeded
+      status: "True"
+  steps:
+    - container:
+      terminated:
+        exitCode: 0
+`, successConditionCheckName))
+
+	failingConditionCheck := parse.MustParseTaskRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+status:
+  conditions:
+    - type: Succeeded
+      status: "False"
+  steps:
+    - container:
+      terminated:
+        exitCode: 127
+`, failingConditionCheckName))
+
+	successrcc := ResolvedConditionCheck{
+		ConditionRegisterName: successCondition.Name + "-0",
+		ConditionCheckName:    successConditionCheckName,
+		Condition:             successCondition,
+		ConditionCheck:        conditionCheckFromTaskRun(successConditionCheck),
+	}
+	failingrcc := ResolvedConditionCheck{
+		ConditionRegisterName: failingCondition.Name + "-0",
+		ConditionCheckName:    failingConditionCheckName,
+		Condition:             failingCondition,
+		ConditionCheck:        conditionCheckFromTaskRun(failingConditionCheck),
+	}
+
+	successConditionCheckStatus := &v1beta1.PipelineRunConditionCheckStatus{
+		ConditionName: successrcc.ConditionRegisterName,
+		Status: &v1beta1.ConditionCheckStatus{
+			ConditionCheckStatusFields: v1beta1.ConditionCheckStatusFields{
+				Check: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+				},
+			},
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionTrue}},
+			},
+		},
+	}
+
+	failingConditionCheckStatus := &v1beta1.PipelineRunConditionCheckStatus{
+		ConditionName: failingrcc.ConditionRegisterName,
+		Status: &v1beta1.ConditionCheckStatus{
+			ConditionCheckStatusFields: v1beta1.ConditionCheckStatusFields{
+				Check: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 127},
+				},
+			},
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{Type: apis.ConditionSucceeded, Status: corev1.ConditionFalse}},
+			},
+		},
+	}
+
+	return successrcc, successConditionCheckStatus, failingrcc, failingConditionCheckStatus
 }


### PR DESCRIPTION
# Changes

This builds on #4694, #4734, and #4753. It will feed into a revamped #4739, all as part
of https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md
and #3140.

Specifically, this adds functionality to `pkg/reconciler/pipelinerun/resources` in
`pipelinerunresolution.go` and `pipelinerunstate.go` which will be needed for the
full implementation. These changes won't have any effects in the current situation,
because `pr.Status.ChildReferences` is never populated, so can be made independently
of the rest of the implementation, thus also shrinking the size of the rest of the
implementation PR(s) for easier review.

/kind tep
/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
