### PR TITLE
TEP-0090: Matrix - Add example and document expected PipelineRun status

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -31,9 +31,6 @@ Documentation for specifying `Matrix` in a `Pipeline`:
 > :seedling: **`Matrix` is an [alpha](install.md#alpha-features) feature.**
 > The `enable-api-fields` feature flag must be set to `"alpha"` to specify `Matrix` in a `PipelineTask`.
 > The `embedded-status` feature flag must be set to `"minimal"` to specify `Matrix` in a `PipelineTask`.
->
-> :warning: This feature is in a preview mode. 
-> It is still in a very early stage of development and is not yet fully functional.
 
 ## Configuring a Matrix
 
@@ -193,6 +190,8 @@ spec:
           name: platform-browsers
 ```
 
+When the above `PipelineRun` is executed, these are the `TaskRuns` that are created:
+
 ```shell
 $ tkn taskruns list
 
@@ -207,3 +206,105 @@ matrixed-pr-6lvzk-platforms-and-browsers-1   13 seconds ago   8 seconds    Succe
 matrixed-pr-6lvzk-platforms-and-browsers-2   13 seconds ago   8 seconds    Succeeded
 matrixed-pr-6lvzk-platforms-and-browsers-0   13 seconds ago   8 seconds    Succeeded
 ```
+
+When the above `Pipeline` is executed, its status is populated with `ChildReferences` of the above `TaskRuns`. The
+`PipelineRun` status tracks the status of all the fanned out `TaskRuns`. This is the `PipelineRun` after completing
+successfully:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: matrixed-pr-
+  labels:
+    tekton.dev/pipeline: matrixed-pr-6lvzk
+  name: matrixed-pr-6lvzk
+  namespace: default
+spec:
+  pipelineSpec:
+    tasks:
+    - matrix:
+      - name: platform
+        value:
+        - linux
+        - mac
+        - windows
+      - name: browser
+        value:
+        - chrome
+        - safari
+        - firefox
+      name: platforms-and-browsers
+      taskRef:
+        kind: Task
+        name: platform-browsers
+  serviceAccountName: default
+  timeout: 1h0m0s
+status:
+  pipelineSpec:
+    tasks:
+      - matrix:
+          - name: platform
+            value:
+              - linux
+              - mac
+              - windows
+          - name: browser
+            value:
+              - chrome
+              - safari
+              - firefox
+        name: platforms-and-browsers
+        taskRef:
+          kind: Task
+          name: platform-browsers
+  startTime: "2022-06-23T23:01:11Z"
+  completionTime: "2022-06-23T23:01:20Z"
+  conditions:
+    - lastTransitionTime: "2022-06-23T23:01:20Z"
+      message: 'Tasks Completed: 1 (Failed: 0, Cancelled 0), Skipped: 0'
+      reason: Succeeded
+      status: "True"
+      type: Succeeded
+  childReferences:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-4
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-6
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-2
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-1
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-7
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-0
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-8
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-3
+    pipelineTaskName: platforms-and-browsers
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: matrixed-pr-6lvzk-platforms-and-browsers-5
+    pipelineTaskName: platforms-and-browsers
+```
+
+To execute this example yourself, run [`PipelineRun` with `Matrix`][pr-with-matrix].
+
+[pr-with-matrix]: ../examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix.yaml

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: platform-browsers
+  annotations:
+    description: |
+      A task that does something cool with platforms and browsers
+spec:
+  params:
+    - name: platform
+    - name: browser
+  steps:
+    - name: echo
+      image: alpine
+      script: |
+        echo "$(params.platform) and $(params.browser)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: matrixed-pr-
+spec:
+  serviceAccountName: 'default'
+  pipelineSpec:
+    tasks:
+      - name: platforms-and-browsers
+        matrix:
+          - name: platform
+            value:
+              - linux
+              - mac
+              - windows
+          - name: browser
+            value:
+              - chrome
+              - safari
+              - firefox
+        taskRef:
+          name: platform-browsers


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

Milestone 1 of the implementation plan - fan out `PipelineTasks` with `Tasks` into `TaskRuns` - is completed. In this change, we add an example `PipelineRun` with a `Matrix` and document the expected status of the `PipelineRun` upon completion.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
Fanning out `PipelineTasks` into parallel `TaskRuns` with substitutions from combinations of `Parameters` in a `Matrix` is fully supported. The `ChildReferences` of the fanned out `TaskRuns` will be added to the `PipelineRun` status.
```