### PR TITLE
TEP-0090: Add `TaskRuns` to `ResolvedPipelineRunTask` and implement `isFailure`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -60,6 +60,7 @@ func (e *TaskNotFoundError) Error() string {
 type ResolvedPipelineRunTask struct {
 	TaskRunName string
 	TaskRun     *v1beta1.TaskRun
+	TaskRuns    []*v1beta1.TaskRun
 	// If the PipelineTask is a Custom Task, RunName and Run will be set.
 	CustomTask            bool
 	RunName               string
@@ -115,13 +116,28 @@ func (t ResolvedPipelineRunTask) isFailure() bool {
 	}
 	var c *apis.Condition
 	var isDone bool
-	if t.IsCustomTask() {
+
+	switch {
+	case t.IsCustomTask():
 		if t.Run == nil {
 			return false
 		}
 		c = t.Run.Status.GetCondition(apis.ConditionSucceeded)
 		isDone = t.Run.IsDone()
-	} else {
+	case t.IsMatrixed():
+		if len(t.TaskRuns) == 0 {
+			return false
+		}
+		// is failed on the first failure with no remaining retries to fail fast
+		for _, taskRun := range t.TaskRuns {
+			c = taskRun.Status.GetCondition(apis.ConditionSucceeded)
+			isDone = taskRun.IsDone()
+			if isDone && c.IsFalse() && !t.hasRemainingRetries() {
+				return true
+			}
+		}
+		return false
+	default:
 		if t.TaskRun == nil {
 			return false
 		}
@@ -135,12 +151,25 @@ func (t ResolvedPipelineRunTask) isFailure() bool {
 // is less than the number of retries allowed.
 func (t ResolvedPipelineRunTask) hasRemainingRetries() bool {
 	var retriesDone int
-	if t.IsCustomTask() {
+	switch {
+	case t.IsCustomTask():
 		if t.Run == nil {
 			return true
 		}
 		retriesDone = len(t.Run.Status.RetriesStatus)
-	} else {
+	case t.IsMatrixed():
+		if len(t.TaskRuns) == 0 {
+			return true
+		}
+		// has remaining retries when any TaskRun has a remaining retry
+		for _, taskRun := range t.TaskRuns {
+			retriesDone = len(taskRun.Status.RetriesStatus)
+			if retriesDone < t.PipelineTask.Retries {
+				return true
+			}
+		}
+		return false
+	default:
 		if t.TaskRun == nil {
 			return true
 		}
@@ -151,18 +180,32 @@ func (t ResolvedPipelineRunTask) hasRemainingRetries() bool {
 
 // isCancelled returns true only if the run is cancelled
 func (t ResolvedPipelineRunTask) isCancelled() bool {
-	if t.IsCustomTask() {
+	switch {
+	case t.IsCustomTask():
 		if t.Run == nil {
 			return false
 		}
 		c := t.Run.Status.GetCondition(apis.ConditionSucceeded)
 		return c != nil && c.IsFalse() && c.Reason == v1alpha1.RunReasonCancelled
-	}
-	if t.TaskRun == nil {
+	case t.IsMatrixed():
+		if len(t.TaskRuns) == 0 {
+			return false
+		}
+		// is cancelled when any TaskRun is cancelled to fail fast
+		for _, taskRun := range t.TaskRuns {
+			c := taskRun.Status.GetCondition(apis.ConditionSucceeded)
+			if c != nil && c.IsFalse() && c.Reason == v1beta1.TaskRunReasonCancelled.String() {
+				return true
+			}
+		}
 		return false
+	default:
+		if t.TaskRun == nil {
+			return false
+		}
+		c := t.TaskRun.Status.GetCondition(apis.ConditionSucceeded)
+		return c != nil && c.IsFalse() && c.Reason == v1beta1.TaskRunReasonCancelled.String()
 	}
-	c := t.TaskRun.Status.GetCondition(apis.ConditionSucceeded)
-	return c != nil && c.IsFalse() && c.Reason == v1beta1.TaskRunReasonCancelled.String()
 }
 
 // isStarted returns true only if the PipelineRunTask itself has a TaskRun or


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In this change, we add `TaskRuns` field to `ResolvedPipelineRunTask` alongside the `TaskRun` field.
- When a `PipelineTask` does not have a `Matrix`, the `TaskRun` field is populated (as is already being done, no change here).
- When a `PipelineTask` has a `Matrix`, `TaskRuns` will be populated to track all `TaskRuns` from a given matrixed `ResolvedPipelineRunTask`.

When we promote `Matrix` to Beta, we could remove `TaskRun` field and  migrate to using `TaskRuns` field only where it would have one `TaskRun` only when the `PipelineTask` does not have a `Matrix`. However, the current separation is helpful to isolate the Matrix feature in  alpha.

In this change, we also implement the `isFailure` and other member functions of `ResolvedPipelineRunTask` that `isFailure` uses: `isCancelled` and `hasRemainingRetries`. The failure strategy in `Matrix` is to fail fast. We can explore other failure strategies, if needed, before promoting to Beta.


[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```