### PR TITLE
Validation for Task Result expressions in Pipeline Result

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -252,16 +252,20 @@ func filter(arr []string, cond func(string) bool) []string {
 func validatePipelineResults(results []PipelineResult) (errs *apis.FieldError) {
 	for idx, result := range results {
 		expressions, ok := GetVarSubstitutionExpressionsForPipelineResult(result)
-		if ok {
-			if LooksLikeContainsResultRefs(expressions) {
-				expressions = filter(expressions, looksLikeResultRef)
-				resultRefs := NewResultRefs(expressions)
-				if len(expressions) != len(resultRefs) {
-					errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("expected all of the expressions %v to be result expressions but only %v were", expressions, resultRefs),
-						"value").ViaFieldIndex("results", idx))
-				}
+		if !ok {
+			errs = errs.Also(apis.ErrInvalidValue("expected pipeline results to be task result expressions but no expressions were found",
+				"value").ViaFieldIndex("results", idx))
+		}
+
+		if LooksLikeContainsResultRefs(expressions) {
+			expressions = filter(expressions, looksLikeResultRef)
+			resultRefs := NewResultRefs(expressions)
+			if len(expressions) != len(resultRefs) {
+				errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("expected all of the expressions %v to be result expressions but only %v were", expressions, resultRefs),
+					"value").ViaFieldIndex("results", idx))
 			}
 		}
+
 	}
 
 	return errs


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Prior to this commit, the validation for static strings for Task Result expressions in Pipeline Results was not extensive.

This commit adds the case where a pipeline would be invalid if there is no expression following the valid form
`$(tasks.<task-name>.results.<result-name>)`.

Please reference this [doc](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#emitting-results-from-a-pipeline) for more information.

Fixes bug [#4922](https://github.com/tektoncd/pipeline/issues/4922)

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->
/kind bug
/cc @jerop 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
NONE
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
NONE
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
Fixed a bug where static strings were not invalidated in `Pipeline Results`.
```