### PR TITLE
.github: update pull-request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,8 @@
 
 # Changes
 
-<!-- 
-Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 
+<!--
+Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!
 
 In addition, categorize the changes you're making using the "/kind" Prow command, example:
 
@@ -37,19 +37,21 @@ Examples of user facing changes:
 
 For pull requests with a release note:
 
-```release-note
+``` release-note
 Your release note here
 ```
 
 For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
 
-```release-note
+``` release-note
 action required: your release note here
 ```
 
 For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
 
-```release-note
+``` release-note
 NONE
 ```
+
+Remove the extra space between the backticks and `release-note` as well
 -->


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The main goal of this change is to make sure that, not editing
anything from the template makes the `release-note` check unhappy
instead of happy, so that it "gives" feedback that something needs to
be updated.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
