### PR TITLE
Finish up removal of `Conditions` 🧹

### DIFF
--- a/pkg/apis/pipeline/register.go
+++ b/pkg/apis/pipeline/register.go
@@ -40,12 +40,6 @@ const (
 	// PipelineTaskLabelKey is used as the label identifier for a PipelineTask
 	PipelineTaskLabelKey = GroupName + "/pipelineTask"
 
-	// ConditionCheckKey is used as the label identifier for a ConditionCheck
-	ConditionCheckKey = GroupName + "/conditionCheck"
-
-	// ConditionNameKey is used as the label identifier for a Condition
-	ConditionNameKey = GroupName + "/conditionName"
-
 	// RunKey is used as the label identifier for a Run
 	RunKey = GroupName + "/run"
 

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -89,9 +89,6 @@ const (
 	// ReasonCouldntGetResource indicates that the reason for the failure status is that the
 	// associated PipelineRun's bound PipelineResources couldn't all be retrieved
 	ReasonCouldntGetResource = "CouldntGetResource"
-	// ReasonCouldntGetCondition indicates that the reason for the failure status is that the
-	// associated Pipeline's Conditions couldn't all be retrieved
-	ReasonCouldntGetCondition = "CouldntGetCondition"
 	// ReasonParameterMissing indicates that the reason for the failure status is that the
 	// associated PipelineRun didn't provide all the required parameters
 	ReasonParameterMissing = "ParameterMissing"

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -321,14 +321,9 @@ func (state PipelineRunState) getRetryableTasks(candidateTasks sets.String) []*R
 					isCancelled = isCancelled || status.Reason == v1alpha1.RunReasonCancelled
 				}
 			}
-			if status.IsFalse() {
-				if !(isCancelled || status.Reason == ReasonConditionCheckFailed) {
-					if t.hasRemainingRetries() {
-						tasks = append(tasks, t)
-					}
-				}
+			if status.IsFalse() && !isCancelled && t.hasRemainingRetries() {
+				tasks = append(tasks, t)
 			}
-
 		}
 	}
 	return tasks

--- a/test/pipelinefinally_test.go
+++ b/test/pipelinefinally_test.go
@@ -266,10 +266,6 @@ spec:
 				t.Errorf("Error waiting for TaskRun to succeed: %v", err)
 			}
 			dagTask2EndTime = taskrunItem.Status.CompletionTime
-		case n == "dagtask3":
-			if !isSkipped(t, n, taskrunItem.Status.Conditions) {
-				t.Fatalf("dag task %s should have skipped due to condition failure", n)
-			}
 		case n == "dagtask4":
 			t.Fatalf("task %s should have skipped due to when expression", n)
 		case n == "dagtask5":
@@ -713,20 +709,6 @@ func isCancelled(t *testing.T, taskRunName string, conds duckv1beta1.Conditions)
 	t.Helper()
 	for _, c := range conds {
 		if c.Type == apis.ConditionSucceeded {
-			return true
-		}
-	}
-	t.Errorf("TaskRun status %q had no Succeeded condition", taskRunName)
-	return false
-}
-
-func isSkipped(t *testing.T, taskRunName string, conds duckv1beta1.Conditions) bool {
-	t.Helper()
-	for _, c := range conds {
-		if c.Type == apis.ConditionSucceeded {
-			if c.Status != corev1.ConditionFalse && c.Reason != resources.ReasonConditionCheckFailed {
-				t.Errorf("TaskRun status %q is not skipped due to condition failure, got %q", taskRunName, c.Status)
-			}
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In https://github.com/tektoncd/pipeline/pull/4942, we removed `Conditions`. However, there was some logic that was left over. In this change, we clean up the remaining logic for `Conditions`.

Issue: https://github.com/tektoncd/pipeline/issues/3377

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```