### PR TITLE
Switch to `cmpopts.SortSlices` rather than explicitly sorting in tests when possible

### DIFF
--- a/pkg/apis/pipeline/v1beta1/resultref_test.go
+++ b/pkg/apis/pipeline/v1beta1/resultref_test.go
@@ -17,10 +17,10 @@ limitations under the License.
 package v1beta1_test
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	"k8s.io/apimachinery/pkg/selection"
@@ -277,16 +277,15 @@ func TestHasResultReference(t *testing.T) {
 				t.Fatalf("expected to find expressions but didn't find any")
 			}
 			got := v1beta1.NewResultRefs(expressions)
-			sort.Slice(got, func(i, j int) bool {
-				if got[i].PipelineTask > got[j].PipelineTask {
+			if d := cmp.Diff(tt.wantRef, got, cmpopts.SortSlices(func(i, j *v1beta1.ResultRef) bool {
+				if i.PipelineTask > j.PipelineTask {
 					return false
 				}
-				if got[i].Result > got[j].Result {
+				if i.Result > j.Result {
 					return false
 				}
 				return true
-			})
-			if d := cmp.Diff(tt.wantRef, got); d != "" {
+			})); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})

--- a/pkg/pullrequest/disk_test.go
+++ b/pkg/pullrequest/disk_test.go
@@ -22,12 +22,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"reflect"
-	"sort"
 	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jenkins-x/go-scm/scm"
 	"github.com/tektoncd/pipeline/test/diff"
 )
@@ -725,15 +724,10 @@ func TestLabelsFromDisk(t *testing.T) {
 				derefed = append(derefed, *l)
 			}
 
-			sort.Slice(derefed, func(i, j int) bool {
-				return derefed[i].Name < derefed[j].Name
-			})
-			sort.Slice(tt.want, func(i, j int) bool {
-				return tt.want[i].Name < tt.want[j].Name
-			})
-
-			if !reflect.DeepEqual(derefed, tt.want) {
-				t.Errorf("labelsFromDisk() = %v, want %v", derefed, tt.want)
+			if d := cmp.Diff(tt.want, derefed, cmpopts.SortSlices(func(i, j scm.Label) bool {
+				return i.Name < j.Name
+			})); d != "" {
+				t.Errorf("expected labelsFromDisk() to match %#v. Diff %s", derefed, diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -566,7 +566,7 @@ spec:
   timeout: 1h0m0s
 `)
 	// ignore IgnoreUnexported ignore both after and before steps fields
-	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name })); d != "" {
+	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, cmpopts.SortSlices(lessTaskResourceBindings)); d != "" {
 		t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRun, diff.PrintWantGot(d))
 	}
 	// test taskrun is able to recreate correct pipeline-pvc-name
@@ -6441,7 +6441,7 @@ spec:
   timeout: 1h0m0s
 `, ref))
 
-	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name })); d != "" {
+	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, cmpopts.SortSlices(lessTaskResourceBindings)); d != "" {
 		t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRun, diff.PrintWantGot(d))
 	}
 
@@ -6547,7 +6547,7 @@ spec:
   timeout: 1h0m0s
 `)
 
-	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, cmpopts.SortSlices(func(x, y v1beta1.TaskResourceBinding) bool { return x.Name < y.Name })); d != "" {
+	if d := cmp.Diff(expectedTaskRun, actual, ignoreTypeMeta, cmpopts.SortSlices(lessTaskResourceBindings)); d != "" {
 		t.Errorf("expected to see TaskRun %v created. Diff %s", expectedTaskRun, diff.PrintWantGot(d))
 	}
 
@@ -7748,4 +7748,8 @@ spec:
 			}
 		})
 	}
+}
+
+func lessTaskResourceBindings(i, j v1beta1.TaskResourceBinding) bool {
+	return i.Name < j.Name
 }

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -20,18 +20,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"testing"
 
-	"github.com/tektoncd/pipeline/test/parse"
-
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/test/diff"
-
-	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
-
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
+	"github.com/tektoncd/pipeline/test/diff"
+	"github.com/tektoncd/pipeline/test/parse"
 	jsonpatch "gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -391,9 +388,9 @@ spec:
 
 	actualSkippedTasks := pr.Status.SkippedTasks
 	// Sort tasks based on their names to get similar order as in expected list
-	sort.Slice(actualSkippedTasks, func(i int, j int) bool { return actualSkippedTasks[i].Name < actualSkippedTasks[j].Name })
-
-	if d := cmp.Diff(actualSkippedTasks, expectedSkippedTasks); d != "" {
+	if d := cmp.Diff(actualSkippedTasks, expectedSkippedTasks, cmpopts.SortSlices(func(i, j v1beta1.SkippedTask) bool {
+		return i.Name < j.Name
+	})); d != "" {
 		t.Fatalf("Expected four skipped tasks, dag task with condition failure dagtask3, dag task with when expression,"+
 			"two final tasks with missing result reference finaltaskconsumingdagtask1 and finaltaskconsumingdagtask4 in SkippedTasks."+
 			" Diff: %s", diff.PrintWantGot(d))


### PR DESCRIPTION
# Changes

There are a couple cases where I left explicit sorts in place because the test wasn't using `cmp.Diff` in the first place, etc, but most are changed.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```
