### PR TITLE
TEP-0075: Add examples with object params and results

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/pipeline-object-param.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipeline-object-param.yaml
@@ -1,0 +1,52 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: mock-clone-task
+spec:
+  params:
+    - name: arg
+      type: object
+      properties:
+        url:
+          type: string
+        commit:
+          type: string
+  steps:
+    - name: mock-clone-git
+      image: bash
+      args: [
+        "echo",
+        "--url=$(params.arg.url)",
+        "--commit=$(params.arg.commit)"
+      ]
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: mock-clone-pipeline
+spec:
+  params:
+    - name: gitrepo
+      properties:
+        url: {}
+        commit: {}
+  tasks:
+    - name: mock-clone
+      params:
+        - name: arg
+          value: $(params.gitrepo[*])
+      taskRef:
+        name: mock-clone-task
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-object-param-
+spec:
+  params:
+    - name: gitrepo
+      value:
+        url: abc.com
+        commit: sha123
+  pipelineRef:
+    name: mock-clone-pipeline

--- a/examples/v1beta1/taskruns/alpha/object-param-result.yaml
+++ b/examples/v1beta1/taskruns/alpha/object-param-result.yaml
@@ -1,0 +1,36 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: object-param-result-
+spec:
+  params:
+    - name: gitrepo
+      value:
+        url: "xyz.com"
+        commit: "sha123"
+  taskSpec:
+    params:
+      - name: gitrepo
+        type: object
+        properties:
+          url: {type: string}
+          commit: {type: string}
+    results:
+      - name: object-results
+        type: object
+        properties:
+          IMAGE_URL: {type: string}
+          IMAGE_DIGEST: {type: string}
+    steps:
+      - name: echo-object-params
+        image: bash
+        args: [
+          "echo",
+          "--url=$(params.gitrepo.url)",
+          "--commit=$(params.gitrepo.commit)"
+        ]
+      - name: write-object-result
+        image: bash:latest
+        script: |
+          #!/usr/bin/env bash
+          echo -n "{\"IMAGE_URL\":\"ar.com\", \"IMAGE_DIGEST\":\"sha234\"}" > $(results.object-results.path)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Added a taskrun level example that uses object param and
object result.

- Added a pipeline level example that uses individual variables of an
object param and uses the whole object param.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add taskrun & pipelinerun examples that use object param and result.
```
