### PR TITLE
`GetChildReferences` checks for non-nil `TaskRuns`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -249,7 +249,9 @@ func (state PipelineRunState) GetChildReferences() []v1beta1.ChildStatusReferenc
 			childRefs = append(childRefs, rprt.getChildRefForTaskRun(rprt.TaskRun))
 		case len(rprt.TaskRuns) != 0:
 			for _, taskRun := range rprt.TaskRuns {
-				childRefs = append(childRefs, rprt.getChildRefForTaskRun(taskRun))
+				if taskRun != nil {
+					childRefs = append(childRefs, rprt.getChildRefForTaskRun(taskRun))
+				}
 			}
 		}
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2566,6 +2566,34 @@ func TestPipelineRunState_GetChildReferences(t *testing.T) {
 			}},
 		},
 		{
+			name: "unresolved-matrixed-task",
+			state: PipelineRunState{{
+				TaskRunNames: []string{"task-run-0", "task-run-1", "task-run-2", "task-run-3"},
+				PipelineTask: &v1beta1.PipelineTask{
+					Name: "matrixed-task",
+					TaskRef: &v1beta1.TaskRef{
+						Name:       "task",
+						Kind:       "Task",
+						APIVersion: "v1beta1",
+					},
+					WhenExpressions: []v1beta1.WhenExpression{{
+						Input:    "foo",
+						Operator: selection.In,
+						Values:   []string{"foo", "bar"},
+					}},
+					Matrix: []v1beta1.Param{{
+						Name:  "foobar",
+						Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"foo", "bar"}},
+					}, {
+						Name:  "quxbaz",
+						Value: v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{"qux", "baz"}},
+					}},
+				},
+				TaskRuns: []*v1beta1.TaskRun{nil, nil, nil, nil},
+			}},
+			childRefs: nil,
+		},
+		{
 			name: "matrixed-task",
 			state: PipelineRunState{{
 				TaskRunName: "matrixed-task-run-0",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In https://github.com/tektoncd/pipeline/pull/5006, we refactored `GetChildReferences` such that it checks that `TaskRun` is non-nil before calling the helper function `getChildRefForTaskRun` that expects a non-nil `TaskRun`.

In this change, we add a check that each `TaskRun` from matrixed `PipelineTask` is non-nil before calling `getChildRefForTaskRun`.

Related PR: https://github.com/tektoncd/pipeline/pull/5008

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```