### PR TITLE
Export ValidateObjectKeys function

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -400,13 +400,13 @@ func validateObjectUsage(ctx context.Context, steps []Step, params []ParamSpec) 
 // slice of ParamSpecs are provided in default iff the default section is provided.
 func validateObjectDefault(objectParams []ParamSpec) (errs *apis.FieldError) {
 	for _, p := range objectParams {
-		errs = errs.Also(validateObjectKeys(p.Properties, p.Default).ViaField(p.Name))
+		errs = errs.Also(ValidateObjectKeys(p.Properties, p.Default).ViaField(p.Name))
 	}
 	return errs
 }
 
-// validateObjectKeys validates if object keys defined in properties are all provided in its value provider iff the provider is not nil.
-func validateObjectKeys(properties map[string]PropertySpec, propertiesProvider *ArrayOrString) (errs *apis.FieldError) {
+// ValidateObjectKeys validates if object keys defined in properties are all provided in its value provider iff the provider is not nil.
+func ValidateObjectKeys(properties map[string]PropertySpec, propertiesProvider *ArrayOrString) (errs *apis.FieldError) {
 	if propertiesProvider == nil || propertiesProvider.ObjectVal == nil {
 		return nil
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Export this function for chains to use it.
https://github.com/tektoncd/pipeline/issues/5072
<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

```release-note
ValidateObjectKeys function is now available for usage outside the v1beta1 package.
```

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->
