### PR TITLE
Instrument (almost all of) e2e tests for logstream

### DIFF
--- a/test/artifact_bucket_test.go
+++ b/test/artifact_bucket_test.go
@@ -35,17 +35,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 const (
-	helloworldResourceName    = "helloworldgit"
-	addFileTaskName           = "add-file-to-resource-task"
-	runFileTaskName           = "run-new-file-task"
-	bucketTestPipelineName    = "bucket-test-pipeline"
-	bucketTestPipelineRunName = "bucket-test-pipeline-run"
-	systemNamespace           = "tekton-pipelines"
-	bucketSecretName          = "bucket-secret"
-	bucketSecretKey           = "bucket-secret-key"
+	systemNamespace  = "tekton-pipelines"
+	bucketSecretName = "bucket-secret"
+	bucketSecretKey  = "bucket-secret-key"
 )
 
 // TestStorageBucketPipelineRun is an integration test that will verify a pipeline
@@ -65,6 +61,12 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
+	helloworldResourceName := helpers.ObjectNameForTest(t)
+	addFileTaskName := helpers.ObjectNameForTest(t)
+	runFileTaskName := helpers.ObjectNameForTest(t)
+	bucketTestPipelineName := helpers.ObjectNameForTest(t)
+	bucketTestPipelineRunName := helpers.ObjectNameForTest(t)
+
 	bucketName := fmt.Sprintf("build-pipeline-test-%s-%d", namespace, time.Now().Unix())
 
 	t.Logf("Creating Secret %s", bucketSecretName)
@@ -76,7 +78,7 @@ func TestStorageBucketPipelineRun(t *testing.T) {
 	t.Logf("Creating GCS bucket %s", bucketName)
 	createbuckettask := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
-  name: createbuckettask
+  name: %s
   namespace: %s
 spec:
   steps:
@@ -94,29 +96,29 @@ spec:
   - name: bucket-secret-volume
     secret:
       secretName: %s
-`, namespace, bucketName, bucketSecretName, bucketSecretName, bucketSecretKey, bucketSecretName))
+`, helpers.ObjectNameForTest(t), namespace, bucketName, bucketSecretName, bucketSecretName, bucketSecretKey, bucketSecretName))
 
-	t.Logf("Creating Task %s", "createbuckettask")
+	t.Logf("Creating Task %s", createbuckettask.Name)
 	if _, err := c.TaskClient.Create(ctx, createbuckettask, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", "createbuckettask", err)
+		t.Fatalf("Failed to create Task `%s`: %s", createbuckettask.Name, err)
 	}
 
 	createbuckettaskrun := parse.MustParseTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: createbuckettaskrun
+  name: %s
   namespace: %s
 spec:
   taskRef:
-    name: createbuckettask
-`, namespace))
+    name: %s
+`, helpers.ObjectNameForTest(t), namespace, createbuckettask.Name))
 
-	t.Logf("Creating TaskRun %s", "createbuckettaskrun")
+	t.Logf("Creating TaskRun %s", createbuckettaskrun.Name)
 	if _, err := c.TaskRunClient.Create(ctx, createbuckettaskrun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun `%s`: %s", "createbuckettaskrun", err)
+		t.Fatalf("Failed to create TaskRun `%s`: %s", createbuckettaskrun.Name, err)
 	}
 
-	if err := WaitForTaskRunState(ctx, c, "createbuckettaskrun", TaskRunSucceed("createbuckettaskrun"), "TaskRunSuccess"); err != nil {
-		t.Errorf("Error waiting for TaskRun %s to finish: %s", "createbuckettaskrun", err)
+	if err := WaitForTaskRunState(ctx, c, createbuckettaskrun.Name, TaskRunSucceed(createbuckettaskrun.Name), "TaskRunSuccess"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", createbuckettaskrun.Name, err)
 	}
 
 	defer runTaskToDeleteBucket(ctx, c, t, namespace, bucketName, bucketSecretName, bucketSecretKey)
@@ -308,7 +310,7 @@ func resetConfigMap(ctx context.Context, t *testing.T, c *clients, namespace, co
 func runTaskToDeleteBucket(ctx context.Context, c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
 	deletelbuckettask := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
-  name: deletelbuckettask
+  name: %s
   namespace: %s
 spec:
   steps:
@@ -327,28 +329,28 @@ spec:
   - name: bucket-secret-volume
     secret:
       secretName: %s
-`, namespace, bucketName, bucketSecretName, bucketSecretKey, bucketSecretName, bucketSecretName))
+`, helpers.ObjectNameForTest(t), namespace, bucketName, bucketSecretName, bucketSecretKey, bucketSecretName, bucketSecretName))
 
-	t.Logf("Creating Task %s", "deletelbuckettask")
+	t.Logf("Creating Task %s", deletelbuckettask.Name)
 	if _, err := c.TaskClient.Create(ctx, deletelbuckettask, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", "deletelbuckettask", err)
+		t.Fatalf("Failed to create Task `%s`: %s", deletelbuckettask.Name, err)
 	}
 
 	deletelbuckettaskrun := parse.MustParseTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: deletelbuckettaskrun
+  name: %s
   namespace: %s
 spec:
   taskRef:
-    name: deletelbuckettask
-`, namespace))
+    name: %s
+`, helpers.ObjectNameForTest(t), namespace, deletelbuckettask.Name))
 
-	t.Logf("Creating TaskRun %s", "deletelbuckettaskrun")
+	t.Logf("Creating TaskRun %s", deletelbuckettaskrun.Name)
 	if _, err := c.TaskRunClient.Create(ctx, deletelbuckettaskrun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun `%s`: %s", "deletelbuckettaskrun", err)
+		t.Fatalf("Failed to create TaskRun `%s`: %s", deletelbuckettaskrun.Name, err)
 	}
 
-	if err := WaitForTaskRunState(ctx, c, "deletelbuckettaskrun", TaskRunSucceed("deletelbuckettaskrun"), "TaskRunSuccess"); err != nil {
-		t.Errorf("Error waiting for TaskRun %s to finish: %s", "deletelbuckettaskrun", err)
+	if err := WaitForTaskRunState(ctx, c, deletelbuckettaskrun.Name, TaskRunSucceed(deletelbuckettaskrun.Name), "TaskRunSuccess"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", deletelbuckettaskrun.Name, err)
 	}
 }

