### PR TITLE
Add support for projected volumes as workspace type

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -434,6 +434,7 @@ Features currently in "alpha" are:
 | [Matrix](./matrix.md)                                                                                 | [TEP-0090](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)                                      |                                                                      |                             |
 | [Embedded Statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses)           | [TEP-0100](https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) |                                                                |                             |
 | [Task-level Resource Requirements](compute-resources.md#task-level-compute-resources-configuration)   | [TEP-0104](https://github.com/tektoncd/community/blob/main/teps/0104-tasklevel-resource-requirements.md)             |                                                                      |                             |
+| [Projected Workspace Type](workspaces.md#projected)                                                   |                  |                                                                |                             |
 | [CSI Workspace Type](workspaces.md#csi)                                                               |                  |                                                                |                             |
 
 ## Configuring High Availability

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -512,6 +512,29 @@ workspaces:
       secretName: my-secret
 ```
 
+##### `projected`
+
+This is an alpha feature. The `enable-api-fields` feature flag [must be set to `"alpha"`](./install.md)
+for projected volume source to function.
+
+The `projected` field references a [`projected` volume](https://kubernetes.io/docs/concepts/storage/projected-volumes).
+Using a `projected` volume has the following limitations:
+
+- `projected` volume sources are always mounted as read-only. `Steps` cannot write to them and will error out if they try.
+- The volumes you want to project as a `Workspace` must exist prior to submitting the `TaskRun`.
+- The following volumes can be projected: `configMap`, `secret`, `serviceAccountToken` and `downwardApi`
+
+```yaml
+workspaces:
+  - name: myworkspace
+    projected:
+      sources:
+        - configMap:
+            name: my-configmap
+        - secret:
+            name: my-secret
+```
+
 ##### `csi`
 
 This is an alpha feature. The `enable-api-fields` feature flag [must be set to `"alpha"`](./install.md)

--- a/examples/v1beta1/pipelineruns/alpha/workspaces-projected.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/workspaces-projected.yaml
@@ -1,0 +1,133 @@
+# In this contrived example two different kinds of workspace volume are used to thread
+# data through a pipeline's tasks.
+# 1. A projected volume combines a:
+#   - ConfigMap as source of recipe data.
+#   - Secret to store a password.
+# 2. A PVC is used to share data from one task to the next.
+#
+# The end result is a pipeline that first checks if the password is correct and, if so,
+# copies data out of a recipe store onto a shared volume. The recipe data is then read
+# by a subsequent task and printed to screen.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sensitive-recipe-storage
+data:
+  brownies: |
+    1. Heat oven to 325 degrees F
+    2. Melt 1/2 cup butter w/ 1/2 cup cocoa, stirring smooth.
+    3. Remove from heat, allow to cool for a few minutes.
+    4. Transfer to bowl.
+    5. Whisk in 2 eggs, one at a time.
+    6. Stir in vanilla.
+    7. Separately combine 1 cup sugar, 1/4 cup flour, 1 cup chopped
+       walnuts and pinch of salt
+    8. Combine mixtures.
+    9. Bake in greased pan for 30 minutes. Watch carefully for
+       appropriate level of gooeyness.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-password
+type: Opaque
+data:
+  password: aHVudGVyMg==
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-task-storage
+spec:
+  resources:
+    requests:
+      storage: 16Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: fetch-secure-data
+spec:
+  workspaces:
+  - name: secure-store
+  - name: filedrop
+  steps:
+  - name: fetch-and-write
+    image: ubuntu
+    script: |
+      if [ "hunter2" = "$(cat $(workspaces.secure-store.path)/password)" ]; then
+        cp $(workspaces.secure-store.path)/recipe.txt $(workspaces.filedrop.path)
+      else
+        echo "wrong password!"
+        exit 1
+      fi
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: print-data
+spec:
+  workspaces:
+  - name: storage
+    readOnly: true
+  params:
+  - name: filename
+  steps:
+  - name: print-secrets
+    image: ubuntu
+    script: cat $(workspaces.storage.path)/$(params.filename)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: fetch-and-print-recipe
+spec:
+  workspaces:
+  - name: data-store
+  - name: shared-data
+  tasks:
+  - name: fetch-the-recipe
+    taskRef:
+      name: fetch-secure-data
+    workspaces:
+    - name: secure-store
+      workspace: data-store
+    - name: filedrop
+      workspace: shared-data
+  - name: print-the-recipe
+    taskRef:
+      name: print-data
+    # Note: this is currently required to ensure order of write / read on PVC is correct.
+    runAfter:
+      - fetch-the-recipe
+    params:
+    - name: filename
+      value: recipe.txt
+    workspaces:
+    - name: storage
+      workspace: shared-data
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: recipe-time-
+spec:
+  pipelineRef:
+    name: fetch-and-print-recipe
+  workspaces:
+  - name: data-store
+    projected:
+      sources:
+        - secret:
+            name: secret-password
+        - configMap:
+            name: sensitive-recipe-storage
+            items:
+              - key: brownies
+                path: recipe.txt
+  - name: shared-data
+    persistentVolumeClaim:
+      claimName: shared-task-storage

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -5199,6 +5199,12 @@ func schema_pkg_apis_pipeline_v1beta1_WorkspaceBinding(ref common.ReferenceCallb
 							Ref:         ref("k8s.io/api/core/v1.SecretVolumeSource"),
 						},
 					},
+					"projected": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Projected represents a projected volume that should populate this workspace.",
+							Ref:         ref("k8s.io/api/core/v1.ProjectedVolumeSource"),
+						},
+					},
 					"csi": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
@@ -5210,7 +5216,7 @@ func schema_pkg_apis_pipeline_v1beta1_WorkspaceBinding(ref common.ReferenceCallb
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
+			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.ProjectedVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2887,6 +2887,10 @@
           "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.",
           "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
         },
+        "projected": {
+          "description": "Projected represents a projected volume that should populate this workspace.",
+          "$ref": "#/definitions/v1.ProjectedVolumeSource"
+        },
         "secret": {
           "description": "Secret represents a secret that should populate this workspace.",
           "$ref": "#/definitions/v1.SecretVolumeSource"

--- a/pkg/apis/pipeline/v1beta1/workspace_types.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_types.go
@@ -77,6 +77,9 @@ type WorkspaceBinding struct {
 	// Secret represents a secret that should populate this workspace.
 	// +optional
 	Secret *corev1.SecretVolumeSource `json:"secret,omitempty"`
+	// Projected represents a projected volume that should populate this workspace.
+	// +optional
+	Projected *corev1.ProjectedVolumeSource `json:"projected,omitempty"`
 	// CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
 	// +optional
 	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`

--- a/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_validation_test.go
@@ -83,6 +83,27 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 			},
 		},
 	}, {
+		name: "Valid projected",
+		binding: &v1beta1.WorkspaceBinding{
+			Name: "beth",
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{
+					ConfigMap: &corev1.ConfigMapProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "a-configmap-name",
+						},
+					},
+				}, {
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "my-secret",
+						},
+					},
+				}},
+			},
+		},
+		wc: config.EnableAlphaAPIFields,
+	}, {
 		name: "Valid csi",
 		binding: &v1beta1.WorkspaceBinding{
 			Name: "beth",
@@ -145,6 +166,19 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 			Name:   "beth",
 			Secret: &corev1.SecretVolumeSource{},
 		},
+	}, {
+		name: "projected workspace should be disallowed without alpha feature gate",
+		binding: &v1beta1.WorkspaceBinding{
+			Name:      "beth",
+			Projected: &corev1.ProjectedVolumeSource{},
+		},
+	}, {
+		name: "Provide projected without sources",
+		binding: &v1beta1.WorkspaceBinding{
+			Name:      "beth",
+			Projected: &corev1.ProjectedVolumeSource{},
+		},
+		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "csi workspace should be disallowed without alpha feature gate",
 		binding: &v1beta1.WorkspaceBinding{

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -2212,6 +2212,11 @@ func (in *WorkspaceBinding) DeepCopyInto(out *WorkspaceBinding) {
 		*out = new(v1.SecretVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Projected != nil {
+		in, out := &in.Projected, &out.Projected
+		*out = new(v1.ProjectedVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.CSI != nil {
 		in, out := &in.CSI, &out.CSI
 		*out = new(v1.CSIVolumeSource)

--- a/pkg/workspace/apply.go
+++ b/pkg/workspace/apply.go
@@ -70,6 +70,9 @@ func CreateVolumes(wb []v1beta1.WorkspaceBinding) map[string]corev1.Volume {
 		case w.Secret != nil:
 			s := *w.Secret
 			v.setVolumeSource(w.Name, name, corev1.VolumeSource{Secret: &s})
+		case w.Projected != nil:
+			s := *w.Projected
+			v.setVolumeSource(w.Name, name, corev1.VolumeSource{Projected: &s})
 		case w.CSI != nil:
 			csi := *w.CSI
 			v.setVolumeSource(w.Name, name, corev1.VolumeSource{CSI: &csi})

--- a/pkg/workspace/apply_test.go
+++ b/pkg/workspace/apply_test.go
@@ -116,6 +116,65 @@ func TestCreateVolumes(t *testing.T) {
 			},
 		},
 	}, {
+		name: "binding a single workspace with projected",
+		workspaces: []v1beta1.WorkspaceBinding{{
+			Name: "custom",
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{
+					ConfigMap: &corev1.ConfigMapProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "foobarconfigmap",
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  "foobar",
+							Path: "foobar.txt",
+						}},
+					},
+				}, {
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "foobarsecret",
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  "foobar",
+							Path: "foobar.txt",
+						}},
+					},
+				}},
+			},
+			SubPath: "/foo/bar/baz",
+		}},
+		expectedVolumes: map[string]corev1.Volume{
+			"custom": {
+				Name: "ws-6nl7g",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "foobarconfigmap",
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  "foobar",
+									Path: "foobar.txt",
+								}},
+							},
+						}, {
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "foobarsecret",
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  "foobar",
+									Path: "foobar.txt",
+								}},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}, {
 		name:            "0 workspace bindings",
 		workspaces:      []v1beta1.WorkspaceBinding{},
 		expectedVolumes: map[string]corev1.Volume{},
@@ -135,7 +194,7 @@ func TestCreateVolumes(t *testing.T) {
 		}},
 		expectedVolumes: map[string]corev1.Volume{
 			"custom": {
-				Name: "ws-6nl7g",
+				Name: "ws-j2tds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -143,7 +202,7 @@ func TestCreateVolumes(t *testing.T) {
 				},
 			},
 			"even-more-custom": {
-				Name: "ws-j2tds",
+				Name: "ws-vr6ds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "myotherpvc",
@@ -168,7 +227,7 @@ func TestCreateVolumes(t *testing.T) {
 		}},
 		expectedVolumes: map[string]corev1.Volume{
 			"custom": {
-				Name: "ws-vr6ds",
+				Name: "ws-l22wn",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -177,7 +236,7 @@ func TestCreateVolumes(t *testing.T) {
 			},
 			"custom2": {
 				// Since it is the same PVC source, it can't be added twice with two different names
-				Name: "ws-vr6ds",
+				Name: "ws-l22wn",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -271,6 +330,80 @@ func TestApply(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "binding a single workspace with projected",
+		ts: v1beta1.TaskSpec{
+			Workspaces: []v1beta1.WorkspaceDeclaration{{
+				Name: "custom",
+			},
+			}},
+		workspaces: []v1beta1.WorkspaceBinding{{
+			Name: "custom",
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{
+					ConfigMap: &corev1.ConfigMapProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "foobarconfigmap",
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  "foobar",
+							Path: "foobar.txt",
+						}},
+					},
+				}, {
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "foobarsecret",
+						},
+						Items: []corev1.KeyToPath{{
+							Key:  "foobar",
+							Path: "foobar.txt",
+						}},
+					},
+				}},
+			},
+			SubPath: "/foo/bar/baz",
+		}},
+		expectedTaskSpec: v1beta1.TaskSpec{
+			StepTemplate: &v1beta1.StepTemplate{
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "ws-mssqb",
+					MountPath: "/workspace/custom",
+					SubPath:   "/foo/bar/baz", // TODO: what happens when you use subPath with emptyDir
+				}},
+			},
+			Volumes: []corev1.Volume{{
+				Name: "ws-mssqb",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "foobarconfigmap",
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  "foobar",
+									Path: "foobar.txt",
+								}},
+							},
+						}, {
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "foobarsecret",
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  "foobar",
+									Path: "foobar.txt",
+								}},
+							},
+						}},
+					},
+				},
+			}},
+			Workspaces: []v1beta1.WorkspaceDeclaration{{
+				Name: "custom",
+			}},
+		},
+	}, {
 		name: "task spec already has volumes and stepTemplate",
 		ts: v1beta1.TaskSpec{
 			StepTemplate: &v1beta1.StepTemplate{
@@ -302,7 +435,7 @@ func TestApply(t *testing.T) {
 					Name:      "awesome-volume",
 					MountPath: "/",
 				}, {
-					Name:      "ws-mssqb",
+					Name:      "ws-78c5n",
 					MountPath: "/workspace/custom",
 					SubPath:   "/foo/bar/baz", // TODO: what happens when you use subPath with emptyDir
 				}},
@@ -313,7 +446,7 @@ func TestApply(t *testing.T) {
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
 			}, {
-				Name: "ws-mssqb",
+				Name: "ws-78c5n",
 				VolumeSource: corev1.VolumeSource{
 					EmptyDir: &corev1.EmptyDirVolumeSource{
 						Medium: corev1.StorageMediumMemory,
@@ -361,24 +494,24 @@ func TestApply(t *testing.T) {
 		expectedTaskSpec: v1beta1.TaskSpec{
 			StepTemplate: &v1beta1.StepTemplate{
 				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "ws-78c5n",
+					Name:      "ws-6nl7g",
 					MountPath: "/workspace/custom",
 					SubPath:   "/foo/bar/baz",
 				}, {
-					Name:      "ws-6nl7g",
+					Name:      "ws-j2tds",
 					MountPath: "/workspace/even-more-custom",
 					SubPath:   "",
 				}},
 			},
 			Volumes: []corev1.Volume{{
-				Name: "ws-78c5n",
+				Name: "ws-6nl7g",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
 					},
 				},
 			}, {
-				Name: "ws-6nl7g",
+				Name: "ws-j2tds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "myotherpvc",
@@ -415,17 +548,17 @@ func TestApply(t *testing.T) {
 		expectedTaskSpec: v1beta1.TaskSpec{
 			StepTemplate: &v1beta1.StepTemplate{
 				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "ws-j2tds",
+					Name:      "ws-vr6ds",
 					MountPath: "/workspace/custom",
 					SubPath:   "/foo/bar/baz",
 				}, {
-					Name:      "ws-j2tds",
+					Name:      "ws-vr6ds",
 					MountPath: "/workspace/custom2",
 					SubPath:   "/very/professional/work/space",
 				}},
 			},
 			Volumes: []corev1.Volume{{
-				Name: "ws-j2tds",
+				Name: "ws-vr6ds",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -455,12 +588,12 @@ func TestApply(t *testing.T) {
 		expectedTaskSpec: v1beta1.TaskSpec{
 			StepTemplate: &v1beta1.StepTemplate{
 				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "ws-l22wn",
+					Name:      "ws-twkr2",
 					MountPath: "/my/fancy/mount/path",
 				}},
 			},
 			Volumes: []corev1.Volume{{
-				Name: "ws-l22wn",
+				Name: "ws-twkr2",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -490,13 +623,13 @@ func TestApply(t *testing.T) {
 		expectedTaskSpec: v1beta1.TaskSpec{
 			StepTemplate: &v1beta1.StepTemplate{
 				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "ws-twkr2",
+					Name:      "ws-mnq6l",
 					MountPath: "/my/fancy/mount/path",
 					ReadOnly:  true,
 				}},
 			},
 			Volumes: []corev1.Volume{{
-				Name: "ws-twkr2",
+				Name: "ws-mnq6l",
 				VolumeSource: corev1.VolumeSource{
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 						ClaimName: "mypvc",
@@ -528,14 +661,14 @@ func TestApply(t *testing.T) {
 		expectedTaskSpec: v1beta1.TaskSpec{
 			StepTemplate: &v1beta1.StepTemplate{
 				VolumeMounts: []corev1.VolumeMount{{
-					Name:      "ws-mnq6l",
+					Name:      "ws-hvpvf",
 					MountPath: "/workspace/csi",
 					SubPath:   "/foo/bar/baz",
 					ReadOnly:  true,
 				}},
 			},
 			Volumes: []corev1.Volume{{
-				Name: "ws-mnq6l",
+				Name: "ws-hvpvf",
 				VolumeSource: corev1.VolumeSource{
 					CSI: &corev1.CSIVolumeSource{
 						Driver: "secrets-store.csi.k8s.io",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

Add support for projected volumes as workspace type

By adding support for projected volumes [1] as workspace type an
arbitrary amount of ConfigMaps or Secrets can be passed to a
TaskRun/PipelineRun without modifying the actual Task/ClusterTask.

This allows to pass data to Tasks/Pipelines in a flexible way.

Fixes #5075

[1] https://kubernetes.io/docs/concepts/storage/projected-volumes

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Add support for projected volumes as workspace type
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
Add support for projected volumes as workspace type
```

Remove the extra space between the backticks and `release-note` as well
--->

```release-note
Add support for projected volumes as workspace type
```