### PR TITLE
Rely on knative/pkg to update TaskRuns

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -62,16 +62,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var version string
-
-func init() {
-	var err error
-	version, err = changeset.Get()
-	if err != nil {
-		version = "unknown"
-	}
-}
-
 // Reconciler implements controller.Reconciler for Configuration resources.
 type Reconciler struct {
 	KubeClientSet     kubernetes.Interface
@@ -110,7 +100,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1beta1.TaskRun) pkg
 	if len(tr.Annotations) == 0 {
 		tr.Annotations = map[string]string{}
 	}
-	tr.Annotations[podconvert.ReleaseAnnotation] = version
+	tr.Annotations[podconvert.ReleaseAnnotation] = changeset.Get()
 
 	defer emitEvents(ctx, tr, before)
 

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -698,14 +698,12 @@ spec:
 		TaskRuns: []*v1beta1.TaskRun{taskRun},
 	}
 
-	d.ConfigMaps = []*corev1.ConfigMap{
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
-			Data: map[string]string{
-				"default-cloud-events-sink": "http://synk:8080",
-			},
+	d.ConfigMaps = []*corev1.ConfigMap{{
+		ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
+		Data: map[string]string{
+			"default-cloud-events-sink": "http://synk:8080",
 		},
-	}
+	}}
 
 	testAssets, cancel := getTaskRunController(t, d)
 	defer cancel()
@@ -746,9 +744,8 @@ spec:
 		"Normal Start",
 		"Normal Running",
 	}
-	err = eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents)
-	if !(err == nil) {
-		t.Errorf(err.Error())
+	if err := eventstest.CheckEventsOrdered(t, testAssets.Recorder.Events, "reconcile-cloud-events", wantEvents); err != nil {
+		t.Errorf("CheckEventsOrdered: %v", err.Error())
 	}
 
 	wantCloudEvents := []string{
@@ -756,9 +753,8 @@ spec:
 		`(?s)dev.tekton.event.taskrun.running.v1.*test-taskrun-not-started`,
 	}
 	ceClient := clients.CloudEvents.(cloudevent.FakeClient)
-	err = eventstest.CheckEventsUnordered(t, ceClient.Events, "reconcile-cloud-events", wantCloudEvents)
-	if !(err == nil) {
-		t.Errorf(err.Error())
+	if err := eventstest.CheckEventsUnordered(t, ceClient.Events, "reconcile-cloud-events", wantCloudEvents); err != nil {
+		t.Errorf("CheckEventsUnordered: %v", err.Error())
 	}
 }
 


### PR DESCRIPTION
This changes the TaskRun reconciler to never call Update itself;
instead, Knative controller infrastructure will be responsible for
Updating TaskRuns if it has determined they've changed.
    
This also changes changeset detection to happen once at init-time, since
it doesn't change for the lifetime of the controller.
    
finishReconcileUpdateEmitEvents is now only responsible for emitting
events. This could be simplified even further in a later change.

Proof of concept for https://github.com/tektoncd/pipeline/issues/5146

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

PR friction log:
- the kind label wasn't set when I created the PR with `/kind cleanup`, causing CI ❌ 
- manually adding the label didn't cause the label check to run, so still ❌ 