### PR TITLE
TEP-0090: Failure Strategies - Remove Fail Fast

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1120,12 +1120,12 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "one matrixed taskruns failed",
+		name: "one matrixed taskrun failed, one matrixed taskrun running",
 		rprt: ResolvedPipelineRunTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
 		},
-		want: true,
+		want: false,
 	}, {
 		name: "matrixed taskruns failed: retries remaining",
 		rprt: ResolvedPipelineRunTask{
@@ -1155,12 +1155,12 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "one matrixed taskrun cancelled",
+		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
 		rprt: ResolvedPipelineRunTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
 		},
-		want: true,
+		want: false,
 	}, {
 		name: "matrixed taskruns cancelled but not failed",
 		rprt: ResolvedPipelineRunTask{
@@ -1183,12 +1183,12 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "one matrixed taskrun cancelled: retries remaining",
+		name: "one matrixed taskrun cancelled: retries remaining, one matrixed taskrun running",
 		rprt: ResolvedPipelineRunTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
 		},
-		want: true,
+		want: false,
 	}, {
 		name: "matrixed taskruns cancelled: no retries remaining",
 		rprt: ResolvedPipelineRunTask{
@@ -1197,12 +1197,12 @@ func TestIsFailure(t *testing.T) {
 		},
 		want: true,
 	}, {
-		name: "one matrixed taskrun cancelled: no retries remaining",
+		name: "one matrixed taskrun cancelled: no retries remaining, one matrixed taskrun running",
 		rprt: ResolvedPipelineRunTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), makeStarted(trs[1])},
 		},
-		want: true,
+		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.rprt.isFailure(); got != tc.want {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In https://github.com/tektoncd/pipeline/pull/4951, we implemented `isFailure` for matrixed `TaskRuns` where we applied fail-fast failure strategy. We discussed failure strategies further in this PR - https://github.com/tektoncd/community/pull/724 - and API WG on 13 June 2022. We agreed to leave early termination upon failure out of scope for the initial release of Matrix. We plan to explore failure strategies, including fail-fast, in future work. And these failure strategies may apply more broadly beyond Matrix.

In this change, we update `isFailure` to evaluate to `true` only when there's a failure and there are no running `TaskRuns` in the `rprt`.

/kind feature 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```