### PR TITLE
Add singular to Tekton CRDs.

### DIFF
--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -64,6 +64,7 @@ spec:
   names:
     kind: ClusterTask
     plural: clustertasks
+    singular: clustertask
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-condition.yaml
+++ b/config/300-condition.yaml
@@ -45,6 +45,7 @@ spec:
   names:
     kind: Condition
     plural: conditions
+    singular: condition
     categories:
       - tekton
       - tekton-pipelines

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -64,6 +64,7 @@ spec:
   names:
     kind: Pipeline
     plural: pipelines
+    singular: pipeline
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -90,7 +90,7 @@ spec:
   names:
     kind: PipelineRun
     plural: pipelineruns
-    singular: pipelineruns
+    singular: pipelinerun
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -90,6 +90,7 @@ spec:
   names:
     kind: PipelineRun
     plural: pipelineruns
+    singular: pipelineruns
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-resource.yaml
+++ b/config/300-resource.yaml
@@ -45,6 +45,7 @@ spec:
   names:
     kind: PipelineResource
     plural: pipelineresources
+    singular: pipelineresource
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-run.yaml
+++ b/config/300-run.yaml
@@ -59,6 +59,7 @@ spec:
   names:
     kind: Run
     plural: runs
+    singular: run
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -64,6 +64,7 @@ spec:
   names:
     kind: Task
     plural: tasks
+    singular: task
     categories:
     - tekton
     - tekton-pipelines

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -90,6 +90,7 @@ spec:
   names:
     kind: TaskRun
     plural: taskruns
+    singular: taskrun
     categories:
     - tekton
     - tekton-pipelines


### PR DESCRIPTION
I noticed `singular:` was missing from most of the Tekton CRDs, so this populates them.

Fixes: #4874

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
