### PR TITLE
TEP-0090: Fan Out `TaskRuns`

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1012,17 +1012,19 @@ Task Runs:
 
 The name of the `TaskRuns` and `Runs` owned by a `PipelineRun`  are univocally associated to the owning resource.
 If a `PipelineRun` resource is deleted and created with the same name, the child `TaskRuns` will be created with the
-same name as before. The base format of the name is `<pipelinerun-name>-<pipelinetask-name>`. The name may vary
-according the logic of [`kmeta.ChildName`](https://pkg.go.dev/github.com/knative/pkg/kmeta#ChildName).
+same name as before. The base format of the name is `<pipelinerun-name>-<pipelinetask-name>`. If the `PipelineTask`
+has a `Matrix`, the name will have an int suffix with format `<pipelinerun-name>-<pipelinetask-name>-<combination-id>`.
+The name may vary according the logic of [`kmeta.ChildName`](https://pkg.go.dev/github.com/knative/pkg/kmeta#ChildName).
 
 Some examples:
 
-| `PipelineRun` Name       | `PipelineTask` Name          | `TaskRun` Name     |
-|--------------------------|------------------------------|--------------------|
-| pipeline-run             | task1                        | pipeline-run-task1 |
-| pipeline-run             | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-runee4a397d6eab67777d4e6f9991cd19e6-task2-0123456789-0 |
-| pipeline-run-0123456789-0123456789-0123456789-0123456789 | task3 | pipeline-run-0123456789-0123456789-0123456789-0123456789-task3 |
-| pipeline-run-0123456789-0123456789-0123456789-0123456789 | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b5c |
+| `PipelineRun` Name                                       | `PipelineTask` Name                                          | `TaskRun` Names                                                                        |
+|----------------------------------------------------------|--------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| pipeline-run                                             | task1                                                        | pipeline-run-task1                                                                     |
+| pipeline-run                                             | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-runee4a397d6eab67777d4e6f9991cd19e6-task2-0123456789-0                        |
+| pipeline-run-0123456789-0123456789-0123456789-0123456789 | task3                                                        | pipeline-run-0123456789-0123456789-0123456789-0123456789-task3                         |
+| pipeline-run-0123456789-0123456789-0123456789-0123456789 | task2-0123456789-0123456789-0123456789-0123456789-0123456789 | pipeline-run-0123456789-012345607ad8c7aac5873cdfabe472a68996b5c                        |
+| pipeline-run                                             | task4 (with 2x2 `Matrix`)                                    | pipeline-run-task1-0, pipeline-run-task1-2, pipeline-run-task1-3, pipeline-run-task1-4 |
 
 ## Cancelling a `PipelineRun`
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -310,7 +310,7 @@ func (pt *PipelineTask) validateMatrix(ctx context.Context) (errs *apis.FieldErr
 }
 
 func (pt *PipelineTask) validateMatrixCombinationsCount(ctx context.Context) (errs *apis.FieldError) {
-	matrixCombinationsCount := pt.getMatrixCombinationsCount()
+	matrixCombinationsCount := pt.GetMatrixCombinationsCount()
 	maxMatrixCombinationsCount := config.FromContextOrDefaults(ctx).Defaults.DefaultMaxMatrixCombinationsCount
 	if matrixCombinationsCount > maxMatrixCombinationsCount {
 		errs = errs.Also(apis.ErrOutOfBoundsValue(matrixCombinationsCount, 0, maxMatrixCombinationsCount, "matrix"))
@@ -318,7 +318,8 @@ func (pt *PipelineTask) validateMatrixCombinationsCount(ctx context.Context) (er
 	return errs
 }
 
-func (pt *PipelineTask) getMatrixCombinationsCount() int {
+// GetMatrixCombinationsCount returns the count of combinations of Parameters generated from the Matrix in PipelineTask.
+func (pt *PipelineTask) GetMatrixCombinationsCount() int {
 	if len(pt.Matrix) == 0 {
 		return 0
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -791,7 +791,7 @@ func TestPipelineTask_validateMatrix(t *testing.T) {
 	}
 }
 
-func TestPipelineTask_getMatrixCombinationsCount(t *testing.T) {
+func TestPipelineTask_GetMatrixCombinationsCount(t *testing.T) {
 	tests := []struct {
 		name                    string
 		pt                      *PipelineTask
@@ -860,8 +860,8 @@ func TestPipelineTask_getMatrixCombinationsCount(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if d := cmp.Diff(tt.matrixCombinationsCount, tt.pt.getMatrixCombinationsCount()); d != "" {
-				t.Errorf("PipelineTask.getMatrixCombinationsCount() errors diff %s", diff.PrintWantGot(d))
+			if d := cmp.Diff(tt.matrixCombinationsCount, tt.pt.GetMatrixCombinationsCount()); d != "" {
+				t.Errorf("PipelineTask.GetMatrixCombinationsCount() errors diff %s", diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 	listersv1alpha1 "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1alpha1"
 	listers "github.com/tektoncd/pipeline/pkg/client/listers/pipeline/v1beta1"
 	resourcelisters "github.com/tektoncd/pipeline/pkg/client/resource/listers/resource/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/matrix"
 	"github.com/tektoncd/pipeline/pkg/pipelinerunmetrics"
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events"
@@ -688,7 +690,8 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 		if rprt == nil || rprt.Skip(pipelineRunFacts).IsSkipped || rprt.IsFinallySkipped(pipelineRunFacts).IsSkipped {
 			continue
 		}
-		if rprt.IsCustomTask() {
+		switch {
+		case rprt.IsCustomTask():
 			if rprt.IsFinalTask(pipelineRunFacts) {
 				rprt.Run, err = c.createRun(ctx, rprt, pr, getFinallyTaskRunTimeout)
 			} else {
@@ -698,16 +701,27 @@ func (c *Reconciler) runNextSchedulableTask(ctx context.Context, pr *v1beta1.Pip
 				recorder.Eventf(pr, corev1.EventTypeWarning, "RunCreationFailed", "Failed to create Run %q: %v", rprt.RunName, err)
 				return fmt.Errorf("error creating Run called %s for PipelineTask %s from PipelineRun %s: %w", rprt.RunName, rprt.PipelineTask.Name, pr.Name, err)
 			}
-		} else {
+		case rprt.IsMatrixed():
 			if rprt.IsFinalTask(pipelineRunFacts) {
-				rprt.TaskRun, err = c.createTaskRun(ctx, rprt, pr, as.StorageBasePath(pr), getFinallyTaskRunTimeout)
+				rprt.TaskRuns, err = c.createTaskRuns(ctx, rprt, pr, as.StorageBasePath(pr), getFinallyTaskRunTimeout)
 			} else {
-				rprt.TaskRun, err = c.createTaskRun(ctx, rprt, pr, as.StorageBasePath(pr), getTaskRunTimeout)
+				rprt.TaskRuns, err = c.createTaskRuns(ctx, rprt, pr, as.StorageBasePath(pr), getTaskRunTimeout)
+			}
+			if err != nil {
+				recorder.Eventf(pr, corev1.EventTypeWarning, "TaskRunsCreationFailed", "Failed to create TaskRuns %q: %v", rprt.TaskRunNames, err)
+				return fmt.Errorf("error creating TaskRuns called %s for PipelineTask %s from PipelineRun %s: %w", rprt.TaskRunNames, rprt.PipelineTask.Name, pr.Name, err)
+			}
+		default:
+			if rprt.IsFinalTask(pipelineRunFacts) {
+				rprt.TaskRun, err = c.createTaskRun(ctx, rprt.TaskRunName, nil, rprt, pr, as.StorageBasePath(pr), getFinallyTaskRunTimeout)
+			} else {
+				rprt.TaskRun, err = c.createTaskRun(ctx, rprt.TaskRunName, nil, rprt, pr, as.StorageBasePath(pr), getTaskRunTimeout)
 			}
 			if err != nil {
 				recorder.Eventf(pr, corev1.EventTypeWarning, "TaskRunCreationFailed", "Failed to create TaskRun %q: %v", rprt.TaskRunName, err)
 				return fmt.Errorf("error creating TaskRun called %s for PipelineTask %s from PipelineRun %s: %w", rprt.TaskRunName, rprt.PipelineTask.Name, pr.Name, err)
 			}
+
 		}
 	}
 	return nil
@@ -750,10 +764,24 @@ func (c *Reconciler) updateRunsStatusDirectly(pr *v1beta1.PipelineRun) error {
 
 type getTimeoutFunc func(ctx context.Context, pr *v1beta1.PipelineRun, rprt *resources.ResolvedPipelineRunTask, c clock.PassiveClock) *metav1.Duration
 
-func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.ResolvedPipelineRunTask, pr *v1beta1.PipelineRun, storageBasePath string, getTimeoutFunc getTimeoutFunc) (*v1beta1.TaskRun, error) {
+func (c *Reconciler) createTaskRuns(ctx context.Context, rprt *resources.ResolvedPipelineRunTask, pr *v1beta1.PipelineRun, storageBasePath string, getTimeoutFunc getTimeoutFunc) ([]*v1beta1.TaskRun, error) {
+	var taskRuns []*v1beta1.TaskRun
+	matrixCombinations := matrix.FanOut(rprt.PipelineTask.Matrix).ToMap()
+	for i, taskRunName := range rprt.TaskRunNames {
+		params := matrixCombinations[strconv.Itoa(i)]
+		taskRun, err := c.createTaskRun(ctx, taskRunName, params, rprt, pr, storageBasePath, getTimeoutFunc)
+		if err != nil {
+			return nil, err
+		}
+		taskRuns = append(taskRuns, taskRun)
+	}
+	return taskRuns, nil
+}
+
+func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, params []v1beta1.Param, rprt *resources.ResolvedPipelineRunTask, pr *v1beta1.PipelineRun, storageBasePath string, getTimeoutFunc getTimeoutFunc) (*v1beta1.TaskRun, error) {
 	logger := logging.FromContext(ctx)
 
-	tr, _ := c.taskRunLister.TaskRuns(pr.Namespace).Get(rprt.TaskRunName)
+	tr, _ := c.taskRunLister.TaskRuns(pr.Namespace).Get(taskRunName)
 	if tr != nil {
 		// Don't modify the lister cache's copy.
 		tr = tr.DeepCopy()
@@ -767,16 +795,19 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 
 	rprt.PipelineTask = resources.ApplyPipelineTaskContexts(rprt.PipelineTask)
 	taskRunSpec := pr.GetTaskRunSpec(rprt.PipelineTask.Name)
+	if len(params) == 0 {
+		params = rprt.PipelineTask.Params
+	}
 	tr = &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            rprt.TaskRunName,
+			Name:            taskRunName,
 			Namespace:       pr.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(pr)},
 			Labels:          combineTaskRunAndTaskSpecLabels(pr, rprt.PipelineTask),
 			Annotations:     combineTaskRunAndTaskSpecAnnotations(pr, rprt.PipelineTask),
 		},
 		Spec: v1beta1.TaskRunSpec{
-			Params:             rprt.PipelineTask.Params,
+			Params:             params,
 			ServiceAccountName: taskRunSpec.TaskServiceAccountName,
 			Timeout:            getTimeoutFunc(ctx, pr, rprt, c.Clock),
 			PodTemplate:        taskRunSpec.TaskPodTemplate,
@@ -803,7 +834,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, rprt *resources.Resolved
 	}
 
 	resources.WrapSteps(&tr.Spec, rprt.PipelineTask, rprt.ResolvedTaskResources.Inputs, rprt.ResolvedTaskResources.Outputs, storageBasePath)
-	logger.Infof("Creating a new TaskRun object %s for pipeline task %s", rprt.TaskRunName, rprt.PipelineTask.Name)
+	logger.Infof("Creating a new TaskRun object %s for pipeline task %s", taskRunName, rprt.PipelineTask.Name)
 	return c.PipelineClientSet.TektonV1beta1().TaskRuns(pr.Namespace).Create(ctx, tr, metav1.CreateOptions{})
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -56,12 +56,12 @@ func (e *TaskNotFoundError) Error() string {
 	return fmt.Sprintf("Couldn't retrieve Task %q: %s", e.Name, e.Msg)
 }
 
-// ResolvedPipelineRunTask contains a Task and its associated TaskRun, if it
-// exists. TaskRun can be nil to represent there being no TaskRun.
+// ResolvedPipelineRunTask contains a PipelineTask and its associated TaskRun(s) or Runs, if they exist.
 type ResolvedPipelineRunTask struct {
-	TaskRunName string
-	TaskRun     *v1beta1.TaskRun
-	TaskRuns    []*v1beta1.TaskRun
+	TaskRunName  string
+	TaskRun      *v1beta1.TaskRun
+	TaskRunNames []string
+	TaskRuns     []*v1beta1.TaskRun
 	// If the PipelineTask is a Custom Task, RunName and Run will be set.
 	CustomTask            bool
 	RunName               string
@@ -523,14 +523,22 @@ func ResolvePipelineRunTask(
 		PipelineTask: &pipelineTask,
 	}
 	rprt.CustomTask = isCustomTask(ctx, rprt)
-	if rprt.IsCustomTask() {
+	switch {
+	case rprt.IsCustomTask():
 		rprt.RunName = getRunName(pipelineRun.Status.Runs, pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name)
 		run, err := getRun(rprt.RunName)
 		if err != nil && !kerrors.IsNotFound(err) {
 			return nil, fmt.Errorf("error retrieving Run %s: %w", rprt.RunName, err)
 		}
 		rprt.Run = run
-	} else {
+	case rprt.IsMatrixed():
+		rprt.TaskRunNames = GetNamesOfTaskRuns(pipelineRun.Status.TaskRuns, pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name, pipelineTask.GetMatrixCombinationsCount())
+		for _, taskRunName := range rprt.TaskRunNames {
+			if err := rprt.resolvePipelineRunTaskWithTaskRun(ctx, taskRunName, getTask, getTaskRun, pipelineTask, providedResources); err != nil {
+				return nil, err
+			}
+		}
+	default:
 		rprt.TaskRunName = GetTaskRunName(pipelineRun.Status.TaskRuns, pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name)
 		if err := rprt.resolvePipelineRunTaskWithTaskRun(ctx, rprt.TaskRunName, getTask, getTaskRun, pipelineTask, providedResources); err != nil {
 			return nil, err
@@ -554,10 +562,14 @@ func (t *ResolvedPipelineRunTask) resolvePipelineRunTaskWithTaskRun(
 		}
 	}
 	if taskRun != nil {
-		t.TaskRun = taskRun
+		if t.IsMatrixed() {
+			t.TaskRuns = append(t.TaskRuns, taskRun)
+		} else {
+			t.TaskRun = taskRun
+		}
 	}
 
-	if err := t.resolveTaskResources(ctx, getTask, pipelineTask, providedResources, t.TaskRun); err != nil {
+	if err := t.resolveTaskResources(ctx, getTask, pipelineTask, providedResources, taskRun); err != nil {
 		return err
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1682,10 +1682,20 @@ func TestResolvePipelineRun_PipelineTaskHasNoResources(t *testing.T) {
 }
 
 func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
-	pt := v1beta1.PipelineTask{
+	pts := []v1beta1.PipelineTask{{
 		Name:    "mytask1",
 		TaskRef: &v1beta1.TaskRef{Name: "task"},
-	}
+	}, {
+		Name:    "mytask2",
+		TaskRef: &v1beta1.TaskRef{Name: "task"},
+		Matrix: []v1beta1.Param{{
+			Name:  "foo",
+			Value: *v1beta1.NewArrayOrString("f", "o", "o"),
+		}, {
+			Name:  "bar",
+			Value: *v1beta1.NewArrayOrString("b", "a", "r"),
+		}},
+	}}
 	providedResources := map[string]*resourcev1alpha1.PipelineResource{}
 
 	// Return an error when the Task is retrieved, as if it didn't exist
@@ -1700,14 +1710,16 @@ func TestResolvePipelineRun_TaskDoesntExist(t *testing.T) {
 			Name: "pipelinerun",
 		},
 	}
-	_, err := ResolvePipelineRunTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt, providedResources)
-	switch err := err.(type) {
-	case nil:
-		t.Fatalf("Expected error getting non-existent Tasks for Pipeline %s but got none", p.Name)
-	case *TaskNotFoundError:
-		// expected error
-	default:
-		t.Fatalf("Expected specific error type returned by func for non-existent Task for Pipeline %s but got %s", p.Name, err)
+	for _, pt := range pts {
+		_, err := ResolvePipelineRunTask(context.Background(), pr, getTask, getTaskRun, nopGetRun, pt, providedResources)
+		switch err := err.(type) {
+		case nil:
+			t.Fatalf("Expected error getting non-existent Tasks for Pipeline %s but got none", p.Name)
+		case *TaskNotFoundError:
+			// expected error
+		default:
+			t.Fatalf("Expected specific error type returned by func for non-existent Task for Pipeline %s but got %s", p.Name, err)
+		}
 	}
 }
 
@@ -2996,6 +3008,111 @@ func TestIsMatrixed(t *testing.T) {
 			got := rprt.IsMatrixed()
 			if d := cmp.Diff(tc.want, got); d != "" {
 				t.Errorf("IsMatrixed: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestResolvePipelineRunTask_WithMatrix(t *testing.T) {
+	pipelineRunName := "pipelinerun"
+	pipelineTaskName := "pipelinetask"
+
+	pr := v1beta1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pipelineRunName,
+		},
+	}
+
+	var taskRuns []*v1beta1.TaskRun
+	var taskRunsNames []string
+	taskRunsMap := map[string]*v1beta1.TaskRun{}
+	for i := 0; i < 9; i++ {
+		trName := fmt.Sprintf("%s-%s-%d", pipelineRunName, pipelineTaskName, i)
+		tr := &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: trName,
+			},
+		}
+		taskRuns = append(taskRuns, tr)
+		taskRunsNames = append(taskRunsNames, trName)
+		taskRunsMap[trName] = tr
+	}
+
+	pts := []v1beta1.PipelineTask{{
+		Name: "pipelinetask",
+		TaskRef: &v1beta1.TaskRef{
+			Name: "my-task",
+		},
+		Matrix: []v1beta1.Param{{
+			Name:  "platform",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
+		}},
+	}, {
+		Name: "pipelinetask",
+		TaskRef: &v1beta1.TaskRef{
+			Name: "my-task",
+		},
+		Matrix: []v1beta1.Param{{
+			Name:  "platform",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"linux", "mac", "windows"}},
+		}, {
+			Name:  "browsers",
+			Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"chrome", "safari", "firefox"}},
+		}},
+	}}
+
+	rtr := &resources.ResolvedTaskResources{
+		TaskName: "task",
+		TaskSpec: &v1beta1.TaskSpec{Steps: []v1beta1.Step{{
+			Name: "step1",
+		}}},
+		Inputs:  map[string]*v1alpha1.PipelineResource{},
+		Outputs: map[string]*v1alpha1.PipelineResource{},
+	}
+
+	getTask := func(ctx context.Context, name string) (v1beta1.TaskObject, error) { return task, nil }
+	getTaskRun := func(name string) (*v1beta1.TaskRun, error) { return taskRunsMap[name], nil }
+	getRun := func(name string) (*v1alpha1.Run, error) { return &runs[0], nil }
+
+	for _, tc := range []struct {
+		name string
+		pt   v1beta1.PipelineTask
+		want *ResolvedPipelineRunTask
+	}{{
+		name: "task with matrix - single parameter",
+		pt:   pts[0],
+		want: &ResolvedPipelineRunTask{
+			TaskRunNames:          taskRunsNames[:3],
+			TaskRuns:              taskRuns[:3],
+			PipelineTask:          &pts[0],
+			ResolvedTaskResources: rtr,
+		},
+	}, {
+		name: "task with matrix - multiple parameters",
+		pt:   pts[1],
+		want: &ResolvedPipelineRunTask{
+			TaskRunNames:          taskRunsNames,
+			TaskRuns:              taskRuns,
+			PipelineTask:          &pts[1],
+			ResolvedTaskResources: rtr,
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			cfg := config.NewStore(logtesting.TestLogger(t))
+			cfg.OnConfigChanged(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
+				Data: map[string]string{
+					"enable-api-fields": "alpha",
+				},
+			})
+			ctx = cfg.ToContext(ctx)
+			rprt, err := ResolvePipelineRunTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, nil)
+			if err != nil {
+				t.Fatalf("Did not expect error when resolving PipelineRun: %v", err)
+			}
+			if d := cmp.Diff(tc.want, rprt); d != "" {
+				t.Errorf("Did not get expected ResolvePipelineRunTask with Matrix: %s", diff.PrintWantGot(d))
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

This change implements the fan out of `TaskRuns` from a `PipelineTask` with a `Matrix`. The fanned-out `TaskRuns` are executed in parallel.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
A `PipelineTask` with a `Matrix` is fanned out into parallel `TaskRuns` which are executed in parallel.
```