### PR TITLE
LimitRange calculation should only split Requests for Step Containers

### DIFF
--- a/pkg/internal/limitrange/transformer.go
+++ b/pkg/internal/limitrange/transformer.go
@@ -45,45 +45,32 @@ func NewTransformer(ctx context.Context, namespace string, lister corev1listers.
 
 		// The assumption here is that the min, max, default, ratio have already been
 		// computed if there is multiple LimitRange to satisfy the most (if we can).
-		// Count the number of containers (that we know) in the Pod.
+		// Count the number of "step" containers in the Pod.
 		// This should help us find the smallest request to apply to containers
-		nbContainers := len(p.Spec.Containers)
-		// FIXME(#4230) maxLimitRequestRatio to support later
-		defaultLimits := getDefaultLimits(limitRange)
-		defaultInitRequests := getDefaultInitContainerRequest(limitRange)
-		for i := range p.Spec.InitContainers {
-			// We are trying to set the smallest requests possible
-			if p.Spec.InitContainers[i].Resources.Requests == nil {
-				p.Spec.InitContainers[i].Resources.Requests = defaultInitRequests
-			} else {
-				for _, name := range resourceNames {
-					setRequestsOrLimits(name, p.Spec.InitContainers[i].Resources.Requests, defaultInitRequests)
-				}
-			}
-			// We are trying to set the highest limits possible
-			if p.Spec.InitContainers[i].Resources.Limits == nil {
-				p.Spec.InitContainers[i].Resources.Limits = defaultLimits
-			} else {
-				for _, name := range resourceNames {
-					setRequestsOrLimits(name, p.Spec.InitContainers[i].Resources.Limits, defaultLimits)
-				}
+		stepContainers := []*corev1.Container{}
+		for i, c := range p.Spec.Containers {
+			if pod.IsContainerStep(c.Name) {
+				stepContainers = append(stepContainers, &p.Spec.Containers[i])
 			}
 		}
+		// No step containers, bail early we don't have anything to transform.
+		if len(stepContainers) == 0 {
+			return p, nil
+		}
 
-		defaultRequests := getDefaultAppContainerRequest(limitRange, nbContainers)
-		for i := range p.Spec.Containers {
-			if p.Spec.Containers[i].Resources.Requests == nil {
-				p.Spec.Containers[i].Resources.Requests = defaultRequests
+		defaultStepRequests := getDefaultStepContainerRequest(limitRange, len(stepContainers))
+
+		// Empty LimitRange Requests, bail early we don't have anything to transform.
+		if len(defaultStepRequests) == 0 {
+			return p, nil
+		}
+
+		for _, c := range stepContainers {
+			if c.Resources.Requests == nil {
+				c.Resources.Requests = defaultStepRequests
 			} else {
 				for _, name := range resourceNames {
-					setRequestsOrLimits(name, p.Spec.Containers[i].Resources.Requests, defaultRequests)
-				}
-			}
-			if p.Spec.Containers[i].Resources.Limits == nil {
-				p.Spec.Containers[i].Resources.Limits = defaultLimits
-			} else {
-				for _, name := range resourceNames {
-					setRequestsOrLimits(name, p.Spec.Containers[i].Resources.Limits, defaultLimits)
+					setRequests(name, c.Resources.Requests, defaultStepRequests)
 				}
 			}
 		}
@@ -91,52 +78,45 @@ func NewTransformer(ctx context.Context, namespace string, lister corev1listers.
 	}
 }
 
-func setRequestsOrLimits(name corev1.ResourceName, dst, src corev1.ResourceList) {
+func setRequests(name corev1.ResourceName, dst, src corev1.ResourceList) {
 	if isZero(dst[name]) && !isZero(src[name]) {
 		dst[name] = src[name]
 	}
 }
 
-// Returns the default requests to use for each app container, determined by dividing the LimitRange default requests
-// among the app containers, and applying the LimitRange minimum if necessary
-func getDefaultAppContainerRequest(limitRange *corev1.LimitRange, nbContainers int) corev1.ResourceList {
+// Returns the default requests to use for each step container, determined by dividing the LimitRange default requests
+// among the step containers, and applying the LimitRange minimum if necessary
+// FIXME(#4230) maxLimitRequestRatio to support later
+func getDefaultStepContainerRequest(limitRange *corev1.LimitRange, nbContainers int) corev1.ResourceList {
 	// Support only Type Container to start with
 	var r corev1.ResourceList = map[corev1.ResourceName]resource.Quantity{}
 	for _, item := range limitRange.Spec.Limits {
 		// Only support LimitTypeContainer
 		if item.Type == corev1.LimitTypeContainer {
 			for _, name := range resourceNames {
-				var defaultRequest resource.Quantity
-				var min resource.Quantity
+				// get previous request value if set
 				request := r[name]
+
+				var defaultRequest resource.Quantity
 				if item.DefaultRequest != nil {
 					defaultRequest = item.DefaultRequest[name]
 				}
+
+				var min resource.Quantity
 				if item.Min != nil {
 					min = item.Min[name]
 				}
-				if name == corev1.ResourceMemory || name == corev1.ResourceEphemeralStorage {
-					r[name] = takeTheMax(request, *resource.NewQuantity(defaultRequest.Value()/int64(nbContainers), defaultRequest.Format), min)
-				} else {
-					r[name] = takeTheMax(request, *resource.NewMilliQuantity(defaultRequest.MilliValue()/int64(nbContainers), defaultRequest.Format), min)
-				}
-			}
-		}
-	}
-	return r
-}
 
-// Returns the default requests to use for each init container, determined by the LimitRange default requests and minimums
-func getDefaultInitContainerRequest(limitRange *corev1.LimitRange) corev1.ResourceList {
-	// Support only Type Container to start with
-	var r corev1.ResourceList
-	for _, item := range limitRange.Spec.Limits {
-		// Only support LimitTypeContainer
-		if item.Type == corev1.LimitTypeContainer {
-			if item.DefaultRequest != nil {
-				r = item.DefaultRequest
-			} else if item.Min != nil {
-				r = item.Min
+				var result resource.Quantity
+				if name == corev1.ResourceMemory || name == corev1.ResourceEphemeralStorage {
+					result = takeTheMax(request, *resource.NewQuantity(defaultRequest.Value()/int64(nbContainers), defaultRequest.Format), min)
+				} else {
+					result = takeTheMax(request, *resource.NewMilliQuantity(defaultRequest.MilliValue()/int64(nbContainers), defaultRequest.Format), min)
+				}
+				// only set non-zero request values
+				if !isZero(result) {
+					r[name] = result
+				}
 			}
 		}
 	}
@@ -152,19 +132,4 @@ func takeTheMax(requestQ, defaultQ, maxQ resource.Quantity) resource.Quantity {
 		q = maxQ
 	}
 	return q
-}
-
-func getDefaultLimits(limitRange *corev1.LimitRange) corev1.ResourceList {
-	// Support only Type Container to start with
-	var l corev1.ResourceList
-	for _, item := range limitRange.Spec.Limits {
-		if item.Type == corev1.LimitTypeContainer {
-			if item.Default != nil {
-				l = item.Default
-			} else if item.Max != nil {
-				l = item.Max
-			}
-		}
-	}
-	return l
 }

--- a/pkg/internal/limitrange/transformer_test.go
+++ b/pkg/internal/limitrange/transformer_test.go
@@ -35,7 +35,7 @@ var resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
 	return x.Cmp(y) == 0
 })
 
-func TestTransformerOneContainer(t *testing.T) {
+func TestTransformerOneStepContainer(t *testing.T) {
 	for _, tc := range []struct {
 		description string
 		limitranges []corev1.LimitRangeItem
@@ -49,7 +49,7 @@ func TestTransformerOneContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -91,33 +91,18 @@ func TestTransformerOneContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.Quantity{},
-						corev1.ResourceMemory:           resource.Quantity{},
-						corev1.ResourceEphemeralStorage: resource.Quantity{},
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 		},
 	}, {
@@ -136,19 +121,14 @@ func TestTransformerOneContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
@@ -181,32 +161,18 @@ func TestTransformerOneContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
+				// Just requests set
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -216,7 +182,7 @@ func TestTransformerOneContainer(t *testing.T) {
 			}},
 		},
 	}, {
-		description: "limitRange with not default but min and max and no resources on containers",
+		description: "limitRange with no default but min and max and no resources on containers",
 		limitranges: []corev1.LimitRangeItem{{
 			Type: corev1.LimitTypeContainer,
 			Min: corev1.ResourceList{
@@ -236,32 +202,18 @@ func TestTransformerOneContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
+					// Just requests set
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -295,7 +247,7 @@ func TestTransformerOneContainer(t *testing.T) {
 				},
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
@@ -312,11 +264,9 @@ func TestTransformerOneContainer(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4"),
-						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU: resource.MustParse("4"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
@@ -365,32 +315,17 @@ func TestTransformerOneContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -437,7 +372,7 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -447,7 +382,7 @@ func TestTransformerMultipleContainer(t *testing.T) {
 					},
 				},
 			}, {
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
@@ -465,9 +400,8 @@ func TestTransformerMultipleContainer(t *testing.T) {
 					},
 				},
 			}, {
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 		},
 	}, {
@@ -495,40 +429,15 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.Quantity{},
-						corev1.ResourceMemory:           resource.Quantity{},
-						corev1.ResourceEphemeralStorage: resource.Quantity{},
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}, {
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.Quantity{},
-						corev1.ResourceMemory:           resource.Quantity{},
-						corev1.ResourceEphemeralStorage: resource.Quantity{},
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 		},
 	}, {
@@ -547,22 +456,17 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}, {
-				Name:  "bar",
+				Name:  "step-bar",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1000m"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
@@ -603,35 +507,20 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}, {
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -640,11 +529,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -654,7 +538,7 @@ func TestTransformerMultipleContainer(t *testing.T) {
 			}},
 		},
 	}, {
-		description: "limitRange with not default but min and max and no resources on containers",
+		description: "limitRange with no default but min and max and no resources on containers",
 		limitranges: []corev1.LimitRangeItem{{
 			Type: corev1.LimitTypeContainer,
 			Min: corev1.ResourceList{
@@ -674,35 +558,20 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}, {
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -711,11 +580,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -755,35 +619,20 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}, {
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("700m"),
 						corev1.ResourceMemory:           resource.MustParse("70Mi"),
@@ -792,15 +641,128 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("700m"),
 						corev1.ResourceMemory:           resource.MustParse("70Mi"),
 						corev1.ResourceEphemeralStorage: resource.MustParse("700Mi"),
+					},
+				},
+			}},
+		},
+	}, {
+		description: "limitRange with default requests and no resources on 2 step containers and a sidecar",
+		limitranges: []corev1.LimitRangeItem{{
+			Type: corev1.LimitTypeContainer,
+			DefaultRequest: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("1"),
+				corev1.ResourceMemory:           resource.MustParse("100Mi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+			},
+		}},
+		podspec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:  "bar",
+				Image: "foo",
+			}},
+			Containers: []corev1.Container{{
+				Name:  "step-foo",
+				Image: "baz",
+			}, {
+				Name:  "step-bar",
+				Image: "baz",
+			}, {
+				Name:  "sidecar-fizz",
+				Image: "baz",
+			}},
+		},
+		want: corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
+			}},
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+					},
+				},
+			}, {
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+					},
+				},
+			}, {
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
+			}},
+		},
+	}, {
+		description: "limitRange with default requests and no resources on 2 step containers and a sidecar with resources",
+		limitranges: []corev1.LimitRangeItem{{
+			Type: corev1.LimitTypeContainer,
+			DefaultRequest: corev1.ResourceList{
+				corev1.ResourceCPU:              resource.MustParse("1"),
+				corev1.ResourceMemory:           resource.MustParse("100Mi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+			},
+		}},
+		podspec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:  "bar",
+				Image: "foo",
+			}},
+			Containers: []corev1.Container{{
+				Name:  "step-foo",
+				Image: "baz",
+			}, {
+				Name:  "step-bar",
+				Image: "baz",
+			}, {
+				Name:  "sidecar-fizz",
+				Image: "baz",
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
+					},
+				},
+			}},
+		},
+		want: corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
+			}},
+			Containers: []corev1.Container{{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+					},
+				},
+			}, {
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:              resource.MustParse("500m"),
+						corev1.ResourceMemory:           resource.MustParse("50Mi"),
+						corev1.ResourceEphemeralStorage: *resource.NewQuantity(536870912, resource.BinarySI),
+					},
+				},
+			}, {
+				Resources: corev1.ResourceRequirements{
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
 			}},
@@ -898,32 +860,17 @@ func TestTransformerOneContainerMultipleLimitRange(t *testing.T) {
 				Image: "foo",
 			}},
 			Containers: []corev1.Container{{
-				Name:  "foo",
+				Name:  "step-foo",
 				Image: "baz",
 			}},
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				// No resources set
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),


### PR DESCRIPTION
# Changes
This commit changes  how resource requirements are calculated when one or more LimitRanges are present in the namespace where a TaskRun is.

We now will only transform "step" containers and exclude all other app containers (e.g. sidecars and any other containers) when splitting "requests" from LimitRanges. This behavior is "nearly" consistent with what the current docs say as the split request limits are referred to only with respect to Step containers but they still needed some updates (now included).

This commit also removes the setting of hard "limits" as splitting is not desired and the LimitRanger does this correctly already and we should not reimplement this logic ourselves.

All existing tests have been fixed and two additional tests have been added to verify behavior when a sidecar is present. In addition this patch has been manually tested in our development environment with live pipelines.

Fixes #4978

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Only use step containers for limitrange default request calculations
```