--- a/test/cluster_resource_test.go
+++ b/test/cluster_resource_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestClusterResource(t *testing.T) {
@@ -41,9 +42,9 @@ func TestClusterResource(t *testing.T) {
 
 	secretName := "hw-secret"
 	configName := "hw-config"
-	resourceName := "helloworld-cluster"
-	taskName := "helloworld-cluster-task"
-	taskRunName := "helloworld-cluster-taskrun"
+	resourceName := helpers.ObjectNameForTest(t)
+	taskName := helpers.ObjectNameForTest(t)
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	c, namespace := setup(ctx, t)
 	t.Parallel()

--- a/test/conformance_test.go
+++ b/test/conformance_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 type conditionFn func(name string) ConditionAccessorFn
@@ -51,24 +52,22 @@ func TestTaskRun(t *testing.T) {
 
 	for _, tc := range []struct {
 		name                    string
-		trName                  string
 		tr                      *v1beta1.TaskRun
 		fn                      conditionFn
 		expectedConditionStatus corev1.ConditionStatus
 		expectedStepState       []v1beta1.StepState
 	}{{
-		name:   "successful-task-run",
-		trName: "echo-hello-task-run",
+		name: "successful-task-run",
 		tr: parse.MustParseTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: echo-hello-task-run
+  name: %s
   namespace: %s
 spec:
   taskSpec:
     steps:
     - image: %s
       command: ['echo', '"hello"']
-`, namespace, fqImageName)),
+`, helpers.ObjectNameForTest(t), namespace, fqImageName)),
 		fn:                      TaskRunSucceed,
 		expectedConditionStatus: corev1.ConditionTrue,
 		expectedStepState: []v1beta1.StepState{{
@@ -80,11 +79,10 @@ spec:
 			},
 		}},
 	}, {
-		name:   "failed-task-run",
-		trName: "failed-echo-hello-task-run",
+		name: "failed-task-run",
 		tr: parse.MustParseTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: failed-echo-hello-task-run
+  name: %s
   namespace: %s
 spec:
   taskSpec:
@@ -98,7 +96,7 @@ spec:
     - image: %s
       command: ['/bin/sh']
       args: ['-c', 'sleep 30s']
-`, namespace, fqImageName, fqImageName, fqImageName)),
+`, helpers.ObjectNameForTest(t), namespace, fqImageName, fqImageName, fqImageName)),
 		fn:                      TaskRunFailed,
 		expectedConditionStatus: corev1.ConditionFalse,
 		expectedStepState: []v1beta1.StepState{{
@@ -125,18 +123,18 @@ spec:
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Logf("Creating TaskRun %s", tc.trName)
+			t.Logf("Creating TaskRun %s", tc.tr.Name)
 			if _, err := c.TaskRunClient.Create(ctx, tc.tr, metav1.CreateOptions{}); err != nil {
-				t.Fatalf("Failed to create TaskRun `%s`: %s", tc.trName, err)
+				t.Fatalf("Failed to create TaskRun `%s`: %s", tc.tr.Name, err)
 			}
 
-			if err := WaitForTaskRunState(ctx, c, tc.trName, tc.fn(tc.trName), "WaitTaskRunDone"); err != nil {
+			if err := WaitForTaskRunState(ctx, c, tc.tr.Name, tc.fn(tc.tr.Name), "WaitTaskRunDone"); err != nil {
 				t.Errorf("Error waiting for TaskRun to finish: %s", err)
 				return
 			}
-			tr, err := c.TaskRunClient.Get(ctx, tc.trName, metav1.GetOptions{})
+			tr, err := c.TaskRunClient.Get(ctx, tc.tr.Name, metav1.GetOptions{})
 			if err != nil {
-				t.Fatalf("Failed to get TaskRun `%s`: %s", tc.trName, err)
+				t.Fatalf("Failed to get TaskRun `%s`: %s", tc.tr.Name, err)
 			}
 
 			// Check required fields in TaskRun ObjectMeta

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -67,7 +67,7 @@ func TestCustomTask(t *testing.T) {
 	customTaskRawSpec := []byte(`{"field1":123,"field2":"value"}`)
 	metadataLabel := map[string]string{"test-label": "test"}
 	// Create a PipelineRun that runs a Custom Task.
-	pipelineRunName := "custom-task-pipeline"
+	pipelineRunName := helpers.ObjectNameForTest(t)
 	if _, err := c.PipelineRunClient.Create(
 		ctx,
 		parse.MustParsePipelineRun(t, fmt.Sprintf(`

--- a/test/entrypoint_test.go
+++ b/test/entrypoint_test.go
@@ -28,9 +28,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
-
-const epTaskRunName = "ep-task-run"
 
 // TestEntrypointRunningStepsInOrder is an integration test that will
 // verify attempt to the get the entrypoint of a container image
@@ -45,6 +44,8 @@ func TestEntrypointRunningStepsInOrder(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	epTaskRunName := helpers.ObjectNameForTest(t)
 
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 	if _, err := c.TaskRunClient.Create(ctx, parse.MustParseTaskRun(t, fmt.Sprintf(`

--- a/test/git_checkout_test.go
+++ b/test/git_checkout_test.go
@@ -31,11 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
-)
-
-const (
-	gitSourceResourceName  = "git-source-resource"
-	gitTestPipelineRunName = "git-check-pipeline-run"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestGitPipelineRun is an integration test that will verify the source code
@@ -108,6 +104,9 @@ func TestGitPipelineRun(t *testing.T) {
 			c, namespace := setup(ctx, t)
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
+
+			gitSourceResourceName := helpers.ObjectNameForTest(t)
+			gitTestPipelineRunName := helpers.ObjectNameForTest(t)
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
 			// Still using the struct here rather than YAML because we'd have to conditionally determine which fields to set in the YAML.
@@ -189,6 +188,9 @@ func TestGitPipelineRunFail(t *testing.T) {
 			c, namespace := setup(ctx, t)
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
+
+			gitSourceResourceName := helpers.ObjectNameForTest(t)
+			gitTestPipelineRunName := helpers.ObjectNameForTest(t)
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
 			// Still using the struct here rather than YAML because we'd have to conditionally determine which fields to set in the YAML.

--- a/test/ignore_step_error_test.go
+++ b/test/ignore_step_error_test.go
@@ -21,6 +21,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/tektoncd/pipeline/test/parse"
@@ -28,6 +29,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestMissingResultWhenStepErrorIsIgnored(t *testing.T) {
@@ -38,9 +40,9 @@ func TestMissingResultWhenStepErrorIsIgnored(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	pipelineRun := parse.MustParsePipelineRun(t, `
+	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
 metadata:
-  name: pipelinerun-with-failing-step
+  name: %s
 spec:
   pipelineSpec:
     tasks:
@@ -68,7 +70,7 @@ spec:
         steps:
         - name: foo
           image: busybox
-          script: 'exit 0'`)
+          script: 'exit 0'`, helpers.ObjectNameForTest(t)))
 
 	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)

--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -34,6 +34,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestTaskRunRetry tests that retries behave as expected, by creating multiple
@@ -50,7 +51,7 @@ func TestTaskRunRetry(t *testing.T) {
 
 	// Create a PipelineRun with a single TaskRun that can only fail,
 	// configured to retry 5 times.
-	pipelineRunName := "retry-pipeline"
+	pipelineRunName := helpers.ObjectNameForTest(t)
 	numRetries := 5
 	if _, err := c.PipelineRunClient.Create(ctx, parse.MustParsePipelineRun(t, fmt.Sprintf(`
 metadata:

--- a/test/serviceaccount_test.go
+++ b/test/serviceaccount_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestPipelineRunWithServiceAccounts(t *testing.T) {
@@ -116,7 +117,7 @@ func TestPipelineRunWithServiceAccounts(t *testing.T) {
 	// Create a Pipeline with multiple tasks
 	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
 metadata:
-  name: pipelinewithsas
+  name: %s
   namespace: %s
 spec:
   tasks:
@@ -135,7 +136,7 @@ spec:
       steps:
       - image: ubuntu
         script: echo task3
-`, namespace))
+`, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
@@ -143,11 +144,11 @@ spec:
 	// Create a PipelineRun that uses those ServiceAccount
 	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
 metadata:
-  name: pipelinerunwithasas
+  name: %s
   namespace: %s
 spec:
   pipelineRef:
-    name: pipelinewithsas
+    name: %s
   serviceAccountName: sa1
   serviceAccountNames:
   - serviceAccountName: sa2
@@ -155,7 +156,7 @@ spec:
   taskRunSpecs:
   - pipelineTaskName: task3
     taskServiceAccountName: sa3
-`, namespace))
+`, helpers.ObjectNameForTest(t), namespace, pipeline.Name))
 
 	_, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{})
 	if err != nil {
@@ -234,7 +235,7 @@ func TestPipelineRunWithServiceAccountNameAndTaskRunSpec(t *testing.T) {
 	// Create a Pipeline with multiple tasks
 	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
 metadata:
-  name: pipelinewithsas
+  name: %s
   namespace: %s
 spec:
   tasks:
@@ -244,7 +245,7 @@ spec:
       steps:
       - image: ubuntu
         script: echo task1
-`, namespace))
+`, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
@@ -253,17 +254,17 @@ spec:
 	// Create a PipelineRun that uses those ServiceAccount
 	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
 metadata:
-  name: pipelinerunwithasas
+  name: %s
   namespace: %s
 spec:
   pipelineRef:
-    name: pipelinewithsas
+    name: %s
   serviceAccountName: sa1
   taskRunSpecs:
   - pipelineTaskName: task1
     taskPodTemplate:
       dnsPolicy: %s
-`, namespace, dnsPolicy))
+`, helpers.ObjectNameForTest(t), namespace, pipeline.Name, dnsPolicy))
 
 	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)

--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -30,11 +30,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 const (
-	sidecarTaskName      = "sidecar-test-task"
-	sidecarTaskRunName   = "sidecar-test-task-run"
 	sidecarContainerName = "sidecar-container"
 	primaryContainerName = "primary"
 )
@@ -62,8 +61,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 	ctx := context.Background()
 	t.Parallel()
 
-	for i, test := range tests {
-		i := i
+	for _, test := range tests {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
@@ -74,8 +72,8 @@ func TestSidecarTaskSupport(t *testing.T) {
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, clients, namespace) }, t.Logf)
 			defer tearDown(ctx, t, clients, namespace)
 
-			sidecarTaskName := fmt.Sprintf("%s-%d", sidecarTaskName, i)
-			sidecarTaskRunName := fmt.Sprintf("%s-%d", sidecarTaskRunName, i)
+			sidecarTaskName := helpers.ObjectNameForTest(t)
+			sidecarTaskRunName := helpers.ObjectNameForTest(t)
 			task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/start_time_test.go
+++ b/test/start_time_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestStartTime tests that step start times are reported accurately.
@@ -49,7 +50,7 @@ func TestStartTime(t *testing.T) {
 	t.Logf("Creating TaskRun in namespace %q", namespace)
 	tr, err := c.TaskRunClient.Create(ctx, parse.MustParseTaskRun(t, fmt.Sprintf(`
 metadata:
-  generateName: start-time-test-
+  name: %s
   namespace: %s
 spec:
   taskSpec:
@@ -64,7 +65,7 @@ spec:
       script: sleep 2
     - image: busybox
       script: sleep 2
-`, namespace)), metav1.CreateOptions{})
+`, helpers.ObjectNameForTest(t), namespace)), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating TaskRun: %v", err)
 	}

--- a/test/status_test.go
+++ b/test/status_test.go
@@ -21,12 +21,14 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/tektoncd/pipeline/test/parse"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestTaskRunPipelineRunStatus is an integration test that will
@@ -43,57 +45,57 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := parse.MustParseTask(t, `
+	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
-  name: banana
+  name: %s
 spec:
   steps:
   - name: foo
     image: busybox
-    command: ['ls', '-la']`)
+    command: ['ls', '-la']`, helpers.ObjectNameForTest(t)))
 	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := parse.MustParseTaskRun(t, `
+	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: apple
+  name: %s
 spec:
   taskRef:
-    name: banana
-  serviceAccountName: inexistent`)
+    name: %s
+  serviceAccountName: inexistent`, helpers.ObjectNameForTest(t), task.Name))
 	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, "apple", TaskRunFailed("apple"), "BuildValidationFailed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, TaskRunFailed(taskRun.Name), "BuildValidationFailed"); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	pipeline := parse.MustParsePipeline(t, `
+	pipeline := parse.MustParsePipeline(t, fmt.Sprintf(`
 metadata:
-  name: tomatoes
+  name: %s
 spec:
   tasks:
   - name: foo
     taskRef:
-      name: banana`)
+      name: %s`, helpers.ObjectNameForTest(t), task.Name))
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
+		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
-	pipelineRun := parse.MustParsePipelineRun(t, `
+	pipelineRun := parse.MustParsePipelineRun(t, fmt.Sprintf(`
 metadata:
-  name: pear
+  name: %s
 spec:
   pipelineRef:
-    name: tomatoes
-  serviceAccountName: inexistent`)
+    name: %s
+  serviceAccountName: inexistent`, helpers.ObjectNameForTest(t), pipeline.Name))
 	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, "pear", timeout, PipelineRunFailed("pear"), "BuildValidationFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, timeout, PipelineRunFailed(pipelineRun.Name), "BuildValidationFailed"); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 }

--- a/test/taskrun_test.go
+++ b/test/taskrun_test.go
@@ -35,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestTaskRunFailure(t *testing.T) {
@@ -48,12 +49,12 @@ func TestTaskRunFailure(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskRunName := "failing-taskrun"
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
-  name: failing-task
+  name: %s
   namespace: %s
 spec:
   steps:
@@ -66,7 +67,7 @@ spec:
   - image: busybox
     command: ['/bin/sh']
     args: ['-c', 'sleep 30s']
-`, namespace))
+`, helpers.ObjectNameForTest(t), namespace))
 	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
@@ -76,8 +77,8 @@ metadata:
   namespace: %s
 spec:
   taskRef:
-    name: failing-task
-`, taskRunName, namespace))
+    name: %s
+`, taskRunName, namespace, task.Name))
 	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
@@ -144,21 +145,21 @@ func TestTaskRunStatus(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskRunName := "status-taskrun"
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	fqImageName := getTestImage(busyboxImage)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
-  name: status-task
+  name: %s
   namespace: %s
 spec:
   steps:
   - image: %s
     command: ['/bin/sh']
     args: ['-c', 'echo hello']
-`, namespace, fqImageName))
+`, helpers.ObjectNameForTest(t), namespace, fqImageName))
 	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
@@ -168,8 +169,8 @@ metadata:
   namespace: %s
 spec:
   taskRef:
-    name: status-task
-`, taskRunName, namespace))
+    name: %s
+`, taskRunName, namespace, task.Name))
 	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}

--- a/test/tektonbundles_test.go
+++ b/test/tektonbundles_test.go
@@ -46,6 +46,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 var requireFeatureFlags = requireAnyGate(map[string]string{
@@ -64,9 +65,9 @@ func TestTektonBundlesSimpleWorkingExample(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskName := "hello-world"
-	pipelineName := "hello-world-pipeline"
-	pipelineRunName := "hello-world-piplinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlessimple", getRegistryServiceIP(ctx, t, c, namespace))
 
 	ref, err := name.ParseReference(repo)
@@ -202,9 +203,9 @@ func TestTektonBundlesUsingRegularImage(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskName := "hello-world-dne"
-	pipelineName := "hello-world-pipeline-dne"
-	pipelineRunName := "hello-world-piplinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlesregularimage", getRegistryServiceIP(ctx, t, c, namespace))
 
 	ref, err := name.ParseReference(repo)
@@ -285,9 +286,9 @@ func TestTektonBundlesUsingImproperFormat(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskName := "hello-world"
-	pipelineName := "hello-world-pipeline"
-	pipelineRunName := "hello-world-piplinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 	repo := fmt.Sprintf("%s:5000/tektonbundlesimproperformat", getRegistryServiceIP(ctx, t, c, namespace))
 
 	ref, err := name.ParseReference(repo)

--- a/test/v1alpha1/artifact_bucket_test.go
+++ b/test/v1alpha1/artifact_bucket_test.go
@@ -34,22 +34,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 const (
-	helloworldResourceName    = "helloworldgit"
-	addFileTaskName           = "add-file-to-resource-task"
-	runFileTaskName           = "run-new-file-task"
-	bucketTestPipelineName    = "bucket-test-pipeline"
-	bucketTestPipelineRunName = "bucket-test-pipeline-run"
-	systemNamespace           = "tekton-pipelines"
-	bucketSecretName          = "bucket-secret"
-	bucketSecretKey           = "bucket-secret-key"
+	systemNamespace  = "tekton-pipelines"
+	bucketSecretName = "bucket-secret"
+	bucketSecretKey  = "bucket-secret-key"
 )
 
 // TestStorageBucketPipelineRun is an integration test that will verify a pipeline
 // can use a bucket for temporary storage of artifacts shared between tasks
 func TestStorageBucketPipelineRun(t *testing.T) {
+	var (
+		helloworldResourceName    = helpers.ObjectNameForTest(t)
+		addFileTaskName           = helpers.ObjectNameForTest(t)
+		runFileTaskName           = helpers.ObjectNameForTest(t)
+		bucketTestPipelineName    = helpers.ObjectNameForTest(t)
+		bucketTestPipelineRunName = helpers.ObjectNameForTest(t)
+	)
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -304,33 +307,33 @@ func resetConfigMap(ctx context.Context, t *testing.T, c *clients, namespace, co
 func runTaskToDeleteBucket(ctx context.Context, c *clients, t *testing.T, namespace, bucketName, bucketSecretName, bucketSecretKey string) {
 	deletelbuckettask := parse.MustParseAlphaTask(t, fmt.Sprintf(`
 metadata:
-  name: deletelbuckettask
+  name: %s
 spec:
   volumes:
   - name: bucket-secret-volume
     secret:
       secretName: %s
-`, bucketSecretName))
+`, helpers.ObjectNameForTest(t), bucketSecretName))
 
