### PR TITLE
Add wlynch to entrypoint OWNERS

### DIFF
--- a/pkg/entrypoint/OWNERS
+++ b/pkg/entrypoint/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- wlynch
+labels:
+- area/entrypoint


### PR DESCRIPTION
# Changes

wlynch is a Pipelines reviewer with significant familiarity/contributions to the entrypoint.
(Author of #4352, #4278, and #4238--the last is entrypoint docs.)

Our [contributor ladder](https://github.com/tektoncd/community/blob/main/process.md#reviewer)
states that reviewers "Can be allowed to /approve pull requests in specific sub-directories of a project
(by maintainer discretion)". However, this isn't frequently done in Pipelines in practice.
This change will allow us to experiment with more directory-based permissions as a potential pathway
for growing reviewers and approvers for Pipelines.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```