### PR TITLE
[0.35: cherry-pick] Fix TestTaskRunRetry for k8s 1.22.9 and later

### DIFF
--- a/test/retry_test.go
+++ b/test/retry_test.go
@@ -146,8 +146,14 @@ spec:
 		if _, found := podNames[p.Name]; !found {
 			t.Errorf("BUG: TaskRunStatus.RetriesStatus did not report pod name %q", p.Name)
 		}
-		if p.Status.Phase != corev1.PodFailed {
-			t.Errorf("BUG: Pod %q is not failed: %v", p.Name, p.Status.Phase)
+		// Check each container in the pod, rather than the phase, since the phase doesn't update to a terminal state instantly.
+		// See https://github.com/kubernetes/kubernetes/pull/108366
+		for _, c := range p.Status.ContainerStatuses {
+			if c.State.Terminated == nil {
+				t.Errorf("BUG: Container %s in pod %s is not terminated", c.Name, p.Name)
+			} else if c.State.Terminated.ExitCode != 1 {
+				t.Errorf("BUG: Container %s in pod %s has exit code %d, expected 1", c.Name, p.Name, c.State.Terminated.ExitCode)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Changes

From #4944:

> We just switched to k8s 1.22.9 on CI last night, and `TestTaskRunRetry` started failing. After a bunch of investigation, I determined this was due to https://github.com/kubernetes/kubernetes/pull/108366, which went into k8s 1.22.9. This resulted in the `pod.Status.Phase` that `TestTaskRunRetry` expected to be updated instantly having a delay. I could have fixed this with a sleep, but decided verifying that each container in the pod had terminated with the expected exit code was cleaner.

Backported from b5ea3e9

Needed for #5097 to pass tests.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
