### PR TITLE
Fix the release pipeline

### DIFF
--- a/tekton/release-pipeline.yaml
+++ b/tekton/release-pipeline.yaml
@@ -105,7 +105,7 @@ spec:
           workspace: workarea
           subpath: git
     - name: publish-images
-      runAfter: [build-base-image]
+      runAfter: [unit-tests, build]
       taskRef:
         name: publish-release
       params:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The build base image task has been removed from the release pipeline
however a dependency to it was left, which breaks the pipeline.

Run the image build and publish after unit and build tests have been
executed.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

/kind misc


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
