### PR TITLE
TEP-0090: Update PipelineRun Status from Child Refs

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -720,6 +720,47 @@ metadata:
 			trs:              taskRunsWithNoOwner,
 			runs:             runsWithNoOwner,
 			expectedPrStatus: prStatusWithEmptyChildRefs,
+		}, {
+			prName:   "matrixed-taskruns-pr",
+			prStatus: prStatusWithEmptyChildRefs,
+			trs: []*v1beta1.TaskRun{
+				parse.MustParseTaskRun(t, `
+metadata:
+  labels:
+    tekton.dev/pipelineTask: task
+  name: pr-task-0-xxyyy
+  ownerReferences:
+  - uid: 11111111-1111-1111-1111-111111111111
+`),
+				parse.MustParseTaskRun(t, `
+metadata:
+  labels:
+    tekton.dev/pipelineTask: task
+  name: pr-task-1-xxyyy
+  ownerReferences:
+  - uid: 11111111-1111-1111-1111-111111111111
+`),
+			},
+			runs: nil,
+			expectedPrStatus: v1beta1.PipelineRunStatus{
+				Status: prRunningStatus,
+				PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					ChildReferences: []v1beta1.ChildStatusReference{
+						mustParseChildStatusReference(t, `
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+name: pr-task-0-xxyyy
+pipelineTaskName: task
+`),
+						mustParseChildStatusReference(t, `
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+name: pr-task-1-xxyyy
+pipelineTaskName: task
+`),
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Prior to this change, the function that ensures that PipelineRun
status stays in sync with actual TaskRuns and Runs used a map
whose key was a PipelineTask name and value was a ChildReference.

In this change, we modify the key to be the TaskRun or Run names.
This allows us to handle matrixed scenarios, where one PipelineTask
has multiple TaskRuns and Runs - hence multiple ChildReferences.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```