### PR TITLE
Unset replicas for webhook deployment

### DIFF
--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -31,7 +31,8 @@ metadata:
     # labels below are related to istio and should not be used for resource lookup
     version: "devel"
 spec:
-  replicas: 1
+  # replicas is unset, webhook will be autoscaled using HPA in webhook-hpa.yaml
+  # See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook


### PR DESCRIPTION
The configured HPA will control how many replicas the job should have
(default 1-5 replicas), and if the deployment also specifies replicas:1,
then when it's applied it will temporarily override the HPA until HPA
can re-scale it up.

Fixes https://github.com/tektoncd/pipeline/issues/4892
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Unset replicas:1 in the webhook Deployment; HPA will autoscale the deployment (1-5 replicas by default)
```