### PR TITLE
TEP-0090: Matrix - Max Matrix Combinations Count is 256

### DIFF
--- a/pkg/apis/config/default.go
+++ b/pkg/apis/config/default.go
@@ -39,6 +39,8 @@ const (
 	DefaultManagedByLabelValue = "tekton-pipelines"
 	// DefaultCloudEventSinkValue is the default value for cloud event sinks.
 	DefaultCloudEventSinkValue = ""
+	// DefaultMaxMatrixCombinationsCount is used when no max matrix combinations count is specified.
+	DefaultMaxMatrixCombinationsCount = 256
 
 	defaultTimeoutMinutesKey             = "default-timeout-minutes"
 	defaultServiceAccountKey             = "default-service-account"
@@ -88,16 +90,18 @@ func (cfg *Defaults) Equals(other *Defaults) bool {
 		other.DefaultPodTemplate.Equals(cfg.DefaultPodTemplate) &&
 		other.DefaultAAPodTemplate.Equals(cfg.DefaultAAPodTemplate) &&
 		other.DefaultCloudEventsSink == cfg.DefaultCloudEventsSink &&
-		other.DefaultTaskRunWorkspaceBinding == cfg.DefaultTaskRunWorkspaceBinding
+		other.DefaultTaskRunWorkspaceBinding == cfg.DefaultTaskRunWorkspaceBinding &&
+		other.DefaultMaxMatrixCombinationsCount == cfg.DefaultMaxMatrixCombinationsCount
 }
 
 // NewDefaultsFromMap returns a Config given a map corresponding to a ConfigMap
 func NewDefaultsFromMap(cfgMap map[string]string) (*Defaults, error) {
 	tc := Defaults{
-		DefaultTimeoutMinutes:      DefaultTimeoutMinutes,
-		DefaultServiceAccount:      DefaultServiceAccountValue,
-		DefaultManagedByLabelValue: DefaultManagedByLabelValue,
-		DefaultCloudEventsSink:     DefaultCloudEventSinkValue,
+		DefaultTimeoutMinutes:             DefaultTimeoutMinutes,
+		DefaultServiceAccount:             DefaultServiceAccountValue,
+		DefaultManagedByLabelValue:        DefaultManagedByLabelValue,
+		DefaultCloudEventsSink:            DefaultCloudEventSinkValue,
+		DefaultMaxMatrixCombinationsCount: DefaultMaxMatrixCombinationsCount,
 	}
 
 	if defaultTimeoutMin, ok := cfgMap[defaultTimeoutMinutesKey]; ok {

--- a/pkg/apis/config/default_test.go
+++ b/pkg/apis/config/default_test.go
@@ -36,9 +36,10 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 	testCases := []testCase{
 		{
 			expectedConfig: &config.Defaults{
-				DefaultTimeoutMinutes:      50,
-				DefaultServiceAccount:      "tekton",
-				DefaultManagedByLabelValue: "something-else",
+				DefaultTimeoutMinutes:             50,
+				DefaultServiceAccount:             "tekton",
+				DefaultManagedByLabelValue:        "something-else",
+				DefaultMaxMatrixCombinationsCount: 256,
 			},
 			fileName: config.GetDefaultsConfigName(),
 		},
@@ -57,6 +58,7 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 						"label": "value2",
 					},
 				},
+				DefaultMaxMatrixCombinationsCount: 256,
 			},
 			fileName: "config-defaults-with-pod-template",
 		},
@@ -71,20 +73,22 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 			expectedError: false,
 			fileName:      "config-defaults-pod-template-err",
 			expectedConfig: &config.Defaults{
-				DefaultTimeoutMinutes:      50,
-				DefaultServiceAccount:      "tekton",
-				DefaultManagedByLabelValue: config.DefaultManagedByLabelValue,
-				DefaultPodTemplate:         &pod.Template{},
+				DefaultTimeoutMinutes:             50,
+				DefaultServiceAccount:             "tekton",
+				DefaultManagedByLabelValue:        config.DefaultManagedByLabelValue,
+				DefaultPodTemplate:                &pod.Template{},
+				DefaultMaxMatrixCombinationsCount: 256,
 			},
 		},
 		{
 			expectedError: false,
 			fileName:      "config-defaults-aa-pod-template-err",
 			expectedConfig: &config.Defaults{
-				DefaultTimeoutMinutes:      50,
-				DefaultServiceAccount:      "tekton",
-				DefaultManagedByLabelValue: config.DefaultManagedByLabelValue,
-				DefaultAAPodTemplate:       &pod.AffinityAssistantTemplate{},
+				DefaultTimeoutMinutes:             50,
+				DefaultServiceAccount:             "tekton",
+				DefaultManagedByLabelValue:        config.DefaultManagedByLabelValue,
+				DefaultAAPodTemplate:              &pod.AffinityAssistantTemplate{},
+				DefaultMaxMatrixCombinationsCount: 256,
 			},
 		},
 		{
@@ -117,9 +121,10 @@ func TestNewDefaultsFromConfigMap(t *testing.T) {
 func TestNewDefaultsFromEmptyConfigMap(t *testing.T) {
 	DefaultsConfigEmptyName := "config-defaults-empty"
 	expectedConfig := &config.Defaults{
-		DefaultTimeoutMinutes:      60,
-		DefaultManagedByLabelValue: "tekton-pipelines",
-		DefaultServiceAccount:      "default",
+		DefaultTimeoutMinutes:             60,
+		DefaultManagedByLabelValue:        "tekton-pipelines",
+		DefaultServiceAccount:             "default",
+		DefaultMaxMatrixCombinationsCount: 256,
 	}
 	verifyConfigFileWithExpectedConfig(t, DefaultsConfigEmptyName, expectedConfig)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In https://github.com/tektoncd/pipeline/pull/4947, we implemented the [concurrency controls][cc]. In this change, we implemented that the default value is 256 if it's not specified by the user.

Docs: https://github.com/tektoncd/pipeline/blob/main/docs/matrix.md#concurrency-control

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md
[cc]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md#concurrency-control

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
The default maximum count of `TaskRuns` or `Runs` from a given `Matrix` is 256.
```