### PR TITLE
Switch PipelineRun timeout -> TaskRun logic to instead signal the TaskRuns to stop

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -582,19 +582,20 @@ steps:
 
 The following tables shows how to read the overall status of a `TaskRun`:
 
-`status`|`reason`|`completionTime` is set|Description
-:-------|:-------|:---------------------:|--------------:
-Unknown|Started|No|The TaskRun has just been picked up by the controller.
-Unknown|Pending|No|The TaskRun is waiting on a Pod in status Pending.
-Unknown|Running|No|The TaskRun has been validated and started to perform its work.
-Unknown|TaskRunCancelled|No|The user requested the TaskRun to be cancelled. Cancellation has not been done yet.
-True|Succeeded|Yes|The TaskRun completed successfully.
-False|Failed|Yes|The TaskRun failed because one of the steps failed.
-False|\[Error message\]|No|The TaskRun encountered a non-permanent error, and it's still running. It may ultimately succeed.
-False|\[Error message\]|Yes|The TaskRun failed with a permanent error (usually validation).
-False|TaskRunCancelled|Yes|The TaskRun was cancelled successfully.
-False|TaskRunTimeout|Yes|The TaskRun timed out.
-False|TaskRunImagePullFailed|Yes|The TaskRun failed due to one of its steps not being able to pull the image. 
+`status`|`reason`|`message`|`completionTime` is set|Description
+:-------|:-------|:--|:---------------------:|--------------:
+Unknown|Started|n/a|No|The TaskRun has just been picked up by the controller.
+Unknown|Pending|n/a|No|The TaskRun is waiting on a Pod in status Pending.
+Unknown|Running|n/a|No|The TaskRun has been validated and started to perform its work.
+Unknown|TaskRunCancelled|n/a|No|The user requested the TaskRun to be cancelled. Cancellation has not been done yet.
+True|Succeeded|n/a|Yes|The TaskRun completed successfully.
+False|Failed|n/a|Yes|The TaskRun failed because one of the steps failed.
+False|\[Error message\]|n/a|No|The TaskRun encountered a non-permanent error, and it's still running. It may ultimately succeed.
+False|\[Error message\]|n/a|Yes|The TaskRun failed with a permanent error (usually validation).
+False|TaskRunCancelled|n/a|Yes|The TaskRun was cancelled successfully.
+False|TaskRunCancelled|TaskRun cancelled as the PipelineRun it belongs to has timed out.|Yes|The TaskRun was cancelled because the PipelineRun timed out.
+False|TaskRunTimeout|n/a|Yes|The TaskRun timed out.
+False|TaskRunImagePullFailed|n/a|Yes|The TaskRun failed due to one of its steps not being able to pull the image.
 
 When a `TaskRun` changes status, [events](events.md#taskruns) are triggered accordingly.
 

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -102,6 +102,8 @@ const (
 	// RunCancelledByPipelineMsg indicates that the PipelineRun of which part this Run was
 	// has been cancelled.
 	RunCancelledByPipelineMsg RunSpecStatusMessage = "Run cancelled as the PipelineRun it belongs to has been cancelled."
+	// RunCancelledByPipelineTimeoutMsg indicates that the Run was cancelled because the PipelineRun running it timed out.
+	RunCancelledByPipelineTimeoutMsg RunSpecStatusMessage = "Run cancelled as the PipelineRun it belongs to has timed out."
 )
 
 // GetParam gets the Param from the RunSpec with the given name

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -1764,6 +1764,12 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatus(ref common.ReferenceCall
 							},
 						},
 					},
+					"finallyStartTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 			},
 		},
@@ -1880,6 +1886,12 @@ func schema_pkg_apis_pipeline_v1beta1_PipelineRunStatusFields(ref common.Referen
 									},
 								},
 							},
+						},
+					},
+					"finallyStartTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types_test.go
@@ -286,6 +286,37 @@ func TestPipelineRunHasTimedOut(t *testing.T) {
 				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
 			}
 		})
