### PR TITLE
Fix a bad format directive.

### DIFF
--- a/test/timeout_test.go
+++ b/test/timeout_test.go
@@ -426,7 +426,7 @@ spec:
 	}
 
 	for i := 1; i <= len(taskrunList.Items); i++ {
-		if <-errChan != nil {
+		if err := <-errChan; err != nil {
 			t.Errorf("Error waiting for TaskRun %s to be running: %s", taskrunList.Items[i-1].Name, err)
 		}
 	}

--- a/test/v1alpha1/timeout_test.go
+++ b/test/v1alpha1/timeout_test.go
@@ -109,7 +109,7 @@ spec:
 	}
 
 	for i := 1; i <= len(taskrunList.Items); i++ {
-		if <-errChan != nil {
+		if err := <-errChan; err != nil {
 			t.Errorf("Error waiting for TaskRun %s to be running: %s", taskrunList.Items[i-1].Name, err)
 		}
 	}


### PR DESCRIPTION
Downstream we see:
```
timeout_test.go:113: Error waiting for TaskRun pipeline-run-timeout-pjyoxlbt-foo to be running: %!s(<nil>)
```

We need to capture `err` to print it!

This follows the same pattern as the rest of the file.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
