### PR TITLE
Cleanup unused arguments - mostly removing unused ctx 🧹

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -61,7 +61,7 @@ type PropertySpec struct {
 }
 
 // SetDefaults set the default type
-func (pp *ParamSpec) SetDefaults(ctx context.Context) {
+func (pp *ParamSpec) SetDefaults(context.Context) {
 	if pp == nil {
 		return
 	}
@@ -72,11 +72,11 @@ func (pp *ParamSpec) SetDefaults(ctx context.Context) {
 	switch {
 	case pp.Type != "":
 		// If param type is provided by the author, do nothing but just set default type for PropertySpec in case `properties` section is provided.
-		pp.setDefaultsForProperties(ctx)
+		pp.setDefaultsForProperties()
 	case pp.Properties != nil:
 		pp.Type = ParamTypeObject
 		// Also set default type for PropertySpec
-		pp.setDefaultsForProperties(ctx)
+		pp.setDefaultsForProperties()
 	case pp.Default == nil:
 		// ParamTypeString is the default value (when no type can be inferred from the default value)
 		pp.Type = ParamTypeString
@@ -92,7 +92,7 @@ func (pp *ParamSpec) SetDefaults(ctx context.Context) {
 }
 
 // setDefaultsForProperties sets default type for PropertySpec (string) if it's not specified
-func (pp *ParamSpec) setDefaultsForProperties(ctx context.Context) {
+func (pp *ParamSpec) setDefaultsForProperties() {
 	for key, propertySpec := range pp.Properties {
 		if propertySpec.Type == "" {
 			pp.Properties[key] = PropertySpec{Type: ParamTypeString}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -97,7 +97,7 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 		}
 	}
 
-	errs = errs.Also(validateSpecStatus(ctx, ps.Status))
+	errs = errs.Also(validateSpecStatus(ps.Status))
 
 	if ps.Workspaces != nil {
 		wsNames := make(map[string]int)
@@ -117,7 +117,7 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 	return errs
 }
 
-func validateSpecStatus(ctx context.Context, status PipelineRunSpecStatus) *apis.FieldError {
+func validateSpecStatus(status PipelineRunSpecStatus) *apis.FieldError {
 	switch status {
 	case "":
 		return nil

--- a/pkg/apis/pipeline/v1beta1/resource_types_validation.go
+++ b/pkg/apis/pipeline/v1beta1/resource_types_validation.go
@@ -26,7 +26,7 @@ import (
 )
 
 // Validate implements apis.Validatable
-func (tr *TaskResources) Validate(ctx context.Context) (errs *apis.FieldError) {
+func (tr *TaskResources) Validate(context.Context) (errs *apis.FieldError) {
 	if tr != nil {
 		errs = errs.Also(validateTaskResources(tr.Inputs).ViaField("inputs"))
 		errs = errs.Also(validateTaskResources(tr.Outputs).ViaField("outputs"))

--- a/pkg/apis/pipeline/v1beta1/result_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults.go
@@ -16,7 +16,7 @@ package v1beta1
 import "context"
 
 // SetDefaults set the default type for TaskResult
-func (tr *TaskResult) SetDefaults(ctx context.Context) {
+func (tr *TaskResult) SetDefaults(context.Context) {
 	if tr != nil && tr.Type == "" {
 		// ResultsTypeString is the default value
 		tr.Type = ResultsTypeString

--- a/pkg/apis/pipeline/v1beta1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation.go
@@ -36,7 +36,7 @@ var allVolumeSourceFields = []string{
 // Validate looks at the Volume provided in wb and makes sure that it is valid.
 // This means that only one VolumeSource can be specified, and also that the
 // supported VolumeSource is itself valid.
-func (b *WorkspaceBinding) Validate(ctx context.Context) *apis.FieldError {
+func (b *WorkspaceBinding) Validate(context.Context) *apis.FieldError {
 	if equality.Semantic.DeepEqual(b, &WorkspaceBinding{}) || b == nil {
 		return apis.ErrMissingField(apis.CurrentField)
 	}

--- a/pkg/internal/limitrange/limitrange.go
+++ b/pkg/internal/limitrange/limitrange.go
@@ -17,15 +17,13 @@ limitations under the License.
 package limitrange
 
 import (
-	"context"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 )
 
-func getVirtualLimitRange(ctx context.Context, namespace string, lister corev1listers.LimitRangeLister) (*corev1.LimitRange, error) {
+func getVirtualLimitRange(namespace string, lister corev1listers.LimitRangeLister) (*corev1.LimitRange, error) {
 	limitRanges, err := lister.LimitRanges(namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err

--- a/pkg/internal/limitrange/transformer.go
+++ b/pkg/internal/limitrange/transformer.go
@@ -34,7 +34,7 @@ func isZero(q resource.Quantity) bool {
 // NewTransformer returns a pod.Transformer that will modify limits if needed
 func NewTransformer(ctx context.Context, namespace string, lister corev1listers.LimitRangeLister) pod.Transformer {
 	return func(p *corev1.Pod) (*corev1.Pod, error) {
-		limitRange, err := getVirtualLimitRange(ctx, namespace, lister)
+		limitRange, err := getVirtualLimitRange(namespace, lister)
 		if err != nil {
 			return p, err
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2470,7 +2470,7 @@ status:
 	}}
 	for _, tc := range testcases {
 		t.Run(tc.description, func(t *testing.T) {
-			c.handlePodCreationError(testAssets.Ctx, taskRun, tc.err)
+			c.handlePodCreationError(taskRun, tc.err)
 			foundCondition := false
 			for _, cond := range taskRun.Status.Conditions {
 				if cond.Type == tc.expectedType && cond.Status == tc.expectedStatus && cond.Reason == tc.expectedReason {
@@ -4132,8 +4132,6 @@ status:
 }
 
 func Test_validateTaskSpecRequestResources_ValidResources(t *testing.T) {
-	ctx := context.Background()
-
 	tcs := []struct {
 		name     string
 		taskSpec *v1beta1.TaskSpec
@@ -4238,7 +4236,7 @@ func Test_validateTaskSpecRequestResources_ValidResources(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateTaskSpecRequestResources(ctx, tc.taskSpec); err != nil {
+			if err := validateTaskSpecRequestResources(tc.taskSpec); err != nil {
 				t.Fatalf("Expected to see error when validating invalid TaskSpec resources but saw none")
 			}
 		})
@@ -4247,7 +4245,6 @@ func Test_validateTaskSpecRequestResources_ValidResources(t *testing.T) {
 }
 
 func Test_validateTaskSpecRequestResources_InvalidResources(t *testing.T) {
-	ctx := context.Background()
 	tcs := []struct {
 		name     string
 		taskSpec *v1beta1.TaskSpec
@@ -4294,7 +4291,7 @@ func Test_validateTaskSpecRequestResources_InvalidResources(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := validateTaskSpecRequestResources(ctx, tc.taskSpec); err == nil {
+			if err := validateTaskSpecRequestResources(tc.taskSpec); err == nil {
 				t.Fatalf("Expected to see error when validating invalid TaskSpec resources but saw none")
 			}
 		})
@@ -4347,7 +4344,7 @@ func podVolumeMounts(idx, totalSteps int) []corev1.VolumeMount {
 	return mnts
 }
 
-func podArgs(stepName string, cmd string, additionalArgs []string, idx int) []string {
+func podArgs(cmd string, additionalArgs []string, idx int) []string {
 	args := []string{
 		"-wait_file",
 	}
@@ -4452,7 +4449,7 @@ func expectedPod(podName, taskName, taskRunName, ns, saName string, isClusterTas
 			VolumeMounts:           podVolumeMounts(idx, len(steps)),
 			TerminationMessagePath: "/tekton/termination",
 		}
-		stepContainer.Args = podArgs(s.name, s.cmd, s.args, idx)
+		stepContainer.Args = podArgs(s.cmd, s.args, idx)
 
 		for k, v := range s.envVars {
 			stepContainer.Env = append(stepContainer.Env, corev1.EnvVar{

--- a/pkg/reconciler/taskrun/validate_resources.go
+++ b/pkg/reconciler/taskrun/validate_resources.go
@@ -223,7 +223,7 @@ func ValidateResolvedTaskResources(ctx context.Context, params []v1beta1.Param, 
 	return nil
 }
 
-func validateTaskSpecRequestResources(ctx context.Context, taskSpec *v1beta1.TaskSpec) error {
+func validateTaskSpecRequestResources(taskSpec *v1beta1.TaskSpec) error {
 	if taskSpec != nil {
 		for _, step := range taskSpec.Steps {
 			for k, request := range step.Resources.Requests {
@@ -250,13 +250,13 @@ func validateTaskSpecRequestResources(ctx context.Context, taskSpec *v1beta1.Tas
 }
 
 // validateOverrides validates that all stepOverrides map to valid steps, and likewise for sidecarOverrides
-func validateOverrides(ctx context.Context, ts *v1beta1.TaskSpec, trs *v1beta1.TaskRunSpec) error {
-	stepErr := validateStepOverrides(ctx, ts, trs)
-	sidecarErr := validateSidecarOverrides(ctx, ts, trs)
+func validateOverrides(ts *v1beta1.TaskSpec, trs *v1beta1.TaskRunSpec) error {
+	stepErr := validateStepOverrides(ts, trs)
+	sidecarErr := validateSidecarOverrides(ts, trs)
 	return multierror.Append(stepErr, sidecarErr).ErrorOrNil()
 }
 
-func validateStepOverrides(ctx context.Context, ts *v1beta1.TaskSpec, trs *v1beta1.TaskRunSpec) error {
+func validateStepOverrides(ts *v1beta1.TaskSpec, trs *v1beta1.TaskRunSpec) error {
 	var err error
 	stepNames := sets.NewString()
 	for _, step := range ts.Steps {
@@ -270,7 +270,7 @@ func validateStepOverrides(ctx context.Context, ts *v1beta1.TaskSpec, trs *v1bet
 	return err
 }
 
-func validateSidecarOverrides(ctx context.Context, ts *v1beta1.TaskSpec, trs *v1beta1.TaskRunSpec) error {
+func validateSidecarOverrides(ts *v1beta1.TaskSpec, trs *v1beta1.TaskRunSpec) error {
 	var err error
 	sidecarNames := sets.NewString()
 	for _, sidecar := range ts.Sidecars {

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -543,7 +543,7 @@ func TestValidateOverrides(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateOverrides(context.Background(), tc.ts, tc.trs)
+			err := validateOverrides(tc.ts, tc.trs)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("expected err: %t, but got err %s", tc.wantErr, err)
 			}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In this change, we cleanup unused arguments in functions, mostly removing unused "ctx".

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```