### PR TITLE
Get Names of TaskRuns from ChildReferences only

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -2831,15 +2831,6 @@ func TestGetTaskRunName(t *testing.T) {
 
 func TestGetNamesOfTaskRuns(t *testing.T) {
 	prName := "mypipelinerun"
-	taskRunsStatus := map[string]*v1beta1.PipelineRunTaskRunStatus{
-		"mypipelinerun-mytask-0": {
-			PipelineTaskName: "mytask",
-		},
-		"mypipelinerun-mytask-1": {
-			PipelineTaskName: "mytask",
-		},
-	}
-
 	childRefs := []v1beta1.ChildStatusReference{{
 		TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
 		Name:             "mypipelinerun-mytask-0",
@@ -2892,12 +2883,7 @@ func TestGetNamesOfTaskRuns(t *testing.T) {
 			if tc.prName != "" {
 				testPrName = tc.prName
 			}
-			namesOfTaskRunsFromTaskRunsStatus := GetNamesOfTaskRuns(taskRunsStatus, nil, tc.ptName, testPrName, 2)
-			sort.Strings(namesOfTaskRunsFromTaskRunsStatus)
-			if d := cmp.Diff(tc.wantTrNames, namesOfTaskRunsFromTaskRunsStatus); d != "" {
-				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))
-			}
-			namesOfTaskRunsFromChildRefs := GetNamesOfTaskRuns(nil, childRefs, tc.ptName, testPrName, 2)
+			namesOfTaskRunsFromChildRefs := GetNamesOfTaskRuns(childRefs, tc.ptName, testPrName, 2)
 			sort.Strings(namesOfTaskRunsFromChildRefs)
 			if d := cmp.Diff(tc.wantTrNames, namesOfTaskRunsFromChildRefs); d != "" {
 				t.Errorf("GetTaskRunName: %s", diff.PrintWantGot(d))


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

In https://github.com/tektoncd/community/pull/736, we decided that `Matrix` will use `ChildReferences` only. Therefore, it is unnecessary to check the `TaskRuns` field of `PipelineRun` status when getting the names of `TaskRuns` for matrixed `PipelineTasks`.

Related PR: https://github.com/tektoncd/pipeline/pull/5019

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```