### PR TITLE
Simplify Release Notes section of the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,56 +2,23 @@
 
 # Changes
 
-<!--
-Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!
-
-In addition, categorize the changes you're making using the "/kind" Prow command, example:
-
-/kind <kind>
-
-Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
--->
+<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
 
 # Submitter Checklist
 
 As the author of this PR, please check off the items in this checklist:
 
-- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
-- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
+- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
+- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
 - [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
 - [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
   functionality, content, code)
-- [ ] Release notes block below has been filled in
-(if there are no user facing changes, use release note "NONE")
+- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
+- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
+- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release
 
 # Release Notes
-
-<!--
-Describe any user facing changes here, or delete this block.
-
-Examples of user facing changes:
-- API changes
-- Bug fixes
-- Any changes in behavior
-- Changes requiring upgrade notices or deprecation warnings
-
-For pull requests with a release note:
-
-``` release-note
-Your release note here
-```
-
-For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
-
-``` release-note
-action required: your release note here
-```
-
-For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
 
 ``` release-note
 NONE
 ```
-
-Remove the extra space between the backticks and `release-note` as well
--->


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

This commit simplifies the release notes section by replacing the existing
comment with a default `NONE` release note. In addition it updates the
submitter checklist instruction to expect the submitter to update the release
note if needed. In addition, it adds two new items to the checklist - 1. to add
a kind label using the /kind command and 2. add an `action required:` to the
release note if needed.

Fixes #5093

Signed-off-by: Dibyo Mukherjee <dibyo@google.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

``` release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

``` release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

``` release-note
NONE
```

Remove the extra space between the backticks and `release-note` as well
-->

```release-note
NONE
```