### PR TITLE
TEP-0090: Support both `matrix` and `params` in a `PipelineTask`

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -11,6 +11,7 @@ weight: 11
 - [Configuring a Matrix](#configuring-a-matrix)
   - [Concurrency Control](#concurrency-control)
   - [Parameters](#parameters)
+    - [Specifying both `params` and `matrix` in a `PipelineTask`](#specifying-both-params-and-matrix-in-a-pipelinetask)
   - [Context Variables](#context-variables)
   - [Results](#results)
     - [Specifying Results in a Matrix](#specifying-results-in-a-matrix)
@@ -111,6 +112,38 @@ A `Parameter` can be passed to either the `matrix` or `params` field, not both.
 
 For further details on specifying `Parameters` in the `Pipeline` and passing them to
 `PipelineTasks`, see [documentation](pipelines.md#specifying-parameters).
+
+#### Specifying both `params` and `matrix` in a `PipelineTask`
+
+In the example below, the *test* `Task` takes *browser* and *platform* `Parameters` of type
+`"string"`. A `Pipeline` used to run the `Task` on three browsers (using `matrix`) and one
+platform (using `params`) would be specified as such and execute three `TaskRuns`:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: platform-browser-tests
+spec:
+  tasks:
+  - name: fetch-repository
+    taskRef:
+      name: git-clone
+    ...
+  - name: test
+    matrix:
+      - name: browser
+        value:
+          - chrome
+          - safari
+          - firefox
+    params:
+      - name: platform
+        value: linux
+    taskRef:
+      name: browser-test
+  ...
+```
 
 ### Context Variables
 

--- a/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
@@ -37,3 +37,15 @@ spec:
               - firefox
         taskRef:
           name: platform-browsers
+      - name: matrix-and-params
+        matrix:
+          - name: platform
+            value:
+              - linux
+              - mac
+              - windows
+        params:
+          - name: browser
+            value: chrome
+        taskRef:
+          name: platform-browsers

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -793,9 +793,7 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 
 	rpt.PipelineTask = resources.ApplyPipelineTaskContexts(rpt.PipelineTask)
 	taskRunSpec := pr.GetTaskRunSpec(rpt.PipelineTask.Name)
-	if len(params) == 0 {
-		params = rpt.PipelineTask.Params
-	}
+	params = append(params, rpt.PipelineTask.Params...)
 	tr = &v1beta1.TaskRun{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            taskRunName,

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7513,11 +7513,12 @@ spec:
   params:
     - name: platform
     - name: browser
+    - name: version
   steps:
     - name: echo
       image: alpine
       script: |
-        echo "$(params.platform) and $(params.browser)"
+        echo "$(params.platform) and $(params.browser) and $(params.version)"
 `)
 
 	expectedTaskRuns := []*v1beta1.TaskRun{
@@ -7531,6 +7532,8 @@ spec:
     value: linux
   - name: browser
     value: chrome
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7547,6 +7550,8 @@ spec:
     value: mac
   - name: browser
     value: chrome
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7563,6 +7568,8 @@ spec:
     value: windows
   - name: browser
     value: chrome
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7579,6 +7586,8 @@ spec:
     value: linux
   - name: browser
     value: safari
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7595,6 +7604,8 @@ spec:
     value: mac
   - name: browser
     value: safari
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7611,6 +7622,8 @@ spec:
     value: windows
   - name: browser
     value: safari
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7627,6 +7640,8 @@ spec:
     value: linux
   - name: browser
     value: firefox
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7643,6 +7658,8 @@ spec:
     value: mac
   - name: browser
     value: firefox
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7659,6 +7676,8 @@ spec:
     value: windows
   - name: browser
     value: firefox
+  - name: version
+    value: v0.33.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7698,6 +7717,9 @@ spec:
             - chrome
             - safari
             - firefox
+      params:
+        - name: version
+          value: v0.33.0
 `, "p-dag")),
 		expectedPipelineRun: parse.MustParsePipelineRun(t, `
 metadata:
@@ -7727,6 +7749,9 @@ status:
             - chrome
             - safari
             - firefox
+      params:
+        - name: version
+          value: v0.33.0
   conditions:
   - type: Succeeded
     status: "Unknown"
@@ -7787,6 +7812,8 @@ spec:
           value: linux
         - name: browser
           value: chrome
+        - name: version
+          value: v0.22.0
       taskRef:
         name: mytask
   finally:
@@ -7804,6 +7831,9 @@ spec:
             - chrome
             - safari
             - firefox
+      params:
+        - name: version
+          value: v0.33.0
 `, "p-finally")),
 		tr: mustParseTaskRunWithObjectMeta(t,
 			taskRunObjectMeta("pr-unmatrixed-pt", "foo",
@@ -7815,6 +7845,8 @@ spec:
     value: linux
   - name: browser
     value: chrome
+  - name: version
+    value: v0.22.0
   resources: {}
   serviceAccountName: test-sa
   taskRef:
@@ -7847,6 +7879,8 @@ status:
           value: linux
         - name: browser
           value: chrome
+        - name: version
+          value: v0.22.0
       taskRef:
         name: mytask
     finally:
@@ -7864,6 +7898,9 @@ status:
             - chrome
             - safari
             - firefox
+      params:
+        - name: version
+          value: v0.33.0
   conditions:
   - type: Succeeded
     status: "Unknown"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

This change implements the fan out of `PipelineTasks` that have both `matrix` and `params` specified. The `matrix` is used to fan out the `PipelineTask` and the `params` are the same in all the `TaskRuns`.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [x] Release notes block below has been filled in (if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
Users can specify both `matrix` and `params` fields. The `matrix` is used to fan out the `PipelineTask` and the `params` are the same in all the `TaskRuns`.
```