### PR TITLE
TEP-0090: Matrix - Get Names of `Runs`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -706,6 +706,25 @@ func getRunName(runsStatus map[string]*v1beta1.PipelineRunRunStatus, childRefs [
 	return kmeta.ChildName(prName, fmt.Sprintf("-%s", ptName))
 }
 
+// getNamesOfRuns should return a unique names for `Runs` if they have not already been defined,
+// and the existing ones otherwise.
+func getNamesOfRuns(childRefs []v1beta1.ChildStatusReference, ptName, prName string, combinationCount int) []string {
+	if runNames := getRunNamesFromChildRefs(childRefs, ptName); runNames != nil {
+		return runNames
+	}
+	return getNewTaskRunNames(ptName, prName, combinationCount)
+}
+
+func getRunNamesFromChildRefs(childRefs []v1beta1.ChildStatusReference, ptName string) []string {
+	var runNames []string
+	for _, cr := range childRefs {
+		if cr.Kind == pipeline.RunControllerName && cr.PipelineTaskName == ptName {
+			runNames = append(runNames, cr.Name)
+		}
+	}
+	return runNames
+}
+
 // resolvePipelineTaskResources matches PipelineResources referenced by pt inputs and outputs with the
 // providedResources and returns an instance of ResolvedTaskResources.
 func resolvePipelineTaskResources(pt v1beta1.PipelineTask, ts *v1beta1.TaskSpec, taskName string, kind v1beta1.TaskKind, providedResources map[string]*resourcev1alpha1.PipelineResource) (*resources.ResolvedTaskResources, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in
parallel `TaskRuns` and `Runs` with substitutions from combinations
of `Parameters` in a `Matrix`.

In this change, we add a function to get names of `TaskRuns` from
Child References. If none are available, it generates new names for
`Runs` based on the `PipelineRun` and `PipelineTask` names.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

Related PR: https://github.com/tektoncd/pipeline/pull/4958

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```