### PR TITLE
Added a unit test for pod status.

### DIFF
--- a/pkg/pod/status_test.go
+++ b/pkg/pod/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +33,61 @@ import (
 )
 
 var ignoreVolatileTime = cmp.Comparer(func(_, _ apis.VolatileTime) bool { return true })
+
+func TestSetTaskRunStatusBasedOnStepStatus(t *testing.T) {
+	for _, c := range []struct {
+		desc              string
+		ContainerStatuses []corev1.ContainerStatus
+	}{{
+		desc: "test result with large pipeline result",
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name: "step-bar-0",
+			State: corev1.ContainerState{
+				Terminated: &corev1.ContainerStateTerminated{
+					Message: `[{"key":"resultName","value":"resultValue", "type":1}, {"key":"digest","value":"sha256:1234","resourceRef":{"name":"source-image"}}]`,
+				},
+			},
+		},
+			{
+				Name: "step-bar1",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message: `[{"key":"resultName","value":"resultValue", "type":1}, {"key":"digest","value":"sha256:1234` + strings.Repeat("a", 3072) + `","resourceRef":{"name":"source-image"}}]`,
+					},
+				},
+			},
+			{
+				Name: "step-bar2",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						Message: `[{"key":"resultName","value":"resultValue", "type":1}, {"key":"digest","value":"sha256:1234` + strings.Repeat("a", 3072) + `","resourceRef":{"name":"source-image"}}]`,
+					},
+				},
+			}},
+	}} {
+		t.Run(c.desc, func(t *testing.T) {
+			startTime := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+			tr := v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "task-run",
+					Namespace: "foo",
+				},
+				Status: v1beta1.TaskRunStatus{
+					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+
+			logger, _ := logging.NewLogger("", "status")
+			merr := setTaskRunStatusBasedOnStepStatus(logger, c.ContainerStatuses, &tr)
+			if merr != nil {
+				t.Errorf("setTaskRunStatusBasedOnStepStatus: %s", merr)
+			}
+
+		})
+	}
+}
 
 func TestMakeTaskRunStatus(t *testing.T) {
 	for _, c := range []struct {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Added a unit test for pod status.

Add unit test with large result for setTaskRunStatusBasedOnStepStatus.
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
None
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```