### PR TITLE
Omit init containers from limitrange default request calculations

### DIFF
--- a/pkg/internal/limitrange/transformer_test.go
+++ b/pkg/internal/limitrange/transformer_test.go
@@ -63,9 +63,7 @@ func TestTransformerOneContainer(t *testing.T) {
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
 				// No resources set
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
@@ -104,11 +102,6 @@ func TestTransformerOneContainer(t *testing.T) {
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
 						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.Quantity{},
-						corev1.ResourceMemory:           resource.Quantity{},
-						corev1.ResourceEphemeralStorage: resource.Quantity{},
 					},
 				},
 			}},
@@ -151,18 +144,18 @@ func TestTransformerOneContainer(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("500m"),
-						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("500m"),
-						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -201,9 +194,9 @@ func TestTransformerOneContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("500m"),
-						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -215,9 +208,9 @@ func TestTransformerOneContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("500m"),
-						corev1.ResourceMemory:           resource.MustParse("50Mi"),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -385,9 +378,9 @@ func TestTransformerOneContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("700m"),
-						corev1.ResourceMemory:           resource.MustParse("70Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("700Mi"),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -399,9 +392,9 @@ func TestTransformerOneContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("700m"),
-						corev1.ResourceMemory:           resource.MustParse("70Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("700Mi"),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -461,9 +454,7 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
 				// No resources set
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
@@ -509,11 +500,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
 						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.Quantity{},
-						corev1.ResourceMemory:           resource.Quantity{},
-						corev1.ResourceEphemeralStorage: resource.Quantity{},
 					},
 				},
 			}},
@@ -572,26 +558,26 @@ func TestTransformerMultipleContainer(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("1000m"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}},
@@ -633,9 +619,9 @@ func TestTransformerMultipleContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -647,9 +633,9 @@ func TestTransformerMultipleContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}, {
@@ -660,9 +646,9 @@ func TestTransformerMultipleContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("333m"),
-						corev1.ResourceMemory:           *resource.NewQuantity(34952533, resource.BinarySI),
-						corev1.ResourceEphemeralStorage: *resource.NewQuantity(357913941, resource.BinarySI),
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
 					},
 				},
 			}},
@@ -785,9 +771,9 @@ func TestTransformerMultipleContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("700m"),
-						corev1.ResourceMemory:           resource.MustParse("70Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("700Mi"),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -925,9 +911,9 @@ func TestTransformerOneContainerMultipleLimitRange(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("800m"),
-						corev1.ResourceMemory:           resource.MustParse("80Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("800Mi"),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},
@@ -939,9 +925,9 @@ func TestTransformerOneContainerMultipleLimitRange(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("800m"),
-						corev1.ResourceMemory:           resource.MustParse("80Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("800Mi"),
+						corev1.ResourceCPU:              resource.MustParse("1"),
+						corev1.ResourceMemory:           resource.MustParse("100Mi"),
+						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
 					},
 				},
 			}},


### PR DESCRIPTION
# Changes

This commit modifies how resource requirements are adjusted based on LimitRanges present
in a namespace. Prior to this commit, the container requests for a resource
were determined by dividing the default requests specified in a LimitRange by the number of
app containers plus 1 (to represent the init container), taking the maximum of this value
and the minimum request specified in the LimitRange, and applying this value to all containers.

However, Kubernetes does not sum init container resource requests to app container resource requests
when determining the pod's effective resource requests, as described [here](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources). Instead, it takes the larger of
the maximum init container resource requests and the sum of app container resource requests.
As a result, the appropriate behavior is to split the default requests only among app containers, and
to apply the default requests directly to init containers. This commit implements that behavior.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Omit init containers from limitrange default request calculations
```