### PR TITLE
Mark TaskRef/PipelineRef Bundle as deprecated

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -258,12 +258,12 @@ func (pt PipelineTask) validateCustomTask() (errs *apis.FieldError) {
 // validateBundle validates bundle specifications - checking name and bundle
 func (pt PipelineTask) validateBundle() (errs *apis.FieldError) {
 	// bundle requires a TaskRef to be specified
-	if (pt.TaskRef != nil && pt.TaskRef.Bundle != "") && pt.TaskRef.Name == "" {
+	if (pt.TaskRef != nil && pt.TaskRef.DeprecatedBundle != "") && pt.TaskRef.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("taskRef.name"))
 	}
 	// If a bundle url is specified, ensure it is parsable
-	if pt.TaskRef != nil && pt.TaskRef.Bundle != "" {
-		if _, err := name.ParseReference(pt.TaskRef.Bundle); err != nil {
+	if pt.TaskRef != nil && pt.TaskRef.DeprecatedBundle != "" {
+		if _, err := name.ParseReference(pt.TaskRef.DeprecatedBundle); err != nil {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("invalid bundle reference (%s)", err.Error()), "taskRef.bundle"))
 		}
 	}
@@ -287,7 +287,7 @@ func (pt PipelineTask) validateTask(ctx context.Context) (errs *apis.FieldError)
 			errs = errs.Also(apis.ErrInvalidValue("taskRef must specify name", "taskRef.name"))
 		}
 		// fail if bundle is present when EnableTektonOCIBundles feature flag is off (as it won't be allowed nor used)
-		if !cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef.Bundle != "" {
+		if !cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef.DeprecatedBundle != "" {
 			errs = errs.Also(apis.ErrDisallowedFields("taskref.bundle"))
 		}
 		if cfg.FeatureFlags.EnableAPIFields != config.AlphaAPIFields {
@@ -502,7 +502,7 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
 		// If EnableTektonOCIBundles feature flag is on, validate bundle specifications
-	case cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef != nil && pt.TaskRef.Bundle != "":
+	case cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef != nil && pt.TaskRef.DeprecatedBundle != "":
 		errs = errs.Also(pt.validateBundle())
 	default:
 		errs = errs.Also(pt.validateTask(ctx))

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -204,14 +204,14 @@ func TestPipelineTask_ValidateBundle_Failure(t *testing.T) {
 		name: "bundle - invalid reference",
 		p: PipelineTask{
 			Name:    "foo",
-			TaskRef: &TaskRef{Name: "bar", Bundle: "invalid reference"},
+			TaskRef: &TaskRef{Name: "bar", DeprecatedBundle: "invalid reference"},
 		},
 		expectedError: *apis.ErrInvalidValue("invalid bundle reference (could not parse reference: invalid reference)", "taskRef.bundle"),
 	}, {
 		name: "bundle - missing taskRef name",
 		p: PipelineTask{
 			Name:    "foo",
-			TaskRef: &TaskRef{Bundle: "valid-bundle"},
+			TaskRef: &TaskRef{DeprecatedBundle: "valid-bundle"},
 		},
 		expectedError: *apis.ErrMissingField("taskRef.name"),
 	}}
@@ -262,7 +262,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 		name: "pipeline task - use of bundle with the feature flag set",
 		tasks: PipelineTask{
 			Name:    "foo",
-			TaskRef: &TaskRef{Name: "bar", Bundle: "docker.io/foo"},
+			TaskRef: &TaskRef{Name: "bar", DeprecatedBundle: "docker.io/foo"},
 		},
 		enableBundles: true,
 	}}
