### PR TITLE
Switch the franken-image to use `static:nonroot` for linux images.

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -95,7 +95,7 @@ spec:
 
       # Combine Distroless with a Windows base image, used for the entrypoint image.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
-        gcr.io/distroless/base:debug-nonroot \
+        gcr.io/distroless/static:nonroot \
         mcr.microsoft.com/windows/nanoserver:1809 \
         ${CONTAINER_REGISTRY}/$(params.package)/combined-base-image:latest)
 


### PR DESCRIPTION
This came up in #4758, but when stitching together a linux + windows image as a base for utility images Jason had inadvertently(?) used `base:debug-nonroot` instead of `static:nonroot` for the linux side.

Given that ~all testing is done with `static:nonroot` for these images, this is probably SAFER than what we're currently doing releasing based on an untested (albeit superset) configuration.

However, the additional things this pulls in are `glibc` and `busybox`, which are unfortunate because `glibc` often has vulnerabilities that these images aren't susceptible to, and `busybox` is a contentious dependency in many settings (to minimizing its use it generally better).

AFAIK this is untested presubmit, and I have no idea how to test this properly, so please review thoroughly!

/cc @imjasonh @vdemeester 
/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Linux builds for windows-compatible images now use gcr.io/distroless/static:nonroot instead of gcr.io/distroless/base:debug-nonroot (drops glibc and busybox)
```
