### PR TITLE
dependabot: remove vendor keys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,3 @@ updates:
     labels:
     - "ok-to-test"
     - "dependencies"
-    vendor: true


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- the current configuration is not correct, we are hitting the
  following error:

      The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed

- dependabot is smart enough to detect we are using the vendor folder

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/kind misc
/cc @wlynch @imjasonh @abayer 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```

