### PR TITLE
docs: add a note on result size and containers

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -645,8 +645,19 @@ a `results` field but it's the responsibility of the `Task` to generate its cont
 It's important to note that Tekton does not perform any processing on the contents of results; they are emitted
 verbatim from your Task including any leading or trailing whitespace characters. Make sure to write only the
 precise string you want returned from your `Task` into the `/tekton/results/` files that your `Task` creates.
-You can use [`$(results.name.path)`](https://github.com/tektoncd/pipeline/blob/main/docs/variables.md#variables-available-in-a-task)
+You can use [`$(results.name.path)`](https://github.com/tektoncd/pipeline/blob/main/docs/variables.md#variables-available-in-a-task)**
 to avoid having to hardcode this path.
+
+Note: Tekton uses [termination
+messages](https://kubernetes.io/docs/tasks/debug/debug-application/determine-reason-pod-failure/#writing-and-reading-a-termination-message). As
+written in
+[tektoncd/pipeline#4808](https://github.com/tektoncd/pipeline/issues/4808),
+this has some *shortcomings*. The main point here is that the more
+containers we have in our pod, *the smaller the allowed size of each container's
+message*, which translates in Tekton to the **more steps you
+have in a Task, the smaller the result for each step can be**. Be aware that the number of
+steps in a Task affects the maximum size of a Result. *For example, if
+you have 10 steps, the size of each step's Result will have a maximum of less than 1KB*.
 
 In the example below, the `Task` specifies two files in the `results` field:
 `current-date-unix-timestamp` and `current-date-human-readable`.


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This adds a small note on how Results work and how the number of steps
can affect the maximum size of the Task results.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind docs

/cc @abayer @afrittoli @jerop @lbernick 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes


```release-note
NONE
```
