### PR TITLE
[TEP-0075] Validate task result variable of object type

### DIFF
--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2691,8 +2691,15 @@ func schema_pkg_apis_pipeline_v1beta1_ResultRef(ref common.ReferenceCallback) co
 							Format:  "int32",
 						},
 					},
+					"property": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
 				},
-				Required: []string{"pipelineTask", "result", "resultsIndex"},
+				Required: []string{"pipelineTask", "result", "resultsIndex", "property"},
 			},
 		},
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1102,6 +1102,10 @@ func TestValidatePipelineResults_Success(t *testing.T) {
 		Name:        "my-pipeline-result",
 		Description: "this is my pipeline result",
 		Value:       "$(tasks.a-task.results.output)",
+	}, {
+		Name:        "my-pipeline-object-result",
+		Description: "this is my pipeline result",
+		Value:       "$(tasks.a-task.results.gitrepo.commit)",
 	}}
 	if err := validatePipelineResults(results); err != nil {
 		t.Errorf("Pipeline.validatePipelineResults() returned error for valid pipeline: %s: %v", desc, err)
@@ -1118,10 +1122,10 @@ func TestValidatePipelineResults_Failure(t *testing.T) {
 		results: []PipelineResult{{
 			Name:        "my-pipeline-result",
 			Description: "this is my pipeline result",
-			Value:       "$(tasks.a-task.results.output.output)",
+			Value:       "$(tasks.a-task.results.output.key1.extra)",
 		}},
 		expectedError: apis.FieldError{
-			Message: `invalid value: expected all of the expressions [tasks.a-task.results.output.output] to be result expressions but only [] were`,
+			Message: `invalid value: expected all of the expressions [tasks.a-task.results.output.key1.extra] to be result expressions but only [] were`,
 			Paths:   []string{"results[0].value"},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1525,10 +1525,15 @@
       "required": [
         "pipelineTask",
         "result",
-        "resultsIndex"
+        "resultsIndex",
+        "property"
       ],
       "properties": {
         "pipelineTask": {
+          "type": "string",
+          "default": ""
+        },
+        "property": {
           "type": "string",
           "default": ""
         },


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Prior to this commit, when providing param value with task result
variable, it only allowed using the task result as whole in the format
of `tasks.<taskName>.results.<resultName>` since result can
be only of type string previously.

As we are adding support for object type result, we need to support
using the result variable of object type in the format of
`tasks.<taskName>.results.<objectResultName>.<individualAttribute>`.

In this commit, we consider the object case in the validation webhook.
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```
add validation and parsing for object result references
For example, $(tasks.mytask.results.myObjectResult[*]) and `$(tasks.mytask.results.myObjectResult.myKey)` 
are valid references to whole object result and a specific key of an object result.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