-	t.Logf("Creating Task %s", "deletelbuckettask")
+	t.Logf("Creating Task %s", deletelbuckettask.Name)
 	if _, err := c.TaskClient.Create(ctx, deletelbuckettask, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", "deletelbuckettask", err)
+		t.Fatalf("Failed to create Task `%s`: %s", deletelbuckettask.Name, err)
 	}
 
 	deletelbuckettaskrun := parse.MustParseAlphaTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: deletelbuckettaskrun
+  name: %s
 spec:
   taskRef:
-    name: deletelbuckettask
-`))
+    name: %s
+`, helpers.ObjectNameForTest(t), deletelbuckettask.Name))
 
-	t.Logf("Creating TaskRun %s", "deletelbuckettaskrun")
+	t.Logf("Creating TaskRun %s", deletelbuckettaskrun.Name)
 	if _, err := c.TaskRunClient.Create(ctx, deletelbuckettaskrun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun `%s`: %s", "deletelbuckettaskrun", err)
+		t.Fatalf("Failed to create TaskRun `%s`: %s", deletelbuckettaskrun.Name, err)
 	}
 
-	if err := WaitForTaskRunState(ctx, c, "deletelbuckettaskrun", TaskRunSucceed("deletelbuckettaskrun"), "TaskRunSuccess"); err != nil {
-		t.Errorf("Error waiting for TaskRun %s to finish: %s", "deletelbuckettaskrun", err)
+	if err := WaitForTaskRunState(ctx, c, deletelbuckettaskrun.Name, TaskRunSucceed(deletelbuckettaskrun.Name), "TaskRunSuccess"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", deletelbuckettaskrun.Name, err)
 	}
 }

