### PR TITLE
Stop using GO111MODULE=off in builds

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -119,8 +119,6 @@ spec:
     env:
     - name: KO_DOCKER_REPO
       value: $(params.imageRegistry)/$(params.imageRegistryPath)
-    - name: GO111MODULE
-      value: "off"
     - name: GOFLAGS
       value: "-mod=vendor"
     script: |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

GO111MODULE=off was set back in 2019 in https://github.com/tektoncd/pipeline/commit/1a1412ef884e972e272d1095efe1c7d140560ea8
probably before we supported go modules for pipeline.

GO111MODULE is not needed anymore, and it breaks SBOM generation.
Rather than setting it GO111MODULE to "on", remove it, since its
default value is "on" since go1.13  and we're now using go 1.18.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
SBOM generated during the release process now works and is available along with released images.
SBOM can be retrieved for instance using "cosign download bom <platform-specific-container-image>"
```