### PR TITLE
Update log keys to match logstream

### DIFF
--- a/config/config-logging.yaml
+++ b/config/config-logging.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
-  # Common configuration for all knative codebase
   zap-logger-config: |
     {
       "level": "info",
@@ -34,11 +33,11 @@ data:
       "errorOutputPaths": ["stderr"],
       "encoding": "json",
       "encoderConfig": {
-        "timeKey": "ts",
-        "levelKey": "level",
+        "timeKey": "timestamp",
+        "levelKey": "severity",
         "nameKey": "logger",
         "callerKey": "caller",
-        "messageKey": "msg",
+        "messageKey": "message",
         "stacktraceKey": "stacktrace",
         "lineEnding": "",
         "levelEncoder": "",


### PR DESCRIPTION
This updates our log message formats to match the standard format used
in Knative, including by its logstream package.

This should prevent lots of logspam during tests.

Fixes https://github.com/tektoncd/pipeline/issues/4777

/kind bug
@vdemeester @afrittoli 

cc @dprotaso 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
action required
Log lines formatted as JSON have the severity in "severity" (was "level"), timestamp in "timestamp" (was "ts"), and message in "message" (was "msg").
```

PR friction log:
- check-pr-has-kind-label failed even though the PR content says `/kind bug` and the label was added by the tekton-robot.
- flaky test retries: 1
- `tide — Not mergeable. PR can't be rebased`