### PR TITLE
Allow PipelineTaskRunSpec.Metadata to be optional.

### DIFF
--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -2883,8 +2883,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineTaskRunSpec(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
+							Ref: ref("github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1.PipelineTaskMetadata"),
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -602,7 +602,7 @@ type PipelineTaskRunSpec struct {
 	SidecarOverrides []TaskRunSidecarOverride `json:"sidecarOverrides,omitempty"`
 
 	// +optional
-	Metadata PipelineTaskMetadata `json:"metadata,omitempty"`
+	Metadata *PipelineTaskMetadata `json:"metadata,omitempty"`
 }
 
 // GetTaskRunSpec returns the task specific spec for a given

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1610,7 +1610,6 @@
       "type": "object",
       "properties": {
         "metadata": {
-          "default": {},
           "$ref": "#/definitions/v1beta1.PipelineTaskMetadata"
         },
         "pipelineTaskName": {

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -1226,7 +1226,11 @@ func (in *PipelineTaskRunSpec) DeepCopyInto(out *PipelineTaskRunSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	in.Metadata.DeepCopyInto(&out.Metadata)
+	if in.Metadata != nil {
+		in, out := &in.Metadata, &out.Metadata
+		*out = new(PipelineTaskMetadata)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1024,7 +1024,9 @@ func combineTaskRunAndTaskSpecLabels(pr *v1beta1.PipelineRun, pipelineTask *v1be
 	labels := make(map[string]string)
 
 	taskRunSpec := pr.GetTaskRunSpec(pipelineTask.Name)
-	addMetadataByPrecedence(labels, taskRunSpec.Metadata.Labels)
+	if taskRunSpec.Metadata != nil {
+		addMetadataByPrecedence(labels, taskRunSpec.Metadata.Labels)
+	}
 
 	addMetadataByPrecedence(labels, getTaskrunLabels(pr, pipelineTask.Name, true))
 
@@ -1039,7 +1041,9 @@ func combineTaskRunAndTaskSpecAnnotations(pr *v1beta1.PipelineRun, pipelineTask 
 	annotations := make(map[string]string)
 
 	taskRunSpec := pr.GetTaskRunSpec(pipelineTask.Name)
-	addMetadataByPrecedence(annotations, taskRunSpec.Metadata.Annotations)
+	if taskRunSpec.Metadata != nil {
+		addMetadataByPrecedence(annotations, taskRunSpec.Metadata.Annotations)
+	}
 
 	addMetadataByPrecedence(annotations, getTaskrunAnnotations(pr))
 


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Previously, this was using a non-pointer value, which means that the
field was not actually optional and was being included in client
requests. If this request was sent to an older server, this would break
during unmarshalling because the field doesn't exist yet for older
servers.

This changes the type to use a pointer so it will actually be omitted in
newer clients if it is not set.

Co-authored-by: Scott Nichols <n3wscott@chainguard.dev>
Signed-off-by: Billy Lynch <billy@chainguard.dev>

/kind bug
Fixes #4913

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind bug

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
```release-note
NONE
```
