### PR TITLE
Throw more compute at e2e tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -19,11 +19,12 @@
 
 source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
-
 # Setting defaults
 PIPELINE_FEATURE_GATE=${PIPELINE_FEATURE_GATE:-stable}
 SKIP_INITIALIZE=${SKIP_INITIALIZE:="false"}
 RUN_YAML_TESTS=${RUN_YAML_TESTS:="true"}
+E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-8}
+E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-5}
 failed=0
 
 # Script entry point.

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -17,14 +17,17 @@
 # This script calls out to scripts in tektoncd/plumbing to setup a cluster
 # and deploy Tekton Pipelines to it for running integration tests.
 
+# Override the machine type and max cluster size so our E2E tests run faster
+# and with fewer timeouts/flakes.
+E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-8}
+E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-5}
+
 source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Setting defaults
 PIPELINE_FEATURE_GATE=${PIPELINE_FEATURE_GATE:-stable}
 SKIP_INITIALIZE=${SKIP_INITIALIZE:="false"}
 RUN_YAML_TESTS=${RUN_YAML_TESTS:="true"}
-E2E_CLUSTER_MACHINE=${E2E_CLUSTER_MACHINE:-n1-standard-8}
-E2E_MAX_CLUSTER_NODES=${E2E_MAX_CLUSTER_NODES:-5}
 failed=0
 
 # Script entry point.


### PR DESCRIPTION

# Changes

End-to-end tests seem to be taking a long time, and failing flakily due to timeouts.

This changes the e2e cluster setup from a cluster with 1-3 n1-standard-4 VMs to one with 1-5 n1-standard-8 VMs. At peak, that's 40 cores, up from 12.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```