### PR TITLE
Resolve Entrypoint and Cmd if there is no command and no args

### DIFF
--- a/pkg/pod/entrypoint_lookup.go
+++ b/pkg/pod/entrypoint_lookup.go
@@ -36,7 +36,7 @@ type EntrypointCache interface {
 	// the reference referred to an index, the returned digest will be the
 	// index's digest, not any platform-specific image contained by the
 	// index.
-	get(ctx context.Context, ref name.Reference, namespace, serviceAccountName string, imagePullSecrets []corev1.LocalObjectReference) (*imageData, error)
+	get(ctx context.Context, ref name.Reference, namespace, serviceAccountName string, imagePullSecrets []corev1.LocalObjectReference, hasArgs bool) (*imageData, error)
 }
 
 // imageData contains information looked up about an image or multi-platform image index.
@@ -62,6 +62,7 @@ func resolveEntrypoints(ctx context.Context, cache EntrypointCache, namespace, s
 		if len(s.Command) > 0 {
 			continue
 		}
+		hasArgs := len(s.Args) > 0
 
 		ref, err := name.ParseReference(s.Image, name.WeakValidation)
 		if err != nil {
@@ -72,7 +73,7 @@ func resolveEntrypoints(ctx context.Context, cache EntrypointCache, namespace, s
 			id = cid
 		} else {
 			// Look it up for real.
-			lid, err := cache.get(ctx, ref, namespace, serviceAccountName, imagePullSecrets)
+			lid, err := cache.get(ctx, ref, namespace, serviceAccountName, imagePullSecrets, hasArgs)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/pod/entrypoint_lookup_test.go
+++ b/pkg/pod/entrypoint_lookup_test.go
@@ -143,7 +143,7 @@ type data struct {
 	seen bool // Whether the image has been looked up before.
 }
 
-func (f fakeCache) get(ctx context.Context, ref name.Reference, _, _ string, _ []corev1.LocalObjectReference) (*imageData, error) {
+func (f fakeCache) get(ctx context.Context, ref name.Reference, _, _ string, _ []corev1.LocalObjectReference, _ bool) (*imageData, error) {
 	if d, ok := ref.(name.Digest); ok {
 		if data, found := f[d.String()]; found {
 			return data.id, nil


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this change, if a Step specify neither `command` nor `args`,
the entrypoint resolver would only resolve the image `Entrypoint` and
thus, only executing that entrypoint. This is confusing to user as it
is not how a `docker run` without args produces.

This make the behavior very close to `docker run`. If there is no
command and no args specified, the entrypoint reslover will join the
image `Entrypoint` and `Cmd`.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind bug

Fixes #4794

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
The entrypoint resolve will now reslove `Entrypoint` and `Cmd` in case
the steps has no command and no args specified.
```
