### PR TITLE
[WIP] Separate facts, resolution, state and status into packages from resources pkg

### DIFF
--- a/pkg/reconciler/pipelinerun/pipeline/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/pipeline/pipelinespec.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package pipeline
 
 import (
 	"context"

--- a/pkg/reconciler/pipelinerun/pipeline/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipeline/pipelinespec_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package pipeline
 
 import (
 	"context"

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -46,6 +46,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/reconciler/events"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
+	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipeline"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resources"
 	"github.com/tektoncd/pipeline/pkg/reconciler/taskrun"
 	tresources "github.com/tektoncd/pipeline/pkg/reconciler/taskrun/resources"
@@ -334,7 +335,7 @@ func (c *Reconciler) resolvePipelineState(
 	return pst, nil
 }
 
-func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, getPipelineFunc resources.GetPipeline) error {
+func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, getPipelineFunc rprp.GetPipeline) error {
 	defer c.durationAndCountMetrics(ctx, pr)
 	logger := logging.FromContext(ctx)
 	cfg := config.FromContextOrDefaults(ctx)
@@ -346,7 +347,7 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 		return nil
 	}
 
-	pipelineMeta, pipelineSpec, err := resources.GetPipelineData(ctx, pr, getPipelineFunc)
+	pipelineMeta, pipelineSpec, err := rprp.GetPipelineData(ctx, pr, getPipelineFunc)
 	switch {
 	case errors.Is(err, remote.ErrorRequestInProgress):
 		message := fmt.Sprintf("PipelineRun %s/%s awaiting remote resource", pr.Namespace, pr.Name)

--- a/pkg/reconciler/pipelinerun/resolution/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resolution/pipelinerunresolution_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package resolution
 
 import (
 	"context"

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	rprp "github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/pipeline"
 	"github.com/tektoncd/pipeline/pkg/remote"
 	"github.com/tektoncd/pipeline/pkg/remote/oci"
 	"github.com/tektoncd/pipeline/pkg/remote/resolution"
@@ -37,7 +38,7 @@ import (
 // GetPipelineFunc is a factory function that will use the given PipelineRef to return a valid GetPipeline function that
 // looks up the pipeline. It uses as context a k8s client, tekton client, namespace, and service account name to return
 // the pipeline. It knows whether it needs to look in the cluster or in a remote location to fetch the reference.
-func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, requester remoteresource.Requester, pipelineRun *v1beta1.PipelineRun) (GetPipeline, error) {
+func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, requester remoteresource.Requester, pipelineRun *v1beta1.PipelineRun) (rprp.GetPipeline, error) {
 	cfg := config.FromContextOrDefaults(ctx)
 	pr := pipelineRun.Spec.PipelineRef
 	namespace := pipelineRun.Namespace

--- a/pkg/reconciler/pipelinerun/state/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/state/pipelinerunstate.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2020 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/reconciler/pipelinerun/resolution"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/apis"
+)
+
+const (
+	// PipelineTaskStateNone indicates that the execution status of a pipelineTask is unknown
+	PipelineTaskStateNone = "None"
+	// PipelineTaskStatusPrefix is a prefix of the param representing execution state of pipelineTask
+	PipelineTaskStatusPrefix = "tasks."
+	// PipelineTaskStatusSuffix is a suffix of the param representing execution state of pipelineTask
+	PipelineTaskStatusSuffix = ".status"
+)
+
+// PipelineRunState is a slice of ResolvedPipelineRunTasks the represents the current execution
+// state of the PipelineRun.
+type PipelineRunState []*resolution.ResolvedPipelineTask
+
+// ToMap returns a map that maps pipeline task name to the resolved pipeline run task
+func (state PipelineRunState) ToMap() map[string]*resolution.ResolvedPipelineTask {
+	m := make(map[string]*resolution.ResolvedPipelineTask)
+	for _, rpt := range state {
+		m[rpt.PipelineTask.Name] = rpt
+	}
+	return m
+}
+
+// IsBeforeFirstTaskRun returns true if the PipelineRun has not yet started its first TaskRun
+func (state PipelineRunState) IsBeforeFirstTaskRun() bool {
+	for _, t := range state {
+		if t.IsCustomTask() && t.Run != nil {
+			return false
+		} else if t.TaskRun != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// AdjustStartTime adjusts potential drift in the PipelineRun's start time.
+//
+// The StartTime will only adjust earlier, so that the PipelineRun's StartTime
+// is no later than any of its constituent TaskRuns.
+//
+// This drift could be due to us either failing to record the Run's start time
+// previously, or our own failure to observe a prior update before reconciling
+// the resource again.
+func (state PipelineRunState) AdjustStartTime(unadjustedStartTime *metav1.Time) *metav1.Time {
+	adjustedStartTime := unadjustedStartTime
+	for _, rpt := range state {
+		if rpt.TaskRun == nil {
+			if rpt.Run != nil {
+				if rpt.Run.CreationTimestamp.Time.Before(adjustedStartTime.Time) {
+					adjustedStartTime = &rpt.Run.CreationTimestamp
+				}
+			}
+		} else {
+			if rpt.TaskRun.CreationTimestamp.Time.Before(adjustedStartTime.Time) {
+				adjustedStartTime = &rpt.TaskRun.CreationTimestamp
+			}
+		}
+	}
+	return adjustedStartTime.DeepCopy()
+}
+
+// GetTaskRunsStatus returns a map of taskrun name and the taskrun
+// ignore a nil taskrun in pipelineRunState, otherwise, capture taskrun object from PipelineRun Status
+// update taskrun status based on the pipelineRunState before returning it in the map
+func (state PipelineRunState) GetTaskRunsStatus(pr *v1beta1.PipelineRun) map[string]*v1beta1.PipelineRunTaskRunStatus {
+	status := make(map[string]*v1beta1.PipelineRunTaskRunStatus)
+	for _, rpt := range state {
+		if rpt.IsCustomTask() {
+			continue
+		}
+
+		if rpt.TaskRun == nil {
+			continue
+		}
+
+		status[rpt.TaskRunName] = rpt.GetTaskRunStatus(rpt.TaskRun, pr)
+	}
+	return status
+}
+
+// GetTaskRunsResults returns a map of all successfully completed TaskRuns in the state, with the pipeline task name as
+// the key and the results from the corresponding TaskRun as the value. It only includes tasks which have completed successfully.
+func (state PipelineRunState) GetTaskRunsResults() map[string][]v1beta1.TaskRunResult {
+	results := make(map[string][]v1beta1.TaskRunResult)
+	for _, rpt := range state {
+		if rpt.IsCustomTask() {
+			continue
+		}
+		if !rpt.IsSuccessful() {
+			continue
+		}
+		if rpt.TaskRun != nil {
+			results[rpt.PipelineTask.Name] = rpt.TaskRun.Status.TaskRunResults
+		}
+	}
+	return results
+}
+
+// GetRunsStatus returns a map of run name and the run.
+// Ignore a nil run in pipelineRunState, otherwise, capture run object from PipelineRun Status.
+// Update run status based on the pipelineRunState before returning it in the map.
+func (state PipelineRunState) GetRunsStatus(pr *v1beta1.PipelineRun) map[string]*v1beta1.PipelineRunRunStatus {
+	status := map[string]*v1beta1.PipelineRunRunStatus{}
+	for _, rpt := range state {
+		if !rpt.IsCustomTask() {
+			continue
+		}
+
+		var prrs *v1beta1.PipelineRunRunStatus
+		if rpt.Run != nil {
+			prrs = pr.Status.Runs[rpt.RunName]
+		}
+
+		if prrs == nil {
+			prrs = &v1beta1.PipelineRunRunStatus{
+				PipelineTaskName: rpt.PipelineTask.Name,
+				WhenExpressions:  rpt.PipelineTask.WhenExpressions,
+			}
+		}
+
+		if rpt.Run != nil {
+			prrs.Status = &rpt.Run.Status
+		}
+
+		status[rpt.RunName] = prrs
+	}
+	return status
+}
+
+// GetRunsResults returns a map of all successfully completed Runs in the state, with the pipeline task name as the key
+// and the results from the corresponding TaskRun as the value. It only includes runs which have completed successfully.
+func (state PipelineRunState) GetRunsResults() map[string][]v1alpha1.RunResult {
+	results := make(map[string][]v1alpha1.RunResult)
+	for _, rpt := range state {
+		if !rpt.IsCustomTask() {
+			continue
+		}
+		if !rpt.IsSuccessful() {
+			continue
+		}
+		if rpt.Run != nil {
+			results[rpt.PipelineTask.Name] = rpt.Run.Status.Results
+		}
+	}
+
+	return results
+}
+
+// GetChildReferences returns a slice of references, including version, kind, name, and pipeline task name, for all
+// TaskRuns and Runs in the state.
+func (state PipelineRunState) GetChildReferences() []v1beta1.ChildStatusReference {
+	var childRefs []v1beta1.ChildStatusReference
+
+	for _, rpt := range state {
+		switch {
+		case rpt.Run != nil:
+			childRefs = append(childRefs, rpt.GetChildRefForRun(rpt.Run.Name))
+		case rpt.TaskRun != nil:
+			childRefs = append(childRefs, rpt.GetChildRefForTaskRun(rpt.TaskRun))
+		case len(rpt.TaskRuns) != 0:
+			for _, taskRun := range rpt.TaskRuns {
+				if taskRun != nil {
+					childRefs = append(childRefs, rpt.GetChildRefForTaskRun(taskRun))
+				}
+			}
+		case len(rpt.Runs) != 0:
+			for _, run := range rpt.Runs {
+				if run != nil {
+					childRefs = append(childRefs, rpt.GetChildRefForRun(run.Name))
+				}
+			}
+		}
+	}
+	return childRefs
+}
+
+// GetNextTasks returns a list of tasks which should be executed next i.e.
+// a list of tasks from candidateTasks which aren't yet indicated in state to be running and
+// a list of cancelled/failed tasks from candidateTasks which haven't exhausted their retries
+func (state PipelineRunState) GetNextTasks(candidateTasks sets.String) []*resolution.ResolvedPipelineTask {
+	tasks := []*resolution.ResolvedPipelineTask{}
+	for _, t := range state {
+		if _, ok := candidateTasks[t.PipelineTask.Name]; ok {
+			if t.TaskRun == nil && t.Run == nil && len(t.TaskRuns) == 0 && len(t.Runs) == 0 {
+				tasks = append(tasks, t)
+			}
+		}
+	}
+	tasks = append(tasks, state.GetRetryableTasks(candidateTasks)...)
+	return tasks
+}
+
+// GetRetryableTasks returns a list of pipelinetasks which should be executed next when the pipelinerun is stopping,
+// i.e. a list of failed pipelinetasks from candidateTasks which haven't exhausted their retries. Note that if a
+// pipelinetask is cancelled, the retries are not exhausted - they are not retryable.
+func (state PipelineRunState) GetRetryableTasks(candidateTasks sets.String) []*resolution.ResolvedPipelineTask {
+	var tasks []*resolution.ResolvedPipelineTask
+	for _, t := range state {
+		if _, ok := candidateTasks[t.PipelineTask.Name]; ok {
+			var status *apis.Condition
+			switch {
+			case t.TaskRun != nil:
+				status = t.TaskRun.Status.GetCondition(apis.ConditionSucceeded)
+			case len(t.TaskRuns) != 0:
+				IsDone := true
+				for _, taskRun := range t.TaskRuns {
+					IsDone = IsDone && taskRun.IsDone()
+					c := taskRun.Status.GetCondition(apis.ConditionSucceeded)
+					if c.IsFalse() {
+						status = c
+					}
+				}
+			case t.Run != nil:
+				status = t.Run.Status.GetCondition(apis.ConditionSucceeded)
+			case len(t.Runs) != 0:
+				IsDone := true
+				for _, run := range t.Runs {
+					IsDone = IsDone && run.IsDone()
+					c := run.Status.GetCondition(apis.ConditionSucceeded)
+					if c.IsFalse() {
+						status = c
+					}
+				}
+			}
+			if status.IsFalse() && !t.IsCancelled() && t.HasRemainingRetries() {
+				tasks = append(tasks, t)
+			}
+		}
+	}
+	return tasks
+}

--- a/pkg/reconciler/pipelinerun/state/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/state/pipelinerunstate_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package resources
+package state
 
 import (
 	"context"

--- a/pkg/reconciler/pipelinerun/status/status.go
+++ b/pkg/reconciler/pipelinerun/status/status.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+
+// TaskSkipStatus stores whether a task was skipped and why
+type TaskSkipStatus struct {
+	IsSkipped      bool
+	SkippingReason v1beta1.SkippingReason
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->


Separates the resources packages into facts/ state/ status/ resolution 
as previously the resources package has been doing too much. 
No functional changes.

Part of #5024 

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

Todo:
- [ ] Change naming of packages.
- [ ] Resolve the import cycle  

# Release Notes
```
NONE
```
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
NONE
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->


