### PR TITLE
Fix context.background() in workspaceBinding validation

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -378,7 +378,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		return nil, nil, controller.NewPermanentError(err)
 	}
 
-	if err := workspace.ValidateBindings(taskSpec.Workspaces, tr.Spec.Workspaces); err != nil {
+	if err := workspace.ValidateBindings(ctx, taskSpec.Workspaces, tr.Spec.Workspaces); err != nil {
 		logger.Errorf("TaskRun %q workspaces are invalid: %v", tr.Name, err)
 		tr.Status.MarkResourceFailed(podconvert.ReasonFailedValidation, err)
 		return nil, nil, controller.NewPermanentError(err)

--- a/pkg/workspace/validate.go
+++ b/pkg/workspace/validate.go
@@ -26,11 +26,11 @@ import (
 
 // ValidateBindings will return an error if the bound workspaces in binds don't satisfy the declared
 // workspaces in decls.
-func ValidateBindings(decls []v1beta1.WorkspaceDeclaration, binds []v1beta1.WorkspaceBinding) error {
+func ValidateBindings(ctx context.Context, decls []v1beta1.WorkspaceDeclaration, binds []v1beta1.WorkspaceBinding) error {
 	// This will also be validated at webhook time but in case the webhook isn't invoked for some
 	// reason we'll invoke the same validation here.
 	for _, b := range binds {
-		if err := b.Validate(context.Background()); err != nil {
+		if err := b.Validate(ctx); err != nil {
 			return fmt.Errorf("binding %q is invalid: %v", b.Name, err)
 		}
 	}

--- a/pkg/workspace/validate_test.go
+++ b/pkg/workspace/validate_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workspace
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -76,7 +77,7 @@ func TestValidateBindingsValid(t *testing.T) {
 		bindings: []v1beta1.WorkspaceBinding{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateBindings(tc.declarations, tc.bindings); err != nil {
+			if err := ValidateBindings(context.Background(), tc.declarations, tc.bindings); err != nil {
 				t.Errorf("didnt expect error for valid bindings but got: %v", err)
 			}
 		})
@@ -143,7 +144,7 @@ func TestValidateBindingsInvalid(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := ValidateBindings(tc.declarations, tc.bindings); err == nil {
+			if err := ValidateBindings(context.Background(), tc.declarations, tc.bindings); err == nil {
 				t.Errorf("expected error for invalid bindings but didn't get any!")
 			}
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This commit fixes the context parameter that should be passed in [ValidateBindings](https://github.com/tektoncd/pipeline/blob/main/pkg/workspace/validate.go/#L33).
The `featureFlags` in the configMap cannot be properly validated without this change. 

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)


# Release Notes

```release-note
NONE
```
