### PR TITLE
Increase timeouts for some workspace YAML tests

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/isolated-workspaces.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/isolated-workspaces.yaml
@@ -17,7 +17,7 @@ apiVersion: tekton.dev/v1beta1
 metadata:
   generateName: isolated-workspaces-
 spec:
-  timeout: 60s
+  timeout: 5m
   workspaces:
   - name: ssh-credentials
     secret:

--- a/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
+++ b/examples/v1beta1/taskruns/workspace-in-sidecar.yaml
@@ -10,7 +10,7 @@ apiVersion: tekton.dev/v1beta1
 metadata:
   generateName: workspace-in-sidecar-
 spec:
-  timeout: 60s
+  timeout: 5m
   workspaces:
   - name: signals
     emptyDir: {}


### PR DESCRIPTION
I've seen these fail due to timeouts lately ([example](https://tekton-releases.appspot.com/build/tekton-prow/pr-logs/pull/tektoncd_pipeline/4865/pull-tekton-pipeline-alpha-integration-tests/1525124401899507713/)), and 60s seems like a very short timeout for a test that might be running in a cluster alongside lots of other tests.

This bumps the timeout from 60s -> 5m.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
