### PR TITLE
Fix TestTaskRunRetry for k8s 1.22.9 and later

### DIFF
--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -146,8 +146,14 @@ spec:
 		if _, found := podNames[p.Name]; !found {
 			t.Errorf("BUG: TaskRunStatus.RetriesStatus did not report pod name %q", p.Name)
 		}
-		if p.Status.Phase != corev1.PodFailed {
-			t.Errorf("BUG: Pod %q is not failed: %v", p.Name, p.Status.Phase)
+		// Check each container in the pod, rather than the phase, since the phase doesn't update to a terminal state instantly.
+		// See https://github.com/kubernetes/kubernetes/pull/108366
+		for _, c := range p.Status.ContainerStatuses {
+			if c.State.Terminated == nil {
+				t.Errorf("BUG: Container %s in pod %s is not terminated", c.Name, p.Name)
+			} else if c.State.Terminated.ExitCode != 1 {
+				t.Errorf("BUG: Container %s in pod %s has exit code %d, expected 1", c.Name, p.Name, c.State.Terminated.ExitCode)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Changes

We just switched to k8s 1.22.9 on CI last night, and `TestTaskRunRetry` started failing. After a bunch of investigation, I determined this was due to https://github.com/kubernetes/kubernetes/pull/108366, which went into k8s 1.22.9. This resulted in the `pod.Status.Phase` that `TestTaskRunRetry` expected to be updated instantly having a delay. I could have fixed this with a sleep, but decided verifying that each container in the pod had terminated with the expected exit code was cleaner.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
