### PR TITLE
TEP-0090: Include `Matrix` in Validation of `Parameters` in `TaskRun` Reconciler

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -482,7 +482,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 
 	for _, rprt := range pipelineRunFacts.State {
 		if !rprt.IsCustomTask() {
-			err := taskrun.ValidateResolvedTaskResources(ctx, rprt.PipelineTask.Params, rprt.ResolvedTaskResources)
+			err := taskrun.ValidateResolvedTaskResources(ctx, rprt.PipelineTask.Params, rprt.PipelineTask.Matrix, rprt.ResolvedTaskResources)
 			if err != nil {
 				logger.Errorf("Failed to validate pipelinerun %q with error %v", pr.Name, err)
 				pr.Status.MarkFailed(ReasonFailedValidation, err.Error())

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -332,7 +332,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
-	if err := ValidateResolvedTaskResources(ctx, tr.Spec.Params, rtr); err != nil {
+	if err := ValidateResolvedTaskResources(ctx, tr.Spec.Params, []v1beta1.Param{}, rtr); err != nil {
 		logger.Errorf("TaskRun %q resources are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -115,7 +115,7 @@ func TestValidateResolvedTaskResources_ValidResources(t *testing.T) {
 			},
 		},
 	}
-	if err := ValidateResolvedTaskResources(ctx, []v1beta1.Param{}, rtr); err != nil {
+	if err := ValidateResolvedTaskResources(ctx, []v1beta1.Param{}, []v1beta1.Param{}, rtr); err != nil {
 		t.Fatalf("Did not expect to see error when validating valid resolved TaskRun but saw %v", err)
 	}
 }
@@ -138,6 +138,10 @@ func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
 					Name: "bar",
 					Type: v1beta1.ParamTypeString,
 				},
+				{
+					Name: "zoo",
+					Type: v1beta1.ParamTypeString,
+				},
 			},
 		},
 	}
@@ -151,7 +155,11 @@ func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
 		Name:  "bar",
 		Value: *v1beta1.NewArrayOrString("somethinggood"),
 	}}
-	if err := ValidateResolvedTaskResources(ctx, p, rtr); err != nil {
+	m := []v1beta1.Param{{
+		Name:  "zoo",
+		Value: *v1beta1.NewArrayOrString("a", "b", "c"),
+	}}
+	if err := ValidateResolvedTaskResources(ctx, p, m, rtr); err != nil {
 		t.Fatalf("Did not expect to see error when validating TaskRun with correct params but saw %v", err)
 	}
 
@@ -161,7 +169,11 @@ func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
 			Name:  "extra",
 			Value: *v1beta1.NewArrayOrString("i am an extra param"),
 		}
-		if err := ValidateResolvedTaskResources(ctx, append(p, extra), rtr); err != nil {
+		extraarray := v1beta1.Param{
+			Name:  "extraarray",
+			Value: *v1beta1.NewArrayOrString("i", "am", "an", "extra", "array", "param"),
+		}
+		if err := ValidateResolvedTaskResources(ctx, append(p, extra), append(m, extraarray), rtr); err != nil {
 			t.Fatalf("Did not expect to see error when validating TaskRun with correct params but saw %v", err)
 		}
 	})
@@ -180,6 +192,9 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 				{
 					Name: "foo",
 					Type: v1beta1.ParamTypeString,
+				}, {
+					Name: "bar",
+					Type: v1beta1.ParamTypeArray,
 				},
 			},
 		},
@@ -188,6 +203,7 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 		name   string
 		rtr    *resources.ResolvedTaskResources
 		params []v1beta1.Param
+		matrix []v1beta1.Param
 	}{{
 		name: "missing-params",
 		rtr: &resources.ResolvedTaskResources{
@@ -197,10 +213,32 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 			Name:  "foobar",
 			Value: *v1beta1.NewArrayOrString("somethingfun"),
 		}},
+		matrix: []v1beta1.Param{{
+			Name:  "barfoo",
+			Value: *v1beta1.NewArrayOrString("bar", "foo"),
+		}},
+	}, {
+		name: "invalid-type-in-params",
+		rtr: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+		params: []v1beta1.Param{{
+			Name:  "foo",
+			Value: *v1beta1.NewArrayOrString("bar", "foo"),
+		}},
+	}, {
+		name: "invalid-type-in-matrix",
+		rtr: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+		matrix: []v1beta1.Param{{
+			Name:  "bar",
+			Value: *v1beta1.NewArrayOrString("bar", "foo"),
+		}},
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateResolvedTaskResources(ctx, tc.params, tc.rtr); err == nil {
+			if err := ValidateResolvedTaskResources(ctx, tc.params, tc.matrix, tc.rtr); err == nil {
 				t.Errorf("Expected to see error when validating invalid resolved TaskRun with wrong params but saw none")
 			}
 		})
@@ -408,7 +446,7 @@ func TestValidateResolvedTaskResources_InvalidResources(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateResolvedTaskResources(ctx, []v1beta1.Param{}, tc.rtr); err == nil {
+			if err := ValidateResolvedTaskResources(ctx, []v1beta1.Param{}, []v1beta1.Param{}, tc.rtr); err == nil {
 				t.Errorf("Expected to see error when validating invalid resolved TaskRun but saw none")
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

The `TaskRun` reconciler validates that the needed `Parameters` are provided,
no extra `Parameters` are provide and the types of `Parameters` are matching.

Prior to this change, the reconciler did the above validation considering the
`params` field in the `PipelineTask` only. In this change, we include `matrix`
field into the validation routine described above. This includes validating
that `Parameters` in the `Matrix` are substituting `Parameters` of type `String`
in the underlying `Task`.

Related:
- https://github.com/tektoncd/pipeline/pull/4704
- https://github.com/tektoncd/pipeline/pull/4841

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```