### PR TITLE
Validation for invalid Task Result expressions in Pipeline Result

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -253,17 +253,20 @@ func validatePipelineResults(results []PipelineResult) (errs *apis.FieldError) {
 	for idx, result := range results {
 		expressions, ok := GetVarSubstitutionExpressionsForPipelineResult(result)
 		if !ok {
-			errs = errs.Also(apis.ErrInvalidValue("expected pipeline results to be task result expressions but no expressions were found",
+			return errs.Also(apis.ErrInvalidValue("expected pipeline results to be task result expressions but no expressions were found",
 				"value").ViaFieldIndex("results", idx))
 		}
 
-		if LooksLikeContainsResultRefs(expressions) {
-			expressions = filter(expressions, looksLikeResultRef)
-			resultRefs := NewResultRefs(expressions)
-			if len(expressions) != len(resultRefs) {
-				errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("expected all of the expressions %v to be result expressions but only %v were", expressions, resultRefs),
-					"value").ViaFieldIndex("results", idx))
-			}
+		if !LooksLikeContainsResultRefs(expressions) {
+			return errs.Also(apis.ErrInvalidValue("expected pipeline results to be task result expressions but an invalid expressions was found",
+				"value").ViaFieldIndex("results", idx))
+		}
+
+		expressions = filter(expressions, looksLikeResultRef)
+		resultRefs := NewResultRefs(expressions)
+		if len(expressions) != len(resultRefs) {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("expected all of the expressions %v to be result expressions but only %v were", expressions, resultRefs),
+				"value").ViaFieldIndex("results", idx))
 		}
 
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1135,6 +1135,17 @@ func TestValidatePipelineResults_Failure(t *testing.T) {
 			Message: `invalid value: expected pipeline results to be task result expressions but no expressions were found`,
 			Paths:   []string{"results[0].value"},
 		},
+	}, {
+		desc: "invalid pipeline result value with invalid expression",
+		results: []PipelineResult{{
+			Name:        "my-pipeline-result",
+			Description: "this is my pipeline result",
+			Value:       "$(foo.bar)",
+		}},
+		expectedError: apis.FieldError{
+			Message: `invalid value: expected pipeline results to be task result expressions but an invalid expressions was found`,
+			Paths:   []string{"results[0].value"},
+		},
 	}}
 	for _, tt := range tests {
 		err := validatePipelineResults(tt.results)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit, the validation for invalid `Task Result` expressions
in `Pipeline` `Result`'s was not extensive.

This commit adds the case where a `Pipeline` would be invalid if there is
no expression following the valid form `$(tasks.<task-name>.results.<result-name>)`.

Please reference this [doc](https://github.com/tektoncd/pipeline/blob/main/docs/pipelines.md#emitting-results-from-a-pipeline) for more information.

Fixes bug [#4922](https://github.com/tektoncd/pipeline/issues/4922)

/kind bug
/cc @jerop


<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Fixed a bug where invalid expressions were not invalidated in `Pipeline Results`.
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
