### PR TITLE
Relax result type validation to avoid nightly build failure

### DIFF
--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -3977,7 +3977,6 @@ func schema_pkg_apis_pipeline_v1beta1_TaskResult(ref common.ReferenceCallback) c
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Description is a human-readable description of the result",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/pipeline/v1beta1/result_types.go
+++ b/pkg/apis/pipeline/v1beta1/result_types.go
@@ -25,7 +25,7 @@ type TaskResult struct {
 
 	// Description is a human-readable description of the result
 	// +optional
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 }
 
 // TaskRunResult used to describe the results of a task

--- a/pkg/apis/pipeline/v1beta1/result_validation.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation.go
@@ -31,6 +31,13 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 		return errs.Also(ValidateEnabledAPIFields(ctx, "results type", config.AlphaAPIFields))
 	}
 
+	// Resources created before the result. Type was introduced may not have Type set
+	// and should be considered valid
+	if tr.Type == "" {
+		return nil
+	}
+
+	// By default the result type is string
 	if tr.Type != ResultsTypeString {
 		return apis.ErrInvalidValue(tr.Type, "type", fmt.Sprintf("type must be string"))
 	}

--- a/pkg/apis/pipeline/v1beta1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	"knative.dev/pkg/apis"
+)
+
+func TestResultsValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		Result    v1beta1.TaskResult
+		apiFields string
+	}{{
+		name: "valid result type empty",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Description: "my great result",
+		},
+		apiFields: "stable",
+	}, {
+		name: "valid result type string",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "string",
+			Description: "my great result",
+		},
+
+		apiFields: "stable",
+	}, {
+		name: "valid result type array",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "array",
+			Description: "my great result",
+		},
+
+		apiFields: "alpha",
+	}, {
+		name: "valid result type object",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "array",
+			Description: "my great result",
+		},
+
+		apiFields: "alpha",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := getContextBasedOnFeatureFlag(tt.apiFields)
+			if err := tt.Result.Validate(ctx); err != nil {
+				t.Errorf("TaskSpec.Validate() = %v", err)
+			}
+		})
+	}
+}
+
+func TestResultsValidateError(t *testing.T) {
+	tests := []struct {
+		name          string
+		Result        v1beta1.TaskResult
+		apiFields     string
+		expectedError apis.FieldError
+	}{{
+		name: "invalid result type in stable",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "wrong",
+			Description: "my great result",
+		},
+		apiFields: "stable",
+		expectedError: apis.FieldError{
+			Message: `invalid value: wrong`,
+			Paths:   []string{"type"},
+			Details: "type must be string",
+		},
+	}, {
+		name: "invalid result type in alpha",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "wrong",
+			Description: "my great result",
+		},
+		apiFields: "alpha",
+		expectedError: apis.FieldError{
+			Message: `invalid value: wrong`,
+			Paths:   []string{"type"},
+			Details: "type must be string",
+		},
+	}, {
+		name: "invalid array result type in stable",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "array",
+			Description: "my great result",
+		},
+		apiFields: "stable",
+		expectedError: apis.FieldError{
+			Message: "results type requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"",
+		},
+	}, {
+		name: "invalid object result type in stable",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        "object",
+			Description: "my great result",
+		},
+		apiFields: "stable",
+		expectedError: apis.FieldError{
+			Message: "results type requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"",
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := getContextBasedOnFeatureFlag(tt.apiFields)
+			err := tt.Result.Validate(ctx)
+			if err == nil {
+				t.Fatalf("Expected an error, got nothing for %v", tt.Result)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2243,8 +2243,7 @@
       "properties": {
         "description": {
           "description": "Description is a human-readable description of the result",
-          "type": "string",
-          "default": ""
+          "type": "string"
         },
         "name": {
           "description": "Name the given name",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the string result type validation, PR #4779 adds
result type and asumes that the default type should be string via
mutating webhook. PR #4818 adds the validation for this. However,
resources that did already exist in etcd didn't get the default. So this
commit relaxes this validation.

/kind bug

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes
```release-note
Relax the result type validation of string type to avoid nightly builds failing
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
