### PR TITLE
Extract full parameter name when using dots in bracket notation.

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -833,8 +833,10 @@ variable values as follows:
 - To reference a parameter in a `Task`, use the following syntax, where `<name>` is the name of the parameter:
   ```shell
   # dot notation
-  $(params.<name>)
+  # Here, the name cannot contain dots (eg. foo.bar is not allowed). If the name contains `dots`, it can only be accessed via the bracket notation.
+  $(params.<name> )
   # or bracket notation (wrapping <name> with either single or double quotes):
+  # Here, the name can contain dots (eg. foo.bar is allowed).
   $(params['<name>'])
   $(params["<name>"])
   ```

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -151,6 +151,52 @@ func TestValidateVariablePs(t *testing.T) {
 		},
 		expectedError: nil,
 	}, {
+		name: "valid variable with double quote bracket and dots",
+		args: args{
+			input:  "--flag=$(params[\"foo.bar.baz\"])",
+			prefix: "params",
+			vars:   sets.NewString("foo.bar.baz"),
+		},
+		expectedError: nil,
+	}, {
+		name: "valid variable with single quote bracket and dots",
+		args: args{
+			input:  "--flag=$(params['foo.bar.baz'])",
+			prefix: "params",
+			vars:   sets.NewString("foo.bar.baz"),
+		},
+		expectedError: nil,
+	}, {
+		name: "invalid variable with only dots referencing parameters",
+		args: args{
+			input:  "--flag=$(params.foo.bar.baz)",
+			prefix: "params",
+			vars:   sets.NewString("foo.bar.baz"),
+		},
+		expectedError: &apis.FieldError{
+			Message: `Invalid referencing of parameters in --flag=$(params.foo.bar.baz) !!! You can only use the dots inside single or double quotes. eg. $(params["org.foo.blah"]) or $(params['org.foo.blah']) are valid references but NOT $params.org.foo.blah.`,
+			Paths:   []string{""},
+		},
+	}, {
+		name: "valid variable with dots referencing resources",
+		args: args{
+			input:  "--flag=$(resources.inputs.foo.bar)",
+			prefix: "resources.(?:inputs|outputs)",
+			vars:   sets.NewString("foo"),
+		},
+		expectedError: nil,
+	}, {
+		name: "invalid variable with dots referencing resources",
+		args: args{
+			input:  "--flag=$(resources.inputs.foo.bar.baz)",
+			prefix: "resources.(?:inputs|outputs)",
+			vars:   sets.NewString("foo.bar"),
+		},
+		expectedError: &apis.FieldError{
+			Message: `Invalid referencing of parameters in --flag=$(resources.inputs.foo.bar.baz) !!! resources.* can only have 4 components (eg. resources.inputs.foo.bar). Found more than 4 components.`,
+			Paths:   []string{""},
+		},
+	}, {
 		name: "valid variable contains diffetent chars",
 		args: args{
 			input:  "--flag=$(inputs.params['ba-_9z'])",


### PR DESCRIPTION
Prior to this, when using `$params["<NAME>"]` or `$params['<NAME>']`,
if `NAME` contained `dots(.)` (eg. `org.foo.blah`), only the first part (ie. `org`) would be
extracted, instead of the entire name`org.foo.blah`. This PR now properly fetches the
entire name and throws an error if using `dots (.)` without `single`
or `double` quotes.

The following references show whats valid and whats not:

`$params.org.foo.blah` : Not Valid: the webhook will throw a validation error.
`$params["org.foo.blah"]`: Valid: Properly extracts the entire `NAME` (`org.foo.blah`).
`$params['org.foo.blah']`: Valid: Properly extracts the entire `NAME` (`org.foo.blah`).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```
Extract full parameter name when using dots inside single/double quotes.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
