### PR TITLE
[TEP-0076]Validate Pipeline results array index

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1005,6 +1005,14 @@ Array and object results is supported as alpha feature, see [`Array Results` in 
 
 ```yaml
     results:
+      - name: array-results
+        type: array
+        description: whole array
+        value: $(tasks.task1.results.array-results[*])
+      - name: array-indexing-results
+        type: string
+        description: array element
+        value: $(tasks.task1.results.array-results[1])
       - name: object-results
         type: object
         description: whole object

--- a/examples/v1beta1/pipelineruns/alpha/pipeline-emitting-results.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipeline-emitting-results.yaml
@@ -41,6 +41,10 @@ spec:
         type: array
         description: whole array
         value: $(tasks.task1.results.array-results[*])
+      - name: array-results-from-array-indexing-and-object-elements
+        type: array
+        description: whole array
+        value: ["$(tasks.task1.results.array-results[0])", "$(tasks.task2.results.object-results.foo)"]
       - name: array-indexing-results
         type: string
         description: array element

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -128,6 +128,9 @@ func GetVarSubstitutionExpressionsForParam(param Param) ([]string, bool) {
 // GetVarSubstitutionExpressionsForPipelineResult extracts all the value between "$(" and ")"" for a pipeline result
 func GetVarSubstitutionExpressionsForPipelineResult(result PipelineResult) ([]string, bool) {
 	allExpressions := validateString(result.Value.StringVal)
+	for _, v := range result.Value.ArrayVal {
+		allExpressions = append(allExpressions, validateString(v)...)
+	}
 	for _, v := range result.Value.ObjectVal {
 		allExpressions = append(allExpressions, validateString(v)...)
 	}

--- a/pkg/apis/pipeline/v1beta1/resultref_test.go
+++ b/pkg/apis/pipeline/v1beta1/resultref_test.go
@@ -732,20 +732,27 @@ func TestGetVarSubstitutionExpressionsForPipelineResult(t *testing.T) {
 			Value: *v1beta1.NewArrayOrString("$(tasks.task1.results.result1) and $(tasks.task2.results.result2)"),
 		},
 		want: []string{"tasks.task1.results.result1", "tasks.task2.results.result2"},
-	},
-		{
-			name: "get object result expressions",
-			result: v1beta1.PipelineResult{
-				Name: "object result",
-				Type: v1beta1.ResultsTypeString,
-				Value: *v1beta1.NewObject(map[string]string{
-					"key1": "$(tasks.task1.results.result1)",
-					"key2": "$(tasks.task2.results.result2) and another one $(tasks.task3.results.result3)",
-					"key3": "no ref here",
-				}),
-			},
-			want: []string{"tasks.task1.results.result1", "tasks.task2.results.result2", "tasks.task3.results.result3"},
+	}, {
+		name: "get array result expressions",
+		result: v1beta1.PipelineResult{
+			Name:  "array result",
+			Type:  v1beta1.ResultsTypeString,
+			Value: *v1beta1.NewArrayOrString("$(tasks.task1.results.result1)", "$(tasks.task2.results.result2)"),
 		},
+		want: []string{"tasks.task1.results.result1", "tasks.task2.results.result2"},
+	}, {
+		name: "get object result expressions",
+		result: v1beta1.PipelineResult{
+			Name: "object result",
+			Type: v1beta1.ResultsTypeString,
+			Value: *v1beta1.NewObject(map[string]string{
+				"key1": "$(tasks.task1.results.result1)",
+				"key2": "$(tasks.task2.results.result2) and another one $(tasks.task3.results.result3)",
+				"key3": "no ref here",
+			}),
+		},
+		want: []string{"tasks.task1.results.result1", "tasks.task2.results.result2", "tasks.task3.results.result3"},
+	},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -303,6 +303,9 @@ func ApplyTaskResultsToPipelineResults(
 							intIdx, _ := strconv.Atoi(stringIdx)
 							if intIdx < len(resultValue.ArrayVal) {
 								stringReplacements[variable] = resultValue.ArrayVal[intIdx]
+							} else {
+								invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
+								validPipelineResult = false
 							}
 						} else {
 							arrayReplacements[substitution.StripStarVarSubExpression(variable)] = resultValue.ArrayVal

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -2080,6 +2080,22 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 		},
 		expectedResults: nil,
 	}, {
+		description: "array-index-out-of-bound",
+		results: []v1beta1.PipelineResult{{
+			Name:  "pipeline-result-1",
+			Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.foo[4])"),
+		}},
+		taskResults: map[string][]v1beta1.TaskRunResult{
+			"pt1": {
+				{
+					Name:  "foo",
+					Value: *v1beta1.NewArrayOrString("do", "rae", "mi"),
+				},
+			},
+		},
+		expectedResults: nil,
+		expectedError:   fmt.Errorf("invalid pipelineresults [pipeline-result-1], the referred results don't exist"),
+	}, {
 		description: "object-reference-not-exist",
 		results: []v1beta1.PipelineResult{{
 			Name:  "pipeline-result-1",
@@ -2190,6 +2206,33 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 				"pkey1": "val1",
 				"pkey2": "rae",
 			}),
+		}},
+	}, {
+		description: "array-results-from-array-indexing-and-object-element",
+		results: []v1beta1.PipelineResult{{
+			Name:  "pipeline-result-1",
+			Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.foo.key1)", "$(tasks.pt2.results.bar[1])"),
+		}},
+		taskResults: map[string][]v1beta1.TaskRunResult{
+			"pt1": {
+				{
+					Name: "foo",
+					Value: *v1beta1.NewObject(map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+					}),
+				},
+			},
+			"pt2": {
+				{
+					Name:  "bar",
+					Value: *v1beta1.NewArrayOrString("do", "rae", "mi"),
+				},
+			},
+		},
+		expectedResults: []v1beta1.PipelineRunResult{{
+			Name:  "pipeline-result-1",
+			Value: *v1beta1.NewArrayOrString("val1", "rae"),
 		}},
 	}, {
 		description: "apply-object-element",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This is part of work in TEP-0076.
Previous to this commit, we have added support for pipeline array
results indexing. This commit adds the validation to check if it is out
of bound.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
pipelinerun will fail if pipelineresults array index is out of bound
```

