### PR TITLE
double MaximumBundleObjects and update tests

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -364,7 +364,11 @@ spec:
 `"true"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior)**
 
 You may also specify your `Task` reference using a `Tekton Bundle`. A `Tekton Bundle` is an OCI artifact that
-contains Tekton resources like `Tasks` which can be referenced within a `taskRef`.
+contains Tekton resources like `Tasks` which can be referenced within a `taskRef`.  
+
+There is currently a hard limit of 20 objects in a bundle.
+
+
 
  ```yaml
  spec:

--- a/pkg/remote/oci/resolver.go
+++ b/pkg/remote/oci/resolver.go
@@ -42,7 +42,7 @@ const (
 	// TitleAnnotation is an OCI annotation for the bundle title
 	TitleAnnotation = "dev.tekton.image.name"
 	// MaximumBundleObjects defines the maximum number of objects in a bundle
-	MaximumBundleObjects = 10
+	MaximumBundleObjects = 20
 )
 
 // Resolver implements the Resolver interface using OCI images.

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -61,6 +61,24 @@ func TestOCIResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// setup to many objects in oci bundle test
+	toManyObjErr := fmt.Sprintf("contained more than the maximum %d allow objects", oci.MaximumBundleObjects)
+
+	var toManyObj []runtime.Object
+	for i := 0; i <= oci.MaximumBundleObjects; i++ {
+		name := fmt.Sprintf("%d-task", i)
+		obj := v1beta1.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "tekton.dev/v1beta1",
+				Kind:       "Task",
+			},
+		}
+		toManyObj = append(toManyObj, &obj)
+	}
+
 	testcases := []struct {
 		name         string
 		objs         []runtime.Object
@@ -129,111 +147,11 @@ func TestOCIResolver(t *testing.T) {
 			},
 		},
 		{
-			name: "too-many-objects",
-			objs: []runtime.Object{
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "first-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "second-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "third-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "fourth-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "fifth-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "sixth-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "seventh-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "eighth-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "ninth-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "tenth-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-				&v1beta1.Task{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "eleventh-task",
-					},
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "tekton.dev/v1beta1",
-						Kind:       "Task",
-					},
-				},
-			},
+			name:         "too-many-objects",
+			objs:         toManyObj,
 			mapper:       test.DefaultObjectAnnotationMapper,
 			listExpected: []remote.ResolvedObject{},
-			wantErr:      "contained more than the maximum 10 allow objects",
+			wantErr:      toManyObjErr,
 		},
 		{
 			name:         "single-task-no-version",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Doubling the MaximumBundleObjects from 10 to 20. The official hard limit is 255 ( for oci images ). This feature is currently in alpha and there is a plan to move bundles to beta, but the current limit is very low, and would love to continue testing the use cases for bundles with larger images. 

Slack conversation about doubling the max [here](https://tektoncd.slack.com/archives/CLCCEBUMU/p1651617395226089) 😸  

/kind misc


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
Should only have user facing changes if a bundle size is larger than the max, the current error will just display the updated value. 

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings


```release-note
NONE
```

