### PR TITLE
Prepare tests for impending knative/pkg version bump

### DIFF
--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -69,7 +69,7 @@ var (
 	volumeMountSort = cmpopts.SortSlices(func(i, j corev1.VolumeMount) bool { return i.Name < j.Name })
 )
 
-const fakeVersion = "0000000000000000000000000000000000000000"
+const fakeVersion = "a728ce3"
 
 func init() {
 	os.Setenv("KO_DATA_PATH", "./testdata/")

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8s "k8s.io/client-go/kubernetes/fake"
-	"knative.dev/pkg/changeset"
 	logtesting "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/system"
 
@@ -63,8 +62,6 @@ var (
 
 	defaultActiveDeadlineSeconds = int64(config.DefaultTimeoutMinutes * 60 * deadlineFactor)
 
-	fakeVersion string
-
 	resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
 		return x.Cmp(y) == 0
 	})
@@ -72,13 +69,10 @@ var (
 	volumeMountSort = cmpopts.SortSlices(func(i, j corev1.VolumeMount) bool { return i.Name < j.Name })
 )
 
+const fakeVersion = "0000000000000000000000000000000000000000"
+
 func init() {
 	os.Setenv("KO_DATA_PATH", "./testdata/")
-	commit, err := changeset.Get()
-	if err != nil {
-		panic(err)
-	}
-	fakeVersion = commit
 }
 
 func TestPodBuild(t *testing.T) {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -61,7 +61,6 @@ import (
 	ktesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
-	"knative.dev/pkg/changeset"
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/kmeta"
@@ -398,11 +397,12 @@ var (
 		},
 	}
 
-	fakeVersion                string
 	gitResourceSecurityContext = &corev1.SecurityContext{
 		RunAsUser: ptr.Int64(0),
 	}
 )
+
+const fakeVersion string = "0000000000000000000000000000000000000000"
 
 func placeToolsInitContainer(steps []string) corev1.Container {
 	return corev1.Container{
@@ -442,11 +442,6 @@ func createServiceAccount(t *testing.T, assets test.Assets, name string, namespa
 
 func init() {
 	os.Setenv("KO_DATA_PATH", "./testdata/")
-	commit, err := changeset.Get()
-	if err != nil {
-		panic(err)
-	}
-	fakeVersion = commit
 }
 
 func getRunName(tr *v1beta1.TaskRun) string {

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -402,7 +402,7 @@ var (
 	}
 )
 
-const fakeVersion string = "0000000000000000000000000000000000000000"
+const fakeVersion string = "a728ce3"
 
 func placeToolsInitContainer(steps []string) corev1.Container {
 	return corev1.Container{


### PR DESCRIPTION
https://github.com/knative/pkg/pull/2548 changes pkg/changeset.Get to
read VCS information from information embedded by the Go compiler into
built binaries, instead of relying on the convention that a kodata/HEAD
symlink exists pointing to the repo's .git/HEAD, and a kodata/refs
points to .git/refs.

This fails in tests though, since tests don't stamp this information
into the binary where it can be read.

This change removes our tests' usage of changeset.Get and instead
replaces those fake commit SHAs with more obviously placeholder values.
It doesn't seem that the tests cared that it was an actual SHA, let
along the actual current SHA, they just needed any value that looked
like a SHA.

/kind cleanup

/assign @vdemeester 
/assign @abayer 
/release-note-none
cc @dprotaso 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```


---

PR friction log:
- scolded for not adding a release note label, because the PR template included a space between ``` and `release-note` -- was this intentional?
- integration test flake: https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5145/pull-tekton-pipeline-alpha-integration-tests/1548197852407140352