--- a/test/v1alpha1/cancel_test.go
+++ b/test/v1alpha1/cancel_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestTaskRunPipelineRunCancel cancels a PipelineRun and verifies TaskRun statuses and Pod deletions.
@@ -53,7 +54,7 @@ func TestTaskRunPipelineRunCancel(t *testing.T) {
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
 
-			pipelineRunName := "cancel-me"
+			pipelineRunName := helpers.ObjectNameForTest(t)
 			pipelineRun := parse.MustParseAlphaPipelineRun(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/v1alpha1/cluster_resource_test.go
+++ b/test/v1alpha1/cluster_resource_test.go
@@ -31,14 +31,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestClusterResource(t *testing.T) {
 	secretName := "hw-secret"
 	configName := "hw-config"
-	resourceName := "helloworld-cluster"
-	taskName := "helloworld-cluster-task"
-	taskRunName := "helloworld-cluster-taskrun"
+	resourceName := helpers.ObjectNameForTest(t)
+	taskName := helpers.ObjectNameForTest(t)
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)

--- a/test/v1alpha1/dag_test.go
+++ b/test/v1alpha1/dag_test.go
@@ -33,6 +33,7 @@ import (
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/typed/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 const sleepDuration = 15 * time.Second
@@ -61,7 +62,7 @@ func TestDAGPipelineRun(t *testing.T) {
 	// Create the Task that echoes text
 	echoTask := parse.MustParseAlphaTask(t, fmt.Sprintf(`
 metadata:
-  name: echo-task
+  name: %s
   namespace: %s
 spec:
   resources:
@@ -84,21 +85,21 @@ spec:
     script: 'sleep %d'
   - image: busybox
     script: 'ln -s $(resources.inputs.repo.path) $(resources.outputs.repo.path)'
-`, namespace, int(sleepDuration.Seconds())))
+`, helpers.ObjectNameForTest(t), namespace, int(sleepDuration.Seconds())))
 	if _, err := c.TaskClient.Create(ctx, echoTask, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create echo Task: %s", err)
 	}
 
 	// Create the repo PipelineResource (doesn't really matter which repo we use)
-	repoResource := parse.MustParsePipelineResource(t, `
+	repoResource := parse.MustParsePipelineResource(t, fmt.Sprintf(`
 metadata:
-  name: repo
+  name: %s
 spec:
   type: git
   params:
   - name: Url
     value: https://github.com/githubtraining/example-basic
-`)
+`, helpers.ObjectNameForTest(t)))
 	if _, err := c.PipelineResourceClient.Create(ctx, repoResource, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create simple repo PipelineResource: %s", err)
 	}
@@ -107,7 +108,7 @@ spec:
 	// of execution isn't at all dependent on the order they are declared in
 	pipeline := parse.MustParseAlphaPipeline(t, fmt.Sprintf(`
 metadata:
-  name: dag-pipeline
+  name: %s
   namespace: %s
 spec:
   resources:
@@ -129,7 +130,7 @@ spec:
       - name: repo
         resource: repo
     taskRef:
-      name: echo-task
+      name: %s
   - name: pipeline-task-2-parallel-2
     params:
     - name: text
@@ -144,7 +145,7 @@ spec:
       - name: repo
         resource: repo
     taskRef:
-      name: echo-task
+      name: %s
   - name: pipeline-task-4
     params:
     - name: text
@@ -159,7 +160,7 @@ spec:
     runAfter:
     - pipeline-task-3
     taskRef:
-      name: echo-task
+      name: %s
   - name: pipeline-task-2-parallel-1
     params:
     - name: text
@@ -174,7 +175,7 @@ spec:
       - name: repo
         resource: repo
     taskRef:
-      name: echo-task
+      name: %s
   - name: pipeline-task-1
     params:
     - name: text
@@ -187,35 +188,35 @@ spec:
       - name: repo
         resource: repo
     taskRef:
-      name: echo-task
-`, namespace))
+      name: %s
+`, helpers.ObjectNameForTest(t), namespace, echoTask.Name, echoTask.Name, echoTask.Name, echoTask.Name, echoTask.Name))
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag-pipeline: %s", err)
 	}
 	pipelineRun := parse.MustParseAlphaPipelineRun(t, fmt.Sprintf(`
 metadata:
-  name: dag-pipeline-run
+  name: %s
   namespace: %s
 spec:
   pipelineRef:
-    name: dag-pipeline
+    name: %s
   resources:
   - name: repo
     resourceRef:
-      name: repo
-`, namespace))
+      name: %s
+`, helpers.ObjectNameForTest(t), namespace, pipeline.Name, repoResource.Name))
 	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create dag-pipeline-run PipelineRun: %s", err)
 	}
 	t.Logf("Waiting for DAG pipeline to complete")
-	if err := WaitForPipelineRunState(ctx, c, "dag-pipeline-run", pipelineRunTimeout, PipelineRunSucceed("dag-pipeline-run"), "PipelineRunSuccess"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, PipelineRunSucceed(pipelineRun.Name), "PipelineRunSuccess"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish: %s", err)
 	}
 
-	verifyExpectedOrder(ctx, t, c.TaskRunClient)
+	verifyExpectedOrder(ctx, t, c.TaskRunClient, pipelineRun.Name)
 }
 
-func verifyExpectedOrder(ctx context.Context, t *testing.T, c clientset.TaskRunInterface) {
+func verifyExpectedOrder(ctx context.Context, t *testing.T, c clientset.TaskRunInterface, prName string) {
 	t.Logf("Verifying order of execution")
 
 	taskRunsResp, err := c.List(ctx, metav1.ListOptions{})
@@ -234,12 +235,12 @@ func verifyExpectedOrder(ctx context.Context, t *testing.T, c clientset.TaskRunI
 	})
 
 	wantPrefixes := []string{
-		"dag-pipeline-run-pipeline-task-1",
+		prName + "-pipeline-task-1",
 		// Could be task-2-parallel-1 or task-2-parallel-2
-		"dag-pipeline-run-pipeline-task-2-parallel",
-		"dag-pipeline-run-pipeline-task-2-parallel",
-		"dag-pipeline-run-pipeline-task-3",
-		"dag-pipeline-run-pipeline-task-4",
+		prName + "-pipeline-task-2-parallel",
+		prName + "-pipeline-task-2-parallel",
+		prName + "-pipeline-task-3",
+		prName + "-pipeline-task-4",
 	}
 	for i, wp := range wantPrefixes {
 		if !strings.HasPrefix(taskRuns[i].Name, wp) {

--- a/test/v1alpha1/embed_test.go
+++ b/test/v1alpha1/embed_test.go
@@ -30,12 +30,10 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 const (
-	embedTaskName    = "helloworld"
-	embedTaskRunName = "helloworld-run"
-
 	// TODO(#127) Currently not reliable to retrieve this output
 	taskOutput = "do you want to build a snowman"
 )
@@ -52,17 +50,19 @@ func TestTaskRun_EmbeddedResource(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
+	task := getEmbeddedTask(t, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)})
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	if _, err := c.TaskClient.Create(ctx, getEmbeddedTask(t, []string{"/bin/sh", "-c", fmt.Sprintf("echo %s", taskOutput)}), metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Task `%s`: %s", embedTaskName, err)
+	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Task `%s`: %s", task.Name, err)
 	}
-	if _, err := c.TaskRunClient.Create(ctx, getEmbeddedTaskRun(t, namespace), metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create TaskRun `%s`: %s", embedTaskRunName, err)
+	taskRun := getEmbeddedTaskRun(t, namespace, task.Name)
+	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create TaskRun `%s`: %s", taskRun.Name, err)
 	}
 
-	t.Logf("Waiting for TaskRun %s in namespace %s to complete", embedTaskRunName, namespace)
-	if err := WaitForTaskRunState(ctx, c, embedTaskRunName, TaskRunSucceed(embedTaskRunName), "TaskRunSuccess"); err != nil {
-		t.Errorf("Error waiting for TaskRun %s to finish: %s", embedTaskRunName, err)
+	t.Logf("Waiting for TaskRun %s in namespace %s to complete", taskRun.Name, namespace)
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, TaskRunSucceed(taskRun.Name), "TaskRunSuccess"); err != nil {
+		t.Errorf("Error waiting for TaskRun %s to finish: %s", taskRun.Name, err)
 	}
 
 	// TODO(#127) Currently we have no reliable access to logs from the TaskRun so we'll assume successful
@@ -88,10 +88,10 @@ spec:
     args: ['-c', 'cat /workspace/docs/LICENSE']
   - image: busybox
     command: %s
-`, embedTaskName, fmt.Sprintf("[%s]", strings.Join(argsForYaml, ", "))))
+`, helpers.ObjectNameForTest(t), fmt.Sprintf("[%s]", strings.Join(argsForYaml, ", "))))
 }
 
-func getEmbeddedTaskRun(t *testing.T, namespace string) *v1alpha1.TaskRun {
+func getEmbeddedTaskRun(t *testing.T, namespace, taskName string) *v1alpha1.TaskRun {
 	return parse.MustParseAlphaTaskRun(t, fmt.Sprintf(`
 metadata:
   name: %s
