### PR TITLE
Update PipelineSpec and TaskSpec fields of PipelineRun and TaskRun Status fields

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -476,6 +476,8 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	pipelineSpec = resources.ApplyParameters(ctx, pipelineSpec, pr)
 	pipelineSpec = resources.ApplyContexts(ctx, pipelineSpec, pipelineMeta.Name, pr)
 	pipelineSpec = resources.ApplyWorkspaces(ctx, pipelineSpec, pr)
+	// Update pipelinespec of pipelinerun's status field
+	pr.Status.PipelineSpec = pipelineSpec
 
 	// pipelineState holds a list of pipeline tasks after resolving conditions and pipeline resources
 	// pipelineState also holds a taskRun for each pipeline task after the taskRun is created

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2079,8 +2079,8 @@ spec:
 		Kind:     "Task",
 		TaskSpec: &v1beta1.TaskSpec{Steps: simpleTask.Spec.Steps, Workspaces: simpleTask.Spec.Workspaces},
 	}
-
-	pod, err := r.createPod(testAssets.Ctx, taskRun, rtr)
+	taskSpec := updateTaskSpecParamsContextsResults(taskRun, rtr)
+	pod, err := r.createPod(testAssets.Ctx, taskSpec, taskRun, rtr)
 
 	if err != nil {
 		t.Fatalf("create pod threw error %v", err)
@@ -2183,7 +2183,8 @@ spec:
 		TaskSpec: &v1beta1.TaskSpec{Steps: simpleTask.Spec.Steps, Workspaces: simpleTask.Spec.Workspaces},
 	}
 
-	_, err := r.createPod(testAssets.Ctx, taskRun, rtr)
+	taskSpec := updateTaskSpecParamsContextsResults(taskRun, rtr)
+	_, err := r.createPod(testAssets.Ctx, taskSpec, taskRun, rtr)
 
 	if err == nil || err.Error() != expectedError {
 		t.Errorf("Expected to fail validation for duplicate Workspace mount paths, error was %v", err)


### PR DESCRIPTION
`PipelineSpec` was only stored in the `PipelineRun` `Status` field [once](https://github.com/tektoncd/pipeline/blob/6f633b2a41455c6d7cad12d51243b2d1a8716544/pkg/reconciler/pipelinerun/pipelinerun.go#L358), before any substitutions. The same thing was happening with the `TaskSpec` field of the `TaskRun's` `Status` (see [here](https://github.com/tektoncd/pipeline/blob/6f633b2a41455c6d7cad12d51243b2d1a8716544/pkg/reconciler/taskrun/taskrun.go#L310)). As a result, after execution of the `pipelinerun` or `taskrun`, the `(task/pipeline)specs` of the `status` fields were not updated leading to confusion.

This commit also updates the `TaskSpec and PipelineSpec` of `Status` fields of `TaskRun` and `PipelineRun`, respectively, after application of the substitutions. As a result, the replacements are now visible in the run status. This PR addresses issue https://github.com/tektoncd/pipeline/issues/4849. 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```
Update PipelineSpec and TaskSpec fields of PipelineRun and TaskRun Status fields
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
