### PR TITLE
TEP-0075: Validate Pipeline object variables in value, matrix and when

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -284,23 +284,32 @@ func ArrayReference(a string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(a, "$("+ParamsPrefix+"."), "[*])")
 }
 
-func validatePipelineParametersVariablesInTaskParameters(params []Param, prefix string, paramNames sets.String, arrayParamNames sets.String) (errs *apis.FieldError) {
+// validatePipelineParametersVariablesInTaskParameters validates param value that
+// may contain the reference(s) to other params to make sure those references are used appropriately.
+func validatePipelineParametersVariablesInTaskParameters(params []Param, prefix string, paramNames sets.String, arrayParamNames sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
 	for _, param := range params {
-		if param.Value.Type == ParamTypeString {
-			errs = errs.Also(validateStringVariable(param.Value.StringVal, prefix, paramNames, arrayParamNames).ViaFieldKey("params", param.Name))
-		} else {
+		switch param.Value.Type {
+		case ParamTypeArray:
 			for idx, arrayElement := range param.Value.ArrayVal {
-				errs = errs.Also(validateArrayVariable(arrayElement, prefix, paramNames, arrayParamNames).ViaFieldIndex("value", idx).ViaFieldKey("params", param.Name))
+				errs = errs.Also(validateArrayVariable(arrayElement, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaFieldIndex("value", idx).ViaFieldKey("params", param.Name))
 			}
+		case ParamTypeObject:
+			for key, val := range param.Value.ObjectVal {
+				errs = errs.Also(validateStringVariable(val, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaFieldKey("properties", key).ViaFieldKey("params", param.Name))
+			}
+		default:
+			errs = errs.Also(validateParamStringValue(param, prefix, paramNames, arrayParamNames, objectParamNameKeys))
 		}
 	}
 	return errs
 }
 
-func validatePipelineParametersVariablesInMatrixParameters(matrix []Param, prefix string, paramNames sets.String, arrayParamNames sets.String) (errs *apis.FieldError) {
+// validatePipelineParametersVariablesInMatrixParameters validates matrix param value
+// that may contain the reference(s) to other params to make sure those references are used appropriately.
+func validatePipelineParametersVariablesInMatrixParameters(matrix []Param, prefix string, paramNames sets.String, arrayParamNames sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
 	for _, param := range matrix {
 		for idx, arrayElement := range param.Value.ArrayVal {
-			errs = errs.Also(validateArrayVariable(arrayElement, prefix, paramNames, arrayParamNames).ViaFieldIndex("value", idx).ViaFieldKey("matrix", param.Name))
+			errs = errs.Also(validateArrayVariable(arrayElement, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaFieldIndex("value", idx).ViaFieldKey("matrix", param.Name))
 		}
 	}
 	return errs
@@ -328,12 +337,42 @@ func validateParameterInOneOfMatrixOrParams(matrix []Param, params []Param) (err
 	return errs
 }
 
-func validateStringVariable(value, prefix string, stringVars sets.String, arrayVars sets.String) *apis.FieldError {
+// validateParamStringValue validates the param value field of string type
+// that may contain references to other isolated array/object params other than string param.
+func validateParamStringValue(param Param, prefix string, paramNames sets.String, arrayVars sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
+	stringValue := param.Value.StringVal
+
+	// if the provided param value is an isolated reference to the whole array/object, we just check if the param name exists.
+	isIsolated, errs := substitution.ValidateWholeArrayOrObjectRefInStringVariable(param.Name, stringValue, prefix, paramNames)
+	if isIsolated {
+		return errs
+	}
+
+	// if the provided param value is string literal and/or contains multiple variables
+	// valid example: "$(params.myString) and another $(params.myObject.key1)"
+	// invalid example: "$(params.myString) and another $(params.myObject[*])"
+	return validateStringVariable(stringValue, prefix, paramNames, arrayVars, objectParamNameKeys).ViaFieldKey("params", param.Name)
+}
+
+// validateStringVariable validates the normal string fields that can only accept references to string param or individual keys of object param
+func validateStringVariable(value, prefix string, stringVars sets.String, arrayVars sets.String, objectParamNameKeys map[string][]string) *apis.FieldError {
 	errs := substitution.ValidateVariableP(value, prefix, stringVars)
+	errs = errs.Also(validateObjectVariable(value, prefix, objectParamNameKeys))
 	return errs.Also(substitution.ValidateVariableProhibitedP(value, prefix, arrayVars))
 }
 
-func validateArrayVariable(value, prefix string, stringVars sets.String, arrayVars sets.String) *apis.FieldError {
+func validateArrayVariable(value, prefix string, stringVars sets.String, arrayVars sets.String, objectParamNameKeys map[string][]string) *apis.FieldError {
 	errs := substitution.ValidateVariableP(value, prefix, stringVars)
+	errs = errs.Also(validateObjectVariable(value, prefix, objectParamNameKeys))
 	return errs.Also(substitution.ValidateVariableIsolatedP(value, prefix, arrayVars))
+}
+
+func validateObjectVariable(value, prefix string, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
+	objectNames := sets.NewString()
+	for objectParamName, keys := range objectParamNameKeys {
+		objectNames.Insert(objectParamName)
+		errs = errs.Also(substitution.ValidateVariableP(value, fmt.Sprintf("%s\\.%s", prefix, objectParamName), sets.NewString(keys...)))
+	}
+
+	return errs.Also(substitution.ValidateEntireVariableProhibitedP(value, prefix, objectNames))
 }

--- a/pkg/apis/pipeline/v1beta1/when_validation.go
+++ b/pkg/apis/pipeline/v1beta1/when_validation.go
@@ -74,17 +74,17 @@ func (wes WhenExpressions) validateTaskResultsVariables() *apis.FieldError {
 	return nil
 }
 
-func (wes WhenExpressions) validatePipelineParametersVariables(prefix string, paramNames sets.String, arrayParamNames sets.String) (errs *apis.FieldError) {
+func (wes WhenExpressions) validatePipelineParametersVariables(prefix string, paramNames sets.String, arrayParamNames sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {
 	for idx, we := range wes {
-		errs = errs.Also(validateStringVariable(we.Input, prefix, paramNames, arrayParamNames).ViaField("input").ViaFieldIndex("when", idx))
+		errs = errs.Also(validateStringVariable(we.Input, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaField("input").ViaFieldIndex("when", idx))
 		for _, val := range we.Values {
 			// one of the values could be a reference to an array param, such as, $(params.foo[*])
 			// extract the variable name from the pattern $(params.foo[*]), if the variable name matches with one of the array params
 			// validate the param as an array variable otherwise, validate it as a string variable
 			if arrayParamNames.Has(ArrayReference(val)) {
-				errs = errs.Also(validateArrayVariable(val, prefix, paramNames, arrayParamNames).ViaField("values").ViaFieldIndex("when", idx))
+				errs = errs.Also(validateArrayVariable(val, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaField("values").ViaFieldIndex("when", idx))
 			} else {
-				errs = errs.Also(validateStringVariable(val, prefix, paramNames, arrayParamNames).ViaField("values").ViaFieldIndex("when", idx))
+				errs = errs.Also(validateStringVariable(val, prefix, paramNames, arrayParamNames, objectParamNameKeys).ViaField("values").ViaFieldIndex("when", idx))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Besides task steps, parameter variables can be used as the value of
another param, matrix or when expression.

- Allowed referencing the whole object value but added validation to make sure it can only be used when providing values
for other object param. example:
```
 	params:
 	- name: arg
           value: $(params.myObject[*])
```
- In all other cases (string/array val, matrix and when expression), only individual object attributes can be referenced i.e. `$(params.myobject.key1)`.
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
