### PR TITLE
[TEP-0076] Add indexing into array for pipeline params reference

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -19,6 +19,9 @@ For instructions on using variable substitutions see the relevant section of [th
 | `params.<param name>` | The value of the parameter at runtime. |
 | `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
+| `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
+| `params['<param name>'][i]` | (see above) |
+| `params["<param name>"][i]` | (see above) |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
 | `tasks.<taskName>.results['<resultName>']` | (see above)) |
 | `tasks.<taskName>.results["<resultName>"]` | (see above)) |

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-param-array-indexing.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-param-array-indexing.yaml
@@ -1,0 +1,58 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deploy
+spec:
+  params:
+    - name: environments
+      type: array
+  tasks:
+    - name: deploy
+      params:
+        - name: environment1
+          value: '$(params.environments[0])'
+        - name: environment2
+          value: '$(params.environments[1])'
+      taskSpec:
+        params:
+          - name: environment1
+            type: string
+          - name: environment2
+            type: string
+        steps:
+          # this step should echo "staging"
+          - name: echo-params-1
+            image: bash:3.2
+            args: [
+              "echo",
+              "$(params.environment1)",
+            ]
+          # this step should echo "staging"
+          - name: echo-params-2
+            image: ubuntu
+            script: |
+              #!/bin/bash
+              VALUE=$(params.environment2)
+              EXPECTED="qa"
+              diff=$(diff <(printf "%s\n" "${VALUE[@]}") <(printf "%s\n" "${EXPECTED[@]}"))
+              if [[ -z "$diff" ]]; then
+                  echo "Get expected: ${VALUE}"
+                  exit 0
+              else
+                  echo "Want: ${EXPECTED} Got: ${VALUE}"
+                  exit 1
+              fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: deployrun
+spec:
+  pipelineRef:
+    name: deploy
+  params:
+    - name: environments
+      value:
+        - 'staging'
+        - 'qa'
+        - 'prod'

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -231,6 +231,13 @@ func TestArrayOrString_ApplyReplacements(t *testing.T) {
 		},
 		expectedOutput: v1beta1.NewArrayOrString("a", "b", "c"),
 	}, {
+		name: "array indexing replacement on string val",
+		args: args{
+			input:              v1beta1.NewArrayOrString("$(params.myarray[0])"),
+			stringReplacements: map[string]string{"params.myarray[0]": "a", "params.myarray[1]": "b"},
+		},
+		expectedOutput: v1beta1.NewArrayOrString("a"),
+	}, {
 		name: "object replacement on string val",
 		args: args{
 			input: v1beta1.NewArrayOrString("$(params.object)"),

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -39,6 +39,7 @@ func ApplyParameters(ctx context.Context, p *v1beta1.PipelineSpec, pr *v1beta1.P
 	stringReplacements := map[string]string{}
 	arrayReplacements := map[string][]string{}
 	objectReplacements := map[string]map[string]string{}
+	cfg := config.FromContextOrDefaults(ctx)
 
 	patterns := []string{
 		"params.%s",
@@ -55,6 +56,12 @@ func ApplyParameters(ctx context.Context, p *v1beta1.PipelineSpec, pr *v1beta1.P
 			switch p.Default.Type {
 			case v1beta1.ParamTypeArray:
 				for _, pattern := range patterns {
+					// array indexing for param is alpha feature
+					if cfg.FeatureFlags.EnableAPIFields == config.AlphaAPIFields {
+						for i := 0; i < len(p.Default.ArrayVal); i++ {
+							stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Default.ArrayVal[i]
+						}
+					}
 					arrayReplacements[fmt.Sprintf(pattern, p.Name)] = p.Default.ArrayVal
 				}
 			case v1beta1.ParamTypeObject:
@@ -76,6 +83,12 @@ func ApplyParameters(ctx context.Context, p *v1beta1.PipelineSpec, pr *v1beta1.P
 		switch p.Value.Type {
 		case v1beta1.ParamTypeArray:
 			for _, pattern := range patterns {
+				// array indexing for param is alpha feature
+				if cfg.FeatureFlags.EnableAPIFields == config.AlphaAPIFields {
+					for i := 0; i < len(p.Value.ArrayVal); i++ {
+						stringReplacements[fmt.Sprintf(pattern+"[%d]", p.Name, i)] = p.Value.ArrayVal[i]
+					}
+				}
 				arrayReplacements[fmt.Sprintf(pattern, p.Name)] = p.Value.ArrayVal
 			}
 		case v1beta1.ParamTypeObject:

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -17,10 +17,16 @@ limitations under the License.
 package resources
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func TestValidateParamTypesMatching_Valid(t *testing.T) {
@@ -291,6 +297,399 @@ func TestValidateObjectParamRequiredKeys_Valid(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := ValidateObjectParamRequiredKeys(tc.pp, tc.prp); err != nil {
 				t.Errorf("Didn't expect to see error when validating invalid object parameter keys but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateParamArrayIndex_valid(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags.EnableAPIFields = config.AlphaAPIFields
+	ctx = config.ToContext(ctx, cfg)
+	for _, tt := range []struct {
+		name     string
+		original v1beta1.PipelineSpec
+		params   []v1beta1.Param
+	}{{
+		name: "single parameter",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeString},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[1])")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[0])")},
+					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString("static value")},
+				},
+			}},
+		},
+		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+	}, {
+		name: "single parameter with when expression",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeString},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "$(params.first-param[1])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[0])"},
+				}},
+			}},
+		},
+		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+	}, {
+		name: "pipeline parameter nested inside task parameter",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("$(input.workspace.$(params.first-param[0]))")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("$(input.workspace.$(params.second-param[1]))")},
+				},
+			}},
+		},
+		params: nil, // no parameter values.
+	}, {
+		name: "array parameter",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default", "array", "value")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("firstelement", "$(params.first-param)")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("firstelement", "$(params.second-param[0])")},
+				},
+			}},
+		},
+		params: []v1beta1.Param{
+			{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "array")},
+		},
+	}, {
+		name: "parameter evaluation with final tasks",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Finally: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[0])")},
+					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[1])")},
+				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "$(params.first-param[0])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[1])"},
+				}},
+			}},
+		},
+		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+	}, {
+		name: "parameter evaluation with both tasks and final tasks",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[0])")},
+					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[1])")},
+				},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[0])")},
+					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[1])")},
+				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "$(params.first-param[0])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[1])"},
+				}},
+			}},
+		},
+		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+	}, {
+		name: "parameter references with bracket notation and special characters",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first.param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second/param", Type: v1beta1.ParamTypeArray},
+				{Name: "third.param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "fourth/param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString(`$(params["first.param"][0])`)},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString(`$(params["second/param"][0])`)},
+					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString(`$(params['third.param'][1])`)},
+					{Name: "first-task-fourth-param", Value: *v1beta1.NewArrayOrString(`$(params['fourth/param'][1])`)},
+					{Name: "first-task-fifth-param", Value: *v1beta1.NewArrayOrString("static value")},
+				},
+			}},
+		},
+		params: []v1beta1.Param{
+			{Name: "second/param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")},
+			{Name: "fourth/param", Value: *v1beta1.NewArrayOrString("fourth-value", "fourth-value-again")},
+		},
+	}, {
+		name: "single parameter in workspace subpath",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[0])")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("static value")},
+				},
+				Workspaces: []v1beta1.WorkspacePipelineTaskBinding{
+					{
+						Name:      "first-workspace",
+						Workspace: "first-workspace",
+						SubPath:   "$(params.second-param[1])",
+					},
+				},
+			}},
+		},
+		params: []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+	},
+	} {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			run := &v1beta1.PipelineRun{
+				Spec: v1beta1.PipelineRunSpec{
+					Params: tt.params,
+				},
+			}
+			err := ValidateParamArrayIndex(ctx, &tt.original, run)
+			if err != nil {
+				t.Errorf("ValidateParamArrayIndex() got err %s", err)
+			}
+		})
+	}
+}
+
+func TestValidateParamArrayIndex_invalid(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags.EnableAPIFields = config.AlphaAPIFields
+	ctx = config.ToContext(ctx, cfg)
+	for _, tt := range []struct {
+		name     string
+		original v1beta1.PipelineSpec
+		params   []v1beta1.Param
+		expected error
+	}{{
+		name: "single parameter reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeString},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[2])")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[2])")},
+					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString("static value")},
+				},
+			}},
+		},
+		params:   []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[2])]"),
+	}, {
+		name: "single parameter reference with when expression out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeString},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "$(params.first-param[2])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[2])"},
+				}},
+			}},
+		},
+		params:   []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[2])]"),
+	}, {
+		name: "pipeline parameter reference nested inside task parameter out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("$(input.workspace.$(params.first-param[2]))")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("$(input.workspace.$(params.second-param[2]))")},
+				},
+			}},
+		},
+		params:   nil, // no parameter values.
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[2])]"),
+	}, {
+		name: "array parameter reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default", "array", "value")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("firstelement", "$(params.first-param[3])")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("firstelement", "$(params.second-param[4])")},
+				},
+			}},
+		},
+		params: []v1beta1.Param{
+			{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "array")},
+		},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[3]) $(params.second-param[4])]"),
+	}, {
+		name: "object parameter reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default", "array", "value")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewObject(map[string]string{
+						"val1": "$(params.first-param[4])",
+						"val2": "$(params.second-param[4])",
+					})},
+				},
+			}},
+		},
+		params: []v1beta1.Param{
+			{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "array")},
+		},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[4]) $(params.second-param[4])]"),
+	}, {
+		name: "parameter evaluation with final tasks reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Finally: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[2])")},
+					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[2])")},
+				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "$(params.first-param[0])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[1])"},
+				}},
+			}},
+		},
+		params:   []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[2])]"),
+	}, {
+		name: "parameter evaluation with both tasks and final tasks reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[2])")},
+					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[2])")},
+				},
+			}},
+			Finally: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "final-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[3])")},
+					{Name: "final-task-second-param", Value: *v1beta1.NewArrayOrString("$(params.second-param[3])")},
+				},
+				WhenExpressions: v1beta1.WhenExpressions{{
+					Input:    "$(params.first-param[2])",
+					Operator: selection.In,
+					Values:   []string{"$(params.second-param[2])"},
+				}},
+			}},
+		},
+		params:   []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.first-param[3]) $(params.second-param[2]) $(params.second-param[3])]"),
+	}, {
+		name: "parameter references with bracket notation and special characters reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first.param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second/param", Type: v1beta1.ParamTypeArray},
+				{Name: "third.param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "fourth/param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString(`$(params["first.param"][2])`)},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString(`$(params["second/param"][2])`)},
+					{Name: "first-task-third-param", Value: *v1beta1.NewArrayOrString(`$(params['third.param'][2])`)},
+					{Name: "first-task-fourth-param", Value: *v1beta1.NewArrayOrString(`$(params['fourth/param'][2])`)},
+					{Name: "first-task-fifth-param", Value: *v1beta1.NewArrayOrString("static value")},
+				},
+			}},
+		},
+		params: []v1beta1.Param{
+			{Name: "second/param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")},
+			{Name: "fourth/param", Value: *v1beta1.NewArrayOrString("fourth-value", "fourth-value-again")},
+		},
+		expected: fmt.Errorf("non-existent param references:[$(params[\"first.param\"][2]) $(params[\"second/param\"][2]) $(params['fourth/param'][2]) $(params['third.param'][2])]"),
+	}, {
+		name: "single parameter in workspace subpath reference out of bound",
+		original: v1beta1.PipelineSpec{
+			Params: []v1beta1.ParamSpec{
+				{Name: "first-param", Type: v1beta1.ParamTypeArray, Default: v1beta1.NewArrayOrString("default-value", "default-value-again")},
+				{Name: "second-param", Type: v1beta1.ParamTypeArray},
+			},
+			Tasks: []v1beta1.PipelineTask{{
+				Params: []v1beta1.Param{
+					{Name: "first-task-first-param", Value: *v1beta1.NewArrayOrString("$(params.first-param[2])")},
+					{Name: "first-task-second-param", Value: *v1beta1.NewArrayOrString("static value")},
+				},
+				Workspaces: []v1beta1.WorkspacePipelineTaskBinding{
+					{
+						Name:      "first-workspace",
+						Workspace: "first-workspace",
+						SubPath:   "$(params.second-param[3])",
+					},
+				},
+			}},
+		},
+		params:   []v1beta1.Param{{Name: "second-param", Value: *v1beta1.NewArrayOrString("second-value", "second-value-again")}},
+		expected: fmt.Errorf("non-existent param references:[$(params.first-param[2]) $(params.second-param[3])]"),
+	},
+	} {
+		tt := tt // capture range variable
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			run := &v1beta1.PipelineRun{
+				Spec: v1beta1.PipelineRunSpec{
+					Params: tt.params,
+				},
+			}
+			err := ValidateParamArrayIndex(ctx, &tt.original, run)
+			if d := cmp.Diff(tt.expected.Error(), err.Error()); d != "" {
+				t.Errorf("ValidateParamArrayIndex() errors diff %s", diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -478,3 +478,98 @@ func TestApplyArrayReplacements(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractParamsExpressions(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{{
+		name:  "normal string",
+		input: "hello world",
+		want:  nil,
+	}, {
+		name:  "param reference",
+		input: "$(params.paramName)",
+		want:  nil,
+	}, {
+		name:  "param star reference",
+		input: "$(params.paramName[*])",
+		want:  nil,
+	}, {
+		name:  "param index reference",
+		input: "$(params.paramName[1])",
+		want:  []string{"$(params.paramName[1])"},
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := substitution.ExtractParamsExpressions(tt.input)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestExtractIntIndex(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{{
+		name:  "normal string",
+		input: "hello world",
+		want:  "",
+	}, {
+		name:  "param reference",
+		input: "$(params.paramName)",
+		want:  "",
+	}, {
+		name:  "param star reference",
+		input: "$(params.paramName[*])",
+		want:  "",
+	}, {
+		name:  "param index reference",
+		input: "$(params.paramName[1])",
+		want:  "[1]",
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := substitution.ExtractIndexString(tt.input)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestTrimSquareBrackets(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{{
+		name:  "normal string",
+		input: "hello world",
+		want:  0,
+	}, {
+		name:  "star in square bracket",
+		input: "[*]",
+		want:  0,
+	}, {
+		name:  "index in square bracket",
+		input: "[1]",
+		want:  1,
+	},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := substitution.ExtractIndex(tt.input)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit provides the indexing into array for params for pipeline level reference and gated by
alpha feature flag. Before this commit we can only refer to the whole
array param, with this feature we can refer to array's element such as
$(params.param-name[i]).

/kind feature

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Indexing into array for pipeline params is now an alpha feature, element of array params can be accessed via $(params.param-name[i]).
```
