### PR TITLE
Exclude managed fields from e2e test failure object YAML dumps

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -199,6 +199,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get pipeline: %w", err)
 	}
 	for _, i := range ps.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -207,6 +208,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get pipelinerun resource: %w", err)
 	}
 	for _, i := range prs.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -215,6 +217,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get pipelinerun: %w", err)
 	}
 	for _, i := range prrs.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -223,6 +226,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get tasks: %w", err)
 	}
 	for _, i := range ts.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -231,6 +235,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get clustertasks: %w", err)
 	}
 	for _, i := range cts.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -239,6 +244,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get taskruns: %w", err)
 	}
 	for _, i := range trs.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -247,6 +253,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get runs: %v", err)
 	}
 	for _, i := range rs.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 
@@ -255,6 +262,7 @@ func getCRDYaml(ctx context.Context, cs *clients, ns string) ([]byte, error) {
 		return nil, fmt.Errorf("could not get pods: %w", err)
 	}
 	for _, i := range pods.Items {
+		i.SetManagedFields(nil)
 		printOrAdd(i)
 	}
 


### PR DESCRIPTION
# Changes

Including `.metadata.managedFields` creates a lot of excessive noise for no real value, so let's shrink the size of the YAML dumps a bit.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
