### PR TITLE
Set explicit parallelism for e2e tests, increase Kaniko e2e test timeouts

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -59,7 +59,7 @@ function run_e2e() {
   # and they cause a lot of noise in the logs, making it harder to debug integration
   # test failures.
   if [ "${RUN_YAML_TESTS}" == "true" ]; then
-    go_test_e2e -mod=readonly -tags=examples -timeout=20m ./test/ || failed=1
+    go_test_e2e -parallel=4 -mod=readonly -tags=examples -timeout=20m ./test/ || failed=1
   fi
 }
 

--- a/test/kaniko_task_test.go
+++ b/test/kaniko_task_test.go
@@ -199,7 +199,7 @@ metadata:
 spec:
   taskRef:
     name: %s
-  timeout: 2m
+  timeout: 5m
   resources:
     inputs:
     - name: gitsource

--- a/test/v1alpha1/kaniko_task_test.go
+++ b/test/v1alpha1/kaniko_task_test.go
@@ -193,7 +193,7 @@ metadata:
 spec:
   taskRef:
     name: %s
-  timeout: 2m
+  timeout: 5m
   inputs:
     resources:
     - name: gitsource


### PR DESCRIPTION
# Changes

fixes #4863

The parallelism change appears to make a real difference in cutting down on flaky
tests, while only increasing total duration of the integration test runs to ~30-35
minutes from ~25, which seems like a worthy trade to me.

Also bumps the timeout for Kaniko tasks in e2e tests to 5 minutes, where a timeout
was specified in the first place.

/kind flake

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
