### PR TITLE
Unexport RPRT member functions used within resources pkg only

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1066,8 +1066,8 @@ func TestIsFailure(t *testing.T) {
 		want: true,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.rprt.IsFailure(); got != tc.want {
-				t.Errorf("expected IsFailure: %t but got %t", tc.want, got)
+			if got := tc.rprt.isFailure(); got != tc.want {
+				t.Errorf("expected isFailure: %t but got %t", tc.want, got)
 			}
 
 		})

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -234,9 +234,9 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 				t.Errorf("Didn't get expected checkTasksDone %s", diff.PrintWantGot(d))
 			}
 			for i, pt := range tc.state {
-				isDone = pt.IsDone(&facts)
+				isDone = pt.isDone(&facts)
 				if d := cmp.Diff(tc.ptExpected[i], isDone); d != "" {
-					t.Errorf("Didn't get expected (ResolvedPipelineRunTask) IsDone %s", diff.PrintWantGot(d))
+					t.Errorf("Didn't get expected (ResolvedPipelineRunTask) isDone %s", diff.PrintWantGot(d))
 				}
 
 			}

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -146,7 +146,7 @@ func resolveResultRef(pipelineState PipelineRunState, resultRef *v1beta1.ResultR
 	if referencedPipelineTask == nil {
 		return nil, resultRef.PipelineTask, fmt.Errorf("could not find task %q referenced by result", resultRef.PipelineTask)
 	}
-	if !referencedPipelineTask.IsSuccessful() {
+	if !referencedPipelineTask.isSuccessful() {
 		return nil, resultRef.PipelineTask, fmt.Errorf("task %q referenced by result was not successful", referencedPipelineTask.PipelineTask.Name)
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Some member functions of ResolvedPipelineRunTask are exported but they are used within the resources package only: `IsDone`, `IsSuccessful`, `IsFailure`, `IsRunning`, `HasRemainingRetries`, `IsCancelled`, `IsConditionStatusFalse`, and `IsStarted`.

These functions, except `IsDone`, are not tested but the exported functions that use them within the resources package are tested.

In this change, we unexport the above member functions that are used within resources package only. We do not add tests for the now-unexported functions as recommended in [guidelines][guidelines], but we can add them later if we change the guidelines.

Follow up to refactor done in PR: https://github.com/tektoncd/pipeline/pull/4943

[guidelines]: https://github.com/tektoncd/community/blob/ac0ae1b304ef515e8099f772f42b91aac1b26e6b/standards.md#tests


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```

cc @pritidesai 