### PR TITLE
Add validation for duplicated param names in TaskSpec

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -321,8 +321,12 @@ func ValidateParameterVariables(steps []Step, params []ParamSpec) *apis.FieldErr
 	parameterNames := sets.NewString()
 	arrayParameterNames := sets.NewString()
 	objectParamSpecs := []ParamSpec{}
-
+	var errs *apis.FieldError
 	for _, p := range params {
+		// validate no duplicate names
+		if parameterNames.Has(p.Name) {
+			errs = errs.Also(apis.ErrGeneric("parameter appears more than once", "").ViaFieldKey("params", p.Name))
+		}
 		parameterNames.Insert(p.Name)
 		if p.Type == ParamTypeArray {
 			arrayParameterNames.Insert(p.Name)
@@ -332,7 +336,7 @@ func ValidateParameterVariables(steps []Step, params []ParamSpec) *apis.FieldErr
 		}
 	}
 
-	errs := validateVariables(steps, "params", parameterNames)
+	errs = errs.Also(validateVariables(steps, "params", parameterNames))
 	errs = errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
 	return errs.Also(validateObjectUsage(steps, objectParamSpecs))
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -530,6 +530,26 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Details: "Names: \nMust only contain alphanumeric characters, hyphens (-), underscores (_), and dots (.)\nMust begin with a letter or an underscore (_)",
 		},
 	}, {
+		name: "duplicated param names",
+		fields: fields{
+			Params: []v1beta1.ParamSpec{{
+				Name:        "foo",
+				Type:        v1beta1.ParamTypeString,
+				Description: "parameter",
+				Default:     v1beta1.NewArrayOrString("value1"),
+			}, {
+				Name:        "foo",
+				Type:        v1beta1.ParamTypeString,
+				Description: "parameter",
+				Default:     v1beta1.NewArrayOrString("value2"),
+			}},
+			Steps: validSteps,
+		},
+		expectedError: apis.FieldError{
+			Message: `parameter appears more than once`,
+			Paths:   []string{"params[foo]"},
+		},
+	}, {
 		name: "invalid param type",
 		fields: fields{
 			Params: []v1beta1.ParamSpec{{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Prior to this, when duplicated names for parameters were assigned in
`taskSpec`, the param value would be overwritten by the last value.

# Changes
To avoid this, a validation check was added to ensure that no param name
is duplicated in TaskSpec. This PR address issue #4798. 
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```
Add validation for duplicated param names in TaskSpec.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
