### PR TITLE
Use Constants in ChildReferences

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1398,7 +1398,7 @@ func updatePipelineRunStatusFromChildRefs(logger *zap.SugaredLogger, pr *v1beta1
 			childRefByName[tr.Name] = &v1beta1.ChildStatusReference{
 				TypeMeta: runtime.TypeMeta{
 					APIVersion: v1beta1.SchemeGroupVersion.String(),
-					Kind:       "TaskRun",
+					Kind:       pipeline.TaskRunControllerName,
 				},
 				Name:             tr.Name,
 				PipelineTaskName: pipelineTaskName,
@@ -1420,7 +1420,7 @@ func updatePipelineRunStatusFromChildRefs(logger *zap.SugaredLogger, pr *v1beta1
 			childRefByName[r.Name] = &v1beta1.ChildStatusReference{
 				TypeMeta: runtime.TypeMeta{
 					APIVersion: v1alpha1.SchemeGroupVersion.String(),
-					Kind:       "Run",
+					Kind:       pipeline.RunControllerName,
 				},
 				Name:             r.Name,
 				PipelineTaskName: pipelineTaskName,

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -262,7 +262,7 @@ func (state PipelineRunState) GetChildReferences() []v1beta1.ChildStatusReferenc
 func (t *ResolvedPipelineTask) getChildRefForRun() v1beta1.ChildStatusReference {
 	return v1beta1.ChildStatusReference{
 		TypeMeta: runtime.TypeMeta{
-			APIVersion: t.Run.APIVersion,
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       pipeline.RunControllerName,
 		},
 		Name:             t.RunName,
@@ -274,7 +274,7 @@ func (t *ResolvedPipelineTask) getChildRefForRun() v1beta1.ChildStatusReference 
 func (t *ResolvedPipelineTask) getChildRefForTaskRun(taskRun *v1beta1.TaskRun) v1beta1.ChildStatusReference {
 	return v1beta1.ChildStatusReference{
 		TypeMeta: runtime.TypeMeta{
-			APIVersion: taskRun.APIVersion,
+			APIVersion: v1beta1.SchemeGroupVersion.String(),
 			Kind:       pipeline.TaskRunControllerName,
 		},
 		Name:             taskRun.Name,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Prior to this commit, the APIVersion and Kind fields used different variables depending on where they were used. In this cleanup, they use the same constants everywhere.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```
