### PR TITLE
Set git-clone tasks in examples to run as root

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -58,6 +58,8 @@ spec:
   steps:
     - name: clone
       image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      securityContext:
+        runAsUser: 0 # This needs root, and git-init is nonroot by default
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -81,6 +81,8 @@ spec:
   steps:
   - name: clone
     image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    securityContext:
+      runAsUser: 0 # This needs root, and git-init is nonroot by default
     script: |
       CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
       cleandir() {


### PR DESCRIPTION
# Changes

Similar to https://github.com/tektoncd/pipeline/commit/ba2e7f3655d57d3ba3921462f21ece7f86b31488 - with https://github.com/tektoncd/pipeline/pull/4758, `git-init` now uses `ghcr.io/distroless/git` as its base image, and that image needs to run as root. `git-init` by default does _not_ run as root. So the two examples using copy-pasted old versions of the `git-clone` catalog task need to be changed to run as root, or the example tests will keep failing forever.

An equivalent change will be needed in the `git-clone` catalog task once it's bumped to using `git-init:v0.35.0` or later - currently, it's using `v0.29.0`.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
