### PR TITLE
Add details to `isFailure` docstring

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -108,6 +108,7 @@ func (t ResolvedPipelineRunTask) isSuccessful() bool {
 }
 
 // isFailure returns true only if the run has failed and will not be retried.
+// If the PipelineTask has a Matrix, isFailure returns true if any run has failed and will not be retried.
 func (t ResolvedPipelineRunTask) isFailure() bool {
 	if t.isCancelled() {
 		return true
@@ -129,7 +130,6 @@ func (t ResolvedPipelineRunTask) isFailure() bool {
 		if len(t.TaskRuns) == 0 {
 			return false
 		}
-		// is failed on the first failure with no remaining retries to fail fast
 		for _, taskRun := range t.TaskRuns {
 			c = taskRun.Status.GetCondition(apis.ConditionSucceeded)
 			isDone = taskRun.IsDone()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In this change, we add details to `isFailure` to address how it handles `Matrix`. We also remove the the inline comment that may be confusing.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```