### PR TITLE
Fix ApplyTaskResultsToPipelineResults missing object validation

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -288,8 +288,8 @@ func ApplyTaskResultsToPipelineResults(
 				continue
 			}
 			switch len(variableParts) {
-			// For string result: tasks.<taskName>.results.<objectResultName>
-			// For array result: tasks.<taskName>.results.<objectResultName>[*], tasks.<taskName>.results.<objectResultName>[i]
+			// For string result: tasks.<taskName>.results.<stringResultName>
+			// For array result: tasks.<taskName>.results.<arrayResultName>[*], tasks.<taskName>.results.<arrayResultName>[i]
 			// For object result: tasks.<taskName>.results.<objectResultName>[*],
 			case resultsParseNumber:
 				taskName, resultName := variableParts[1], variableParts[3]
@@ -304,6 +304,7 @@ func ApplyTaskResultsToPipelineResults(
 							if intIdx < len(resultValue.ArrayVal) {
 								stringReplacements[variable] = resultValue.ArrayVal[intIdx]
 							} else {
+								// referred array index out of bound
 								invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
 								validPipelineResult = false
 							}
@@ -316,7 +317,7 @@ func ApplyTaskResultsToPipelineResults(
 				} else if resultValue := runResultValue(taskName, resultName, customTaskResults); resultValue != nil {
 					stringReplacements[variable] = *resultValue
 				} else {
-					// referred array index out of bound
+					// referred result name is not existent
 					invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
 					validPipelineResult = false
 				}
@@ -332,6 +333,10 @@ func ApplyTaskResultsToPipelineResults(
 						invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
 						validPipelineResult = false
 					}
+				} else {
+					// referred result name is not existent
+					invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
+					validPipelineResult = false
 				}
 			default:
 				invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -2096,10 +2096,29 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 		expectedResults: nil,
 		expectedError:   fmt.Errorf("invalid pipelineresults [pipeline-result-1], the referred results don't exist"),
 	}, {
-		description: "object-reference-not-exist",
+		description: "object-reference-key-not-exist",
 		results: []v1beta1.PipelineResult{{
 			Name:  "pipeline-result-1",
 			Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.foo.key3)"),
+		}},
+		taskResults: map[string][]v1beta1.TaskRunResult{
+			"pt1": {
+				{
+					Name: "foo",
+					Value: *v1beta1.NewObject(map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+					}),
+				},
+			},
+		},
+		expectedResults: nil,
+		expectedError:   fmt.Errorf("invalid pipelineresults [pipeline-result-1], the referred results don't exist"),
+	}, {
+		description: "object-results-resultname-not-exist",
+		results: []v1beta1.PipelineResult{{
+			Name:  "pipeline-result-1",
+			Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.bar.key1)"),
 		}},
 		taskResults: map[string][]v1beta1.TaskRunResult{
 			"pt1": {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixed the missing validation of object resultname
missing. Before this commit for tasks.taskName.results.objectResultName.individualAttribute
if the objectResultName or taskName is missing it is not captured. This commit adds
this case and some cleanup on comments.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