@@ -326,7 +326,7 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 		name: "pipeline task - use of bundle without the feature flag set",
 		task: PipelineTask{
 			Name:    "foo",
-			TaskRef: &TaskRef{Name: "bar", Bundle: "docker.io/foo"},
+			TaskRef: &TaskRef{Name: "bar", DeprecatedBundle: "docker.io/foo"},
 		},
 		expectedError: *apis.ErrDisallowedFields("taskref.bundle"),
 	}, {
@@ -376,7 +376,7 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 		name: "invalid bundle without bundle name",
 		p: PipelineTask{
 			Name:    "invalid-bundle",
-			TaskRef: &TaskRef{Bundle: "bundle"},
+			TaskRef: &TaskRef{DeprecatedBundle: "bundle"},
 		},
 		expectedError: apis.FieldError{
 			Message: `missing field(s)`,
@@ -672,7 +672,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 			TaskRef: &TaskRef{APIVersion: "example.com", Kind: "custom"},
 		}, {
 			Name:    "valid-bundle",
-			TaskRef: &TaskRef{Bundle: "bundle", Name: "bundle"},
+			TaskRef: &TaskRef{DeprecatedBundle: "bundle", Name: "bundle"},
 		}, {
 			Name:    "valid-task",
 			TaskRef: &TaskRef{Name: "task"},
@@ -686,7 +686,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 			TaskRef: &TaskRef{APIVersion: "example.com", Kind: "custom"},
 		}, {
 			Name:    "valid-bundle",
-			TaskRef: &TaskRef{Bundle: "bundle", Name: "bundle"},
+			TaskRef: &TaskRef{DeprecatedBundle: "bundle", Name: "bundle"},
 		}, {
 			Name:    "invalid-task-without-name",
 			TaskRef: &TaskRef{Name: ""},
@@ -701,7 +701,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 			TaskRef: &TaskRef{APIVersion: "example.com", Kind: "custom"},
 		}, {
 			Name:    "invalid-bundle",
-			TaskRef: &TaskRef{Bundle: "bundle"},
+			TaskRef: &TaskRef{DeprecatedBundle: "bundle"},
 		}, {
 			Name:    "invalid-task-without-name",
 			TaskRef: &TaskRef{Name: ""},
@@ -717,7 +717,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 			TaskRef: &TaskRef{APIVersion: "example.com"},
 		}, {
 			Name:    "invalid-bundle",
-			TaskRef: &TaskRef{Bundle: "bundle"},
+			TaskRef: &TaskRef{DeprecatedBundle: "bundle"},
 		}, {
 			Name:    "invalid-task",
 			TaskRef: &TaskRef{Name: ""},

--- a/pkg/apis/pipeline/v1beta1/pipelineref_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_types.go
@@ -23,9 +23,10 @@ type PipelineRef struct {
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
-	// Bundle url reference to a Tekton Bundle.
+	// Deprecated. This field will be removed in a future release, use ResolverRef instead.
+	// DeprecatedBundle url reference to a Tekton Bundle.
 	// +optional
-	Bundle string `json:"bundle,omitempty"`
+	DeprecatedBundle string `json:"bundle,omitempty"`
 
 	// ResolverRef allows referencing a Pipeline in a remote location
 	// like a git repo. This field is only supported when the alpha

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
@@ -39,7 +39,7 @@ func (ref *PipelineRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if ref.Name != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("name", "resolver"))
 		}
-		if ref.Bundle != "" {
+		if ref.DeprecatedBundle != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("bundle", "resolver"))
 		}
 	case ref.Resource != nil:
@@ -47,7 +47,7 @@ func (ref *PipelineRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if ref.Name != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("name", "resource"))
 		}
