### PR TITLE
`isFailure` includes `isCancelled`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -86,7 +86,7 @@ func (t ResolvedPipelineRunTask) isRunning() bool {
 			return false
 		}
 	}
-	return !t.isSuccessful() && !t.isFailure() && !t.isCancelled()
+	return !t.isSuccessful() && !t.isFailure()
 }
 
 // IsCustomTask returns true if the PipelineTask references a Custom Task.

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -339,9 +339,6 @@ func (state PipelineRunState) getRetryableTasks(candidateTasks sets.String) []*R
 func (facts *PipelineRunFacts) IsStopping() bool {
 	for _, t := range facts.State {
 		if facts.isDAGTask(t.PipelineTask.Name) {
-			if t.isCancelled() {
-				return true
-			}
 			if t.isFailure() {
 				return true
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

`isFailure` includes `isCancelled`, but some functions are calling these `isFailure` and `isCancelled` separately.

https://github.com/tektoncd/pipeline/blob/43b733028e441be2f88362c1369fed2d3dddadd7/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L112-L115

This change removes the separate calls to `isCancelled` where `isFailure` already exists.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```