### PR TITLE
Refactor `GetChildReferences`

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -590,8 +590,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 	}
 
 	if cfg.FeatureFlags.EmbeddedStatus == config.MinimalEmbeddedStatus || cfg.FeatureFlags.EmbeddedStatus == config.BothEmbeddedStatus {
-		pr.Status.ChildReferences = pipelineRunFacts.State.GetChildReferences(v1beta1.SchemeGroupVersion.String(),
-			v1alpha1.SchemeGroupVersion.String())
+		pr.Status.ChildReferences = pipelineRunFacts.State.GetChildReferences()
 	}
 
 	pr.Status.SkippedTasks = pipelineRunFacts.GetSkippedTasks()

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -238,27 +238,24 @@ func (state PipelineRunState) GetRunsResults() map[string][]v1alpha1.RunResult {
 
 // GetChildReferences returns a slice of references, including version, kind, name, and pipeline task name, for all
 // TaskRuns and Runs in the state.
-func (state PipelineRunState) GetChildReferences(taskRunVersion string, runVersion string) []v1beta1.ChildStatusReference {
+func (state PipelineRunState) GetChildReferences() []v1beta1.ChildStatusReference {
 	var childRefs []v1beta1.ChildStatusReference
 
 	for _, rprt := range state {
-		if rprt.CustomTask {
-			childRefs = append(childRefs, rprt.getChildRefForRun(runVersion))
-		} else if rprt.TaskRun != nil {
-			childRefs = append(childRefs, rprt.getChildRefForTaskRun(taskRunVersion))
+		switch {
+		case rprt.Run != nil:
+			childRefs = append(childRefs, rprt.getChildRefForRun())
+		case rprt.TaskRun != nil:
+			childRefs = append(childRefs, rprt.getChildRefForTaskRun())
 		}
 	}
 	return childRefs
 }
 
-func (rprt *ResolvedPipelineRunTask) getChildRefForRun(runVersion string) v1beta1.ChildStatusReference {
-	if rprt.Run != nil {
-		runVersion = rprt.Run.APIVersion
-	}
-
+func (rprt *ResolvedPipelineRunTask) getChildRefForRun() v1beta1.ChildStatusReference {
 	return v1beta1.ChildStatusReference{
 		TypeMeta: runtime.TypeMeta{
-			APIVersion: runVersion,
+			APIVersion: rprt.Run.APIVersion,
 			Kind:       pipeline.RunControllerName,
 		},
 		Name:             rprt.RunName,
@@ -267,14 +264,10 @@ func (rprt *ResolvedPipelineRunTask) getChildRefForRun(runVersion string) v1beta
 	}
 }
 
-func (rprt *ResolvedPipelineRunTask) getChildRefForTaskRun(taskRunVersion string) v1beta1.ChildStatusReference {
-	if rprt.TaskRun != nil {
-		taskRunVersion = rprt.TaskRun.APIVersion
-	}
-
+func (rprt *ResolvedPipelineRunTask) getChildRefForTaskRun() v1beta1.ChildStatusReference {
 	return v1beta1.ChildStatusReference{
 		TypeMeta: runtime.TypeMeta{
-			APIVersion: taskRunVersion,
+			APIVersion: rprt.TaskRun.APIVersion,
 			Kind:       pipeline.TaskRunControllerName,
 		},
 		Name:             rprt.TaskRunName,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2442,14 +2442,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 					},
 				},
 			}},
-			childRefs: []v1beta1.ChildStatusReference{{
-				TypeMeta: runtime.TypeMeta{
-					APIVersion: "tekton.dev/v1alpha1",
-					Kind:       "Run",
-				},
-				Name:             "unresolved-custom-task-run",
-				PipelineTaskName: "unresolved-custom-task-1",
-			}},
+			childRefs: nil,
 		},
 		{
 			name: "single-task",
@@ -2576,7 +2569,7 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			childRefs := tc.state.GetChildReferences(v1beta1.SchemeGroupVersion.String(), v1alpha1.SchemeGroupVersion.String())
+			childRefs := tc.state.GetChildReferences()
 			if d := cmp.Diff(tc.childRefs, childRefs); d != "" {
 				t.Errorf("Didn't get expected child references for %s: %s", tc.name, diff.PrintWantGot(d))
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Prior to this change, `GetChildReferences` treated `TaskRuns` and `Runs` differently. It added a`ChildReference` only when a `TaskRun` was not nil, but did not do the check for `Runs`.

In this change, we consistently add `ChildReference` only when the `Run` or `TaskRun` is not nil.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```