-		if ref.Bundle != "" {
+		if ref.DeprecatedBundle != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("bundle", "resource"))
 		}
 		if ref.Resolver == "" {
@@ -55,9 +55,9 @@ func (ref *PipelineRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	case ref.Name == "":
 		errs = errs.Also(apis.ErrMissingField("name"))
-	case ref.Bundle != "":
+	case ref.DeprecatedBundle != "":
 		errs = errs.Also(validateBundleFeatureFlag(ctx, "bundle", true).ViaField("bundle"))
-		if _, err := name.ParseReference(ref.Bundle); err != nil {
+		if _, err := name.ParseReference(ref.DeprecatedBundle); err != nil {
 			errs = errs.Also(apis.ErrInvalidValue("invalid bundle reference", "bundle", err.Error()))
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -39,22 +39,22 @@ func TestPipelineRef_Invalid(t *testing.T) {
 	}{{
 		name: "use of bundle without the feature flag set",
 		ref: &v1beta1.PipelineRef{
-			Name:   "my-pipeline",
-			Bundle: "docker.io/foo",
+			Name:             "my-pipeline",
+			DeprecatedBundle: "docker.io/foo",
 		},
 		wantErr: apis.ErrGeneric("bundle requires \"enable-tekton-oci-bundles\" feature gate to be true but it is false"),
 	}, {
 		name: "bundle missing name",
 		ref: &v1beta1.PipelineRef{
-			Bundle: "docker.io/foo",
+			DeprecatedBundle: "docker.io/foo",
 		},
 		wantErr:     apis.ErrMissingField("name"),
 		withContext: enableTektonOCIBundles(t),
 	}, {
 		name: "invalid bundle reference",
 		ref: &v1beta1.PipelineRef{
-			Name:   "my-pipeline",
-			Bundle: "not a valid reference",
+			Name:             "my-pipeline",
+			DeprecatedBundle: "not a valid reference",
 		},
 		wantErr:     apis.ErrInvalidValue("invalid bundle reference", "bundle", "could not parse reference: not a valid reference"),
 		withContext: enableTektonOCIBundles(t),
@@ -100,7 +100,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 	}, {
 		name: "pipelineref resolver disallowed in conjunction with pipelineref bundle",
 		ref: &v1beta1.PipelineRef{
-			Bundle: "foo",
+			DeprecatedBundle: "foo",
 			ResolverRef: v1beta1.ResolverRef{
 				Resolver: "baz",
 			},
@@ -123,7 +123,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 	}, {
 		name: "pipelineref resource disallowed in conjunction with pipelineref bundle",
 		ref: &v1beta1.PipelineRef{
-			Bundle: "bar",
+			DeprecatedBundle: "bar",
 			ResolverRef: v1beta1.ResolverRef{
 				Resource: []v1beta1.ResolverParam{{
 					Name:  "foo",

--- a/pkg/apis/pipeline/v1beta1/taskref_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_types.go
@@ -25,9 +25,10 @@ type TaskRef struct {
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`
-	// Bundle url reference to a Tekton Bundle.
+	// Deprecated. This field will be removed in a future release, use ResolverRef instead.
+	// DeprecatedBundle url reference to a Tekton Bundle.
 	// +optional
-	Bundle string `json:"bundle,omitempty"`
+	DeprecatedBundle string `json:"bundle,omitempty"`
 
 	// ResolverRef allows referencing a Task in a remote location
 	// like a git repo. This field is only supported when the alpha

--- a/pkg/apis/pipeline/v1beta1/taskref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation.go
@@ -38,7 +38,7 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if ref.Name != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("name", "resolver"))
 		}
-		if ref.Bundle != "" {
+		if ref.DeprecatedBundle != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("bundle", "resolver"))
 		}
 	case ref.Resource != nil:
@@ -46,7 +46,7 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if ref.Name != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("name", "resource"))
 		}
-		if ref.Bundle != "" {
+		if ref.DeprecatedBundle != "" {
 			errs = errs.Also(apis.ErrMultipleOneOf("bundle", "resource"))
 		}
 		if ref.Resolver == "" {
@@ -54,9 +54,9 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	case ref.Name == "":
 		errs = errs.Also(apis.ErrMissingField("name"))
-	case ref.Bundle != "":
+	case ref.DeprecatedBundle != "":
 		errs = errs.Also(validateBundleFeatureFlag(ctx, "bundle", true).ViaField("bundle"))
-		if _, err := name.ParseReference(ref.Bundle); err != nil {
+		if _, err := name.ParseReference(ref.DeprecatedBundle); err != nil {
 			errs = errs.Also(apis.ErrInvalidValue("invalid bundle reference", "bundle", err.Error()))
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -54,8 +54,8 @@ func TestTaskRef_Valid(t *testing.T) {
 	}, {
 		name: "valid bundle",
 		taskRef: &v1beta1.TaskRef{
-			Name:   "bundled-task",
-			Bundle: "gcr.io/my-bundle"},
+			Name:             "bundled-task",
+			DeprecatedBundle: "gcr.io/my-bundle"},
 		wc: config.EnableAlphaAPIFields,
 	}}
 	for _, ts := range tests {
@@ -84,22 +84,22 @@ func TestTaskRef_Invalid(t *testing.T) {
 	}, {
 		name: "use of bundle without the feature flag set",
 		taskRef: &v1beta1.TaskRef{
-			Name:   "my-task",
-			Bundle: "docker.io/foo",
+			Name:             "my-task",
+			DeprecatedBundle: "docker.io/foo",
 		},
 		wantErr: apis.ErrGeneric("bundle requires \"enable-tekton-oci-bundles\" feature gate to be true but it is false"),
 	}, {
 		name: "bundle missing name",
 		taskRef: &v1beta1.TaskRef{
-			Bundle: "docker.io/foo",
+			DeprecatedBundle: "docker.io/foo",
 		},
 		wantErr: apis.ErrMissingField("name"),
 		wc:      enableTektonOCIBundles(t),
 	}, {
 		name: "invalid bundle reference",
 		taskRef: &v1beta1.TaskRef{
-			Name:   "my-task",
-			Bundle: "invalid reference",
+			Name:             "my-task",
+			DeprecatedBundle: "invalid reference",
 		},
 		wantErr: apis.ErrInvalidValue("invalid bundle reference", "bundle", "could not parse reference: invalid reference"),
 		wc:      enableTektonOCIBundles(t),
@@ -141,7 +141,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 	}, {
 		name: "taskref resolver disallowed in conjunction with taskref bundle",
 		taskRef: &v1beta1.TaskRef{
-			Bundle: "bar",
+			DeprecatedBundle: "bar",
 			ResolverRef: v1beta1.ResolverRef{
 				Resolver: "git",
 			},
@@ -164,7 +164,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 	}, {
 		name: "taskref resource disallowed in conjunction with taskref bundle",
 		taskRef: &v1beta1.TaskRef{
-			Bundle: "bar",
+			DeprecatedBundle: "bar",
 			ResolverRef: v1beta1.ResolverRef{
 				Resource: []v1beta1.ResolverParam{{
 					Name:  "foo",

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -55,7 +55,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 		}, nil
 	}
 	switch {
-	case cfg.FeatureFlags.EnableTektonOCIBundles && pr != nil && pr.Bundle != "":
+	case cfg.FeatureFlags.EnableTektonOCIBundles && pr != nil && pr.DeprecatedBundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a PipelineObject.
 		return func(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
@@ -67,7 +67,7 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 			if err != nil {
 				return nil, fmt.Errorf("failed to get keychain: %w", err)
 			}
-			resolver := oci.NewResolver(pr.Bundle, kc)
+			resolver := oci.NewResolver(pr.DeprecatedBundle, kc)
 			return resolvePipeline(ctx, resolver, name)
 		}, nil
 	case cfg.FeatureFlags.EnableAPIFields == config.AlphaAPIFields && pr != nil && pr.Resolver != "" && requester != nil:

--- a/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref_test.go
@@ -140,8 +140,8 @@ func TestGetPipelineFunc(t *testing.T) {
 		},
 		remotePipelines: []runtime.Object{simplePipeline(), dummyPipeline},
 		ref: &v1beta1.PipelineRef{
-			Name:   "simple",
-			Bundle: u.Host + "/remote-pipeline",
+			Name:             "simple",
+			DeprecatedBundle: u.Host + "/remote-pipeline",
 		},
 		expected: simplePipeline(),
 	}, {
@@ -162,8 +162,8 @@ func TestGetPipelineFunc(t *testing.T) {
 			simplePipelineWithSpecAndParam(""),
 			dummyPipeline},
 		ref: &v1beta1.PipelineRef{
-			Name:   "simple",
-			Bundle: u.Host + "/remote-pipeline-without-defaults",
+			Name:             "simple",
+			DeprecatedBundle: u.Host + "/remote-pipeline-without-defaults",
 		},
 		expected: simplePipelineWithSpecParamAndKind(v1beta1.ParamTypeString, v1beta1.NamespacedTaskKind),
 	}}

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -84,7 +84,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 	}
 
 	switch {
-	case cfg.FeatureFlags.EnableTektonOCIBundles && tr != nil && tr.Bundle != "":
+	case cfg.FeatureFlags.EnableTektonOCIBundles && tr != nil && tr.DeprecatedBundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a TaskObject.
 		return func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
@@ -96,7 +96,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			if err != nil {
 				return nil, fmt.Errorf("failed to get keychain: %w", err)
 			}
-			resolver := oci.NewResolver(tr.Bundle, kc)
+			resolver := oci.NewResolver(tr.DeprecatedBundle, kc)
 
 			return resolveTask(ctx, resolver, name, kind)
 		}, nil

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -267,8 +267,8 @@ func TestGetTaskFunc(t *testing.T) {
 				},
 			},
 			ref: &v1beta1.TaskRef{
-				Name:   "simple",
-				Bundle: u.Host + "/remote-task",
+				Name:             "simple",
+				DeprecatedBundle: u.Host + "/remote-task",
 			},
 			expected: &v1beta1.Task{
 				ObjectMeta: metav1.ObjectMeta{
@@ -304,8 +304,8 @@ func TestGetTaskFunc(t *testing.T) {
 					},
 				}},
 			ref: &v1beta1.TaskRef{
-				Name:   "simple",
-				Bundle: u.Host + "/remote-task-without-defaults",
+				Name:             "simple",
+				DeprecatedBundle: u.Host + "/remote-task-without-defaults",
 			},
 			expected: &v1beta1.Task{
 				ObjectMeta: metav1.ObjectMeta{
@@ -375,10 +375,10 @@ func TestGetTaskFunc(t *testing.T) {
 				},
 			},
 			ref: &v1beta1.TaskRef{
-				Name:       "simple",
-				APIVersion: "tekton.dev/v1beta1",
-				Kind:       v1beta1.ClusterTaskKind,
-				Bundle:     u.Host + "/remote-cluster-task",
+				Name:             "simple",
+				APIVersion:       "tekton.dev/v1beta1",
+				Kind:             v1beta1.ClusterTaskKind,
+				DeprecatedBundle: u.Host + "/remote-cluster-task",
 			},
 			expected: &v1beta1.ClusterTask{
 				ObjectMeta: metav1.ObjectMeta{Name: "simple"},


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Using an OCI bundle is now possible through the remote resolution, in
case of the oci bundle resolver being available in the cluster. For
more information about remote resolution, see
https://github.com/tektoncd/community/blob/main/teps/0060-remote-resource-resolution.md.

This means, there is now two different ways to refer to a Tekton OCI
bundle. As remote resolution (using the `resolver` field on
`PipelineRef` and `TaskRef`) is more generic, we are going to
deprecate the `bundle` field.

From now on, it is recommended to use resolver instead of bundle.

```
spec:
  pipelineRef:
    bundle: foo.io/bar/baz:tag
    name: my-pipeline
```

becomes

```
spec:
  pipelineRef:
    resolver: bundle
    resource:
    - name: bundle
      value: foo.io/bar/baz:tag
    - name: name
      value: my-pipeline
    - name: kind
      value: pipeline
```

Closes #3661 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/hold

Few things to to still:
- [ ] Output some warnings to the user that using this field is deprecated
- [ ] Most likely, have the `kind` parameter default to `pipeline` or `task` depending on the object it's refered from (`TaskRef` versus `PipelineRef`). cc @abayer @sbwsg 
- [ ] Make sure we ship the `bundle` resolver by default with the release that brings this in (otherwise, we will break a lot of users)
- [ ] Update deprecation table and documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
TaskRef/PipelineRef bundle field is deprecated in favor of using the bundle resolver
```
