### PR TITLE
Test `isSuccessful`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -3000,3 +3000,171 @@ func TestIsMatrixed(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSuccessful(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rprt ResolvedPipelineRunTask
+		want bool
+	}{{
+		name: "taskrun not started",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+		},
+		want: false,
+	}, {
+		name: "run not started",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+		},
+		want: false,
+	}, {
+		name: "taskrun running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRun:      makeStarted(trs[0]),
+		},
+		want: false,
+	}, {
+
+		name: "run running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+			Run:          makeRunStarted(runs[0]),
+		},
+		want: false,
+	}, {
+		name: "taskrun succeeded",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRun:      makeSucceeded(trs[0]),
+		},
+		want: true,
+	}, {
+
+		name: "run succeeded",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+			Run:          makeRunSucceeded(runs[0]),
+		},
+		want: true,
+	}, {
+		name: "taskrun failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRun:      makeFailed(trs[0]),
+		},
+		want: false,
+	}, {
+
+		name: "run failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			CustomTask:   true,
+			Run:          makeRunFailed(runs[0]),
+		},
+		want: false,
+	}, {
+		name: "taskrun failed: retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			TaskRun:      makeFailed(trs[0]),
+		},
+		want: false,
+	}, {
+
+		name: "run failed: retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			CustomTask:   true,
+			Run:          makeRunFailed(runs[0]),
+		},
+		want: false,
+	}, {
+		name: "taskrun failed: no retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			TaskRun:      withRetries(makeFailed(trs[0])),
+		},
+		want: false,
+	}, {
+
+		name: "run failed: no retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			CustomTask:   true,
+			Run:          withRunRetries(makeRunFailed(runs[0])),
+		},
+		want: false,
+	}, {
+		name: "taskrun cancelled",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRun:      withCancelled(makeFailed(trs[0])),
+		},
+		want: false,
+	}, {
+		name: "taskrun cancelled but not failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			TaskRun:      withCancelled(newTaskRun(trs[0])),
+		},
+		want: false,
+	}, {
+		name: "run cancelled",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			Run:          withRunCancelled(makeRunFailed(runs[0])),
+			CustomTask:   true,
+		},
+		want: false,
+	}, {
+		name: "run cancelled but not failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task"},
+			Run:          withRunCancelled(newRun(runs[0])),
+			CustomTask:   true,
+		},
+		want: false,
+	}, {
+		name: "taskrun cancelled: retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			TaskRun:      withCancelled(makeFailed(trs[0])),
+		},
+		want: false,
+	}, {
+		name: "run cancelled: retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			Run:          withRunCancelled(makeRunFailed(runs[0])),
+			CustomTask:   true,
+		},
+		want: false,
+	}, {
+		name: "taskrun cancelled: no retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			TaskRun:      withCancelled(withRetries(makeFailed(trs[0]))),
+		},
+		want: false,
+	}, {
+		name: "run cancelled: no retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: &v1beta1.PipelineTask{Name: "task", Retries: 1},
+			Run:          withRunCancelled(withRunRetries(makeRunFailed(runs[0]))),
+			CustomTask:   true,
+		},
+		want: false,
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.rprt.isSuccessful(); got != tc.want {
+				t.Errorf("expected isSuccessful: %t but got %t", tc.want, got)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

`isSuccessful` is an unexported function, so it did not have tests
per the in [guidelines][guidelines]. The recommendation is to not
test unexported function, and if needed to move the function into
a package, test it then export the function. However, this is hard
to do for the resources package because of cyclic dependencies. We
already have tests for another unexported function - `isFailure` -
and discussions to make exceptions for that guideline are ongoing.

In this change, we add tests for `isSuccessful` to ensure it works
as expected, as we prepare to make changes to the function to support
`Matrix`.

[guidelines]: https://github.com/tektoncd/community/blob/ac0ae1b304ef515e8099f772f42b91aac1b26e6b/standards.md#tests

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```