### PR TITLE
`ResolvedPipelineRunTask` to `ResolvedPipelineTask`

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -3066,12 +3066,12 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		timeoutDuration *metav1.Duration
 		timeoutFields   *v1beta1.TimeoutFields
 		startTime       time.Time
-		rprt            *resources.ResolvedPipelineRunTask
+		rpt             *resources.ResolvedPipelineTask
 		expected        *metav1.Duration
 	}{{
 		name:      "nil timeout duration",
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: nil,
 			},
@@ -3081,7 +3081,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		name:            "timeout specified in pr",
 		timeoutDuration: &metav1.Duration{Duration: 20 * time.Minute},
 		startTime:       now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: nil,
 			},
@@ -3091,7 +3091,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		name:            "0 timeout duration",
 		timeoutDuration: &metav1.Duration{Duration: 0 * time.Minute},
 		startTime:       now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: nil,
 			},
@@ -3101,7 +3101,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		name:            "taskrun being created after timeout expired",
 		timeoutDuration: &metav1.Duration{Duration: 1 * time.Minute},
 		startTime:       now.Add(-2 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: nil,
 			},
@@ -3111,7 +3111,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		name:            "taskrun being created with timeout for PipelineTask",
 		timeoutDuration: &metav1.Duration{Duration: 20 * time.Minute},
 		startTime:       now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
 			},
@@ -3121,7 +3121,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 		name:            "0 timeout duration for PipelineRun, PipelineTask timeout still applied",
 		timeoutDuration: &metav1.Duration{Duration: 0 * time.Minute},
 		startTime:       now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
 			},
@@ -3133,7 +3133,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: nil,
 			},
@@ -3146,7 +3146,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks:    &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: nil,
 			},
@@ -3158,7 +3158,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
 			},
@@ -3170,7 +3170,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks: &metav1.Duration{Duration: 1 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
 			},
@@ -3182,7 +3182,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now.Add(-10 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 			TaskRun: &v1beta1.TaskRun{
 				Status: v1beta1.TaskRunStatus{
@@ -3199,7 +3199,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now.Add(-10 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 15 * time.Minute},
 			},
@@ -3218,7 +3218,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 			Tasks: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now.Add(-10 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 15 * time.Minute},
 			},
@@ -3248,7 +3248,7 @@ func TestGetTaskRunTimeout(t *testing.T) {
 					},
 				},
 			}
-			if d := cmp.Diff(getTaskRunTimeout(context.TODO(), pr, tc.rprt, testClock), tc.expected); d != "" {
+			if d := cmp.Diff(getTaskRunTimeout(context.TODO(), pr, tc.rpt, testClock), tc.expected); d != "" {
 				t.Errorf("Unexpected task run timeout. Diff %s", diff.PrintWantGot(d))
 			}
 		})
@@ -3266,12 +3266,12 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 		timeoutFields   *v1beta1.TimeoutFields
 		startTime       time.Time
 		pr              *v1beta1.PipelineRun
-		rprt            *resources.ResolvedPipelineRunTask
+		rpt             *resources.ResolvedPipelineTask
 		expected        *metav1.Duration
 	}{{
 		name:      "nil timeout duration",
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 60 * time.Minute},
@@ -3279,7 +3279,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 		name:            "timeout specified in pr",
 		timeoutDuration: &metav1.Duration{Duration: 20 * time.Minute},
 		startTime:       now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
@@ -3287,7 +3287,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 		name:            "taskrun being created after timeout expired",
 		timeoutDuration: &metav1.Duration{Duration: 1 * time.Minute},
 		startTime:       now.Add(-2 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 1 * time.Second},
@@ -3298,7 +3298,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Tasks:    &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
@@ -3308,7 +3308,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Finally: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
@@ -3320,14 +3320,14 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Finally:  &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 		},
 		expected: &metav1.Duration{Duration: 20 * time.Minute},
 	}, {
 		name:      "use pipeline.finally[].timeout",
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
 			},
@@ -3340,7 +3340,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Finally:  &metav1.Duration{Duration: 1 * time.Minute},
 		},
 		startTime: now,
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 2 * time.Minute},
 			},
