### PR TITLE
Refactor the usage of MustCompile and simplify function signatures

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -34,9 +34,14 @@ import (
 	"knative.dev/pkg/apis"
 )
 
-var _ apis.Validatable = (*Task)(nil)
-
+// This regex pattern makes sure the variable name format follows the rules
+// - Must only contain alphanumeric characters, hyphens (-), underscores (_), and dots (.)
+// - Must begin with a letter or an underscore (_)
 const variableNameFormat = "^[_a-zA-Z][_a-zA-Z0-9.-]*$"
+
+var paramNameFormatRegex = regexp.MustCompile(variableNameFormat)
+
+var _ apis.Validatable = (*Task)(nil)
 
 // Validate implements apis.Validatable
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
@@ -451,15 +456,11 @@ func validateStepArrayUsage(step Step, prefix string, vars sets.String) *apis.Fi
 }
 
 func validateVariables(ctx context.Context, steps []Step, prefix string, vars sets.String) (errs *apis.FieldError) {
-	// validate that the variable name format follows the rules
-	// - Must only contain alphanumeric characters, hyphens (-), underscores (_), and dots (.)
-	// - Must begin with a letter or an underscore (_)
-	re := regexp.MustCompile(variableNameFormat)
 	invalidNames := []string{}
 	// Converting to sorted list here rather than just looping map keys
 	// because we want the order of items in vars to be deterministic for purpose of unit testing
 	for _, name := range vars.List() {
-		if !re.MatchString(name) {
+		if !paramNameFormatRegex.MatchString(name) {
 			invalidNames = append(invalidNames, name)
 		}
 	}

--- a/pkg/substitution/substitution_test.go
+++ b/pkg/substitution/substitution_test.go
@@ -174,7 +174,7 @@ func TestValidateVariablePs(t *testing.T) {
 			vars:   sets.NewString("foo.bar.baz"),
 		},
 		expectedError: &apis.FieldError{
-			Message: `Invalid referencing of parameters in --flag=$(params.foo.bar.baz) !!! You can only use the dots inside single or double quotes. eg. $(params["org.foo.blah"]) or $(params['org.foo.blah']) are valid references but NOT $params.org.foo.blah.`,
+			Message: `fail to extract variables from string: invalid referencing of parameters in --flag=$(params.foo.bar.baz) !!! You can only use the dots inside single or double quotes. eg. $(params["org.foo.blah"]) or $(params['org.foo.blah']) are valid references but NOT $(params.org.foo.blah)`,
 			Paths:   []string{""},
 		},
 	}, {
@@ -193,7 +193,7 @@ func TestValidateVariablePs(t *testing.T) {
 			vars:   sets.NewString("foo.bar"),
 		},
 		expectedError: &apis.FieldError{
-			Message: `Invalid referencing of parameters in --flag=$(resources.inputs.foo.bar.baz) !!! resources.* can only have 4 components (eg. resources.inputs.foo.bar). Found more than 4 components.`,
+			Message: `fail to extract variables from string: invalid referencing of parameters in --flag=$(resources.inputs.foo.bar.baz) !!! resources.* can only have 4 components (eg. resources.inputs.foo.bar). Found more than 4 components`,
 			Paths:   []string{""},
 		},
 	}, {


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Prior to this commit:
1. MustCompile sometimes is used inside a function though it is meant for
initializing global variables holding compiled regular expressions
according to this ([docs](https://pkg.go.dev/regexp#MustCompile)). Using
it in a function could possibly panic.
2. function `extractExpressionFromString` and `extractVariablesFromString`
return too many values i.e. extracted value (slice/string), present (bool)
and errorMessage (string)

In this fix:
1. regex compiled from from MustCompile is changed to be global, or
MustCompile is replaced with Compile so that we can return error rather
than causing potential panic.
2. the two functions signatures are simplified to just return extracted
value and error.
<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
