### PR TITLE
TEP-0090: Matrix - implement `getNextTasks`

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -121,6 +121,48 @@ var pts = []v1beta1.PipelineTask{{
 	Name:    "mytask15",
 	TaskRef: &v1beta1.TaskRef{Name: "taskWithReferenceToTaskResult"},
 	Params:  []v1beta1.Param{{Name: "param1", Value: *v1beta1.NewArrayOrString("$(tasks.mytask1.results.result1)")}},
+}, {
+	Name: "mytask16",
+	Matrix: []v1beta1.Param{{
+		Name:  "browser",
+		Value: v1beta1.ArrayOrString{ArrayVal: []string{"safari", "chrome"}},
+	}},
+}, {
+	Name: "mytask17",
+	Matrix: []v1beta1.Param{{
+		Name:  "browser",
+		Value: v1beta1.ArrayOrString{ArrayVal: []string{"safari", "chrome"}},
+	}},
+}, {
+	Name:    "mytask18",
+	TaskRef: &v1beta1.TaskRef{Name: "task"},
+	Retries: 1,
+	Matrix: []v1beta1.Param{{
+		Name:  "browser",
+		Value: v1beta1.ArrayOrString{ArrayVal: []string{"safari", "chrome"}},
+	}},
+}, {
+	Name:    "mytask19",
+	TaskRef: &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
+	Matrix: []v1beta1.Param{{
+		Name:  "browser",
+		Value: v1beta1.ArrayOrString{ArrayVal: []string{"safari", "chrome"}},
+	}},
+}, {
+	Name:    "mytask20",
+	TaskRef: &v1beta1.TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: "customtask"},
+	Matrix: []v1beta1.Param{{
+		Name:  "browser",
+		Value: v1beta1.ArrayOrString{ArrayVal: []string{"safari", "chrome"}},
+	}},
+}, {
+	Name:    "mytask21",
+	TaskRef: &v1beta1.TaskRef{Name: "task"},
+	Retries: 2,
+	Matrix: []v1beta1.Param{{
+		Name:  "browser",
+		Value: v1beta1.ArrayOrString{ArrayVal: []string{"safari", "chrome"}},
+	}},
 }}
 
 var p = &v1beta1.Pipeline{
@@ -496,6 +538,147 @@ var runCancelled = PipelineRunState{{
 	PipelineTask: &pts[12],
 	RunName:      "pipelinerun-mytask13",
 	Run:          withRunCancelled(newRun(runs[0])),
+}}
+
+var noneStartedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[15],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     nil,
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[16],
+	TaskRunNames: []string{"pipelinerun-mytask3"},
+	TaskRuns:     nil,
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var oneStartedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[15],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[16],
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     nil,
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var oneFinishedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[15],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[16],
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     nil,
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var oneFailedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[15],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeFailed(trs[0])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[16],
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRun:      nil,
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var finalScheduledStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[15],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[16],
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     []*v1beta1.TaskRun{makeScheduled(trs[1])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var allFinishedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[15],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}, {
+	PipelineTask: &pts[16],
+	TaskRunNames: []string{"pipelinerun-mytask2"},
+	TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
+}}
+
+var noRunStartedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[18],
+	CustomTask:   true,
+	RunNames:     []string{"pipelinerun-mytask13"},
+	Runs:         nil,
+}, {
+	PipelineTask: &pts[19],
+	CustomTask:   true,
+	RunNames:     []string{"pipelinerun-mytask13"},
+	Runs:         nil,
+}}
+
+var oneRunStartedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[18],
+	CustomTask:   true,
+	RunNames:     []string{"pipelinerun-mytask13"},
+	Runs:         []*v1alpha1.Run{makeRunStarted(runs[0])},
+}, {
+	PipelineTask: &pts[19],
+	CustomTask:   true,
+	RunNames:     []string{"pipelinerun-mytask14"},
+	Runs:         nil,
+}}
+
+var oneRunFailedStateMatrix = PipelineRunState{{
+	PipelineTask: &pts[18],
+	CustomTask:   true,
+	RunNames:     []string{"pipelinerun-mytask13"},
+	Runs:         []*v1alpha1.Run{makeRunFailed(runs[0])},
+}, {
+	PipelineTask: &pts[19],
+	CustomTask:   true,
+	RunNames:     []string{"pipelinerun-mytask14"},
+	Runs:         nil,
+}}
+
+var taskCancelledMatrix = PipelineRunState{{
+	PipelineTask: &pts[20],
+	TaskRunNames: []string{"pipelinerun-mytask1"},
+	TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
+	ResolvedTaskResources: &resources.ResolvedTaskResources{
+		TaskSpec: &task.Spec,
+	},
 }}
 
 var taskWithOptionalResourcesDeprecated = &v1beta1.Task{

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -419,11 +419,151 @@ func TestGetNextTasks(t *testing.T) {
 		state:        oneRunFailedState,
 		candidates:   sets.NewString("mytask13", "mytask14"),
 		expectedNext: []*ResolvedPipelineTask{oneRunFailedState[1]},
+	}, {
+		name:         "no-tasks-started-no-candidates-matrix",
+		state:        noneStartedStateMatrix,
+		candidates:   sets.NewString(),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "no-tasks-started-one-candidate-matrix",
+		state:        noneStartedStateMatrix,
+		candidates:   sets.NewString("mytask16"),
+		expectedNext: []*ResolvedPipelineTask{noneStartedStateMatrix[0]},
+	}, {
+		name:         "no-tasks-started-other-candidate-matrix",
+		state:        noneStartedStateMatrix,
+		candidates:   sets.NewString("mytask17"),
+		expectedNext: []*ResolvedPipelineTask{noneStartedStateMatrix[1]},
+	}, {
+		name:         "no-tasks-started-both-candidates-matrix",
+		state:        noneStartedStateMatrix,
+		candidates:   sets.NewString("mytask16", "mytask17"),
+		expectedNext: []*ResolvedPipelineTask{noneStartedStateMatrix[0], noneStartedStateMatrix[1]},
+	}, {
+		name:         "one-task-started-no-candidates-matrix",
+		state:        oneStartedStateMatrix,
+		candidates:   sets.NewString(),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-task-started-one-candidate-matrix",
+		state:        oneStartedStateMatrix,
+		candidates:   sets.NewString("mytask16"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-task-started-other-candidate-matrix",
+		state:        oneStartedStateMatrix,
+		candidates:   sets.NewString("mytask17"),
+		expectedNext: []*ResolvedPipelineTask{oneStartedStateMatrix[1]},
+	}, {
+		name:         "one-task-started-both-candidates-matrix",
+		state:        oneStartedStateMatrix,
+		candidates:   sets.NewString("mytask16", "mytask17"),
+		expectedNext: []*ResolvedPipelineTask{oneStartedStateMatrix[1]},
+	}, {
+		name:         "one-task-finished-no-candidates-matrix",
+		state:        oneFinishedStateMatrix,
+		candidates:   sets.NewString(),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-task-finished-one-candidate-matrix",
+		state:        oneFinishedStateMatrix,
+		candidates:   sets.NewString("mytask16"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-task-finished-other-candidate-matrix",
+		state:        oneFinishedStateMatrix,
+		candidates:   sets.NewString("mytask17"),
+		expectedNext: []*ResolvedPipelineTask{oneFinishedStateMatrix[1]},
+	}, {
+		name:         "one-task-finished-both-candidate-matrix",
+		state:        oneFinishedStateMatrix,
+		candidates:   sets.NewString("mytask16", "mytask17"),
+		expectedNext: []*ResolvedPipelineTask{oneFinishedStateMatrix[1]},
+	}, {
+		name:         "one-task-failed-no-candidates-matrix",
+		state:        oneFailedStateMatrix,
+		candidates:   sets.NewString(),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-task-failed-one-candidate-matrix",
+		state:        oneFailedStateMatrix,
+		candidates:   sets.NewString("mytask16"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-task-failed-other-candidate-matrix",
+		state:        oneFailedStateMatrix,
+		candidates:   sets.NewString("mytask17"),
+		expectedNext: []*ResolvedPipelineTask{oneFailedStateMatrix[1]},
+	}, {
+		name:         "one-task-failed-both-candidates-matrix",
+		state:        oneFailedStateMatrix,
+		candidates:   sets.NewString("mytask16", "mytask17"),
+		expectedNext: []*ResolvedPipelineTask{oneFailedStateMatrix[1]},
+	}, {
+		name:         "final-task-scheduled-no-candidates-matrix",
+		state:        finalScheduledStateMatrix,
+		candidates:   sets.NewString(),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "final-task-finished-one-candidate-matrix",
+		state:        finalScheduledStateMatrix,
+		candidates:   sets.NewString("mytask16"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "final-task-finished-other-candidate-matrix",
+		state:        finalScheduledStateMatrix,
+		candidates:   sets.NewString("mytask17"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "final-task-finished-both-candidate-matrix",
+		state:        finalScheduledStateMatrix,
+		candidates:   sets.NewString("mytask16", "mytask17"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "all-finished-no-candidates-matrix",
+		state:        allFinishedStateMatrix,
+		candidates:   sets.NewString(),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "all-finished-one-candidate-matrix",
+		state:        allFinishedStateMatrix,
+		candidates:   sets.NewString("mytask16"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "all-finished-other-candidate-matrix",
+		state:        allFinishedStateMatrix,
+		candidates:   sets.NewString("mytask17"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "all-finished-both-candidates-matrix",
+		state:        allFinishedStateMatrix,
+		candidates:   sets.NewString("mytask16", "mytask17"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "one-cancelled-one-candidate-matrix",
+		state:        taskCancelledMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "no-runs-started-both-candidates-matrix",
+		state:        noRunStartedStateMatrix,
+		candidates:   sets.NewString("mytask19", "mytask20"),
+		expectedNext: []*ResolvedPipelineTask{noRunStartedStateMatrix[0], noRunStartedStateMatrix[1]},
+	}, {
+		name:         "one-run-started-both-candidates-matrix",
+		state:        oneRunStartedStateMatrix,
+		candidates:   sets.NewString("mytask19", "mytask20"),
+		expectedNext: []*ResolvedPipelineTask{oneRunStartedStateMatrix[1]},
+	}, {
+		name:         "one-run-failed-both-candidates-matrix",
+		state:        oneRunFailedStateMatrix,
+		candidates:   sets.NewString("mytask19", "mytask20"),
+		expectedNext: []*ResolvedPipelineTask{oneRunFailedStateMatrix[1]},
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			next := tc.state.getNextTasks(tc.candidates)
-			if d := cmp.Diff(next, tc.expectedNext); d != "" {
+			if d := cmp.Diff(tc.expectedNext, next); d != "" {
 				t.Errorf("Didn't get expected next Tasks %s", diff.PrintWantGot(d))
 			}
 		})
@@ -546,6 +686,120 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 		},
 	}}
 
+	var taskCancelledByStatusStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var taskCancelledBySpecStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelledBySpec(makeRetried(trs[0]))},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var taskRunningStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{makeStarted(trs[0])},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var taskSucceededStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{makeSucceeded(trs[0])},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var taskRetriedStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[17], // 1 retry needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withCancelled(makeRetried(trs[0]))},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var taskExpectedStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		TaskRunNames: []string{"pipelinerun-mytask1"},
+		TaskRuns:     []*v1beta1.TaskRun{withRetries(makeFailed(trs[0]))},
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var runCancelledByStatusStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		RunNames:     []string{"pipelinerun-mytask1"},
+		Runs:         []*v1alpha1.Run{withRunCancelled(withRunRetries(newRun(runs[0])))},
+		CustomTask:   true,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var runCancelledBySpecStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		RunNames:     []string{"pipelinerun-mytask1"},
+		Runs:         []*v1alpha1.Run{withRunCancelledBySpec(withRunRetries(newRun(runs[0])))},
+		CustomTask:   true,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var runRunningStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		RunNames:     []string{"pipelinerun-mytask1"},
+		Runs:         []*v1alpha1.Run{makeRunStarted(runs[0])},
+		CustomTask:   true,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var runSucceededStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		RunNames:     []string{"pipelinerun-mytask1"},
+		Runs:         []*v1alpha1.Run{makeRunSucceeded(runs[0])},
+		CustomTask:   true,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var runRetriedStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[17], // 1 retry needed
+		RunNames:     []string{"pipelinerun-mytask1"},
+		Runs:         []*v1alpha1.Run{withRunCancelled(withRunRetries(newRun(runs[0])))},
+		CustomTask:   true,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
+	var runExpectedStateMatrix = PipelineRunState{{
+		PipelineTask: &pts[20], // 2 retries needed
+		RunNames:     []string{"pipelinerun-mytask1"},
+		Runs:         []*v1alpha1.Run{withRunRetries(makeRunFailed(runs[0]))},
+		CustomTask:   true,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+
 	tcs := []struct {
 		name         string
 		state        PipelineRunState
@@ -611,6 +865,66 @@ func TestGetNextTaskWithRetries(t *testing.T) {
 		state:        runExpectedState,
 		candidates:   sets.NewString("mytask5"),
 		expectedNext: []*ResolvedPipelineTask{runExpectedState[0]},
+	}, {
+		name:         "tasks-cancelled-no-candidates-matrix",
+		state:        taskCancelledByStatusStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "tasks-cancelled-bySpec-no-candidates-matrix",
+		state:        taskCancelledBySpecStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "tasks-running-no-candidates-matrix",
+		state:        taskRunningStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "tasks-succeeded-bySpec-no-candidates-matrix",
+		state:        taskSucceededStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "tasks-retried-no-candidates-matrix",
+		state:        taskRetriedStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "tasks-retried-one-candidate-matrix",
+		state:        taskExpectedStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{taskExpectedStateMatrix[0]},
+	}, {
+		name:         "runs-cancelled-no-candidates-matrix",
+		state:        runCancelledByStatusStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "runs-cancelled-bySpec-no-candidates-matrix",
+		state:        runCancelledBySpecStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "runs-running-no-candidates-matrix",
+		state:        runRunningStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "run-succeeded-bySpec-no-candidates-matrix",
+		state:        runSucceededStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "run-retried-no-candidates-matrix",
+		state:        runRetriedStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{},
+	}, {
+		name:         "run-retried-one-candidates-matrix",
+		state:        runExpectedStateMatrix,
+		candidates:   sets.NewString("mytask21"),
+		expectedNext: []*ResolvedPipelineTask{runExpectedStateMatrix[0]},
 	}}
 
 	// iterate over *state* to get from candidate and check if TaskRun or Run is there.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

This change implements the `getNextTasks` which is a member function of `PipelineRunState`. This function is used to get the `PipelineTasks` that should be executed yet, considering some candidate `PipelineTasks`.

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
```release-note
NONE
```