### PR TITLE
Revert "[V1] Add new API versions to /config"

### DIFF
--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -61,24 +61,6 @@ spec:
         # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
         # See issue: https://github.com/knative/serving/issues/912
         x-kubernetes-preserve-unknown-fields: true
-  - name: v1
-    served: false
-    storage: false
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Pipeline
     plural: pipelines

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -87,37 +87,6 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - name: v1
-    served: false
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    additionalPrinterColumns:
-    - name: Succeeded
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
-    - name: StartTime
-      type: date
-      jsonPath: .status.startTime
-    - name: CompletionTime
-      type: date
-      jsonPath: .status.completionTime
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   names:
     kind: PipelineRun
     plural: pipelineruns

--- a/config/300-run.yaml
+++ b/config/300-run.yaml
@@ -56,37 +56,6 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - name: v1beta1
-    served: false
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    additionalPrinterColumns:
-    - name: Succeeded
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
-    - name: StartTime
-      type: date
-      jsonPath: .status.startTime
-    - name: CompletionTime
-      type: date
-      jsonPath: .status.completionTime
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   names:
     kind: Run
     plural: runs

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -61,24 +61,6 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - name: v1
-    served: false
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   names:
     kind: Task
     plural: tasks

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -87,37 +87,6 @@ spec:
     # starts to increment
     subresources:
       status: {}
-  - name: v1
-    served: false
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    additionalPrinterColumns:
-    - name: Succeeded
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
-    - name: StartTime
-      type: date
-      jsonPath: .status.startTime
-    - name: CompletionTime
-      type: date
-      jsonPath: .status.completionTime
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   names:
     kind: TaskRun
     plural: taskruns


### PR DESCRIPTION
Reverts tektoncd/pipeline#4702

This is causing the webhook to fail conversion to v1 types, since the v1 conversion webhook hasn't yet been implemented. Closes #4812.

```release-note
NONE
```