### PR TITLE
Fix bug where PipelineRun hangs after task failure

### DIFF
--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-tasks.yaml
@@ -58,6 +58,8 @@ spec:
   steps:
     - name: clone
       image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+      securityContext:
+        runAsUser: 0 # This needs root, and git-init is nonroot by default
       script: |
         CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
 

--- a/examples/v1beta1/pipelineruns/pipelinerun.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun.yaml
@@ -81,6 +81,8 @@ spec:
   steps:
   - name: clone
     image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:latest
+    securityContext:
+      runAsUser: 0 # This needs root, and git-init is nonroot by default
     script: |
       CHECKOUT_DIR="$(workspaces.output.path)/$(params.subdirectory)"
       cleandir() {

--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -90,12 +90,11 @@ func Build(tasks Tasks, deps map[string][]string) (*Graph, error) {
 	return d, nil
 }
 
-// GetSchedulable returns a set of PipelineTask names that can be scheduled,
-// given a list of successfully finished doneTasks. It returns tasks which have
-// all dependencies marked as done, and thus can be scheduled. If the specified
+// GetCandidateTasks returns a set of names of PipelineTasks whose ancestors are all completed,
+// given a list of finished doneTasks. If the specified
 // doneTasks are invalid (i.e. if it is indicated that a Task is done, but the
 // previous Tasks are not done), an error is returned.
-func GetSchedulable(g *Graph, doneTasks ...string) (sets.String, error) {
+func GetCandidateTasks(g *Graph, doneTasks ...string) (sets.String, error) {
 	roots := getRoots(g)
 	tm := sets.NewString(doneTasks...)
 	d := sets.NewString()

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -75,7 +75,7 @@ func TestGetSchedulable(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			tasks, err := dag.GetSchedulable(g, tc.finished...)
+			tasks, err := dag.GetCandidateTasks(g, tc.finished...)
 			if err != nil {
 				t.Fatalf("Didn't expect error when getting next tasks for %v but got %v", tc.finished, err)
 			}
@@ -115,7 +115,7 @@ func TestGetSchedulable_Invalid(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := dag.GetSchedulable(g, tc.finished...)
+			_, err := dag.GetCandidateTasks(g, tc.finished...)
 			if err == nil {
 				t.Fatalf("Expected error for invalid done tasks %v but got none", tc.finished)
 			}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -429,7 +429,7 @@ func (facts *PipelineRunFacts) DAGExecutionQueue() (PipelineRunState, error) {
 	}
 	// candidateTasks is initialized to DAG root nodes to start pipeline execution
 	// candidateTasks is derived based on successfully finished tasks and/or skipped tasks
-	candidateTasks, err := dag.GetSchedulable(facts.TasksGraph, facts.successfulOrSkippedDAGTasks()...)
+	candidateTasks, err := dag.GetCandidateTasks(facts.TasksGraph, facts.completedOrSkippedDAGTasks()...)
 	if err != nil {
 		return tasks, err
 	}
@@ -622,13 +622,13 @@ func (facts *PipelineRunFacts) GetPipelineTaskStatus() map[string]string {
 	return tStatus
 }
 
-// successfulOrSkippedTasks returns a list of the names of all of the PipelineTasks in state
-// which have successfully completed or skipped
-func (facts *PipelineRunFacts) successfulOrSkippedDAGTasks() []string {
+// completedOrSkippedTasks returns a list of the names of all of the PipelineTasks in state
+// which have completed or skipped
+func (facts *PipelineRunFacts) completedOrSkippedDAGTasks() []string {
 	tasks := []string{}
 	for _, t := range facts.State {
 		if facts.isDAGTask(t.PipelineTask.Name) {
-			if t.IsSuccessful() || t.Skip(facts).IsSkipped {
+			if t.IsDone(facts) {
 				tasks = append(tasks, t.PipelineTask.Name)
 			}
 		}


### PR DESCRIPTION
# Changes

Cherry-pick:
- https://github.com/tektoncd/pipeline/pull/4852: regression fix
- https://github.com/tektoncd/pipeline/pull/4807: required for CI

Previously, the function GetSchedulableTasks was called only if a PipelineRun
was in a running state, and it would return an error if called when a PipelineTask
had failed. A different change resulted in this function being called when the
PipelineRun was in a stopping state due to TaskRun failure, meaning this function
returned an error and the PipelineRun failed to be reconciled.

This commit renames the function GetSchedulableTasks to GetCandidateTasks, indicating
that it returns any tasks with completed ancestors regardless of the state of PipelineRun
execution. It is the resposibility of call sites to determine which of these candidate tasks
are schedulable. It also updates the function DAGExecutionQueue to pass a list of all
completed Tasks (not just successful or skipped ones) to this function.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
[Bug fix] Prevent PipelineRun from hanging when a PipelineTask fails and another PipelineTask depends on it
```