### PR TITLE
Check for non-nil `TaskRun` in `GetTaskRunsResults`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -182,9 +182,10 @@ func (state PipelineRunState) GetTaskRunsResults() map[string][]v1beta1.TaskRunR
 		if !rprt.isSuccessful() {
 			continue
 		}
-		results[rprt.PipelineTask.Name] = rprt.TaskRun.Status.TaskRunResults
+		if rprt.TaskRun != nil {
+			results[rprt.PipelineTask.Name] = rprt.TaskRun.Status.TaskRunResults
+		}
 	}
-
 	return results
 }
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2368,6 +2368,69 @@ func TestPipelineRunState_GetResultsFuncs(t *testing.T) {
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "nil-run-1",
 		},
+	}, {
+		TaskRunNames: []string{
+			"matrixed-task-run-0",
+			"matrixed-task-run-1",
+			"matrixed-task-run-2",
+			"matrixed-task-run-3",
+		},
+		PipelineTask: &v1beta1.PipelineTask{
+			Name: "matrixed-task",
+			TaskRef: &v1beta1.TaskRef{
+				Name:       "task",
+				Kind:       "Task",
+				APIVersion: "v1beta1",
+			},
+			Matrix: []v1beta1.Param{{
+				Name:  "foobar",
+				Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+			}, {
+				Name:  "quxbaz",
+				Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+			}},
+		},
+		TaskRuns: []*v1beta1.TaskRun{{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-0"},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+					Reason: v1beta1.TaskRunReasonSuccessful.String(),
+				}}},
+			},
+		}, {
+			TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-1"},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+					Reason: v1beta1.TaskRunReasonSuccessful.String(),
+				}}},
+			},
+		}, {
+			TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-2"},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+					Reason: v1beta1.TaskRunReasonSuccessful.String(),
+				}}},
+			},
+		}, {
+			TypeMeta:   metav1.TypeMeta{APIVersion: "tekton.dev/v1beta1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "matrixed-task-run-3"},
+			Status: v1beta1.TaskRunStatus{
+				Status: duckv1beta1.Status{Conditions: []apis.Condition{{
+					Type:   apis.ConditionSucceeded,
+					Status: corev1.ConditionTrue,
+					Reason: v1beta1.TaskRunReasonSuccessful.String(),
+				}}},
+			},
+		}},
 	}}
 
 	expectedTaskResults := map[string][]v1beta1.TaskRunResult{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In this change, we handle scenarios where a matrixed `PipelineTask` is successful - so `rprt` is successful but its `TaskRun` field is nil because it has `TaskRuns` instead. We need to add a check that `rprt.TaskRun` is non-nil before attempting to access its field: `rprt.TaskRun.Status.TaskRunResults`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```