### PR TITLE
Use a new base image for the `git-init` image.

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -2,4 +2,4 @@ defaultBaseImage: gcr.io/distroless/static:nonroot
 baseImageOverrides:
   # git-init uses a base image that includes Git, and supports running either
   # as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/git-init: gcr.io/tekton-nightly/github.com/tektoncd/pipeline/git-init-build-base:latest
+  github.com/tektoncd/pipeline/cmd/git-init: ghcr.io/distroless/git

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -109,7 +109,7 @@ spec:
         $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
 
         # This matches values configured in .ko.yaml
-        $(params.package)/cmd/git-init: ${CONTAINER_REGISTRY}/$(params.package)/git-init-build-base:latest
+        $(params.package)/cmd/git-init: ghcr.io/distroless/git
       EOF
 
       cat ${PROJECT_ROOT}/.ko.yaml

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -58,6 +58,8 @@ spec:
   steps:
     - name: clone
       image: ko://github.com/tektoncd/pipeline/cmd/git-init
+      securityContext:
+        runAsUser: 0 # This needs root, and git-init is nonroot by default
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 

--- a/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/test/yamls/v1beta1/pipelineruns/pipelinerun.yaml
@@ -81,6 +81,8 @@ spec:
   steps:
   - name: clone
     image: ko://github.com/tektoncd/pipeline/cmd/git-init
+    securityContext:
+      runAsUser: 0 # This needs root, and git-init is nonroot by default
     script: |
       CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
       cleandir() {


### PR DESCRIPTION
This swaps out the `Dockerfile` based `git-init` base image in favor of `ghcr.io/distroless/git` since it is now possible to produce a `distroless` Git image without losing one's sanity.

This does NOT remove the `Dockerfile` or any logic to build it just yet, in case we want to roll this back, but that should follow in a subsequent change (tracked by the issue below).

Related: https://github.com/tektoncd/pipeline/issues/4752

/kind cleanup
/hold

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
The git-init image is now based on ghcr.io/distroless/git with fewer unused packages installed! 🎉 
```
