### PR TITLE
TEP-0090: Matrix - Implement `isSuccessful`

### DIFF
--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -201,7 +201,7 @@ func (r *Run) HasStarted() bool {
 
 // IsSuccessful returns true if the Run's status indicates that it is done.
 func (r *Run) IsSuccessful() bool {
-	return r.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+	return r != nil && r.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 }
 
 // GetRunKey return the run's key for timeout handler map

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -414,7 +414,7 @@ func (tr *TaskRun) HasStarted() bool {
 
 // IsSuccessful returns true if the TaskRun's status indicates that it is done.
 func (tr *TaskRun) IsSuccessful() bool {
-	return tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
+	return tr != nil && tr.Status.GetCondition(apis.ConditionSucceeded).IsTrue()
 }
 
 // IsCancelled returns true if the TaskRun's spec status is set to Cancelled state

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -100,11 +100,24 @@ func (t ResolvedPipelineRunTask) IsMatrixed() bool {
 }
 
 // isSuccessful returns true only if the run has completed successfully
+// If the PipelineTask has a Matrix, isSuccessful returns true if all runs have completed successfully
 func (t ResolvedPipelineRunTask) isSuccessful() bool {
-	if t.IsCustomTask() {
-		return t.Run != nil && t.Run.IsSuccessful()
+	switch {
+	case t.IsCustomTask():
+		return t.Run.IsSuccessful()
+	case t.IsMatrixed():
+		if len(t.TaskRuns) == 0 {
+			return false
+		}
+		for _, taskRun := range t.TaskRuns {
+			if !taskRun.IsSuccessful() {
+				return false
+			}
+		}
+		return true
+	default:
+		return t.TaskRun.IsSuccessful()
 	}
-	return t.TaskRun != nil && t.TaskRun.IsSuccessful()
 }
 
 // isFailure returns true only if the run has failed and will not be retried.

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -3159,6 +3159,131 @@ func TestIsSuccessful(t *testing.T) {
 			CustomTask:   true,
 		},
 		want: false,
+	}, {
+		name: "matrixed taskruns not started",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeSucceeded(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns succeeded",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+		},
+		want: true,
+	}, {
+		name: "one matrixed taskrun succeeded",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun failed, one matrixed taskrun running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns failed: retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns failed: one taskrun with retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), withRetries(makeFailed(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns failed: no retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{withRetries(makeFailed(trs[0])), withRetries(makeFailed(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns cancelled",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns cancelled but not failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), withCancelled(newTaskRun(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun cancelled but not failed",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: matrixedPipelineTask,
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns cancelled: retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), withCancelled(makeFailed(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun cancelled: retries remaining, one matrixed taskrun running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed taskruns cancelled: no retries remaining",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), withCancelled(withRetries(makeFailed(trs[1])))},
+		},
+		want: false,
+	}, {
+		name: "one matrixed taskrun cancelled: no retries remaining, one matrixed taskrun running",
+		rprt: ResolvedPipelineRunTask{
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), makeStarted(trs[1])},
+		},
+		want: false,
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.rprt.isSuccessful(); got != tc.want {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In this change, we also implement the `isSuccessful` member function of `ResolvedPipelineRunTask`. 

If the `ResolvedPipelineRunTask` is matrixed, it is successful only if all of its `TaskRuns` completed successfully.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```