### PR TITLE
Only create & mount Downward API volume when necessary

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -44,6 +44,14 @@ data:
   # See https://github.com/tektoncd/pipeline/issues/2791 for more
   # info.
   disable-creds-init: "false"
+  # Setting this flag to "false" will stop Tekton from waiting for a
+  # TaskRun's sidecar containers to be running before starting the first
+  # step. This will allow Tasks to be run in environments that don't
+  # support the DownwardAPI volume type, but may lead to unintended
+  # behaviour if sidecars are used.
+  #
+  # See https://github.com/tektoncd/pipeline/issues/4937 for more info.
+  await-sidecar-readiness: "true"
   # This option should be set to false when Pipelines is running in a
   # cluster that does not use injected sidecars such as Istio. Setting
   # it to false should decrease the time it takes for a TaskRun to start

--- a/docs/install.md
+++ b/docs/install.md
@@ -355,11 +355,18 @@ To customize the behavior of the Pipelines Controller, modify the ConfigMap `fea
   node in the cluster must have an appropriate label matching `topologyKey`. If some or all nodes
   are missing the specified `topologyKey` label, it can lead to unintended behavior.
 
-- `running-in-environment-with-injected-sidecars`: set this flag to `"true"` to allow the
-Tekton controller to set the `tekton.dev/ready` annotation at pod creation time for
-TaskRuns with no Sidecars specified. Enabling this option should decrease the time it takes for a TaskRun to
-start running. However, for clusters that use injected sidecars e.g. istio
-enabling this option can lead to unexpected behavior.
+- `await-sidecar-readiness`: set this flag to `"false"` to allow the Tekton controller to start a
+TasksRun's first step immediately without waiting for sidecar containers to be running first. Using
+this option should decrease the time it takes for a TaskRun to start running, and will allow TaskRun
+pods to be scheduled in environments that don't support [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)
+volumes (e.g. some virtual kubelet implementations). However, this may lead to unexpected behaviour
+with Tasks that use sidecars, or in clusters that use injected sidecars (e.g. Istio). Setting this flag
+to `"false"` will mean the `running-in-environment-with-injected-sidecars` flag has no effect.
+
+- `running-in-environment-with-injected-sidecars`: set this flag to `"false"` to allow the
+Tekton controller to start a TasksRun's first step immediately if it has no Sidecars specified.
+Using this option should decrease the time it takes for a TaskRun to start running.
+However, for clusters that use injected sidecars (e.g. Istio) this can lead to unexpected behavior.
 
 - `require-git-ssh-secret-known-hosts`: set this flag to `"true"` to require that
 Git SSH Secrets include a `known_hosts` field. This ensures that a git remote server's

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -45,6 +45,8 @@ const (
 	DefaultDisableCredsInit = false
 	// DefaultRunningInEnvWithInjectedSidecars is the default value for "running-in-environment-with-injected-sidecars".
 	DefaultRunningInEnvWithInjectedSidecars = true
+	// DefaultAwaitSidecarReadiness is the default value for "await-sidecar-readiness".
+	DefaultAwaitSidecarReadiness = true
 	// DefaultRequireGitSSHSecretKnownHosts is the default value for "require-git-ssh-secret-known-hosts".
 	DefaultRequireGitSSHSecretKnownHosts = false
 	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
@@ -61,6 +63,7 @@ const (
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
 	runningInEnvWithInjectedSidecarsKey = "running-in-environment-with-injected-sidecars"
+	awaitSidecarReadinessKey            = "await-sidecar-readiness"
 	requireGitSSHSecretKnownHostsKey    = "require-git-ssh-secret-known-hosts" // nolint: gosec
 	enableTektonOCIBundles              = "enable-tekton-oci-bundles"
 	enableCustomTasks                   = "enable-custom-tasks"
@@ -81,6 +84,7 @@ type FeatureFlags struct {
 	ScopeWhenExpressionsToTask       bool
 	EnableAPIFields                  string
 	SendCloudEventsForRuns           bool
+	AwaitSidecarReadiness            bool
 	EmbeddedStatus                   string
 }
 
@@ -116,6 +120,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setFeature(runningInEnvWithInjectedSidecarsKey, DefaultRunningInEnvWithInjectedSidecars, &tc.RunningInEnvWithInjectedSidecars); err != nil {
+		return nil, err
+	}
+	if err := setFeature(awaitSidecarReadinessKey, DefaultAwaitSidecarReadiness, &tc.AwaitSidecarReadiness); err != nil {
 		return nil, err
 	}
 	if err := setFeature(requireGitSSHSecretKnownHostsKey, DefaultRequireGitSSHSecretKnownHosts, &tc.RequireGitSSHSecretKnownHosts); err != nil {

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -35,9 +35,17 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 	testCases := []testCase{
 		{
 			expectedConfig: &config.FeatureFlags{
-				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
-				EnableAPIFields:                  "stable",
-				EmbeddedStatus:                   config.DefaultEmbeddedStatus,
+				DisableAffinityAssistant:         false,
+				RunningInEnvWithInjectedSidecars: true,
+				RequireGitSSHSecretKnownHosts:    false,
+
+				DisableCredsInit:       config.DefaultDisableCredsInit,
+				AwaitSidecarReadiness:  config.DefaultAwaitSidecarReadiness,
+				EnableTektonOCIBundles: config.DefaultEnableTektonOciBundles,
+				EnableCustomTasks:      config.DefaultEnableCustomTasks,
+				EnableAPIFields:        config.DefaultEnableAPIFields,
+				SendCloudEventsForRuns: config.DefaultSendCloudEventsForRuns,
+				EmbeddedStatus:         config.DefaultEmbeddedStatus,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -45,6 +53,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.FeatureFlags{
 				DisableAffinityAssistant:         true,
 				RunningInEnvWithInjectedSidecars: false,
+				AwaitSidecarReadiness:            false,
 				RequireGitSSHSecretKnownHosts:    true,
 				EnableTektonOCIBundles:           true,
 				EnableCustomTasks:                true,
@@ -62,7 +71,12 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableTektonOCIBundles: true,
 				EnableCustomTasks:      true,
 
+				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
+				DisableCredsInit:                 config.DefaultDisableCredsInit,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+				RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
+				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 				EmbeddedStatus:                   config.DefaultEmbeddedStatus,
 			},
 			fileName: "feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks",
@@ -73,7 +87,12 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableTektonOCIBundles: true,
 				EnableCustomTasks:      true,
 
+				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
+				DisableCredsInit:                 config.DefaultDisableCredsInit,
 				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+				RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
+				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 				EmbeddedStatus:                   config.DefaultEmbeddedStatus,
 			},
 			fileName: "feature-flags-bundles-and-custom-tasks",
@@ -92,8 +111,15 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 	FeatureFlagsConfigEmptyName := "feature-flags-empty"
 	expectedConfig := &config.FeatureFlags{
-		RunningInEnvWithInjectedSidecars: true,
-		EnableAPIFields:                  "stable",
+		DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
+		DisableCredsInit:                 config.DefaultDisableCredsInit,
+		RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+		AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+		RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
+		EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
+		EnableCustomTasks:                config.DefaultEnableCustomTasks,
+		EnableAPIFields:                  config.DefaultEnableAPIFields,
+		SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 		EmbeddedStatus:                   config.DefaultEmbeddedStatus,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -20,6 +20,7 @@ metadata:
 data:
   disable-affinity-assistant: "true"
   running-in-environment-with-injected-sidecars: "false"
+  await-sidecar-readiness: "false"
   require-git-ssh-secret-known-hosts: "true"
   enable-tekton-oci-bundles: "true"
   enable-custom-tasks: "true"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Addresses #4937

  - [X] Instead of always mounting a Downward API volume for reading the "ready" annotation on task Pods, we only create it if the pod will not be "immediately ready" (i.e. if it has sidecars).
  - [X] Add new `await-sidecar-readiness` feature flag, defaulted to `true`. Tasks will always be considered "immediately ready" if this is `false`.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [X] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Added an `await-sidecar-readiness` feature flag, which can be used to remove the of DownwardAPI volumes in TaskRun pods. (#4953, @hWorblehat)
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Added an 'await-sidecar-readiness' feature flag, which can be used to remove the of DownwardAPI volumes in TaskRun pods.
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
