### PR TITLE
Clean up validation for task and pipeline refs

### DIFF
--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1109,7 +1109,7 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRef(ref common.ReferenceCallback) 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "PipelineRef can be used to refer to a specific instance of a Pipeline. Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64",
+				Description: "PipelineRef can be used to refer to a specific instance of a Pipeline.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {
@@ -3763,7 +3763,7 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRef(ref common.ReferenceCallback) comm
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "TaskRef can be used to refer to a specific instance of a task. Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64",
+				Description: "TaskRef can be used to refer to a specific instance of a task.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {

--- a/pkg/apis/pipeline/v1beta1/pipelineref_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_types.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// PipelineRef can be used to refer to a specific instance of a Pipeline.
+type PipelineRef struct {
+	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+	Name string `json:"name,omitempty"`
+	// API version of the referent
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Bundle url reference to a Tekton Bundle.
+	// +optional
+	Bundle string `json:"bundle,omitempty"`
+
+	// ResolverRef allows referencing a Pipeline in a remote location
+	// like a git repo. This field is only supported when the alpha
+	// feature gate is enabled.
+	// +optional
+	ResolverRef `json:",omitempty"`
+}

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestPipelineRef_Invalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		ref         *v1beta1.PipelineRef
+		wantErr     *apis.FieldError
+		withContext func(context.Context) context.Context
+	}{{
+		name: "use of bundle without the feature flag set",
+		ref: &v1beta1.PipelineRef{
+			Name:   "my-pipeline",
+			Bundle: "docker.io/foo",
+		},
+		wantErr: apis.ErrGeneric("bundle requires \"enable-tekton-oci-bundles\" feature gate to be true but it is false"),
+	}, {
+		name: "bundle missing name",
+		ref: &v1beta1.PipelineRef{
+			Bundle: "docker.io/foo",
+		},
+		wantErr:     apis.ErrMissingField("name"),
+		withContext: enableTektonOCIBundles(t),
+	}, {
+		name: "invalid bundle reference",
+		ref: &v1beta1.PipelineRef{
+			Name:   "my-pipeline",
+			Bundle: "not a valid reference",
+		},
+		wantErr:     apis.ErrInvalidValue("invalid bundle reference", "bundle", "could not parse reference: not a valid reference"),
+		withContext: enableTektonOCIBundles(t),
+	}, {
+		name:    "pipelineRef without Pipeline Name",
+		ref:     &v1beta1.PipelineRef{},
+		wantErr: apis.ErrMissingField("name"),
+	}, {
+		name: "pipelineref resolver disallowed without alpha feature gate",
+		ref: &v1beta1.PipelineRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "foo",
+			},
+		},
+		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
+	}, {
+		name: "pipelineref resource disallowed without alpha feature gate",
+		ref: &v1beta1.PipelineRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{},
+			},
+		},
+		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resource requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
+	}, {
+		name: "pipelineref resource disallowed without resolver",
+		ref: &v1beta1.PipelineRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{},
+			},
+		},
+		wantErr:     apis.ErrMissingField("resolver"),
+		withContext: enableAlphaAPIFields,
+	}, {
+		name: "pipelineref resolver disallowed in conjunction with pipelineref name",
+		ref: &v1beta1.PipelineRef{
+			Name: "foo",
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "bar",
+			},
+		},
+		wantErr:     apis.ErrMultipleOneOf("name", "resolver"),
+		withContext: enableAlphaAPIFields,
+	}, {
+		name: "pipelineref resolver disallowed in conjunction with pipelineref bundle",
+		ref: &v1beta1.PipelineRef{
+			Bundle: "foo",
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "baz",
+			},
+		},
+		wantErr:     apis.ErrMultipleOneOf("bundle", "resolver"),
+		withContext: enableAlphaAPIFields,
+	}, {
+		name: "pipelineref resource disallowed in conjunction with pipelineref name",
+		ref: &v1beta1.PipelineRef{
+			Name: "bar",
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{{
+					Name:  "foo",
+					Value: "bar",
+				}},
+			},
+		},
+		wantErr:     apis.ErrMultipleOneOf("name", "resource").Also(apis.ErrMissingField("resolver")),
+		withContext: enableAlphaAPIFields,
+	}, {
+		name: "pipelineref resource disallowed in conjunction with pipelineref bundle",
+		ref: &v1beta1.PipelineRef{
+			Bundle: "bar",
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{{
+					Name:  "foo",
+					Value: "bar",
+				}},
+			},
+		},
+		wantErr:     apis.ErrMultipleOneOf("bundle", "resource").Also(apis.ErrMissingField("resolver")),
+		withContext: enableAlphaAPIFields,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.withContext != nil {
+				ctx = tc.withContext(ctx)
+			}
+			err := tc.ref.Validate(ctx)
+			if d := cmp.Diff(tc.wantErr.Error(), err.Error()); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}
+
+func TestPipelineRef_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  *v1beta1.PipelineRef
+		wc   func(context.Context) context.Context
+	}{{
+		name: "no pipelineRef",
+		ref:  nil,
+	}, {
+		name: "alpha feature: valid resolver",
+		ref:  &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
+		wc:   enableAlphaAPIFields,
+	}, {
+		name: "alpha feature: valid resolver with resource parameters",
+		ref: &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Resource: []v1beta1.ResolverParam{{
+			Name:  "repo",
+			Value: "https://github.com/tektoncd/pipeline.git",
+		}, {
+			Name:  "branch",
+			Value: "baz",
+		}}}},
+		wc: enableAlphaAPIFields,
+	}}
+
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			ctx := context.Background()
+			if ts.wc != nil {
+				ctx = ts.wc(ctx)
+			}
+			if err := ts.ref.Validate(ctx); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func enableTektonOCIBundles(t *testing.T) func(context.Context) context.Context {
+	return func(ctx context.Context) context.Context {
+		s := config.NewStore(logtesting.TestLogger(t))
+		s.OnConfigChanged(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
+			Data: map[string]string{
+				"enable-tekton-oci-bundles": "true",
+			},
+		})
+		return s.ToContext(ctx)
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -265,25 +265,6 @@ const (
 	PipelineRunSpecStatusPending = "PipelineRunPending"
 )
 
-// PipelineRef can be used to refer to a specific instance of a Pipeline.
-// Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64
-type PipelineRef struct {
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name,omitempty"`
-	// API version of the referent
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
-	// Bundle url reference to a Tekton Bundle.
-	// +optional
-	Bundle string `json:"bundle,omitempty"`
-
-	// ResolverRef allows referencing a Pipeline in a remote location
-	// like a git repo. This field is only supported when the alpha
-	// feature gate is enabled.
-	// +optional
-	ResolverRef `json:",omitempty"`
-}
-
 // PipelineRunStatus defines the observed state of PipelineRun
 type PipelineRunStatus struct {
 	duckv1beta1.Status `json:",inline"`

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -29,7 +29,6 @@ import (
 	corev1resources "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	logtesting "knative.dev/pkg/logging/testing"
 )
 
 func TestPipelineRun_Invalid(t *testing.T) {
@@ -93,49 +92,6 @@ func TestPipelineRun_Invalid(t *testing.T) {
 			},
 		},
 		want: apis.ErrInvalidValue("PipelineRunCancell should be Cancelled, CancelledRunFinally, StoppedRunFinally or PipelineRunPending", "spec.status"),
-	}, {
-		name: "use of bundle without the feature flag set",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelinename",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{
-					Name:   "my-pipeline",
-					Bundle: "docker.io/foo",
-				},
-			},
-		},
-		want: apis.ErrDisallowedFields("spec.pipelineRef.bundle"),
-	}, {
-		name: "bundle missing name",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelinename",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{
-					Bundle: "docker.io/foo",
-				},
-			},
-		},
-		want: apis.ErrMissingField("spec.pipelineRef.name"),
-		wc:   enableTektonOCIBundles(t),
-	}, {
-		name: "invalid bundle reference",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pipelinelinename",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{
-					Name:   "my-pipeline",
-					Bundle: "not a valid reference",
-				},
-			},
-		},
-		want: apis.ErrInvalidValue("invalid bundle reference", "spec.pipelineRef.bundle", "could not parse reference: not a valid reference"),
-		wc:   enableTektonOCIBundles(t),
 	}, {
 		name: "pipelinerun pending while running",
 		pr: v1beta1.PipelineRun{
@@ -320,34 +276,6 @@ func TestPipelineRun_Validate(t *testing.T) {
 			},
 		},
 	}, {
-		name: "alpha feature: valid resolver",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pr",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
-			},
-		},
-		wc: enableAlphaAPIFields,
-	}, {
-		name: "alpha feature: valid resolver with resource parameters",
-		pr: v1beta1.PipelineRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "pr",
-			},
-			Spec: v1beta1.PipelineRunSpec{
-				PipelineRef: &v1beta1.PipelineRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Resource: []v1beta1.ResolverParam{{
-					Name:  "repo",
-					Value: "https://github.com/tektoncd/pipeline.git",
-				}, {
-					Name:  "branch",
-					Value: "baz",
-				}}}},
-			},
-		},
-		wc: enableAlphaAPIFields,
-	}, {
 		name: "alpha feature: sidecar and step overrides",
 		pr: v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
@@ -397,12 +325,6 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 		wantErr     *apis.FieldError
 		withContext func(context.Context) context.Context
 	}{{
-		name: "pipelineRef without Pipeline Name",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{},
-		},
-		wantErr: apis.ErrMissingField("pipelineRef.name"),
-	}, {
 		name: "pipelineRef and pipelineSpec together",
 		spec: v1beta1.PipelineRunSpec{
 			PipelineRef: &v1beta1.PipelineRef{
@@ -455,63 +377,6 @@ func TestPipelineRunSpec_Invalidate(t *testing.T) {
 				"workspaces[0].volumeclaimtemplate",
 			},
 		},
-	}, {
-		name: "pipelineref resolver disallowed without alpha feature gate",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				Name: "foo",
-				ResolverRef: v1beta1.ResolverRef{
-					Resolver: "foo",
-				},
-			},
-		},
-		wantErr: apis.ErrDisallowedFields("resolver").ViaField("pipelineRef"),
-	}, {
-		name: "pipelineref resource disallowed without alpha feature gate",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				Name: "foo",
-				ResolverRef: v1beta1.ResolverRef{
-					Resource: []v1beta1.ResolverParam{},
-				},
-			},
-		},
-		wantErr: apis.ErrDisallowedFields("resource").ViaField("pipelineRef"),
-	}, {
-		name: "pipelineref resource disallowed without resolver",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				ResolverRef: v1beta1.ResolverRef{
-					Resource: []v1beta1.ResolverParam{},
-				},
-			},
-		},
-		wantErr:     apis.ErrMissingField("resolver").ViaField("pipelineRef"),
-		withContext: enableAlphaAPIFields,
-	}, {
-		name: "pipelineref resolver disallowed in conjunction with pipelineref name",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				Name: "foo",
-				ResolverRef: v1beta1.ResolverRef{
-					Resolver: "bar",
-				},
-			},
-		},
-		wantErr:     apis.ErrMultipleOneOf("name", "resolver").ViaField("pipelineRef"),
-		withContext: enableAlphaAPIFields,
-	}, {
-		name: "pipelineref resolver disallowed in conjunction with pipelineref bundle",
-		spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				Bundle: "foo",
-				ResolverRef: v1beta1.ResolverRef{
-					Resolver: "baz",
-				},
-			},
-		},
-		wantErr:     apis.ErrMultipleOneOf("bundle", "resolver").ViaField("pipelineRef"),
-		withContext: enableAlphaAPIFields,
 	}, {
 		name: "duplicate stepOverride names",
 		spec: v1beta1.PipelineRunSpec{
@@ -972,19 +837,6 @@ func TestPipelineRunWithTimeout_Validate(t *testing.T) {
 				t.Error(err)
 			}
 		})
