### PR TITLE
Extract parameter name without any pattern.

### DIFF
--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -25,8 +25,7 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-const parameterSubstitution = `[_a-zA-Z][_a-zA-Z0-9.-]*(\[\*\])?`
-
+const parameterSubstitution = `.*?(\[\*\])?`
 const braceMatchingRegex = "(\\$(\\(%s(\\.(?P<var1>%s)|\\[\"(?P<var2>%s)\"\\]|\\['(?P<var3>%s)'\\])\\)))"
 
 // ValidateVariable makes sure all variables in the provided string are known


### PR DESCRIPTION
Extract parameter name without any pattern.

We want to extract everything that `NAME` contains in (`$param.<NAME> | $param.<NAME>[*]`)
or (`param["<NAME>"] | $param["<NAME>"][*]`) or (`param['NAME'][*] | $param['<NAME>'][*]`).
We dont want to enforce the pattern that it should follow. That part should be done by
`Step 1` in https://github.com/tektoncd/pipeline/pull/4799#discussion_r859259763

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The regex pattern substitution `.*?(\[\*\])?` matches and extracts everything that is contained in `<NAME>` or `<NAME>[*]`.

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```
Extract parameter name without any pattern.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
