### PR TITLE
Move parameter validation from `taskspec` to `taskrunspec` when propagating parameters

### DIFF
--- a/pkg/apis/config/contexts.go
+++ b/pkg/apis/config/contexts.go
@@ -23,6 +23,9 @@ import (
 // isSubstituted is used for associating the parameter substitution inside the context.Context.
 type isSubstituted struct{}
 
+// validateEmbeddedVariables is used for deciding whether to validate or skip parameters and workspaces inside the contect.Context.
+type validateEmbeddedVariables string
+
 // WithinSubstituted is used to note that it is calling within
 // the context of a substitute variable operation.
 func WithinSubstituted(ctx context.Context) context.Context {
@@ -32,4 +35,14 @@ func WithinSubstituted(ctx context.Context) context.Context {
 // IsSubstituted indicates that the variables have been substituted.
 func IsSubstituted(ctx context.Context) bool {
 	return ctx.Value(isSubstituted{}) != nil
+}
+
+// SetValidateParameterVariablesAndWorkspaces sets the context to skip validation of parameters when embedded vs referenced to true or false.
+func SetValidateParameterVariablesAndWorkspaces(ctx context.Context, validate bool) context.Context {
+	return context.WithValue(ctx, validateEmbeddedVariables("ValidateParameterVariablesAndWorkspaces"), validate)
+}
+
+// ValidateParameterVariablesAndWorkspaces indicates if validation of paramater variables and workspaces should be conducted.
+func ValidateParameterVariablesAndWorkspaces(ctx context.Context) bool {
+	return ctx.Value(validateEmbeddedVariables("ValidateParameterVariablesAndWorkspaces")) == true
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -19,6 +19,7 @@ package v1beta1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"knative.dev/pkg/apis"
 )
@@ -31,5 +32,6 @@ func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -56,6 +56,7 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
+	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 
@@ -362,9 +363,10 @@ func ValidateParameterVariables(ctx context.Context, steps []Step, params []Para
 			stringParameterNames.Insert(p.Name)
 		}
 	}
-
 	errs = errs.Also(validateNameFormat(stringParameterNames.Insert(arrayParameterNames.List()...), objectParamSpecs))
-	errs = errs.Also(validateVariables(ctx, steps, "params", allParameterNames))
+	if config.ValidateParameterVariablesAndWorkspaces(ctx) == true {
+		errs = errs.Also(validateVariables(ctx, steps, "params", allParameterNames))
+	}
 	errs = errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
 	errs = errs.Also(validateObjectDefault(objectParamSpecs))
 	return errs.Also(validateObjectUsage(ctx, steps, objectParamSpecs))
@@ -585,9 +587,7 @@ func validateStepVariables(ctx context.Context, step Step, prefix string, vars s
 	errs := validateTaskVariable(step.Name, prefix, vars).ViaField("name")
 	errs = errs.Also(validateTaskVariable(step.Image, prefix, vars).ViaField("image"))
 	errs = errs.Also(validateTaskVariable(step.WorkingDir, prefix, vars).ViaField("workingDir"))
-	if !(config.FromContextOrDefaults(ctx).FeatureFlags.EnableAPIFields == "alpha" && prefix == "params") {
-		errs = errs.Also(validateTaskVariable(step.Script, prefix, vars).ViaField("script"))
-	}
+	errs = errs.Also(validateTaskVariable(step.Script, prefix, vars).ViaField("script"))
 	for i, cmd := range step.Command {
 		errs = errs.Also(validateTaskVariable(cmd, prefix, vars).ViaFieldIndex("command", i))
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -55,10 +55,15 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 	// Validate TaskSpec if it's present.
 	if ts.TaskSpec != nil {
+		// skip validation of parameter and workspaces variables since we validate them via taskrunspec below.
+		ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
 		errs = errs.Also(ts.TaskSpec.Validate(ctx).ViaField("taskSpec"))
 	}
 
 	errs = errs.Also(ValidateParameters(ctx, ts.Params).ViaField("params"))
+
+	// Validate propagated parameters
+	errs = errs.Also(ts.validateInlineParameters(ctx))
 	errs = errs.Also(ValidateWorkspaceBindings(ctx, ts.Workspaces).ViaField("workspaces"))
 	errs = errs.Also(ts.Resources.Validate(ctx).ViaField("resources"))
 	if ts.Debug != nil {
@@ -90,6 +95,42 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	}
 
+	return errs
+}
+
+// validateInlineParameters validates that any parameters called in the
+// Task spec are declared in the TaskRun.
+// This is crucial for propagated parameters because the parameters could
+// be defined under taskRun and then called directly in the task steps.
+// In this case, parameters cannot be validated by the underlying taskSpec
+// since they may not have the parameters declared because of propagation.
+func (ts *TaskRunSpec) validateInlineParameters(ctx context.Context) (errs *apis.FieldError) {
+	if ts.TaskSpec == nil {
+		return errs
+	}
+	var paramSpec []ParamSpec
+	for _, p := range ts.Params {
+		pSpec := ParamSpec{
+			Name:    p.Name,
+			Default: &p.Value,
+		}
+		paramSpec = append(paramSpec, pSpec)
+	}
+	for _, p := range ts.TaskSpec.Params {
+		skip := false
+		for _, ps := range paramSpec {
+			if ps.Name == p.Name {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			paramSpec = append(paramSpec, p)
+		}
+	}
+	if ts.TaskSpec != nil && ts.TaskSpec.Steps != nil {
+		errs = errs.Also(ValidateParameterVariables(config.SetValidateParameterVariablesAndWorkspaces(ctx, true), ts.TaskSpec.Steps, paramSpec))
+	}
 	return errs
 }
 

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -700,6 +700,9 @@ func (c *Reconciler) createPod(ctx context.Context, ts *v1beta1.TaskSpec, tr *v1
 	// Apply workspace resource substitution
 	ts = resources.ApplyWorkspaces(ctx, ts, ts.Workspaces, tr.Spec.Workspaces, workspaceVolumes)
 
+	// By this time, params and workspaces should be propagated down so we can
+	// validate that all parameter variables and workspaces used in the TaskSpec are declared by the Task.
+	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
 	if validateErr := ts.Validate(ctx); validateErr != nil {
 		logger.Errorf("Failed to create a pod for taskrun: %s due to task validation error %v", tr.Name, validateErr)
 		return nil, validateErr


### PR DESCRIPTION
Prior to this, propagating parameters only skipped webhook validation
for params defined in script. As a result, when users tried to propagate
params to other fields like `args` or `command`, etc. an webhook
validation was raised. This PR address issue https://github.com/tektoncd/pipeline/issues/5141. 
This PR addresses validations in `taskspec` and `taskrunspec`. The changes for validations in `pipelinespec` and `pipelinerunspec` will be added in a follow up [PR](https://github.com/tektoncd/pipeline/pull/5291).

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Move parameter validation from `taskspec` to `taskrunspec` when propagating parameters
```