+		t.Run("pipeline.timeouts.tasks "+tc.name, func(t *testing.T) {
+			pr := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.PipelineRunSpec{
+					Timeouts: &v1beta1.TimeoutFields{Tasks: &metav1.Duration{Duration: tc.timeout}},
+				},
+				Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime: &metav1.Time{Time: tc.starttime},
+				}},
+			}
+
+			if pr.HaveTasksTimedOut(context.Background(), testClock) != tc.expected {
+				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
+			}
+		})
+		t.Run("pipeline.timeouts.finally "+tc.name, func(t *testing.T) {
+			pr := &v1beta1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: v1beta1.PipelineRunSpec{
+					Timeouts: &v1beta1.TimeoutFields{Finally: &metav1.Duration{Duration: tc.timeout}},
+				},
+				Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+					StartTime:        &metav1.Time{Time: tc.starttime},
+					FinallyStartTime: &metav1.Time{Time: tc.starttime},
+				}},
+			}
+
+			if pr.HasFinallyTimedOut(context.Background(), testClock) != tc.expected {
+				t.Errorf("Expected HasTimedOut to be %t when using pipeline.timeouts.pipeline", tc.expected)
+			}
+		})
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1015,6 +1015,10 @@
           "x-kubernetes-patch-merge-key": "type",
           "x-kubernetes-patch-strategy": "merge"
         },
+        "finallyStartTime": {
+          "description": "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
+          "$ref": "#/definitions/v1.Time"
+        },
         "observedGeneration": {
           "description": "ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.",
           "type": "integer",
@@ -1077,6 +1081,10 @@
         },
         "completionTime": {
           "description": "CompletionTime is the time the PipelineRun completed.",
+          "$ref": "#/definitions/v1.Time"
+        },
+        "finallyStartTime": {
+          "description": "FinallyStartTime is when all non-finally tasks have been completed and only finally tasks are being executed.",
           "$ref": "#/definitions/v1.Time"
         },
         "pipelineResults": {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -101,6 +101,8 @@ const (
 	// TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this
 	// TaskRun was a part of has been cancelled.
 	TaskRunCancelledByPipelineMsg TaskRunSpecStatusMessage = "TaskRun cancelled as the PipelineRun it belongs to has been cancelled."
+	// TaskRunCancelledByPipelineTimeoutMsg indicates that the TaskRun was cancelled because the PipelineRun running it timed out.
+	TaskRunCancelledByPipelineTimeoutMsg TaskRunSpecStatusMessage = "TaskRun cancelled as the PipelineRun it belongs to has timed out."
 )
 
 // TaskRunDebug defines the breakpoint config for a particular TaskRun

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -120,7 +120,7 @@ func TestTaskRunIsDone(t *testing.T) {
 		},
 	}
 	if !tr.IsDone() {
-		t.Fatal("Expected pipelinerun status to be done")
+		t.Fatal("Expected taskrun status to be done")
 	}
 }
 
@@ -131,11 +131,7 @@ func TestTaskRunIsCancelled(t *testing.T) {
 		},
 	}
 	if !tr.IsCancelled() {
-		t.Fatal("Expected pipelinerun status to be cancelled")
-	}
-	expected := ""
-	if string(tr.Spec.StatusMessage) != expected {
-		t.Fatalf("Expected StatusMessage is %s but got %s", expected, tr.Spec.StatusMessage)
+		t.Fatal("Expected taskrun status to be cancelled")
 	}
 }
 

--- a/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1beta1/zz_generated.deepcopy.go
@@ -709,6 +709,10 @@ func (in *PipelineRunStatusFields) DeepCopyInto(out *PipelineRunStatusFields) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.FinallyStartTime != nil {
+		in, out := &in.FinallyStartTime, &out.FinallyStartTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -274,11 +276,12 @@ func TestCancelPipelineRun(t *testing.T) {
 	}
 }
 