@@ -3352,7 +3352,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Finally: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now.Add(-10 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{},
 			TaskRun: &v1beta1.TaskRun{
 				Status: v1beta1.TaskRunStatus{
@@ -3369,7 +3369,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Finally: &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now.Add(-10 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 15 * time.Minute},
 			},
@@ -3389,7 +3389,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 			Finally:  &metav1.Duration{Duration: 20 * time.Minute},
 		},
 		startTime: now.Add(-10 * time.Minute),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rpt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Timeout: &metav1.Duration{Duration: 15 * time.Minute},
 			},
@@ -3419,7 +3419,7 @@ func TestGetFinallyTaskRunTimeout(t *testing.T) {
 					},
 				},
 			}
-			if d := cmp.Diff(tc.expected, getFinallyTaskRunTimeout(context.TODO(), pr, tc.rprt, testClock)); d != "" {
+			if d := cmp.Diff(tc.expected, getFinallyTaskRunTimeout(context.TODO(), pr, tc.rpt, testClock)); d != "" {
 				t.Errorf("Unexpected finally task run timeout. Diff %s", diff.PrintWantGot(d))
 			}
 		})
@@ -7217,7 +7217,7 @@ func TestGetTaskrunWorkspaces_Failure(t *testing.T) {
 	tests := []struct {
 		name          string
 		pr            *v1beta1.PipelineRun
-		rprt          *resources.ResolvedPipelineRunTask
+		rprt          *resources.ResolvedPipelineTask
 		expectedError string
 	}{{
 		name: "failure declaring workspace with different name",
@@ -7227,7 +7227,7 @@ metadata:
 spec:
   workspaces:
     - name: source`),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rprt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "resolved-pipelinetask",
 				Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
@@ -7247,7 +7247,7 @@ spec:
   workspaces:
     - name: source
  `),
-			rprt: &resources.ResolvedPipelineRunTask{
+			rprt: &resources.ResolvedPipelineTask{
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "resolved-pipelinetask",
 					Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
@@ -7277,7 +7277,7 @@ func TestGetTaskrunWorkspaces_Success(t *testing.T) {
 	tests := []struct {
 		name string
 		pr   *v1beta1.PipelineRun
-		rprt *resources.ResolvedPipelineRunTask
+		rprt *resources.ResolvedPipelineTask
 	}{{
 		name: "valid declaration of workspace names",
 		pr: parse.MustParsePipelineRun(t, `
@@ -7286,7 +7286,7 @@ metadata:
 spec:
   workspaces:
     - name: source`),
-		rprt: &resources.ResolvedPipelineRunTask{
+		rprt: &resources.ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Name: "resolved-pipelinetask",
 				Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
@@ -7304,7 +7304,7 @@ metadata:
 spec:
   workspaces:
     - name: source`),
-			rprt: &resources.ResolvedPipelineRunTask{
+			rprt: &resources.ResolvedPipelineTask{
 				PipelineTask: &v1beta1.PipelineTask{
 					Name: "resolved-pipelinetask",
 					Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -236,7 +236,7 @@ func TestPipelineRunFacts_CheckDAGTasksDoneDone(t *testing.T) {
 			for i, pt := range tc.state {
 				isDone = pt.isDone(&facts)
 				if d := cmp.Diff(tc.ptExpected[i], isDone); d != "" {
-					t.Errorf("Didn't get expected (ResolvedPipelineRunTask) isDone %s", diff.PrintWantGot(d))
+					t.Errorf("Didn't get expected (ResolvedPipelineTask) isDone %s", diff.PrintWantGot(d))
 				}
 
 			}
@@ -278,147 +278,147 @@ func TestGetNextTasks(t *testing.T) {
 		name         string
 		state        PipelineRunState
 		candidates   sets.String
-		expectedNext []*ResolvedPipelineRunTask
+		expectedNext []*ResolvedPipelineTask
 	}{{
 		name:         "no-tasks-started-no-candidates",
 		state:        noneStartedState,
 		candidates:   sets.NewString(),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "no-tasks-started-one-candidate",
 		state:        noneStartedState,
 		candidates:   sets.NewString("mytask1"),
-		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0]},
+		expectedNext: []*ResolvedPipelineTask{noneStartedState[0]},
 	}, {
 		name:         "no-tasks-started-other-candidate",
 		state:        noneStartedState,
 		candidates:   sets.NewString("mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[1]},
+		expectedNext: []*ResolvedPipelineTask{noneStartedState[1]},
 	}, {
 		name:         "no-tasks-started-both-candidates",
 		state:        noneStartedState,
 		candidates:   sets.NewString("mytask1", "mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{noneStartedState[0], noneStartedState[1]},
+		expectedNext: []*ResolvedPipelineTask{noneStartedState[0], noneStartedState[1]},
 	}, {
 		name:         "one-task-started-no-candidates",
 		state:        oneStartedState,
 		candidates:   sets.NewString(),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-task-started-one-candidate",
 		state:        oneStartedState,
 		candidates:   sets.NewString("mytask1"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-task-started-other-candidate",
 		state:        oneStartedState,
 		candidates:   sets.NewString("mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneStartedState[1]},
 	}, {
 		name:         "one-task-started-both-candidates",
 		state:        oneStartedState,
 		candidates:   sets.NewString("mytask1", "mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{oneStartedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneStartedState[1]},
 	}, {
 		name:         "one-task-finished-no-candidates",
 		state:        oneFinishedState,
 		candidates:   sets.NewString(),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-task-finished-one-candidate",
 		state:        oneFinishedState,
 		candidates:   sets.NewString("mytask1"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-task-finished-other-candidate",
 		state:        oneFinishedState,
 		candidates:   sets.NewString("mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneFinishedState[1]},
 	}, {
 		name:         "one-task-finished-both-candidate",
 		state:        oneFinishedState,
 		candidates:   sets.NewString("mytask1", "mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{oneFinishedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneFinishedState[1]},
 	}, {
 		name:         "one-task-failed-no-candidates",
 		state:        oneFailedState,
 		candidates:   sets.NewString(),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-task-failed-one-candidate",
 		state:        oneFailedState,
 		candidates:   sets.NewString("mytask1"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-task-failed-other-candidate",
 		state:        oneFailedState,
 		candidates:   sets.NewString("mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneFailedState[1]},
 	}, {
 		name:         "one-task-failed-both-candidates",
 		state:        oneFailedState,
 		candidates:   sets.NewString("mytask1", "mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{oneFailedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneFailedState[1]},
 	}, {
 		name:         "final-task-scheduled-no-candidates",
 		state:        finalScheduledState,
 		candidates:   sets.NewString(),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "final-task-finished-one-candidate",
 		state:        finalScheduledState,
 		candidates:   sets.NewString("mytask1"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "final-task-finished-other-candidate",
 		state:        finalScheduledState,
 		candidates:   sets.NewString("mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "final-task-finished-both-candidate",
 		state:        finalScheduledState,
 		candidates:   sets.NewString("mytask1", "mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "all-finished-no-candidates",
 		state:        allFinishedState,
 		candidates:   sets.NewString(),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "all-finished-one-candidate",
 		state:        allFinishedState,
 		candidates:   sets.NewString("mytask1"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "all-finished-other-candidate",
 		state:        allFinishedState,
 		candidates:   sets.NewString("mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "all-finished-both-candidates",
 		state:        allFinishedState,
 		candidates:   sets.NewString("mytask1", "mytask2"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "one-cancelled-one-candidate",
 		state:        taskCancelled,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "no-runs-started-both-candidates",
 		state:        noRunStartedState,
 		candidates:   sets.NewString("mytask13", "mytask14"),
-		expectedNext: []*ResolvedPipelineRunTask{noRunStartedState[0], noRunStartedState[1]},
+		expectedNext: []*ResolvedPipelineTask{noRunStartedState[0], noRunStartedState[1]},
 	}, {
 		name:         "one-run-started-both-candidates",
 		state:        oneRunStartedState,
 		candidates:   sets.NewString("mytask13", "mytask14"),
-		expectedNext: []*ResolvedPipelineRunTask{oneRunStartedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneRunStartedState[1]},
 	}, {
 		name:         "one-run-failed-both-candidates",
 		state:        oneRunFailedState,
 		candidates:   sets.NewString("mytask13", "mytask14"),
-		expectedNext: []*ResolvedPipelineRunTask{oneRunFailedState[1]},
+		expectedNext: []*ResolvedPipelineTask{oneRunFailedState[1]},
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -550,67 +550,67 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 		name         string
 		state        PipelineRunState
 		candidates   sets.String
-		expectedNext []*ResolvedPipelineRunTask
+		expectedNext []*ResolvedPipelineTask
 	}{{
 		name:         "tasks-cancelled-no-candidates",
 		state:        taskCancelledByStatusState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "tasks-cancelled-bySpec-no-candidates",
 		state:        taskCancelledBySpecState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "tasks-running-no-candidates",
 		state:        taskRunningState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "tasks-succeeded-bySpec-no-candidates",
 		state:        taskSucceededState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "tasks-retried-no-candidates",
 		state:        taskRetriedState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "tasks-retried-one-candidates",
 		state:        taskExpectedState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{taskExpectedState[0]},
+		expectedNext: []*ResolvedPipelineTask{taskExpectedState[0]},
 	}, {
 		name:         "runs-cancelled-no-candidates",
 		state:        runCancelledByStatusState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "runs-cancelled-bySpec-no-candidates",
 		state:        runCancelledBySpecState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "runs-running-no-candidates",
 		state:        runRunningState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "run-succeeded-bySpec-no-candidates",
 		state:        runSucceededState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "run-retried-no-candidates",
 		state:        runRetriedState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{},
+		expectedNext: []*ResolvedPipelineTask{},
 	}, {
 		name:         "run-retried-one-candidates",
 		state:        runExpectedState,
 		candidates:   sets.NewString("mytask5"),
-		expectedNext: []*ResolvedPipelineRunTask{runExpectedState[0]},
+		expectedNext: []*ResolvedPipelineTask{runExpectedState[0]},
 	}}
 
 	// iterate over *state* to get from candidate and check if TaskRun or Run is there.
@@ -629,7 +629,7 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 // TestDAGExecutionQueue tests the DAGExecutionQueue function for PipelineTasks
 // in different states (without dependencies on each other) and the PipelineRun in different states.
 func TestDAGExecutionQueue(t *testing.T) {
-	createdTask := ResolvedPipelineRunTask{
+	createdTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "createdtask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -639,7 +639,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 	}
-	createdRun := ResolvedPipelineRunTask{
+	createdRun := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "createdrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -647,7 +647,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		RunName:    "createdrun",
 		CustomTask: true,
 	}
-	runningTask := ResolvedPipelineRunTask{
+	runningTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "runningtask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -658,7 +658,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 	}
-	runningRun := ResolvedPipelineRunTask{
+	runningRun := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "runningrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -667,7 +667,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		Run:        newRun(runs[0]),
 		CustomTask: true,
 	}
-	successfulTask := ResolvedPipelineRunTask{
+	successfulTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "successfultask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -678,7 +678,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 	}
-	successfulRun := ResolvedPipelineRunTask{
+	successfulRun := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "successfulrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -687,7 +687,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		Run:        makeRunSucceeded(runs[0]),
 		CustomTask: true,
 	}
-	failedTask := ResolvedPipelineRunTask{
+	failedTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "failedtask",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -698,7 +698,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 	}
-	failedRun := ResolvedPipelineRunTask{
+	failedRun := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "failedrun",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -707,7 +707,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 		Run:        makeRunFailed(runs[0]),
 		CustomTask: true,
 	}
-	failedTaskWithRetries := ResolvedPipelineRunTask{
+	failedTaskWithRetries := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "failedtaskwithretries",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -719,7 +719,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 	}
-	failedRunWithRetries := ResolvedPipelineRunTask{
+	failedRunWithRetries := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "failedrunwithretries",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -814,7 +814,7 @@ func TestDAGExecutionQueue(t *testing.T) {
 // TestDAGExecutionQueueSequentialTasks tests the DAGExecutionQueue function for sequential TaskRuns
 // in different states for a running or stopping PipelineRun.
 func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
-	firstTask := ResolvedPipelineRunTask{
+	firstTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "task-1",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -824,7 +824,7 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 	}
-	secondTask := ResolvedPipelineRunTask{
+	secondTask := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:     "task-2",
 			TaskRef:  &v1beta1.TaskRef{Name: "task"},
@@ -907,7 +907,7 @@ func TestDAGExecutionQueueSequentialTasks(t *testing.T) {
 // TestDAGExecutionQueueSequentialRuns tests the DAGExecutionQueue function for sequential Runs
 // in different states for a running or stopping PipelineRun.
 func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
-	firstRun := ResolvedPipelineRunTask{
+	firstRun := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "task-1",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -915,7 +915,7 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 		RunName:    "task-1",
 		CustomTask: true,
 	}
-	secondRun := ResolvedPipelineRunTask{
+	secondRun := ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:     "task-2",
 			TaskRef:  &v1beta1.TaskRef{Name: "task"},
@@ -1085,7 +1085,7 @@ func buildPipelineStateWithLargeDepencyGraph(t *testing.T) PipelineRunState {
 		},
 	}
 	var pipelineRunState PipelineRunState
-	pipelineRunState = []*ResolvedPipelineRunTask{{
+	pipelineRunState = []*ResolvedPipelineTask{{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name:    "t1",
 			TaskRef: &v1beta1.TaskRef{Name: "task"},
@@ -1115,7 +1115,7 @@ func buildPipelineStateWithLargeDepencyGraph(t *testing.T) PipelineRunState {
 				},
 			})
 		}
-		pipelineRunState = append(pipelineRunState, &ResolvedPipelineRunTask{
+		pipelineRunState = append(pipelineRunState, &ResolvedPipelineTask{
 			PipelineTask: &v1beta1.PipelineTask{
 				Name:    fmt.Sprintf("t%d", i),
 				Params:  params,

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution.go
@@ -37,8 +37,8 @@ type ResolvedResultRef struct {
 	FromRun         string
 }
 
-// ResolveResultRef resolves any ResultReference that are found in the target ResolvedPipelineRunTask
-func ResolveResultRef(pipelineRunState PipelineRunState, target *ResolvedPipelineRunTask) (ResolvedResultRefs, string, error) {
+// ResolveResultRef resolves any ResultReference that are found in the target ResolvedPipelineTask
+func ResolveResultRef(pipelineRunState PipelineRunState, target *ResolvedPipelineTask) (ResolvedResultRefs, string, error) {
 	resolvedResultRefs, pt, err := convertToResultRefs(pipelineRunState, target)
 	if err != nil {
 		return nil, pt, err
@@ -46,7 +46,7 @@ func ResolveResultRef(pipelineRunState PipelineRunState, target *ResolvedPipelin
 	return validateArrayResultsIndex(removeDup(resolvedResultRefs))
 }
 
-// ResolveResultRefs resolves any ResultReference that are found in the target ResolvedPipelineRunTask
+// ResolveResultRefs resolves any ResultReference that are found in the target ResolvedPipelineTask
 func ResolveResultRefs(pipelineRunState PipelineRunState, targets PipelineRunState) (ResolvedResultRefs, string, error) {
 	var allResolvedResultRefs ResolvedResultRefs
 	for _, target := range targets {
@@ -129,7 +129,7 @@ func removeDup(refs ResolvedResultRefs) ResolvedResultRefs {
 // found they are resolved to a value by searching pipelineRunState. The list of resolved
 // references are returned. If an error is encountered due to an invalid result reference
 // then a nil list and error is returned instead.
-func convertToResultRefs(pipelineRunState PipelineRunState, target *ResolvedPipelineRunTask) (ResolvedResultRefs, string, error) {
+func convertToResultRefs(pipelineRunState PipelineRunState, target *ResolvedPipelineTask) (ResolvedResultRefs, string, error) {
 	var resolvedResultRefs ResolvedResultRefs
 	for _, ref := range v1beta1.PipelineTaskResultRefs(target.PipelineTask) {
 		resolved, pt, err := resolveResultRef(pipelineRunState, ref)

--- a/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/resultrefresolution_test.go
@@ -622,7 +622,7 @@ func TestResolveResultRefs(t *testing.T) {
 				t.Fatalf("ResolveResultRef %s", diff.PrintWantGot(d))
 			}
 			if d := cmp.Diff(tt.wantPt, pt); d != "" {
-				t.Fatalf("ResolvedPipelineRunTask %s", diff.PrintWantGot(d))
+				t.Fatalf("ResolvedPipelineTask %s", diff.PrintWantGot(d))
 			}
 		})
 	}
@@ -632,7 +632,7 @@ func TestResolveResultRef(t *testing.T) {
 	for _, tt := range []struct {
 		name             string
 		pipelineRunState PipelineRunState
-		target           *ResolvedPipelineRunTask
+		target           *ResolvedPipelineTask
 		want             ResolvedResultRefs
 		wantErr          bool
 		wantPt           string
@@ -706,7 +706,7 @@ func TestResolveResultRef(t *testing.T) {
 				t.Fatalf("ResolveResultRef %s", diff.PrintWantGot(d))
 			}
 			if d := cmp.Diff(tt.wantPt, pt); d != "" {
-				t.Fatalf("ResolvedPipelineRunTask %s", diff.PrintWantGot(d))
+				t.Fatalf("ResolvedPipelineTask %s", diff.PrintWantGot(d))
 			}
 		})
 	}

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies.go
@@ -29,10 +29,10 @@ import (
 // a result name or the referenced task just doesn't return a result with that name.
 func ValidatePipelineTaskResults(state PipelineRunState) error {
 	ptMap := state.ToMap()
-	for _, rprt := range state {
-		for _, ref := range v1beta1.PipelineTaskResultRefs(rprt.PipelineTask) {
+	for _, rpt := range state {
+		for _, ref := range v1beta1.PipelineTaskResultRefs(rpt.PipelineTask) {
 			if err := validateResultRef(ref, ptMap); err != nil {
-				return fmt.Errorf("invalid result reference in pipeline task %q: %s", rprt.PipelineTask.Name, err)
+				return fmt.Errorf("invalid result reference in pipeline task %q: %s", rpt.PipelineTask.Name, err)
 			}
 		}
 	}
@@ -58,9 +58,9 @@ func ValidatePipelineResults(ps *v1beta1.PipelineSpec, state PipelineRunState) e
 }
 
 // validateResultRef takes a ResultRef and searches for the result using the given
-// map of PipelineTask name to ResolvedPipelineRunTask. If the ResultRef does not point
+// map of PipelineTask name to ResolvedPipelineTask. If the ResultRef does not point
 // to a pipeline task or named result then an error is returned.
-func validateResultRef(ref *v1beta1.ResultRef, ptMap map[string]*ResolvedPipelineRunTask) error {
+func validateResultRef(ref *v1beta1.ResultRef, ptMap map[string]*ResolvedPipelineTask) error {
 	if _, ok := ptMap[ref.PipelineTask]; !ok {
 		return fmt.Errorf("referenced pipeline task %q does not exist", ref.PipelineTask)
 	}
@@ -98,13 +98,13 @@ func ValidateOptionalWorkspaces(pipelineWorkspaces []v1beta1.PipelineWorkspaceDe
 		}
 	}
 
-	for _, rprt := range state {
-		for _, pws := range rprt.PipelineTask.Workspaces {
+	for _, rpt := range state {
+		for _, pws := range rpt.PipelineTask.Workspaces {
 			if optionalWorkspaces.Has(pws.Workspace) {
-				for _, tws := range rprt.ResolvedTaskResources.TaskSpec.Workspaces {
+				for _, tws := range rpt.ResolvedTaskResources.TaskSpec.Workspaces {
 					if tws.Name == pws.Name {
 						if !tws.Optional {
-							return fmt.Errorf("pipeline workspace %q is marked optional but pipeline task %q requires it be provided", pws.Workspace, rprt.PipelineTask.Name)
+							return fmt.Errorf("pipeline workspace %q is marked optional but pipeline task %q requires it be provided", pws.Workspace, rpt.PipelineTask.Name)
 						}
 					}
 				}

--- a/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_dependencies_test.go
@@ -136,7 +136,7 @@ func TestValidatePipelineTaskResults_IncorrectTaskName(t *testing.T) {
 // TestValidatePipelineTaskResults_IncorrectResultName tests that a result variable with
 // a misnamed Result is correctly caught by the validatePipelineTaskResults func.
 func TestValidatePipelineTaskResults_IncorrectResultName(t *testing.T) {
-	pt1 := &ResolvedPipelineRunTask{
+	pt1 := &ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "pt1",
 		},
@@ -190,7 +190,7 @@ func TestValidatePipelineTaskResults_IncorrectResultName(t *testing.T) {
 // TestValidatePipelineTaskResults_MissingTaskSpec tests that a malformed PipelineTask
 // with a name but no spec results in a validation error being returned.
 func TestValidatePipelineTaskResults_MissingTaskSpec(t *testing.T) {
-	pt1 := &ResolvedPipelineRunTask{
+	pt1 := &ResolvedPipelineTask{
 		PipelineTask: &v1beta1.PipelineTask{
 			Name: "pt1",
 		},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

`ResolvedPipelineRunTask` is a confusing name for a `PipelineTask`
and its resources, plus we don't have a `PipelineRunTask` object.

This change renames `ResolvedPipelineRunTask` to `ResolvedPipelineTask`.

Issue: https://github.com/tektoncd/pipeline/issues/5024

/kind cleanup

cc @pritidesai 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```