### PR TITLE
TEP-0090: Matrix - `ChildReferences` for `TaskRuns`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -246,7 +246,11 @@ func (state PipelineRunState) GetChildReferences() []v1beta1.ChildStatusReferenc
 		case rprt.Run != nil:
 			childRefs = append(childRefs, rprt.getChildRefForRun())
 		case rprt.TaskRun != nil:
-			childRefs = append(childRefs, rprt.getChildRefForTaskRun())
+			childRefs = append(childRefs, rprt.getChildRefForTaskRun(rprt.TaskRun))
+		case len(rprt.TaskRuns) != 0:
+			for _, taskRun := range rprt.TaskRuns {
+				childRefs = append(childRefs, rprt.getChildRefForTaskRun(taskRun))
+			}
 		}
 	}
 	return childRefs
@@ -264,13 +268,13 @@ func (rprt *ResolvedPipelineRunTask) getChildRefForRun() v1beta1.ChildStatusRefe
 	}
 }
 
-func (rprt *ResolvedPipelineRunTask) getChildRefForTaskRun() v1beta1.ChildStatusReference {
+func (rprt *ResolvedPipelineRunTask) getChildRefForTaskRun(taskRun *v1beta1.TaskRun) v1beta1.ChildStatusReference {
 	return v1beta1.ChildStatusReference{
 		TypeMeta: runtime.TypeMeta{
-			APIVersion: rprt.TaskRun.APIVersion,
+			APIVersion: taskRun.APIVersion,
 			Kind:       pipeline.TaskRunControllerName,
 		},
-		Name:             rprt.TaskRunName,
+		Name:             taskRun.Name,
 		PipelineTaskName: rprt.PipelineTask.Name,
 		WhenExpressions:  rprt.PipelineTask.WhenExpressions,
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2565,6 +2565,94 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 				PipelineTaskName: "single-custom-task-1",
 			}},
 		},
+		{
+			name: "matrixed-task",
+			state: PipelineRunState{{
+				TaskRunName: "matrixed-task-run-0",
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "matrixed-task",
+					TaskRef: &v1beta1.TaskRef{
+						Name:       "task",
+						Kind:       "Task",
+						APIVersion: "v1beta1",
+					},
+					WhenExpressions: []v1beta1.WhenExpression{{
+						Input:    "foo",
+						Operator: selection.In,
+						Values:   []string{"foo", "bar"},
+					}},
+					Matrix: []v1beta1.Param{{
+						Name:  "foobar",
+						Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+					}, {
+						Name:  "quxbaz",
+						Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+					}},
+				},
+				TaskRuns: []*v1beta1.TaskRun{{
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+				}, {
+					TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+					ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+				}},
+			}},
+			childRefs: []v1beta1.ChildStatusReference{{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-0",
+				PipelineTaskName: "matrixed-task",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"foo", "bar"},
+				}},
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-1",
+				PipelineTaskName: "matrixed-task",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"foo", "bar"},
+				}},
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-2",
+				PipelineTaskName: "matrixed-task",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"foo", "bar"},
+				}},
+			}, {
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+					Kind:       "TaskRun",
+				},
+				Name:             "matrixed-task-run-3",
+				PipelineTaskName: "matrixed-task",
+				WhenExpressions: []v1beta1.WhenExpression{{
+					Input:    "foo",
+					Operator: selection.In,
+					Values:   []string{"foo", "bar"},
+				}},
+			}},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

This change implements fetching of `ChildReferences` for `TaskRuns` created from a matrixed `PipelineTask`.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```