-func TestGetChildObjectsFromPRStatus(t *testing.T) {
+func TestGetChildObjectsFromPRStatusForTaskNames(t *testing.T) {
 	testCases := []struct {
 		name             string
 		embeddedStatus   string
 		prStatus         v1beta1.PipelineRunStatus
+		taskNames        sets.String
 		expectedTRNames  []string
 		expectedRunNames []string
 		hasError         bool
@@ -318,6 +321,21 @@ func TestGetChildObjectsFromPRStatus(t *testing.T) {
 			}},
 			expectedTRNames:  []string{"t1"},
 			expectedRunNames: []string{"r1"},
+			hasError:         false,
+		}, {
+			name:           "taskrun and run, default embedded, just want taskrun",
+			embeddedStatus: config.DefaultEmbeddedStatus,
+			prStatus: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+				Runs: map[string]*v1beta1.PipelineRunRunStatus{
+					"r1": {PipelineTaskName: "run-1"},
+				},
+			}},
+			taskNames:        sets.NewString("task-1"),
+			expectedTRNames:  []string{"t1"},
+			expectedRunNames: nil,
 			hasError:         false,
 		}, {
 			name:           "full embedded",
@@ -402,7 +420,7 @@ func TestGetChildObjectsFromPRStatus(t *testing.T) {
 			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
 			ctx = cfg.ToContext(ctx)
 
-			trNames, runNames, err := getChildObjectsFromPRStatus(ctx, tc.prStatus)
+			trNames, runNames, err := getChildObjectsFromPRStatusForTaskNames(ctx, tc.prStatus, tc.taskNames)
 
 			if tc.hasError {
 				if err == nil {

--- a/pkg/reconciler/pipelinerun/timeout.go
+++ b/pkg/reconciler/pipelinerun/timeout.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"gomodules.xyz/jsonpatch/v2"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	clientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+var timeoutTaskRunPatchBytes, timeoutRunPatchBytes []byte
+
+func init() {
+	var err error
+	timeoutTaskRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/status",
+			Value:     v1beta1.TaskRunSpecStatusCancelled,
+		},
+		{
+			Operation: "add",
+			Path:      "/spec/statusMessage",
+			Value:     v1beta1.TaskRunCancelledByPipelineTimeoutMsg,
+		}})
+	if err != nil {
+		log.Fatalf("failed to marshal TaskRun timeout patch bytes: %v", err)
+	}
+	timeoutRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/status",
+			Value:     v1alpha1.RunSpecStatusCancelled,
+		},
+		{
+			Operation: "add",
+			Path:      "/spec/statusMessage",
+			Value:     v1alpha1.RunCancelledByPipelineTimeoutMsg,
+		}})
+	if err != nil {
+		log.Fatalf("failed to marshal Run timeout patch bytes: %v", err)
+	}
+}
+
+// timeoutPipelineRun marks the PipelineRun as timed out and any resolved TaskRun(s) too.
+func timeoutPipelineRun(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface) error {
+	errs := timeoutPipelineTasks(ctx, logger, pr, clientSet)
+
+	// If we successfully timed out all the TaskRuns and Runs, we can consider the PipelineRun timed out.
+	if len(errs) == 0 {
+		reason := v1beta1.PipelineRunReasonTimedOut.String()
+
+		pr.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionFalse,
+			Reason:  reason,
+			Message: fmt.Sprintf("PipelineRun %q failed to finish within %q", pr.Name, pr.PipelineTimeout(ctx).String()),
+		})
+		// update pr completed time
+		pr.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+	} else {
+		e := strings.Join(errs, "\n")
+		// Indicate that we failed to time out the PipelineRun
+		pr.Status.SetCondition(&apis.Condition{
+			Type:    apis.ConditionSucceeded,
+			Status:  corev1.ConditionUnknown,
+			Reason:  ReasonCouldntTimeOut,
+			Message: fmt.Sprintf("PipelineRun %q was timed out but had errors trying to time out TaskRuns and/or Runs: %s", pr.Name, e),
+		})
+		return fmt.Errorf("error(s) from timing out TaskRun(s) from PipelineRun %s: %s", pr.Name, e)
+	}
+	return nil
+}
+
+func timeoutRun(ctx context.Context, runName string, namespace string, clientSet clientset.Interface) error {
+	_, err := clientSet.TektonV1alpha1().Runs(namespace).Patch(ctx, runName, types.JSONPatchType, timeoutRunPatchBytes, metav1.PatchOptions{}, "")
+	return err
+}
+
+// timeoutPipelineTaskRuns patches `TaskRun` and `Run` with canceled status and an appropriate message
+func timeoutPipelineTasks(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface) []string {
+	return timeoutPipelineTasksForTaskNames(ctx, logger, pr, clientSet, sets.NewString())
+}
+
+// timeoutPipelineTasksForTaskNames patches `TaskRun`s and `Run`s for the given task names, or all if no task names are given, with canceled status and appropriate message
+func timeoutPipelineTasksForTaskNames(ctx context.Context, logger *zap.SugaredLogger, pr *v1beta1.PipelineRun, clientSet clientset.Interface, taskNames sets.String) []string {
+	errs := []string{}
+
+	trNames, runNames, err := getChildObjectsFromPRStatusForTaskNames(ctx, pr.Status, taskNames)
+	if err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	for _, taskRunName := range trNames {
+		logger.Infof("cancelling TaskRun %s for timeout", taskRunName)
+
+		if _, err := clientSet.TektonV1beta1().TaskRuns(pr.Namespace).Patch(ctx, taskRunName, types.JSONPatchType, timeoutTaskRunPatchBytes, metav1.PatchOptions{}, ""); err != nil {
+			errs = append(errs, fmt.Errorf("Failed to patch TaskRun `%s` with cancellation: %s", taskRunName, err).Error())
+			continue
+		}
+	}
+
+	for _, runName := range runNames {
+		logger.Infof("cancelling Run %s for timeout", runName)
+
+		if err := timeoutRun(ctx, runName, pr.Namespace, clientSet); err != nil {
+			errs = append(errs, fmt.Errorf("Failed to patch Run `%s` with cancellation: %s", runName, err).Error())
+			continue
+		}
+	}
+
+	return errs
+}

