### PR TITLE
Fix validateNoDuplicateNames

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -260,6 +260,8 @@ to all `persistentVolumeClaims` generated internally.
 
 ### Specifying `Parameters`
 
+(See also [Specifying Parameters in Tasks](tasks.md#specifying-parameters))
+
 You can specify `Parameters` that you want to pass to the `Pipeline` during execution,
 including different values of the same parameter for different `Tasks` in the `Pipeline`.
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -189,7 +189,7 @@ spec:
 
 ### Specifying `Parameters`
 
-If a `Task` has [`parameters`](tasks.md#parameters), you can use the `params` field to specify their values:
+If a `Task` has [`parameters`](tasks.md#specifying-parameters), you can use the `params` field to specify their values:
 
 ```yaml
 spec:

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -447,6 +447,8 @@ Parameter names:
 
 For example, `foo.Is-Bar_` is a valid parameter name, but `barIsBa$` or `0banana` are not.
 
+> NOTE: Parameter names are **case insensitive**. For example, `APPLE` and `apple` will be treated as duplicate parameters. If they appear in the same taskspec's params, validation webhook will complain about that.
+
 Each declared parameter has a `type` field, which can be set to either `array` or `string`. `array` is useful in cases where the number
 of compilation flags being supplied to a task varies throughout the `Task's` execution. If not specified, the `type` field defaults to
 `string`. When the actual parameter value is supplied, its parsed type is validated against the `type` field.

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -159,7 +159,7 @@ func validateNoDuplicateNames(names []string, byIndex bool) (errs *apis.FieldErr
 				errs = errs.Also(apis.ErrMultipleOneOf("name").ViaKey(n))
 			}
 		}
-		seen.Insert(n)
+		seen.Insert(strings.ToLower(n))
 	}
 	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -248,7 +248,7 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			Details: "Task step name must be a valid DNS Label, For more info refer to https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
 		},
 	}, {
-		name: "invalid params",
+		name: "invalid params - exactly same names",
 		spec: v1beta1.TaskRunSpec{
 			Params: []v1beta1.Param{{
 				Name:  "myname",
@@ -260,6 +260,19 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("params[myname].name"),
+	}, {
+		name: "invalid params- same names but different case",
+		spec: v1beta1.TaskRunSpec{
+			Params: []v1beta1.Param{{
+				Name:  "FOO",
+				Value: *v1beta1.NewArrayOrString("value"),
+			}, {
+				Name:  "foo",
+				Value: *v1beta1.NewArrayOrString("value"),
+			}},
+			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
+		},
+		wantErr: apis.ErrMultipleOneOf("params[foo].name"),
 	}, {
 		name: "use of bundle without the feature flag set",
 		spec: v1beta1.TaskRunSpec{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
Fixes #4814

Prior to this fix, `validateNoDuplicateNames` function was intended to check case-insensitive duplications against names, but it saved original names into the set to compare, which can cause that duplicate names cannot be checked correctly - mentioned in #4814.

In this fix:
- `validateNoDuplicateNames` will save names in lower case into the check set and then compare.
- Unit tests are added for this fix.
- Document that parameter names are case insensitive in the `docs/tasks.md` file and add links to this file's `Specifying Parameters` section in other relevant files.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
