### PR TITLE
Make `pkg/git` tests not modifying global git config

### DIFF
--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -29,7 +29,31 @@ import (
 
 const fileMode = 0755 // rwxr-xr-x
 
+func withTemporaryGitConfig(t *testing.T) func() {
+	gitConfigDir := t.TempDir()
+	key := "GIT_CONFIG_GLOBAL"
+	t.Helper()
+	oldValue, envVarExists := os.LookupEnv(key)
+	if err := os.Setenv(key, filepath.Join(gitConfigDir, "config")); err != nil {
+		t.Fatal(err)
+	}
+	clean := func() {
+		t.Helper()
+		if !envVarExists {
+			if err := os.Unsetenv(key); err != nil {
+				t.Fatal(err)
+			}
+			return
+		}
+		if err := os.Setenv(key, oldValue); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return clean
+}
+
 func TestValidateGitSSHURLFormat(t *testing.T) {
+	withTemporaryGitConfig(t)
 	tests := []struct {
 		url  string
 		want bool
@@ -117,6 +141,7 @@ func TestValidateGitSSHURLFormat(t *testing.T) {
 }
 
 func TestValidateGitAuth(t *testing.T) {
+	withTemporaryGitConfig(t)
 	tests := []struct {
 		name       string
 		url        string
@@ -167,6 +192,7 @@ func TestValidateGitAuth(t *testing.T) {
 }
 
 func TestUserHasKnownHostsFile(t *testing.T) {
+	withTemporaryGitConfig(t)
 	tests := []struct {
 		name               string
 		want               bool
@@ -204,6 +230,7 @@ func TestUserHasKnownHostsFile(t *testing.T) {
 }
 
 func TestEnsureHomeEnv(t *testing.T) {
+	withTemporaryGitConfig(t)
 	tests := []struct {
 		name                 string
 		homeenvSet           bool
@@ -257,6 +284,7 @@ func TestEnsureHomeEnv(t *testing.T) {
 }
 
 func TestFetch(t *testing.T) {
+	withTemporaryGitConfig(t)
 	tests := []struct {
 		name       string
 		logMessage string


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Before this patch, running unit tests on `pkg/git` would modify the
content of the machine's global git configuration (usually
`$HOME/.git/config`).

This makes sure we setup a proper isolated git config, per test.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

Closes #4822 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
