### PR TITLE
[TEP-0075]Add more setdefaults features for taskresults

### DIFF
--- a/pkg/apis/pipeline/v1/result_defaults.go
+++ b/pkg/apis/pipeline/v1/result_defaults.go
@@ -17,8 +17,23 @@ import "context"
 
 // SetDefaults set the default type for TaskResult
 func (tr *TaskResult) SetDefaults(context.Context) {
-	if tr != nil && tr.Type == "" {
-		// ResultsTypeString is the default value
-		tr.Type = ResultsTypeString
+	if tr == nil {
+		return
+	}
+	if tr.Type == "" {
+		if tr.Properties != nil {
+			// Set type to object if `properties` is given
+			tr.Type = ResultsTypeObject
+		} else {
+			// ResultsTypeString is the default value
+			tr.Type = ResultsTypeString
+		}
+	}
+
+	// Set default type of object values to string
+	for key, propertySpec := range tr.Properties {
+		if propertySpec.Type == "" {
+			tr.Properties[key] = PropertySpec{Type: ParamType(ResultsTypeString)}
+		}
 	}
 }

--- a/pkg/apis/pipeline/v1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1/result_defaults_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/test/diff"
+)
+
+func TestTaskResult_SetDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		before *v1.TaskResult
+		after  *v1.TaskResult
+	}{{
+		name:   "empty taskresult",
+		before: nil,
+		after:  nil,
+	}, {
+		name: "inferred string type",
+		before: &v1.TaskResult{
+			Name: "resultname",
+		},
+		after: &v1.TaskResult{
+			Name: "resultname",
+			Type: v1.ResultsTypeString,
+		},
+	}, {
+		name: "string type specified not changed",
+		before: &v1.TaskResult{
+			Name: "resultname",
+			Type: v1.ResultsTypeString,
+		},
+		after: &v1.TaskResult{
+			Name: "resultname",
+			Type: v1.ResultsTypeString,
+		},
+	}, {
+		name: "array type specified not changed",
+		before: &v1.TaskResult{
+			Name: "resultname",
+			Type: v1.ResultsTypeArray,
+		},
+		after: &v1.TaskResult{
+			Name: "resultname",
+			Type: v1.ResultsTypeArray,
+		},
+	}, {
+		name: "inferred object type from properties - PropertySpec type is provided",
+		before: &v1.TaskResult{
+			Name:       "resultname",
+			Properties: map[string]v1.PropertySpec{"key1": {v1.ParamTypeString}},
+		},
+		after: &v1.TaskResult{
+			Name:       "resultname",
+			Type:       v1.ResultsTypeObject,
+			Properties: map[string]v1.PropertySpec{"key1": {v1.ParamTypeString}},
+		},
+	}, {
+		name: "inferred type from properties - PropertySpec type is not provided",
+		before: &v1.TaskResult{
+			Name:       "resultname",
+			Properties: map[string]v1.PropertySpec{"key1": {}},
+		},
+		after: &v1.TaskResult{
+			Name:       "resultname",
+			Type:       v1.ResultsTypeObject,
+			Properties: map[string]v1.PropertySpec{"key1": {v1.ParamTypeString}},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			tc.before.SetDefaults(ctx)
+			if d := cmp.Diff(tc.before, tc.after); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/result_defaults.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults.go
@@ -17,8 +17,23 @@ import "context"
 
 // SetDefaults set the default type for TaskResult
 func (tr *TaskResult) SetDefaults(context.Context) {
-	if tr != nil && tr.Type == "" {
-		// ResultsTypeString is the default value
-		tr.Type = ResultsTypeString
+	if tr == nil {
+		return
+	}
+	if tr.Type == "" {
+		if tr.Properties != nil {
+			// Set type to object if `properties` is given
+			tr.Type = ResultsTypeObject
+		} else {
+			// ResultsTypeString is the default value
+			tr.Type = ResultsTypeString
+		}
+	}
+
+	// Set default type of object values to string
+	for key, propertySpec := range tr.Properties {
+		if propertySpec.Type == "" {
+			tr.Properties[key] = PropertySpec{Type: ParamType(ResultsTypeString)}
+		}
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/result_defaults_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_defaults_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Tekton Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+)
+
+func TestTaskResult_SetDefaults(t *testing.T) {
+	tests := []struct {
+		name   string
+		before *v1beta1.TaskResult
+		after  *v1beta1.TaskResult
+	}{{
+		name:   "empty taskresult",
+		before: nil,
+		after:  nil,
+	}, {
+		name: "inferred string type",
+		before: &v1beta1.TaskResult{
+			Name: "resultname",
+		},
+		after: &v1beta1.TaskResult{
+			Name: "resultname",
+			Type: v1beta1.ResultsTypeString,
+		},
+	}, {
+		name: "string type specified not changed",
+		before: &v1beta1.TaskResult{
+			Name: "resultname",
+			Type: v1beta1.ResultsTypeString,
+		},
+		after: &v1beta1.TaskResult{
+			Name: "resultname",
+			Type: v1beta1.ResultsTypeString,
+		},
+	}, {
+		name: "array type specified not changed",
+		before: &v1beta1.TaskResult{
+			Name: "resultname",
+			Type: v1beta1.ResultsTypeArray,
+		},
+		after: &v1beta1.TaskResult{
+			Name: "resultname",
+			Type: v1beta1.ResultsTypeArray,
+		},
+	}, {
+		name: "inferred object type from properties - PropertySpec type is provided",
+		before: &v1beta1.TaskResult{
+			Name:       "resultname",
+			Properties: map[string]v1beta1.PropertySpec{"key1": {v1beta1.ParamTypeString}},
+		},
+		after: &v1beta1.TaskResult{
+			Name:       "resultname",
+			Type:       v1beta1.ResultsTypeObject,
+			Properties: map[string]v1beta1.PropertySpec{"key1": {v1beta1.ParamTypeString}},
+		},
+	}, {
+		name: "inferred type from properties - PropertySpec type is not provided",
+		before: &v1beta1.TaskResult{
+			Name:       "resultname",
+			Properties: map[string]v1beta1.PropertySpec{"key1": {}},
+		},
+		after: &v1beta1.TaskResult{
+			Name:       "resultname",
+			Type:       v1beta1.ResultsTypeObject,
+			Properties: map[string]v1beta1.PropertySpec{"key1": {v1beta1.ParamTypeString}},
+		},
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			tc.before.SetDefaults(ctx)
+			if d := cmp.Diff(tc.before, tc.after); d != "" {
+				t.Error(diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit add more feature for TaskResult's SetDefaults, if the
Properties is set then the result type is inferred as object. For Properties
value it is also set to string by default.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
taskresults is inferred as object if Properties is set, and Properties's value by default is string
```
