### PR TITLE
TEP-0090: Matrix - Implement `isSuccessful` for `Runs`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -66,6 +66,7 @@ type ResolvedPipelineTask struct {
 	CustomTask            bool
 	RunName               string
 	Run                   *v1alpha1.Run
+	Runs                  []*v1alpha1.Run
 	PipelineTask          *v1beta1.PipelineTask
 	ResolvedTaskResources *resources.ResolvedTaskResources
 }
@@ -108,6 +109,16 @@ func (t ResolvedPipelineTask) IsMatrixed() bool {
 // If the PipelineTask has a Matrix, isSuccessful returns true if all runs have completed successfully
 func (t ResolvedPipelineTask) isSuccessful() bool {
 	switch {
+	case t.IsCustomTask() && t.IsMatrixed():
+		if len(t.Runs) == 0 {
+			return false
+		}
+		for _, run := range t.Runs {
+			if !run.IsSuccessful() {
+				return false
+			}
+		}
+		return true
 	case t.IsCustomTask():
 		return t.Run.IsSuccessful()
 	case t.IsMatrixed():

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -3317,10 +3317,25 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "matrixed runs not started",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+		},
+		want: false,
+	}, {
 		name: "matrixed taskruns running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0]), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed runs running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{makeRunStarted(runs[0]), makeRunStarted(runs[1])},
 		},
 		want: false,
 	}, {
@@ -3331,10 +3346,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "one matrixed run running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{makeRunStarted(runs[0]), makeRunSucceeded(runs[1])},
+		},
+		want: false,
+	}, {
 		name: "matrixed taskruns succeeded",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0]), makeSucceeded(trs[1])},
+		},
+		want: true,
+	}, {
+		name: "matrixed runs succeeded",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{makeRunSucceeded(runs[0]), makeRunSucceeded(runs[1])},
 		},
 		want: true,
 	}, {
@@ -3345,10 +3376,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "one matrixed run succeeded",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{makeRunSucceeded(runs[0]), makeRunStarted(runs[1])},
+		},
+		want: false,
+	}, {
 		name: "matrixed taskruns failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed runs failed",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{makeRunFailed(runs[0]), makeRunFailed(runs[1])},
 		},
 		want: false,
 	}, {
@@ -3359,10 +3406,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "one matrixed run failed, one matrixed run running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{makeRunFailed(runs[0]), makeRunStarted(runs[1])},
+		},
+		want: false,
+	}, {
 		name: "matrixed taskruns failed: retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
 			TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0]), makeFailed(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "matrixed runs failed: retries remaining",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{makeRunFailed(runs[0]), makeRunFailed(runs[1])},
 		},
 		want: false,
 	}, {
@@ -3373,10 +3436,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "matrixed runs failed: one run with retries remaining",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{makeRunFailed(runs[0]), withRunRetries(makeRunFailed(runs[1]))},
+		},
+		want: false,
+	}, {
 		name: "matrixed taskruns failed: no retries remaining",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
 			TaskRuns:     []*v1beta1.TaskRun{withRetries(makeFailed(trs[0])), withRetries(makeFailed(trs[1]))},
+		},
+		want: false,
+	}, {
+		name: "matrixed runs failed: no retries remaining",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{withRunRetries(makeRunFailed(runs[0])), withRunRetries(makeRunFailed(runs[1]))},
 		},
 		want: false,
 	}, {
@@ -3387,10 +3466,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "matrixed runs cancelled",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{withRunCancelled(makeRunFailed(runs[0])), withRunCancelled(makeRunFailed(runs[1]))},
+		},
+		want: false,
+	}, {
 		name: "one matrixed taskrun cancelled, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed run cancelled, one matrixed run running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{withRunCancelled(makeRunFailed(runs[0])), makeRunStarted(runs[1])},
 		},
 		want: false,
 	}, {
@@ -3401,10 +3496,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "matrixed runs cancelled but not failed",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{withRunCancelled(newRun(runs[0])), withRunCancelled(newRun(runs[1]))},
+		},
+		want: false,
+	}, {
 		name: "one matrixed taskrun cancelled but not failed",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: matrixedPipelineTask,
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(newTaskRun(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed run cancelled but not failed",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: matrixedPipelineTask,
+			Runs:         []*v1alpha1.Run{withRunCancelled(newRun(runs[0])), makeRunStarted(runs[1])},
 		},
 		want: false,
 	}, {
@@ -3415,10 +3526,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "matrixed runs cancelled: retries remaining",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{withRunCancelled(makeRunFailed(runs[0])), withRunCancelled(makeRunFailed(runs[1]))},
+		},
+		want: false,
+	}, {
 		name: "one matrixed taskrun cancelled: retries remaining, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeFailed(trs[0])), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed run cancelled: retries remaining, one matrixed run running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{withRunCancelled(makeRunFailed(runs[0])), makeRunStarted(runs[1])},
 		},
 		want: false,
 	}, {
@@ -3429,10 +3556,26 @@ func TestIsSuccessful(t *testing.T) {
 		},
 		want: false,
 	}, {
+		name: "matrixed runs cancelled: no retries remaining",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{withRunCancelled(withRunRetries(makeRunFailed(runs[0]))), withRunCancelled(withRunRetries(makeRunFailed(runs[1])))},
+		},
+		want: false,
+	}, {
 		name: "one matrixed taskrun cancelled: no retries remaining, one matrixed taskrun running",
 		rpt: ResolvedPipelineTask{
 			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
 			TaskRuns:     []*v1beta1.TaskRun{withCancelled(withRetries(makeFailed(trs[0]))), makeStarted(trs[1])},
+		},
+		want: false,
+	}, {
+		name: "one matrixed run cancelled: no retries remaining, one matrixed run running",
+		rpt: ResolvedPipelineTask{
+			CustomTask:   true,
+			PipelineTask: withPipelineTaskRetries(*matrixedPipelineTask, 1),
+			Runs:         []*v1alpha1.Run{withRunCancelled(withRunRetries(makeRunFailed(runs[0]))), makeRunStarted(runs[1])},
 		},
 		want: false,
 	}} {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

In this change, we implement the `isSuccessful` member function of `ResolvedPipelineRunTask` for matrixed `Runs`.

If the `ResolvedPipelineRunTask` is matrixed, it is successful only if all of its `Runs` completed successfully.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
Matrixed `PipelineTasks` with `Custom Tasks` are successful when all `Runs` have completed successfully.
```