### PR TITLE
Fix the issue with empty array replacement

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -198,7 +198,7 @@ func (arrayOrString ArrayOrString) MarshalJSON() ([]byte, error) {
 func (arrayOrString *ArrayOrString) ApplyReplacements(stringReplacements map[string]string, arrayReplacements map[string][]string, objectReplacements map[string]map[string]string) {
 	switch arrayOrString.Type {
 	case ParamTypeArray:
-		var newArrayVal []string
+		newArrayVal := []string{}
 		for _, v := range arrayOrString.ArrayVal {
 			newArrayVal = append(newArrayVal, substitution.ApplyArrayReplacements(v, stringReplacements, arrayReplacements)...)
 		}

--- a/pkg/apis/pipeline/v1beta1/param_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/param_types_test.go
@@ -209,7 +209,14 @@ func TestArrayOrString_ApplyReplacements(t *testing.T) {
 		},
 		expectedOutput: v1beta1.NewArrayOrString("firstvalue", "array", "value", "lastvalue", "asdf", "sdfsd"),
 	}, {
-		name: "empty array replacement",
+		name: "empty array replacement without extra elements",
+		args: args{
+			input:             v1beta1.NewArrayOrString("$(arraykey)"),
+			arrayReplacements: map[string][]string{"arraykey": {}},
+		},
+		expectedOutput: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeArray, ArrayVal: []string{}},
+	}, {
+		name: "empty array replacement with extra elements",
 		args: args{
 			input:              v1beta1.NewArrayOrString("firstvalue", "$(arraykey)", "lastvalue"),
 			stringReplacements: map[string]string{"some": "value", "anotherkey": "value"},


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this change, if there is only one element in an array that is
a reference to an empty array, the original array becomes nil after
replacement, but it should be an empty array instead of nil.

Fixes https://github.com/tektoncd/pipeline/issues/5149

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
After the replacement with an empty array, the original array will be empty.

Example:
---
params:
  - name: myarray
     value: "$(params.anEmptyArray[*])"
```