--- a/pkg/reconciler/pipelinerun/timeout_test.go
+++ b/pkg/reconciler/pipelinerun/timeout_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelinerun
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	_ "github.com/tektoncd/pipeline/pkg/pipelinerunmetrics/fake" // Make sure the pipelinerunmetrics are setup
+	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
+	"github.com/tektoncd/pipeline/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestTimeoutPipelineRun(t *testing.T) {
+	testCases := []struct {
+		name           string
+		embeddedStatus string
+		pipelineRun    *v1beta1.PipelineRun
+		taskRuns       []*v1beta1.TaskRun
+		runs           []*v1alpha1.Run
+		wantErr        bool
+	}{{
+		name:           "no-resolved-taskrun",
+		embeddedStatus: config.DefaultEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+		},
+	}, {
+		name:           "one-taskrun",
+		embeddedStatus: config.DefaultEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+				},
+			}},
+		},
+		taskRuns: []*v1beta1.TaskRun{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+		},
+	}, {
+		name:           "multiple-taskruns",
+		embeddedStatus: config.DefaultEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+					"t2": {PipelineTaskName: "task-2"},
+				},
+			}},
+		},
+		taskRuns: []*v1beta1.TaskRun{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
+		},
+	}, {
+		name:           "multiple-runs",
+		embeddedStatus: config.DefaultEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				Runs: map[string]*v1beta1.PipelineRunRunStatus{
+					"t1": {PipelineTaskName: "task-1"},
+					"t2": {PipelineTaskName: "task-2"},
+				},
+			}},
+		},
+		runs: []*v1alpha1.Run{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
+		},
+	}, {
+		name:           "child-references-with-both",
+		embeddedStatus: config.BothEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t1",
+						PipelineTaskName: "task-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t2",
+						PipelineTaskName: "task-2",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r1",
+						PipelineTaskName: "run-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r2",
+						PipelineTaskName: "run-2",
+					},
+				},
+			}},
+		},
+		taskRuns: []*v1beta1.TaskRun{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
+		},
+		runs: []*v1alpha1.Run{
+			{ObjectMeta: metav1.ObjectMeta{Name: "r1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "r2"}},
+		},
+	}, {
+		name:           "child-references-with-minimal",
+		embeddedStatus: config.MinimalEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t1",
+						PipelineTaskName: "task-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "TaskRun"},
+						Name:             "t2",
+						PipelineTaskName: "task-2",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r1",
+						PipelineTaskName: "run-1",
+					},
+					{
+						TypeMeta:         runtime.TypeMeta{Kind: "Run"},
+						Name:             "r2",
+						PipelineTaskName: "run-2",
+					},
+				},
+			}},
+		},
+		taskRuns: []*v1beta1.TaskRun{
+			{ObjectMeta: metav1.ObjectMeta{Name: "t1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "t2"}},
+		},
+		runs: []*v1alpha1.Run{
+			{ObjectMeta: metav1.ObjectMeta{Name: "r1"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "r2"}},
+		},
+	}, {
+		name:           "unknown-kind-on-child-references",
+		embeddedStatus: config.MinimalEmbeddedStatus,
+		pipelineRun: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline-run-timedout"},
+			Spec:       v1beta1.PipelineRunSpec{},
+			Status: v1beta1.PipelineRunStatus{PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
+				ChildReferences: []v1beta1.ChildStatusReference{{
+					TypeMeta:         runtime.TypeMeta{Kind: "InvalidKind"},
+					Name:             "t1",
+					PipelineTaskName: "task-1",
+				}},
+			}},
+		},
+		wantErr: true,
+	}}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			d := test.Data{
+				PipelineRuns: []*v1beta1.PipelineRun{tc.pipelineRun},
+				TaskRuns:     tc.taskRuns,
+				Runs:         tc.runs,
+			}
+			ctx, _ := ttesting.SetupFakeContext(t)
+			cfg := config.NewStore(logtesting.TestLogger(t))
+			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
+			ctx = cfg.ToContext(ctx)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			c, _ := test.SeedTestData(t, ctx, d)
+
+			err := timeoutPipelineRun(ctx, logtesting.TestLogger(t), tc.pipelineRun, c.Pipeline)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected an error, but did not get one")
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				// This PipelineRun should still be complete and false, and the status should reflect that
+				cond := tc.pipelineRun.Status.GetCondition(apis.ConditionSucceeded)
+				if cond.IsTrue() {
+					t.Errorf("Expected PipelineRun status to be complete and false, but was %v", cond)
+				}
+				if tc.taskRuns != nil {
+					for _, expectedTR := range tc.taskRuns {
+						tr, err := c.Pipeline.TektonV1beta1().TaskRuns("").Get(ctx, expectedTR.Name, metav1.GetOptions{})
+						if err != nil {
+							t.Fatalf("couldn't get expected TaskRun %s, got error %s", expectedTR.Name, err)
+						}
+						if tr.Spec.Status != v1beta1.TaskRunSpecStatusCancelled {
+							t.Errorf("expected task %q to be marked as timed out, was %q", tr.Name, tr.Spec.Status)
+						}
+						if tr.Spec.StatusMessage != v1beta1.TaskRunCancelledByPipelineTimeoutMsg {
+							t.Errorf("expected task %s to have the timeout-specific status message, was %s", tr.Name, tr.Spec.StatusMessage)
+						}
+					}
+				}
+				if tc.runs != nil {
+					for _, expectedRun := range tc.runs {
+						r, err := c.Pipeline.TektonV1alpha1().Runs("").Get(ctx, expectedRun.Name, metav1.GetOptions{})
+						if err != nil {
+							t.Fatalf("couldn't get expected Run %s, got error %s", expectedRun.Name, err)
+						}
+						if r.Spec.Status != v1alpha1.RunSpecStatusCancelled {
+							t.Errorf("expected task %q to be marked as cancelled, was %q", r.Name, r.Spec.Status)
+						}
+						if r.Spec.StatusMessage != v1alpha1.RunCancelledByPipelineTimeoutMsg {
+							t.Errorf("expected run %s to have the timeout-specific status message, was %s", r.Name, r.Spec.StatusMessage)
+						}
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Changes

Fixes #5127, #3460

An alternative approach vs #5133, attempting to eliminate the problem entirely rather than just working around it.

As noted in #5127, the logic around calculating a timeout for a `PipelineRun`'s `TaskRun` to make sure that the `TaskRun`'s timeout is always going to end before the `PipelineRun`'s timeout ends is problematic. It can result in race conditions where a `TaskRun` gets timed out, immediately followed by the `PipelineRun` being reconciled while not yet having hit the end of its own timeout. This change gets rid of that behavior, and instead sets the `TaskRun.Spec.Status` to a new value, `TaskRunTimedOut`, with the `TaskRun` reconciler handling that in the same way it does setting `TaskRun.Spec.Status` to `TaskRunCancelled`.

By doing this, we can unify the behavior for both `TaskRun`s and `Run`s upon `PipelineRun`s timing out, given that we already cancel `Run`s upon `PipelineRun` timeout, and we can kill off a bunch of flaky outcomes for `PipelineRun`s.

Also, rather than setting a 1s timeout on tasks which are created after the `.timeouts.pipeline`, `.timeouts.tasks`, or `.timeouts.finally` timeouts have been passed, this change will skip creation of those `TaskRun`s or `Run`s completely. However, it will still report those "tasks" as failed, not skipped, since attempted creation of tasks after the appropriate timeout has been reached is a failure case, and that's the existing expected behavior for `PipelineTask`s which try to start after timeouts have elapsed.

Huge thanks to @jerop for suggesting this approach!

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Change PipelineRun timeout behavior for child TaskRuns and Runs to behave like cancellation rather than explicitly setting timeouts on the child tasks at runtime.
```
