### PR TITLE
Run stopSidecar logic even if TaskSpec has no sidecars to support injected sidecars such as istio-proxy

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -240,8 +240,9 @@ func (c *Reconciler) stopSidecars(ctx context.Context, tr *v1beta1.TaskRun) erro
 		return nil
 	}
 
-	// do not continue if the TaskSpec had no sidecars
-	if tr.Status.TaskSpec != nil && len(tr.Status.TaskSpec.Sidecars) == 0 {
+	// do not continue if Tekton is configured to run without injected sidecars and the TaskSpec had no sidecars
+	cfg := config.FromContextOrDefaults(ctx)
+	if !cfg.FeatureFlags.RunningInEnvWithInjectedSidecars && tr.Status.TaskSpec != nil && len(tr.Status.TaskSpec.Sidecars) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
Run stopSidecar logic even if TaskSpec has no sidecars to support injected sidecars such as istio-proxy

Signed-off-by: Sascha Schwarze <schwarzs@de.ibm.com>

# Changes

Sidecars in a Tekton pod can be declared in the TaskSpec, but could theoretically also be injected by a webhook, such as the istio-proxy.

The logic in `stopSidecars` was optimized to omit loading a Pod unnecessarily. But that did not honor the webhook-injected sidecars.

I am changing the logic to only skip the `stopSidecars` logic if the `running-in-environment-with-injected-sidecars` feature flag is set to `false` (default is `true`).

Still need to work out the unit test.

/kind bug

Fixes #4731

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
The logic to stop sidecars is now running also for TaskRuns without a sidecar in its spec, if the `running-in-environment-with-injected-sidecars` is set to `true`
```
