### PR TITLE
Sort `ChildReferences` in tests

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_updatestatus_test.go
@@ -790,7 +790,10 @@ pipelineTaskName: task
 
 			// Sort the ChildReferences to deal with annoying ordering issues.
 			sort.Slice(actualPrStatus.ChildReferences, func(i, j int) bool {
-				return actualPrStatus.ChildReferences[i].PipelineTaskName < actualPrStatus.ChildReferences[j].PipelineTaskName
+				return actualPrStatus.ChildReferences[i].Name < actualPrStatus.ChildReferences[j].Name
+			})
+			sort.Slice(tc.expectedPrStatus.ChildReferences, func(i, j int) bool {
+				return tc.expectedPrStatus.ChildReferences[i].Name < tc.expectedPrStatus.ChildReferences[j].Name
 			})
 
 			if d := cmp.Diff(tc.expectedPrStatus, actualPrStatus); d != "" {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Prior to this change, the `ChildReferences` in tests were sorted
by `PipelineTaskName`. With `Matrix` multiple `ChildReferences`
could have the same `PipelineTaskName` - this causes the tests to
be flakey because the slices are not always sorted the same way.

In this change, we sort the slices of `ChildReferences` by the name
of the `ChildReferences` - mapping to names of `TaskRuns` or `Runs`.
This ensures the slices are always sorted the same way, and removes
the flakes.

Related PR: https://github.com/tektoncd/pipeline/pull/5014

/kind flake

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```