### PR TITLE
remove spec.replicas from tekton-pipelines-webhook Deployment

### DIFF
--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -31,7 +31,6 @@ metadata:
     # labels below are related to istio and should not be used for resource lookup
     version: "devel"
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: webhook


### PR DESCRIPTION
# Changes

Simply removing the `spec.replicas` field from the `tekton-pipelines-webhook` `Deployment` since it has a HPA, and having this field would cause the webhook to scale to 1 replica upon re-application.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Unset replicas:1 in the webhook Deployment; HPA will autoscale the deployment (1-5 replicas by default).  First reapplication after this change will cause scaling down to 1 replica, but subsequent reapplications will not change the HPA-set replica number.
```

