### PR TITLE
Support setting compute for init containers

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -81,3 +81,10 @@ data:
   # Setting this flag to "true" enables CloudEvents for Runs, as long as a
   # CloudEvents sink is configured in the config-defaults config map
   send-cloudevents-for-runs: "false"
+  # Setting this flag to "true" enables setting compute resources
+  # of Tekton init containers based on the compute resource requirements
+  # of a TaskRun's pod's containers.
+  # This feature is experimental and may be removed.
+  # See https://github.com/tektoncd/pipeline/docs/compute-resources.md
+  # for more information.
+  enable-init-container-resources: "false"

--- a/docs/install.md
+++ b/docs/install.md
@@ -9,26 +9,28 @@ weight: 100
 
 This guide explains how to install Tekton Pipelines. It covers the following topics:
 
-- [Before you begin](#before-you-begin)
-- [Installing Tekton Pipelines on Kubernetes](#installing-tekton-pipelines-on-kubernetes)
+- [Installing Tekton Pipelines](#installing-tekton-pipelines)
+  - [Before you begin](#before-you-begin)
+  - [Installing Tekton Pipelines on Kubernetes](#installing-tekton-pipelines-on-kubernetes)
     - [Installing Tekton Pipelines on OpenShift](#installing-tekton-pipelines-on-openshift)
-- [Configuring PipelineResource storage](#configuring-pipelineresource-storage)
+  - [Configuring PipelineResource storage](#configuring-pipelineresource-storage)
     - [Configuring a persistent volume](#configuring-a-persistent-volume)
     - [Configuring a cloud storage bucket](#configuring-a-cloud-storage-bucket)
-        - [Example configuration for an S3 bucket](#example-configuration-for-an-s3-bucket)
-        - [Example configuration for a GCS bucket](#example-configuration-for-a-gcs-bucket)
-- [Configuring CloudEvents notifications](#configuring-cloudevents-notifications)
-- [Configuring self-signed cert for private registry](#configuring-self-signed-cert-for-private-registry)
-- [Customizing basic execution parameters](#customizing-basic-execution-parameters)
+      - [Example configuration for an S3 bucket](#example-configuration-for-an-s3-bucket)
+      - [Example configuration for a GCS bucket](#example-configuration-for-a-gcs-bucket)
+  - [Configuring CloudEvents notifications](#configuring-cloudevents-notifications)
+  - [Configuring self-signed cert for private registry](#configuring-self-signed-cert-for-private-registry)
+  - [Customizing basic execution parameters](#customizing-basic-execution-parameters)
     - [Customizing the Pipelines Controller behavior](#customizing-the-pipelines-controller-behavior)
     - [Alpha Features](#alpha-features)
-- [Configuring High Availability](#configuring-high-availability)
-- [Configuring tekton pipeline controller performance](#configuring-tekton-pipeline-controller-performance)
-- [Creating a custom release of Tekton Pipelines](#creating-a-custom-release-of-tekton-pipelines)
-- [Verify Tekton Pipelines release](#verify-tekton-pipelines-release)
+  - [Configuring High Availability](#configuring-high-availability)
+  - [Configuring tekton pipeline controller performance](#configuring-tekton-pipeline-controller-performance)
+  - [Platform Support](#platform-support)
+  - [Creating a custom release of Tekton Pipelines](#creating-a-custom-release-of-tekton-pipelines)
+  - [Verify Tekton Pipelines Release](#verify-tekton-pipelines-release)
     - [Verify signatures using `cosign`](#verify-signatures-using-cosign)
-    - [Verify the tansparency logs using `rekor-cli`](#verify-the-transparency-logs-using-rekor-cli)
-- [Next steps](#next-steps)
+    - [Verify the transparency logs using `rekor-cli`](#verify-the-transparency-logs-using-rekor-cli)
+  - [Next steps](#next-steps)
 
 ## Before you begin
 
@@ -400,6 +402,9 @@ features](#alpha-features) to be used.
  `PipelineRun` status. Set it to "minimal" to populate the `ChildReferences` field in the `PipelineRun` status with
   name, kind, and API version information for each `TaskRun` and `Run` in the `PipelineRun` instead. Set it to "both" to
   do both. For more information, see [Configuring usage of `TaskRun` and `Run` embedded statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses).
+
+- `enable-init-container-resources`: set this flag to "true" to set compute resources of Tekton init containers.
+See the [docs on compute resources](./compute-resources.md#enabling-init-container-compute-resources) for more information.
 
 For example:
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -60,6 +60,8 @@ const (
 	DefaultSendCloudEventsForRuns = false
 	// DefaultEmbeddedStatus is the default value for "embedded-status".
 	DefaultEmbeddedStatus = FullEmbeddedStatus
+	// DefaultEnableInitContainerResources is the default value for "enable-init-container-resources".
+	DefaultEnableInitContainerResources = false
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -71,6 +73,7 @@ const (
 	enableAPIFields                     = "enable-api-fields"
 	sendCloudEventsForRuns              = "send-cloudevents-for-runs"
 	embeddedStatus                      = "embedded-status"
+	enableInitContainerResources        = "enable-init-container-resources"
 )
 
 // FeatureFlags holds the features configurations
@@ -87,6 +90,7 @@ type FeatureFlags struct {
 	SendCloudEventsForRuns           bool
 	AwaitSidecarReadiness            bool
 	EmbeddedStatus                   string
+	EnableInitContainerResources     bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -136,6 +140,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setEmbeddedStatus(cfgMap, DefaultEmbeddedStatus, &tc.EmbeddedStatus); err != nil {
+		return nil, err
+	}
+	if err := setFeature(enableInitContainerResources, DefaultEnableInitContainerResources, &tc.EnableInitContainerResources); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -60,6 +60,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableAPIFields:                  "alpha",
 				SendCloudEventsForRuns:           true,
 				EmbeddedStatus:                   "both",
+				EnableInitContainerResources:     true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -27,3 +27,4 @@ data:
   enable-api-fields: "alpha"
   send-cloudevents-for-runs: "true"
   embedded-status: "both"
+  enable-init-container-resources: "true"


### PR DESCRIPTION
# Changes

This commit introduces a flag "enable-init-container-resources" that will
allow a cluster operator to choose whether Tekton should apply compute resources
to its init containers. If this flag is turned on, init container resources will
be set to the maximum values of any of the other containers in the pod. This
provides the init containers with the maximum compute resources possible
without changing the effective resource requirements of the pod.
If LimitRanges are present as well, default values from LimitRanges will be applied
to initContainers only if no Steps or Sidecars have compute resources set.

One potential drawback of this solution is that if Step or Sidecar resource requirements
are set too low, init containers may be OOMkilled or throttled. However, Steps and
Sidecars typically need more compute resources than Tekton init containers do, and this
can be addressed by the user increasing the compute resources of their Steps or Sidecars.

An alternative solution is to provide an installation-level configMap that sets
compute resource requirements for Tekton init containers. (This is the solution pursued in #4552.)
This solution doesn't require anyone to right-size the init containers, so it's easier to maintain.

Setting resource requirements for init containers allows TaskRun pods to be deployed
in namespaces with ResourceQuotas, and provides more flexibility for users who would
like to configure quality of service for Tekton pods without having to use LimitRanges.
However, this doesn't address the problem that ResourceQuotas will consider the
resource usage of the pod to be the sum of the compute resources of its containers
(even though Step containers run sequentially) (#4976).

Closes #2933.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
Introduce feature flag to set compute resources for Tekton init containers
```
