### PR TITLE
tekton: remove build-base-image from pipeline

### DIFF
--- a/tekton/kustomization.yaml
+++ b/tekton/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - build-push-ma-base-image.yaml
   - publish.yaml
   - release-pipeline.yaml

--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -104,27 +104,6 @@ spec:
         - name: source
           workspace: workarea
           subpath: git
-    - name: build-base-image
-      runAfter: [build, unit-tests]
-      taskRef:
-        name: build-multiarch-base-image
-      params:
-        - name: package
-          value: $(params.package)
-        - name: imageRegistry
-          value: $(params.imageRegistry)
-        - name: imageRegistryPath
-          value: $(params.imageRegistryPath)
-        - name: platforms
-          value: $(params.buildPlatforms)
-        - name: serviceAccountPath
-          value: $(params.serviceAccountPath)
-      workspaces:
-        - name: source
-          workspace: workarea
-          subpath: git
-        - name: release-secret
-          workspace: release-secret
     - name: publish-images
       runAfter: [build-base-image]
       taskRef:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The task is not used and defined anymore as we removed the git-init
base image Dockerfile now, we don't need it. It got removed in #4765
but not from the `Pipeline`.

This also removes it from the `kustomization.yml` file. This should
help fix the plumbing issue we have with re-deploying nightly
payload (`Task`, `Pipeline`, …), as the `kustomization.yml` as is was invalid.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/cc @imjasonh @mattmoor @abayer @afrittoli @lbernick @jerop 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
