### PR TITLE
TEP-0107: Implement Parameter Propagation

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/propagating_params_implicit_parameters.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_params_implicit_parameters.yaml
@@ -1,0 +1,18 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pr-echo-
+spec:
+  params:
+    - name: HELLO
+      value: "Pipeline Hello World!"
+  pipelineSpec:
+    tasks:
+      - name: echo-hello
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "$(params.HELLO)"

--- a/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pr-echo-
+spec:
+  params:
+    - name: HELLO
+      value: "Pipeline Hello World!"
+  pipelineSpec:
+    tasks:
+      - name: echo-hello
+        params:
+          - name: HELLO
+            value: "Task Hello World!"
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "$(params.HELLO)"

--- a/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence_default_only.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence_default_only.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pr-echo-
+spec:
+  params:
+    - name: HELLO
+      value: "Pipeline Hello World!"
+  pipelineSpec:
+    tasks:
+      - name: echo-hello
+        taskSpec:
+          params:
+            - name: HELLO
+              default: "Default Hello World!"
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "$(params.HELLO)"

--- a/examples/v1beta1/taskruns/alpha/propagating_params_implicit.yaml
+++ b/examples/v1beta1/taskruns/alpha/propagating_params_implicit.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: hello-
+spec:
+  params:
+    - name: message
+      value: "hello world!"
+  taskSpec:
+    # There are no explicit params defined here. They are derived from the TaskRun.
+    steps:
+    - name: default
+      image: ubuntu
+      script: |
+        echo $(params.message)

--- a/pkg/apis/pipeline/v1alpha1/task_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/task_validation.go
@@ -130,7 +130,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 	}
 
-	if err := v1beta1.ValidateParameterVariables(ts.Steps, ts.Params); err != nil {
+	if err := v1beta1.ValidateParameterVariables(ctx, ts.Steps, ts.Params); err != nil {
 		return err
 	}
 	// Deprecated
@@ -138,7 +138,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) *apis.FieldError {
 		return err
 	}
 
-	if err := v1beta1.ValidateResourcesVariables(ts.Steps, ts.Resources); err != nil {
+	if err := v1beta1.ValidateResourcesVariables(ctx, ts.Steps, ts.Resources); err != nil {
 		return err
 	}
 	// Deprecated

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -473,9 +473,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	}
 
 	// Apply parameter substitution from the PipelineRun
-	pipelineSpec = resources.ApplyParameters(pipelineSpec, pr)
-	pipelineSpec = resources.ApplyContexts(pipelineSpec, pipelineMeta.Name, pr)
-	pipelineSpec = resources.ApplyWorkspaces(pipelineSpec, pr)
+	pipelineSpec = resources.ApplyParameters(ctx, pipelineSpec, pr)
+	pipelineSpec = resources.ApplyContexts(ctx, pipelineSpec, pipelineMeta.Name, pr)
+	pipelineSpec = resources.ApplyWorkspaces(ctx, pipelineSpec, pr)
 
 	// pipelineState holds a list of pipeline tasks after resolving conditions and pipeline resources
 	// pipelineState also holds a taskRun for each pipeline task after the taskRun is created


### PR DESCRIPTION
Tekton Pipelines resources are verbose mostly because of explicitly propagating Parameters. Implicit Parameters feature was added to reduce the verbosity. However, there are challenges caused by mutating specifications to support Implicit Parameters. This PR builds on this prior work by propagating Parameters without mutating specifications to improve usability of Tekton Pipelines. This addresses features proposed in [TEP-0107](https://github.com/tektoncd/community/blob/main/teps/0107-propagating-parameters.md).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
Parameters are propagated in embedded specifications without mutations.
```
