### PR TITLE
Allow setting embedded status feature flag to minimal in tests

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -22,6 +22,7 @@ source $(git rev-parse --show-toplevel)/test/e2e-common.sh
 
 # Setting defaults
 PIPELINE_FEATURE_GATE=${PIPELINE_FEATURE_GATE:-stable}
+EMBEDDED_STATUS_GATE=${EMBEDDED_STATUS_GATE:-full}
 SKIP_INITIALIZE=${SKIP_INITIALIZE:="false"}
 RUN_YAML_TESTS=${RUN_YAML_TESTS:="true"}
 failed=0
@@ -50,6 +51,18 @@ function set_feature_gate() {
   kubectl patch configmap feature-flags -n tekton-pipelines -p "$jsonpatch"
 }
 
+function set_embedded_status() {
+  local status="$1"
+  if [ "$status" != "full" ] && [ "$status" != "minimal" ] && [ "$status" != "both" ] ; then
+    printf "Invalid embedded status %s\n" ${status}
+    exit 255
+  fi
+  printf "Setting embedded status to %s\n", ${status}
+  jsonpatch=$(printf "{\"data\": {\"embedded-status\": \"%s\"}}" $1)
+  echo "feature-flags ConfigMap patch: ${jsonpatch}"
+  kubectl patch configmap feature-flags -n tekton-pipelines -p "$jsonpatch"
+}
+
 function run_e2e() {
   # Run the integration tests
   header "Running Go e2e tests"
@@ -64,6 +77,7 @@ function run_e2e() {
 }
 
 set_feature_gate "$PIPELINE_FEATURE_GATE"
+set_embedded_status "$EMBEDDED_STATUS_GATE"
 run_e2e
 
 (( failed )) && fail_test


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

We recently added support for minimal embedded status, which is gated behind the `embedded-status` feature flag. In this change, we support setting `embedded-status` when running end-to-end tests. It defaults to "full" because this is the current default value for the flag.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```