### PR TITLE
Reject embedded `Task`s with `APIVersion` and/or `Kind` specified

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -291,7 +291,7 @@ spec:
 
  Your `Pipeline` definition must reference at least one [`Task`](tasks.md).
 Each `Task` within a `Pipeline` must have a [valid](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)
-`name` and a `taskRef`. For example:
+`name` and a `taskRef` or a `taskSpec`. For example:
 
 ```yaml
 tasks:
@@ -299,6 +299,19 @@ tasks:
     taskRef:
       name: build-push
 ```
+
+or
+
+```yaml
+tasks:
+  - name: say-hello
+    taskSpec:
+      steps:
+      - image: ubuntu
+        script: echo 'hello there'
+```
+
+Note that any `task` specified in `taskSpec` will be the same version as the `Pipeline`.
 
 ### Specifying `Resources` in `PipelineTasks`
 

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -727,6 +727,48 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 			Message: `expected exactly one, got both`,
 			Paths:   []string{"tasks[1].name"},
 		},
+	}, {
+		name: "apiVersion with steps",
+		tasks: []PipelineTask{{
+			Name: "foo",
+			TaskSpec: &EmbeddedTask{
+				TypeMeta: runtime.TypeMeta{
+					APIVersion: "tekton.dev/v1beta1",
+				},
+				TaskSpec: TaskSpec{
+					Steps: []Step{{
+						Name:  "some-step",
+						Image: "some-image",
+					}},
+				},
+			},
+		}},
+		finalTasks: nil,
+		expectedError: apis.FieldError{
+			Message: "taskSpec.apiVersion cannot be specified when using taskSpec.steps",
+			Paths:   []string{"tasks[0].taskSpec.apiVersion"},
+		},
+	}, {
+		name: "kind with steps",
+		tasks: []PipelineTask{{
+			Name: "foo",
+			TaskSpec: &EmbeddedTask{
+				TypeMeta: runtime.TypeMeta{
+					Kind: "Task",
+				},
+				TaskSpec: TaskSpec{
+					Steps: []Step{{
+						Name:  "some-step",
+						Image: "some-image",
+					}},
+				},
+			},
+		}},
+		finalTasks: nil,
+		expectedError: apis.FieldError{
+			Message: "taskSpec.kind cannot be specified when using taskSpec.steps",
+			Paths:   []string{"tasks[0].taskSpec.kind"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Changes

fixes #4543

If custom tasks are enabled and either of `PipelineTask.TaskSpec.APIVersion` or `PipelineTask.TaskSpec.Kind` are specified, the `PipelineTask` will be treated as a custom task. This is still the case if an actual embedded `Task` is specified in `PipelineTask.TaskSpec.TaskSpec`, so we should be failing validation for those cases.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Fail PipelineTask validation if a normal, non-custom embedded task is specified along with `apiVersion` and/or `kind`
```