@@ -107,5 +107,5 @@ spec:
           value: https://github.com/knative/docs
   taskRef:
     name: %s
-`, embedTaskRunName, namespace, embedTaskName))
+`, helpers.ObjectNameForTest(t), namespace, taskName))
 }

--- a/test/v1alpha1/entrypoint_test.go
+++ b/test/v1alpha1/entrypoint_test.go
@@ -28,9 +28,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
-
-const epTaskRunName = "ep-task-run"
 
 // TestEntrypointRunningStepsInOrder is an integration test that will
 // verify attempt to the get the entrypoint of a container image
@@ -46,6 +45,7 @@ func TestEntrypointRunningStepsInOrder(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
+	epTaskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 	if _, err := c.TaskRunClient.Create(ctx, parse.MustParseAlphaTaskRun(t, fmt.Sprintf(`
 metadata:

--- a/test/v1alpha1/git_checkout_test.go
+++ b/test/v1alpha1/git_checkout_test.go
@@ -31,11 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
-)
-
-const (
-	gitSourceResourceName  = "git-source-resource"
-	gitTestPipelineRunName = "git-check-pipeline-run"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestGitPipelineRun is an integration test that will verify the source code
@@ -106,6 +102,9 @@ func TestGitPipelineRun(t *testing.T) {
 			c, namespace := setup(ctx, t)
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
+
+			gitSourceResourceName := helpers.ObjectNameForTest(t)
+			gitTestPipelineRunName := helpers.ObjectNameForTest(t)
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
 			// Still using the struct here rather than YAML because we'd have to conditionally determine which fields to set in the YAML.
@@ -187,6 +186,9 @@ func TestGitPipelineRunFail(t *testing.T) {
 			c, namespace := setup(ctx, t)
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 			defer tearDown(ctx, t, c, namespace)
+
+			gitSourceResourceName := helpers.ObjectNameForTest(t)
+			gitTestPipelineRunName := helpers.ObjectNameForTest(t)
 
 			t.Logf("Creating Git PipelineResource %s", gitSourceResourceName)
 			// Still using the struct here rather than YAML because we'd have to conditionally determine which fields to set in the YAML.

--- a/test/v1alpha1/retry_test.go
+++ b/test/v1alpha1/retry_test.go
@@ -36,6 +36,7 @@ import (
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestTaskRunRetry tests that retries behave as expected, by creating multiple
@@ -52,7 +53,7 @@ func TestTaskRunRetry(t *testing.T) {
 
 	// Create a PipelineRun with a single TaskRun that can only fail,
 	// configured to retry 5 times.
-	pipelineRunName := "retry-pipeline"
+	pipelineRunName := helpers.ObjectNameForTest(t)
 	numRetries := 5
 	if _, err := c.PipelineRunClient.Create(ctx, parse.MustParseAlphaPipelineRun(t, fmt.Sprintf(`
 metadata:

--- a/test/v1alpha1/sidecar_test.go
+++ b/test/v1alpha1/sidecar_test.go
@@ -29,11 +29,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 const (
-	sidecarTaskName      = "sidecar-test-task"
-	sidecarTaskRunName   = "sidecar-test-task-run"
 	sidecarContainerName = "sidecar-container"
 	primaryContainerName = "primary"
 )
@@ -61,8 +60,7 @@ func TestSidecarTaskSupport(t *testing.T) {
 	ctx := context.Background()
 	t.Parallel()
 
-	for i, test := range tests {
-		i := i
+	for _, test := range tests {
 		test := test
 		t.Run(test.desc, func(t *testing.T) {
 			t.Parallel()
@@ -72,8 +70,8 @@ func TestSidecarTaskSupport(t *testing.T) {
 			clients, namespace := setup(ctx, t)
 			knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, clients, namespace) }, t.Logf)
 			defer tearDown(ctx, t, clients, namespace)
-			sidecarTaskName := fmt.Sprintf("%s-%d", sidecarTaskName, i)
-			sidecarTaskRunName := fmt.Sprintf("%s-%d", sidecarTaskRunName, i)
+			sidecarTaskName := helpers.ObjectNameForTest(t)
+			sidecarTaskRunName := helpers.ObjectNameForTest(t)
 			task := parse.MustParseAlphaTask(t, fmt.Sprintf(`
 metadata:
   name: %s

--- a/test/v1alpha1/start_time_test.go
+++ b/test/v1alpha1/start_time_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestStartTime tests that step start times are reported accurately.
@@ -50,7 +51,7 @@ func TestStartTime(t *testing.T) {
 	t.Logf("Creating TaskRun in namespace %q", namespace)
 	tr, err := c.TaskRunClient.Create(ctx, parse.MustParseAlphaTaskRun(t, fmt.Sprintf(`
 metadata:
-  generateName: start-time-test-
+  name: %s
   namespace: %s
 spec:
   taskSpec:
@@ -65,7 +66,7 @@ spec:
       script: sleep 2
     - image: busybox
       script: sleep 2
-`, namespace)), metav1.CreateOptions{})
+`, helpers.ObjectNameForTest(t), namespace)), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Error creating TaskRun: %v", err)
 	}

--- a/test/v1alpha1/status_test.go
+++ b/test/v1alpha1/status_test.go
@@ -21,12 +21,14 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/tektoncd/pipeline/test/parse"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 // TestTaskRunPipelineRunStatus is an integration test that will
@@ -43,56 +45,56 @@ func TestTaskRunPipelineRunStatus(t *testing.T) {
 	defer tearDown(ctx, t, c, namespace)
 
 	t.Logf("Creating Task and TaskRun in namespace %s", namespace)
-	task := parse.MustParseAlphaTask(t, `
+	task := parse.MustParseAlphaTask(t, fmt.Sprintf(`
 metadata:
-  name: banana
+  name: %s
 spec:
   steps:
   - image: busybox
-    command: ['ls', '-la']`)
+    command: ['ls', '-la']`, helpers.ObjectNameForTest(t)))
 	if _, err := c.TaskClient.Create(ctx, task, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create Task: %s", err)
 	}
-	taskRun := parse.MustParseAlphaTaskRun(t, `
+	taskRun := parse.MustParseAlphaTaskRun(t, fmt.Sprintf(`
 metadata:
-  name: apple
+  name: %s
 spec:
   taskRef:
-    name: banana
-  serviceAccountName: inexistent`)
+    name: %s
+  serviceAccountName: inexistent`, helpers.ObjectNameForTest(t), task.Name))
 	if _, err := c.TaskRunClient.Create(ctx, taskRun, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create TaskRun: %s", err)
 	}
 
 	t.Logf("Waiting for TaskRun in namespace %s to fail", namespace)
-	if err := WaitForTaskRunState(ctx, c, "apple", TaskRunFailed("apple"), "BuildValidationFailed"); err != nil {
+	if err := WaitForTaskRunState(ctx, c, taskRun.Name, TaskRunFailed(taskRun.Name), "BuildValidationFailed"); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 
-	pipeline := parse.MustParseAlphaPipeline(t, `
+	pipeline := parse.MustParseAlphaPipeline(t, fmt.Sprintf(`
 metadata:
-  name: tomatoes
+  name: %s
 spec:
   tasks:
   - name: foo
     taskRef:
-      name: banana`)
-	pipelineRun := parse.MustParseAlphaPipelineRun(t, `
+      name: %s`, helpers.ObjectNameForTest(t), task.Name))
+	pipelineRun := parse.MustParseAlphaPipelineRun(t, fmt.Sprintf(`
 metadata:
-  name: pear
+  name: %s
 spec:
   pipelineRef:
-    name: tomatoes
-  serviceAccountName: inexistent`)
+    name: %s
+  serviceAccountName: inexistent`, helpers.ObjectNameForTest(t), pipeline.Name))
 	if _, err := c.PipelineClient.Create(ctx, pipeline, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Pipeline `%s`: %s", "tomatoes", err)
+		t.Fatalf("Failed to create Pipeline `%s`: %s", pipeline.Name, err)
 	}
 	if _, err := c.PipelineRunClient.Create(ctx, pipelineRun, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create PipelineRun `%s`: %s", "pear", err)
+		t.Fatalf("Failed to create PipelineRun `%s`: %s", pipelineRun.Name, err)
 	}
 
 	t.Logf("Waiting for PipelineRun in namespace %s to fail", namespace)
-	if err := WaitForPipelineRunState(ctx, c, "pear", pipelineRunTimeout, PipelineRunFailed("pear"), "BuildValidationFailed"); err != nil {
+	if err := WaitForPipelineRunState(ctx, c, pipelineRun.Name, pipelineRunTimeout, PipelineRunFailed(pipelineRun.Name), "BuildValidationFailed"); err != nil {
 		t.Errorf("Error waiting for TaskRun to finish: %s", err)
 	}
 }

--- a/test/v1alpha1/workingdir_test.go
+++ b/test/v1alpha1/workingdir_test.go
@@ -30,11 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
-)
-
-const (
-	wdTaskName    = "wd-task"
-	wdTaskRunName = "wd-task-run"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestWorkingDirCreated(t *testing.T) {
@@ -46,6 +42,9 @@ func TestWorkingDirCreated(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	wdTaskName := helpers.ObjectNameForTest(t)
+	wdTaskRunName := helpers.ObjectNameForTest(t)
 
 	task := parse.MustParseAlphaTask(t, fmt.Sprintf(`
 metadata:
@@ -114,6 +113,9 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	wdTaskName := helpers.ObjectNameForTest(t)
+	wdTaskRunName := helpers.ObjectNameForTest(t)
 
 	task := parse.MustParseAlphaTask(t, fmt.Sprintf(`
 metadata:

--- a/test/v1alpha1/workspace_test.go
+++ b/test/v1alpha1/workspace_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
@@ -39,8 +40,8 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "write-disallowed"
-	taskRunName := "write-disallowed-tr"
+	taskName := helpers.ObjectNameForTest(t)
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
@@ -114,9 +115,9 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "read-workspace"
-	pipelineName := "read-workspace-pipeline"
-	pipelineRunName := "read-workspace-pipelinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
@@ -181,9 +182,9 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "read-workspace"
-	pipelineName := "read-workspace-pipeline"
-	pipelineRunName := "read-workspace-pipelinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)

--- a/test/windows_script_test.go
+++ b/test/windows_script_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestWindowsScript(t *testing.T) {
@@ -41,7 +42,7 @@ func TestWindowsScript(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskRunName := "windows-script-taskrun"
+	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
 	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
@@ -112,7 +113,7 @@ func TestWindowsScriptFailure(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskRunName := "failing-windows-taskrun"
+	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
 	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`

--- a/test/windows_test.go
+++ b/test/windows_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 var (
@@ -50,7 +51,7 @@ func TestWindows(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskRunName := "windows-taskrun"
+	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
 	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`
@@ -107,7 +108,7 @@ func TestWindowsFailure(t *testing.T) {
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 
-	taskRunName := "failing-windows-taskrun"
+	taskRunName := helpers.ObjectNameForTest(t)
 	t.Logf("Creating TaskRun in namespace %s", namespace)
 
 	taskRun := parse.MustParseTaskRun(t, fmt.Sprintf(`

--- a/test/workingdir_test.go
+++ b/test/workingdir_test.go
@@ -30,11 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
-)
-
-const (
-	wdTaskName    = "wd-task"
-	wdTaskRunName = "wd-task-run"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestWorkingDirCreated(t *testing.T) {
@@ -46,6 +42,9 @@ func TestWorkingDirCreated(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	wdTaskName := helpers.ObjectNameForTest(t)
+	wdTaskRunName := helpers.ObjectNameForTest(t)
 
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
@@ -116,6 +115,9 @@ func TestWorkingDirIgnoredNonSlashWorkspace(t *testing.T) {
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
+
+	wdTaskName := helpers.ObjectNameForTest(t)
+	wdTaskRunName := helpers.ObjectNameForTest(t)
 
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:

--- a/test/workspace_test.go
+++ b/test/workspace_test.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	knativetest "knative.dev/pkg/test"
+	"knative.dev/pkg/test/helpers"
 )
 
 func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
@@ -39,8 +40,8 @@ func TestWorkspaceReadOnlyDisallowsWrite(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "write-disallowed"
-	taskRunName := "write-disallowed-tr"
+	taskName := helpers.ObjectNameForTest(t)
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
@@ -116,9 +117,9 @@ func TestWorkspacePipelineRunDuplicateWorkspaceEntriesInvalid(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "read-workspace"
-	pipelineName := "read-workspace-pipeline"
-	pipelineRunName := "read-workspace-pipelinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
@@ -186,9 +187,9 @@ func TestWorkspacePipelineRunMissingWorkspaceInvalid(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "read-workspace"
-	pipelineName := "read-workspace-pipeline"
-	pipelineRunName := "read-workspace-pipelinerun"
+	taskName := helpers.ObjectNameForTest(t)
+	pipelineName := helpers.ObjectNameForTest(t)
+	pipelineRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
@@ -256,8 +257,8 @@ func TestWorkspaceVolumeNameMatchesVolumeVariableReplacement(t *testing.T) {
 	defer cancel()
 	c, namespace := setup(ctx, t)
 
-	taskName := "foo-task"
-	taskRunName := "foo-taskrun"
+	taskName := helpers.ObjectNameForTest(t)
+	taskRunName := helpers.ObjectNameForTest(t)
 
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)


### PR DESCRIPTION
# Changes

This entails changing `Task`, `TaskRun`, `Pipeline`, `PipelineRun`, and `PipelineResource`
names to be `helpers.ObjectNameForTest(t)`.

`test/pipelinerun_test.go` and `test/v1alpha1/pipelinerun_test.go` are not yet
instrumented - they're complicated enough that some degree of rewrite is needed
in order to use `helpers.ObjectNameForTest(t)`.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
