### PR TITLE
Don't PATCH Ready annotation if it's already marked ready

### DIFF
--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -213,6 +213,11 @@ func init() {
 // UpdateReady updates the Pod's annotations to signal the first step to start
 // by projecting the ready annotation via the Downward API.
 func UpdateReady(ctx context.Context, kubeclient kubernetes.Interface, pod corev1.Pod) error {
+	// Don't PATCH if the annotation is already Ready.
+	if pod.Annotations[readyAnnotation] == readyAnnotationValue {
+		return nil
+	}
+
 	// PATCH the Pod's annotations to replace the ready annotation with the
 	// "READY" value, to signal the first step to start.
 	_, err := kubeclient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, types.JSONPatchType, replaceReadyPatchBytes, metav1.PatchOptions{})


### PR DESCRIPTION

# Changes

Fixes https://github.com/tektoncd/pipeline/issues/4862
/kind bug


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```release-note
Pods will not be unconditionally PATCHed to set the ready annotation, avoiding some API server traffic.
```

/assign @vdemeester 
/assign @afrittoli 
