### PR TITLE
[TEP-0076]Support Results Array Indexing

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -22,6 +22,9 @@ For instructions on using variable substitutions see the relevant section of [th
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
 | `tasks.<taskName>.results['<resultName>']` | (see above)) |
 | `tasks.<taskName>.results["<resultName>"]` | (see above)) |
+| `tasks.<taskName>.results.<resultName>[i]` | The ith value of the `Task's` array result. Can alter `Task` execution order within a `Pipeline`.) |
+| `tasks.<taskName>.results['<resultName>'][i]` | (see above)) |
+| `tasks.<taskName>.results["<resultName>"][i]` | (see above)) |
 | `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2684,8 +2684,15 @@ func schema_pkg_apis_pipeline_v1beta1_ResultRef(ref common.ReferenceCallback) co
 							Format:  "",
 						},
 					},
+					"resultsIndex": {
+						SchemaProps: spec.SchemaProps{
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
+						},
+					},
 				},
-				Required: []string{"pipelineTask", "result"},
+				Required: []string{"pipelineTask", "result", "resultsIndex"},
 			},
 		},
 	}

--- a/pkg/apis/pipeline/v1beta1/resultref_test.go
+++ b/pkg/apis/pipeline/v1beta1/resultref_test.go
@@ -42,6 +42,27 @@ func TestNewResultReference(t *testing.T) {
 			Result:       "sumResult",
 		}},
 	}, {
+		name: "refer whole array result",
+		param: v1beta1.Param{
+			Name:  "param",
+			Value: *v1beta1.NewArrayOrString("$(tasks.sumTask.results.sumResult[*])"),
+		},
+		want: []*v1beta1.ResultRef{{
+			PipelineTask: "sumTask",
+			Result:       "sumResult",
+		}},
+	}, {
+		name: "refer array indexing result",
+		param: v1beta1.Param{
+			Name:  "param",
+			Value: *v1beta1.NewArrayOrString("$(tasks.sumTask.results.sumResult[1])"),
+		},
+		want: []*v1beta1.ResultRef{{
+			PipelineTask: "sumTask",
+			Result:       "sumResult",
+			ResultsIndex: 1,
+		}},
+	}, {
 		name: "substitution within string",
 		param: v1beta1.Param{
 			Name:  "param",

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1524,7 +1524,8 @@
       "type": "object",
       "required": [
         "pipelineTask",
-        "result"
+        "result",
+        "resultsIndex"
       ],
       "properties": {
         "pipelineTask": {
@@ -1534,6 +1535,11 @@
         "result": {
           "type": "string",
           "default": ""
+        },
+        "resultsIndex": {
+          "type": "integer",
+          "format": "int32",
+          "default": 0
         }
       }
     },

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -281,8 +281,10 @@ func (t *ResolvedPipelineRunTask) skipBecauseResultReferencesAreMissing(facts *P
 	if t.checkParentsDone(facts) && t.hasResultReferences() {
 		resolvedResultRefs, pt, err := ResolveResultRefs(facts.State, PipelineRunState{t})
 		rprt := facts.State.ToMap()[pt]
-		if err != nil && (t.IsFinalTask(facts) || rprt.Skip(facts).SkippingReason == v1beta1.WhenExpressionsSkip) {
-			return true
+		if rprt != nil {
+			if err != nil && (t.IsFinalTask(facts) || rprt.Skip(facts).SkippingReason == v1beta1.WhenExpressionsSkip) {
+				return true
+			}
 		}
 		ApplyTaskResults(PipelineRunState{t}, resolvedResultRefs)
 		facts.ResetSkippedCache()

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -120,6 +120,58 @@ var pipelineRunState = PipelineRunState{{
 			Value: *v1beta1.NewArrayOrString("$(tasks.aCustomPipelineTask.results.aResult)"),
 		}},
 	},
+}, {
+	TaskRunName: "cTaskRun",
+	TaskRun: &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cTaskRun",
+		},
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{successCondition},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{{
+					Name:  "cResult",
+					Value: *v1beta1.NewArrayOrString("arrayResultOne", "arrayResultTwo"),
+				}},
+			},
+		},
+	},
+	PipelineTask: &v1beta1.PipelineTask{
+		Name:    "cTask",
+		TaskRef: &v1beta1.TaskRef{Name: "cTask"},
+		Params: []v1beta1.Param{{
+			Name:  "cParam",
+			Value: *v1beta1.NewArrayOrString("$(tasks.cTask.results.cResult[1])"),
+		}},
+	},
+}, {
+	TaskRunName: "dTaskRun",
+	TaskRun: &v1beta1.TaskRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dTaskRun",
+		},
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{successCondition},
+			},
+			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+				TaskRunResults: []v1beta1.TaskRunResult{{
+					Name:  "dResult",
+					Value: *v1beta1.NewArrayOrString("arrayResultOne", "arrayResultTwo"),
+				}},
+			},
+		},
+	},
+	PipelineTask: &v1beta1.PipelineTask{
+		Name:    "dTask",
+		TaskRef: &v1beta1.TaskRef{Name: "dTask"},
+		Params: []v1beta1.Param{{
+			Name:  "dParam",
+			Value: *v1beta1.NewArrayOrString("$(tasks.dTask.results.dResult[3])"),
+		}},
+	},
 }}
 
 func TestTaskParamResolver_ResolveResultRefs(t *testing.T) {
@@ -479,6 +531,30 @@ func TestResolveResultRefs(t *testing.T) {
 			FromTaskRun: "aTaskRun",
 		}},
 		wantErr: false,
+	}, {
+		name:             "Test successful array result references resolution - params",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[7],
+		},
+		want: ResolvedResultRefs{{
+			Value: *v1beta1.NewArrayOrString("arrayResultOne", "arrayResultTwo"),
+			ResultReference: v1beta1.ResultRef{
+				PipelineTask: "cTask",
+				Result:       "cResult",
+				ResultsIndex: 1,
+			},
+			FromTaskRun: "cTaskRun",
+		}},
+		wantErr: false,
+	}, {
+		name:             "Test unsuccessful result references resolution - params",
+		pipelineRunState: pipelineRunState,
+		targets: PipelineRunState{
+			pipelineRunState[8],
+		},
+		want:    nil,
+		wantErr: true,
 	}, {
 		name:             "Test successful result references resolution - when expressions",
 		pipelineRunState: pipelineRunState,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is part of work in TEP-0076.
This commit provides the support to refer array indexing results.
Previous this commit we support emitting array results so users can
write array results to task level, but we cannot pass array results via
index between tasks within one pipeline. This commit adds the support for this.

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```release-note
Support indexing array results substitution as an alpha feature.

A task can specify a type to produce array result, such as:

  results:
    - name: array-results
       type: array
       description: The array results

And the task script can populate result in an array form with:

echo -n "[\"hello\",\"world\"]" | tee $(results.array-results.path)

and we can refer to the array results elements via index in param like:
  params:
    - name: foo
      value: "$(tasks.task1.results.array-results[1])"

This feature is part of the TEP-0076. 
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