-	}
-}
-
-func enableTektonOCIBundles(t *testing.T) func(context.Context) context.Context {
-	return func(ctx context.Context) context.Context {
-		s := config.NewStore(logtesting.TestLogger(t))
-		s.OnConfigChanged(&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-			Data: map[string]string{
-				"enable-tekton-oci-bundles": "true",
-			},
-		})
-		return s.ToContext(ctx)
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -707,7 +707,7 @@
       }
     },
     "v1beta1.PipelineRef": {
-      "description": "PipelineRef can be used to refer to a specific instance of a Pipeline. Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64",
+      "description": "PipelineRef can be used to refer to a specific instance of a Pipeline.",
       "type": "object",
       "properties": {
         "apiVersion": {
@@ -2134,7 +2134,7 @@
       }
     },
     "v1beta1.TaskRef": {
-      "description": "TaskRef can be used to refer to a specific instance of a task. Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64",
+      "description": "TaskRef can be used to refer to a specific instance of a task.",
       "type": "object",
       "properties": {
         "apiVersion": {

--- a/pkg/apis/pipeline/v1beta1/task_types.go
+++ b/pkg/apis/pipeline/v1beta1/task_types.go
@@ -134,36 +134,3 @@ type TaskList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Task `json:"items"`
 }
-
-// TaskRef can be used to refer to a specific instance of a task.
-// Copied from CrossVersionObjectReference: https://github.com/kubernetes/kubernetes/blob/169df7434155cbbc22f1532cba8e0a9588e29ad8/pkg/apis/autoscaling/types.go#L64
-type TaskRef struct {
-	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name,omitempty"`
-	// TaskKind indicates the kind of the task, namespaced or cluster scoped.
-	Kind TaskKind `json:"kind,omitempty"`
-	// API version of the referent
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty"`
-	// Bundle url reference to a Tekton Bundle.
-	// +optional
-	Bundle string `json:"bundle,omitempty"`
-
-	// ResolverRef allows referencing a Task in a remote location
-	// like a git repo. This field is only supported when the alpha
-	// feature gate is enabled.
-	// +optional
-	ResolverRef `json:",omitempty"`
-}
-
-// Check that Pipeline may be validated and defaulted.
-
-// TaskKind defines the type of Task used by the pipeline.
-type TaskKind string
-
-const (
-	// NamespacedTaskKind indicates that the task type has a namespaced scope.
-	NamespacedTaskKind TaskKind = "Task"
-	// ClusterTaskKind indicates that task type has a cluster scope.
-	ClusterTaskKind TaskKind = "ClusterTask"
-)

--- a/pkg/apis/pipeline/v1beta1/taskref_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_types.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// TaskRef can be used to refer to a specific instance of a task.
+type TaskRef struct {
+	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
+	Name string `json:"name,omitempty"`
+	// TaskKind indicates the kind of the task, namespaced or cluster scoped.
+	Kind TaskKind `json:"kind,omitempty"`
+	// API version of the referent
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
+	// Bundle url reference to a Tekton Bundle.
+	// +optional
+	Bundle string `json:"bundle,omitempty"`
+
+	// ResolverRef allows referencing a Task in a remote location
+	// like a git repo. This field is only supported when the alpha
+	// feature gate is enabled.
+	// +optional
+	ResolverRef `json:",omitempty"`
+}
+
+// Check that Pipeline may be validated and defaulted.
+
+// TaskKind defines the type of Task used by the pipeline.
+type TaskKind string
+
+const (
+	// NamespacedTaskKind indicates that the task type has a namespaced scope.
+	NamespacedTaskKind TaskKind = "Task"
+	// ClusterTaskKind indicates that task type has a cluster scope.
+	ClusterTaskKind TaskKind = "ClusterTask"
+)

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2019 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	"knative.dev/pkg/apis"
+)
+
+func TestTaskRef_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		taskRef *v1beta1.TaskRef
+		wc      func(context.Context) context.Context
+	}{{
+		name: "nil taskref",
+	}, {
+		name:    "simple taskref",
+		taskRef: &v1beta1.TaskRef{Name: "taskrefname"},
+	}, {
+		name:    "alpha feature: valid resolver",
+		taskRef: &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git"}},
+		wc:      enableAlphaAPIFields,
+	}, {
+		name: "alpha feature: valid resolver with resource parameters",
+		taskRef: &v1beta1.TaskRef{ResolverRef: v1beta1.ResolverRef{Resolver: "git", Resource: []v1beta1.ResolverParam{{
+			Name:  "repo",
+			Value: "https://github.com/tektoncd/pipeline.git",
+		}, {
+			Name:  "branch",
+			Value: "baz",
+		}}}},
+		wc: enableAlphaAPIFields,
+	}, {
+		name: "valid bundle",
+		taskRef: &v1beta1.TaskRef{
+			Name:   "bundled-task",
+			Bundle: "gcr.io/my-bundle"},
+		wc: enableAlphaAPIFields,
+	}}
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			ctx := context.Background()
+			if ts.wc != nil {
+				ctx = ts.wc(ctx)
+			}
+			if err := ts.taskRef.Validate(ctx); err != nil {
+				t.Errorf("TaskRef.Validate() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestTaskRef_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		taskRef *v1beta1.TaskRef
+		wantErr *apis.FieldError
+		wc      func(context.Context) context.Context
+	}{{
+		name:    "missing taskref name",
+		taskRef: &v1beta1.TaskRef{},
+		wantErr: apis.ErrMissingField("name"),
+	}, {
+		name: "use of bundle without the feature flag set",
+		taskRef: &v1beta1.TaskRef{
+			Name:   "my-task",
+			Bundle: "docker.io/foo",
+		},
+		wantErr: apis.ErrGeneric("bundle requires \"enable-tekton-oci-bundles\" feature gate to be true but it is false"),
+	}, {
+		name: "bundle missing name",
+		taskRef: &v1beta1.TaskRef{
+			Bundle: "docker.io/foo",
+		},
+		wantErr: apis.ErrMissingField("name"),
+		wc:      enableTektonOCIBundles(t),
+	}, {
+		name: "invalid bundle reference",
+		taskRef: &v1beta1.TaskRef{
+			Name:   "my-task",
+			Bundle: "invalid reference",
+		},
+		wantErr: apis.ErrInvalidValue("invalid bundle reference", "bundle", "could not parse reference: invalid reference"),
+		wc:      enableTektonOCIBundles(t),
+	}, {
+		name: "taskref resolver disallowed without alpha feature gate",
+		taskRef: &v1beta1.TaskRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr: apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
+	}, {
+		name: "taskref resource disallowed without alpha feature gate",
+		taskRef: &v1beta1.TaskRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{},
+			},
+		},
+		wantErr: apis.ErrMissingField("resolver").Also(apis.ErrGeneric("resource requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
+	}, {
+		name: "taskref resource disallowed without resolver",
+		taskRef: &v1beta1.TaskRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{},
+			},
+		},
+		wantErr: apis.ErrMissingField("resolver"),
+		wc:      enableAlphaAPIFields,
+	}, {
+		name: "taskref resolver disallowed in conjunction with taskref name",
+		taskRef: &v1beta1.TaskRef{
+			Name: "foo",
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr: apis.ErrMultipleOneOf("name", "resolver"),
+		wc:      enableAlphaAPIFields,
+	}, {
+		name: "taskref resolver disallowed in conjunction with taskref bundle",
+		taskRef: &v1beta1.TaskRef{
+			Bundle: "bar",
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "git",
+			},
+		},
+		wantErr: apis.ErrMultipleOneOf("bundle", "resolver"),
+		wc:      enableAlphaAPIFields,
+	}, {
+		name: "taskref resource disallowed in conjunction with taskref name",
+		taskRef: &v1beta1.TaskRef{
+			Name: "bar",
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{{
+					Name:  "foo",
+					Value: "bar",
+				}},
+			},
+		},
+		wantErr: apis.ErrMultipleOneOf("name", "resource").Also(apis.ErrMissingField("resolver")),
+		wc:      enableAlphaAPIFields,
+	}, {
+		name: "taskref resource disallowed in conjunction with taskref bundle",
+		taskRef: &v1beta1.TaskRef{
+			Bundle: "bar",
+			ResolverRef: v1beta1.ResolverRef{
+				Resource: []v1beta1.ResolverParam{{
+					Name:  "foo",
+					Value: "bar",
+				}},
+			},
+		},
+		wantErr: apis.ErrMultipleOneOf("bundle", "resource").Also(apis.ErrMissingField("resolver")),
+		wc:      enableAlphaAPIFields,
+	}}
+	for _, ts := range tests {
+		t.Run(ts.name, func(t *testing.T) {
+			ctx := context.Background()
+			if ts.wc != nil {
+				ctx = ts.wc(ctx)
+			}
+			err := ts.taskRef.Validate(ctx)
+			if d := cmp.Diff(ts.wantErr.Error(), err.Error()); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

This commit creates separate files for testing validation of Task and Pipeline
references, and moves test cases related to this validation into those files.
It also updates the error message for when a bundle is included in a reference
without the "enable-tekton-oci-bundles" flag set to "true" to instruct the user
to set that flag. In addition, it updates the error message for when resolvers
are set without the "enable-api-fields" flag set to "alpha" to instruct the user
to set that flag.

/kind  cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
NONE
```