### PR TITLE
Sort slice of `TaskRunNames` in tests

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -624,8 +624,8 @@ func GetTaskRunName(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus,
 	return kmeta.ChildName(prName, fmt.Sprintf("-%s", ptName))
 }
 
-// GetNamesofTaskRuns should return unique names for `TaskRuns` if one has not already been defined, and the existing one otherwise.
-func GetNamesofTaskRuns(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus, childRefs []v1beta1.ChildStatusReference, ptName, prName string, combinationCount int) []string {
+// GetNamesOfTaskRuns should return unique names for `TaskRuns` if one has not already been defined, and the existing one otherwise.
+func GetNamesOfTaskRuns(taskRunsStatus map[string]*v1beta1.PipelineRunTaskRunStatus, childRefs []v1beta1.ChildStatusReference, ptName, prName string, combinationCount int) []string {
 	var taskRunNames []string
 	if taskRunNames = getTaskRunNamesFromChildRefs(childRefs, ptName); taskRunNames != nil {
 		return taskRunNames

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -2782,7 +2783,7 @@ func TestGetTaskRunName(t *testing.T) {
 	}
 }
 
-func TestGetTaskRunNames(t *testing.T) {
+func TestGetNamesOfTaskRuns(t *testing.T) {
 	prName := "mypipelinerun"
 	taskRunsStatus := map[string]*v1beta1.PipelineRunTaskRunStatus{
 		"mypipelinerun-mytask-0": {
@@ -2836,8 +2837,8 @@ func TestGetTaskRunNames(t *testing.T) {
 		ptName: "task2-0123456789-0123456789-0123456789-0123456789-0123456789",
 		prName: "pipeline-run-0123456789-0123456789-0123456789-0123456789",
 		wantTrNames: []string{
-			"pipeline-run-0123456789-01234569d54677e88e96776942290e00b578ca5",
 			"pipeline-run-0123456789-01234563c0313c59d28c85a2c2b3fd3b17a9514",
+			"pipeline-run-0123456789-01234569d54677e88e96776942290e00b578ca5",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2845,12 +2846,14 @@ func TestGetTaskRunNames(t *testing.T) {
 			if tc.prName != "" {
 				testPrName = tc.prName
 			}
-			trNameFromTRStatus := GetNamesofTaskRuns(taskRunsStatus, nil, tc.ptName, testPrName, 2)
-			if d := cmp.Diff(tc.wantTrNames, trNameFromTRStatus); d != "" {
+			namesOfTaskRunsFromTaskRunsStatus := GetNamesOfTaskRuns(taskRunsStatus, nil, tc.ptName, testPrName, 2)
+			sort.Strings(namesOfTaskRunsFromTaskRunsStatus)
+			if d := cmp.Diff(tc.wantTrNames, namesOfTaskRunsFromTaskRunsStatus); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
 			}
-			trNameFromChildRefs := GetNamesofTaskRuns(nil, childRefs, tc.ptName, testPrName, 2)
-			if d := cmp.Diff(tc.wantTrNames, trNameFromChildRefs); d != "" {
+			namesOfTaskRunsFromChildRefs := GetNamesOfTaskRuns(nil, childRefs, tc.ptName, testPrName, 2)
+			sort.Strings(namesOfTaskRunsFromChildRefs)
+			if d := cmp.Diff(tc.wantTrNames, namesOfTaskRunsFromChildRefs); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

`GetNamesOfTaskRuns` returns a slice of the names of `TaskRuns` and the order is not guaranteed - this causes issues with cmp.diff that makes the tests flakey.

In this change, we sort the slice of `TaskRunNames` so that they can be compared in tests.

In this change, we also rename related function names and variables for clarify.


/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```