### PR TITLE
Remove validation of parameter variables after substitution

### DIFF
--- a/pkg/apis/config/contexts.go
+++ b/pkg/apis/config/contexts.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+)
+
+// isSubstituted is used for associating the parameter substitution inside the context.Context.
+type isSubstituted struct{}
+
+// WithinSubstituted is used to note that it is calling within
+// the context of a substitute variable operation.
+func WithinSubstituted(ctx context.Context) context.Context {
+	return context.WithValue(ctx, isSubstituted{}, true)
+}
+
+// IsSubstituted indicates that the variables have been substituted.
+func IsSubstituted(ctx context.Context) bool {
+	return ctx.Value(isSubstituted{}) != nil
+}

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -52,6 +52,15 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if len(ts.Steps) == 0 {
 		errs = errs.Also(apis.ErrMissingField("steps"))
 	}
+
+	if config.IsSubstituted(ctx) {
+		// Validate the task's workspaces only.
+		errs = errs.Also(validateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
+		errs = errs.Also(validateWorkspaceUsages(ctx, ts))
+
+		return errs
+	}
+
 	errs = errs.Also(ValidateVolumes(ts.Volumes).ViaField("volumes"))
 	errs = errs.Also(validateDeclaredWorkspaces(ts.Workspaces, ts.Steps, ts.StepTemplate).ViaField("workspaces"))
 	errs = errs.Also(validateWorkspaceUsages(ctx, ts))

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1378,3 +1378,85 @@ func getContextBasedOnFeatureFlag(featureFlag string) context.Context {
 
 	return config.ToContext(context.Background(), cfg)
 }
+func TestSubstitutedContext(t *testing.T) {
+	type fields struct {
+		Params              []v1beta1.ParamSpec
+		Steps               []v1beta1.Step
+		SubstitutionContext bool
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		expectedError apis.FieldError
+	}{{
+		name: "variable not substituted",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "my-image",
+				Args:  []string{"params"},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(params.a)"`,
+			}},
+			SubstitutionContext: false,
+		},
+		expectedError: apis.FieldError{
+			Message: `non-existent variable in "\n\t\t\t\t#!/usr/bin/env  bash\n\t\t\t\thello \"$(params.a)\""`,
+			Paths:   []string{"steps[0].script"},
+		},
+	}, {
+		name: "variable substituted double quoted",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "my-image",
+				Args:  []string{"params"},
+				Script: `
+				#!/usr/bin/env  bash
+				hello "$(params.a)"`,
+			}},
+			SubstitutionContext: true,
+		},
+	}, {
+		name: "variable substituted not quoted",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image: "my-image",
+				Args:  []string{"params"},
+				Script: `
+				#!/usr/bin/env  bash
+				hello $(params.a)`,
+			}},
+			SubstitutionContext: true,
+		},
+	}, {
+		name: "variable substituted single quoted",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Image:  "my-image",
+				Args:   []string{"params"},
+				Script: "echo `$(params.a)`",
+			}},
+			SubstitutionContext: true,
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := &v1beta1.TaskSpec{
+				Params: tt.fields.Params,
+				Steps:  tt.fields.Steps,
+			}
+			ctx := context.Background()
+			ts.SetDefaults(ctx)
+			if tt.fields.SubstitutionContext {
+				ctx = config.WithinSubstituted(ctx)
+			}
+			err := ts.Validate(ctx)
+			if err == nil && tt.expectedError.Error() != "" {
+				t.Fatalf("Expected an error, got nothing for %v", ts)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -667,7 +667,7 @@ func (c *Reconciler) createPod(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	// Apply step exitCode path substitution
 	ts = resources.ApplyStepExitCodePath(ts)
 
-	if validateErr := ts.Validate(ctx); validateErr != nil {
+	if validateErr := ts.Validate(config.WithinSubstituted(ctx)); validateErr != nil {
 		logger.Errorf("Failed to create a pod for taskrun: %s due to task validation error %v", tr.Name, validateErr)
 		return nil, validateErr
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit removes validation for fields containing a parameter variable
after the parameter value has already been substituted in TaskRun and PipelineRun.
This is done to allow parameter values to contain literal strings like $(params.a); for example, in https://github.com/tektoncd/pipeline/issues/4690.

Removing validation of parameters variables after substitution for PipelineRun is out of the scope of
this PR, since it needs more discussion/analysis 

Note: Passing $(params.x) are not longer being validated after substitution. However, in order to work as expected referring  to #4690 you need to scape special characters to avoid problems with bash or zsh, like the following: 

`'\{\"key\": \"\$\(params.a\)\"\}'`
or
`"{'key': '$(params.a)'}"`

to get the expected output:

`{"key": "$(params.a)"}`



<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```

