### PR TITLE
Use ghcr.io/distroless/static as base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: gcr.io/distroless/static:nonroot
+defaultBaseImage: ghcr.io/distroless/static
 baseImageOverrides:
   # git-init uses a base image that includes Git, and supports running either
   # as root or as user nonroot with UID 65532.

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -80,7 +80,7 @@ spec:
       cp ${DOCKER_CONFIG} /workspace/docker-config.json
 
   - name: create-ko-yaml
-    image: golang:1.17.8
+    image: golang:1.18.3
     script: |
       #!/bin/sh
       set -ex
@@ -95,13 +95,13 @@ spec:
 
       # Combine Distroless with a Windows base image, used for the entrypoint image.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
-        gcr.io/distroless/static:nonroot \
-        mcr.microsoft.com/windows/nanoserver:1809 \
+        ghcr.io/distroless/static \
+        mcr.microsoft.com/windows/nanoserver:ltsc2022 \
         ${CONTAINER_REGISTRY}/$(params.package)/combined-base-image:latest)
 
       cat <<EOF > ${PROJECT_ROOT}/.ko.yaml
       # This matches the value configured in .ko.yaml
-      defaultBaseImage: gcr.io/distroless/static:nonroot
+      defaultBaseImage: ghcr.io/distroless/static
       baseImageOverrides:
         # Use the combined base image for images that should include Windows support.
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}


### PR DESCRIPTION
This also updates the Windows nanoserver base image used by the
entrypoint image, and updates the Go version used to build the combine
command to the latest Go release 1.18.3.

/kind misc

# Changes

The ghcr-distroless image is slightly smaller, and somewhat more well maintained than the gcr-distroless image at this time. Since the image contains almost nothing to begin with, there are no expected behavior changes expected as part of this upgrade.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

``` release-note
Images are based on ghcr.io/distroless/static, and the entrypoint image is updated to use nanoserver:ltsc2022 instead of :1809
```
