### PR TITLE
WIP: Add support for using CSIVolumeSource as workspaces

### DIFF
--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -77,6 +77,9 @@ type WorkspaceBinding struct {
 	// Secret represents a secret that should populate this workspace.
 	// +optional
 	Secret *corev1.SecretVolumeSource `json:"secret,omitempty"`
+	// CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+	// +optional
+	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`
 }
 
 // WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun

--- a/pkg/apis/pipeline/v1beta1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation.go
@@ -88,5 +88,8 @@ func (b *WorkspaceBinding) numSources() int {
 	if b.Secret != nil {
 		n++
 	}
+	if b.CSI != nil {
+		n++
+	}
 	return n
 }

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -2315,6 +2315,11 @@ func (in *WorkspaceBinding) DeepCopyInto(out *WorkspaceBinding) {
 		*out = new(v1.SecretVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.CSI != nil {
+		in, out := &in.CSI, &out.CSI
+		*out = new(v1.CSIVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds support for using kubernetes CSI
volumes (https://kubernetes.io/docs/concepts/storage/volumes/#csi) as
workspaces.

This opens a lot of possibility as it would enable users to use
alternative volumes for their workspace. An example is the Secrets
Store CSI
Driver (https://secrets-store-csi-driver.sigs.k8s.io/introduction.html)
to use Hashicorp Vault.

It could also open doors for Tekton to ship its own CSI driver to
share data between tasks without the need of a PVC.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind feature
/cc @tektoncd/core-maintainers @imjasonh @abayer

Closes #4446 

This still needs
- [ ] Figure out if I need to write a TEP or not 🙏🏼 
- [ ] Tests
- [ ] Docs

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Add support to use any CSI volume driver as a workspace
```
