### PR TITLE
Add taskRef remote resolution support

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -167,8 +167,6 @@ cli *(coming soon)*.
 
 **([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
 
-**Warning: This feature is still in very early stage of development and is not yet functional. Do not use it.**
-
 A `taskRef` field may specify a Task in a remote location such as git.
 Support for specific types of remote will depend on the Resolvers your
 cluster's operator has installed. The below example demonstrates
@@ -179,7 +177,7 @@ spec:
   taskRef:
     resolver: git
     resource:
-    - name: repo
+    - name: url
       value: https://github.com/tektoncd/catalog.git
     - name: commit
       value: abc123

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -140,6 +140,9 @@ const (
 	TaskRunReasonCancelled TaskRunReason = "TaskRunCancelled"
 	// TaskRunReasonTimedOut is the reason set when the Taskrun has timed out
 	TaskRunReasonTimedOut TaskRunReason = "TaskRunTimeout"
+	// TaskRunReasonResolvingTaskRef indicates that the TaskRun is waiting for
+	// its taskRef to be asynchronously resolved.
+	TaskRunReasonResolvingTaskRef = "ResolvingTaskRef"
 )
 
 func (t TaskRunReason) String() string {

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -76,7 +76,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 			for _, p := range pr.Resource {
 				params[p.Name] = p.Value
 			}
-			resolver := resolution.NewResolver(requester, pipelineRun, string(pr.Resolver), params)
+			resolver := resolution.NewResolver(requester, pipelineRun, string(pr.Resolver), "", "", params)
 			return resolvePipeline(ctx, resolver, name)
 		}, nil
 	default:

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,6 +32,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
 	"github.com/tektoncd/pipeline/test"
 	"github.com/tektoncd/pipeline/test/diff"
+	"github.com/tektoncd/pipeline/test/parse"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -416,7 +418,13 @@ func TestGetTaskFunc(t *testing.T) {
 				t.Fatalf("failed to upload test image: %s", err.Error())
 			}
 
-			fn, err := resources.GetTaskFunc(ctx, kubeclient, tektonclient, tc.ref, "default", "default")
+			trForFunc := &v1beta1.TaskRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-tr"},
+				Spec: v1beta1.TaskRunSpec{
+					TaskRef: tc.ref,
+				},
+			}
+			fn, err := resources.GetTaskFunc(ctx, kubeclient, tektonclient, nil, trForFunc, tc.ref, "", "default", "default")
 			if err != nil {
 				t.Fatalf("failed to get task fn: %s", err.Error())
 			}
@@ -477,7 +485,7 @@ echo hello
 		Spec: TaskSpec,
 	}
 
-	fn, err := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, TaskRun)
+	fn, err := resources.GetTaskFuncFromTaskRun(ctx, kubeclient, tektonclient, nil, TaskRun)
 	if err != nil {
 		t.Fatalf("failed to get Task fn: %s", err.Error())
 	}
@@ -490,3 +498,77 @@ echo hello
 		t.Error(diff)
 	}
 }
+
+func TestGetTaskFunc_RemoteResolution(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags.EnableAPIFields = config.AlphaAPIFields
+	ctx = config.ToContext(ctx, cfg)
+	task := parse.MustParseTask(t, taskYAMLString)
+	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
+	taskYAML := strings.Join([]string{
+		"kind: Task",
+		"apiVersion: tekton.dev/v1beta1",
+		taskYAMLString,
+	}, "\n")
+	resolved := test.NewResolvedResource([]byte(taskYAML), nil, nil)
+	requester := test.NewRequester(resolved, nil)
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef:            taskRef,
+			ServiceAccountName: "default",
+		},
+	}
+	fn, err := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
+	if err != nil {
+		t.Fatalf("failed to get task fn: %s", err.Error())
+	}
+
+	resolvedTask, err := fn(ctx, taskRef.Name)
+	if err != nil {
+		t.Fatalf("failed to call pipelinefn: %s", err.Error())
+	}
+
+	if d := cmp.Diff(task, resolvedTask); d != "" {
+		t.Error(d)
+	}
+}
+
+func TestGetPipelineFunc_RemoteResolutionInvalidData(t *testing.T) {
+	ctx := context.Background()
+	cfg := config.FromContextOrDefaults(ctx)
+	cfg.FeatureFlags.EnableAPIFields = config.AlphaAPIFields
+	ctx = config.ToContext(ctx, cfg)
+	taskRef := &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}}
+	resolvesTo := []byte("INVALID YAML")
+	resource := test.NewResolvedResource(resolvesTo, nil, nil)
+	requester := test.NewRequester(resource, nil)
+	tr := &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		Spec: v1beta1.TaskRunSpec{
+			TaskRef:            taskRef,
+			ServiceAccountName: "default",
+		},
+	}
+	fn, err := resources.GetTaskFunc(ctx, nil, nil, requester, tr, tr.Spec.TaskRef, "", "default", "default")
+	if err != nil {
+		t.Fatalf("failed to get pipeline fn: %s", err.Error())
+	}
+	if _, err := fn(ctx, taskRef.Name); err == nil {
+		t.Fatalf("expected error due to invalid pipeline data but saw none")
+	}
+}
+
+// This is missing the kind and apiVersion because those are added by
+// the MustParse helpers from the test package.
+var taskYAMLString = `
+metadata:
+  name: foo
+spec:
+  steps:
+  - name: step1
+    image: ubuntu
+    script: |
+      echo "hello world!"
+`

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -18,8 +18,10 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -39,6 +41,7 @@ type GetClusterTask func(name string) (v1beta1.TaskObject, error)
 func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask) (*metav1.ObjectMeta, *v1beta1.TaskSpec, error) {
 	taskMeta := metav1.ObjectMeta{}
 	taskSpec := v1beta1.TaskSpec{}
+	cfg := config.FromContextOrDefaults(ctx)
 	switch {
 	case taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Name != "":
 		// Get related task for taskrun
@@ -52,6 +55,17 @@ func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask)
 	case taskRun.Spec.TaskSpec != nil:
 		taskMeta = taskRun.ObjectMeta
 		taskSpec = *taskRun.Spec.TaskSpec
+	case cfg.FeatureFlags.EnableAPIFields == config.AlphaAPIFields && taskRun.Spec.TaskRef != nil && taskRun.Spec.TaskRef.Resolver != "":
+		task, err := getTask(ctx, taskRun.Name)
+		switch {
+		case err != nil:
+			return nil, nil, err
+		case task == nil:
+			return nil, nil, errors.New("resolution of remote resource completed successfully but no task was returned")
+		default:
+			taskMeta = task.TaskMetadata()
+			taskSpec = task.TaskSpec()
+		}
 	default:
 		return nil, nil, fmt.Errorf("taskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
 	}


### PR DESCRIPTION
# Changes

Followup to #4596, needed for #4710.

remote resolution, both in explicitly created `TaskRun`s and in `PipelineRun`s' `PipelineTask`s,
from public git repositories using tektoncd/resolution.

To actually see anything happening a dev also needs to deploy [`tektoncd/resolution`](https://github.com/tektoncd/resolution) and the [`gitresolver`](https://github.com/tektoncd/resolution/tree/main/gitresolver).

This is still in alpha.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Allow taskRefs to be resolved directly from public git repos, using the tektoncd/resolution project.
```
