### PR TITLE
Add nonstar reference for pipeline array results and document the usage

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -16,9 +16,12 @@ For instructions on using variable substitutions see the relevant section of [th
 
 | Variable | Description |
 | -------- | ----------- |
-| `params.<param name>` | The value of the parameter at runtime. |
+| `params.<param name>` | The value of the parameter at runtime. Recommend to use star notation for array and object param whole reference|
 | `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
+| `params.<param name>[*]` | Get the whole param array or object.|
+| `params['<param name>'][*]` | (see above) |
+| `params["<param name>"][*]` | (see above) |
 | `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
 | `params['<param name>'][i]` | (see above) |
 | `params["<param name>"][i]` | (see above) |
@@ -31,6 +34,9 @@ For instructions on using variable substitutions see the relevant section of [th
 | `tasks.<taskName>.results.<resultName>[*]` | The array value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`. Cannot be used in `script`.) |
 | `tasks.<taskName>.results['<resultName>'][*]` | (see above)) |
 | `tasks.<taskName>.results["<resultName>"][*]` | (see above)) |
+| `tasks.<taskName>.results.<resultName>` | Get the whole results array or object. Recommend to use star notation) |
+| `tasks.<taskName>.results['<resultName>']` | (see above)) |
+| `tasks.<taskName>.results["<resultName>"]` | (see above)) |
 | `tasks.<taskName>.results.<resultName>.key` | The `key` value of the `Task's` object result. Can alter `Task` execution order within a `Pipeline`.) |
 | `tasks.<taskName>.results['<resultName>'][key]` | (see above)) |
 | `tasks.<taskName>.results["<resultName>"][key]` | (see above)) |
@@ -47,9 +53,12 @@ For instructions on using variable substitutions see the relevant section of [th
 
 | Variable | Description |
 | -------- | ----------- |
-| `params.<param name>` | The value of the parameter at runtime. |
+| `params.<param name>` | The value of the parameter at runtime. Recommend to use star notation for array and object param whole reference|
 | `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
+| `params.<param name>[*]` | Get the whole param array or object.|
+| `params['<param name>'][*]` | (see above) |
+| `params["<param name>"][*]` | (see above) |
 | `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
 | `params['<param name>'][i]` | (see above) |
 | `params["<param name>"][i]` | (see above) |

--- a/examples/v1beta1/pipelineruns/alpha/pipeline-emitting-results.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/pipeline-emitting-results.yaml
@@ -41,6 +41,10 @@ spec:
         type: array
         description: whole array
         value: $(tasks.task1.results.array-results[*])
+      - name: array-results-nonstar-reference
+        type: array
+        description: whole array
+        value: $(tasks.task1.results.array-results)
       - name: array-results-from-array-indexing-and-object-elements
         type: array
         description: whole array
@@ -53,6 +57,10 @@ spec:
         type: object
         description: whole object
         value: $(tasks.task2.results.object-results[*])
+      - name: object-results-nonstar-reference
+        type: object
+        description: whole object
+        value: $(tasks.task2.results.object-results)
       - name: object-results-from-array-indexing-and-object-elements
         type: object
         description: whole object

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -299,7 +299,11 @@ func ApplyTaskResultsToPipelineResults(
 					case v1beta1.ParamTypeString:
 						stringReplacements[variable] = resultValue.StringVal
 					case v1beta1.ParamTypeArray:
-						if stringIdx != "*" {
+						if stringIdx == "*" || stringIdx == "" {
+							// array reference: tasks.<taskName>.results.<arrayResultName>[*] and tasks.<taskName>.results.<arrayResultName>
+							arrayReplacements[substitution.StripStarVarSubExpression(variable)] = resultValue.ArrayVal
+						} else {
+							// array indexing: tasks.<taskName>.results.<arrayResultName>[i]
 							intIdx, _ := strconv.Atoi(stringIdx)
 							if intIdx < len(resultValue.ArrayVal) {
 								stringReplacements[variable] = resultValue.ArrayVal[intIdx]
@@ -307,8 +311,6 @@ func ApplyTaskResultsToPipelineResults(
 								invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
 								validPipelineResult = false
 							}
-						} else {
-							arrayReplacements[substitution.StripStarVarSubExpression(variable)] = resultValue.ArrayVal
 						}
 					case v1beta1.ParamTypeObject:
 						objectReplacements[substitution.StripStarVarSubExpression(variable)] = resultValue.ObjectVal

--- a/pkg/reconciler/pipelinerun/resources/apply_test.go
+++ b/pkg/reconciler/pipelinerun/resources/apply_test.go
@@ -2115,10 +2115,28 @@ func TestApplyTaskResultsToPipelineResults(t *testing.T) {
 		expectedResults: nil,
 		expectedError:   fmt.Errorf("invalid pipelineresults [pipeline-result-1], the referred results don't exist"),
 	}, {
-		description: "apply-array-results",
+		description: "apply-array-results-star-notation",
 		results: []v1beta1.PipelineResult{{
 			Name:  "pipeline-result-1",
 			Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.foo[*])"),
+		}},
+		taskResults: map[string][]v1beta1.TaskRunResult{
+			"pt1": {
+				{
+					Name:  "foo",
+					Value: *v1beta1.NewArrayOrString("do", "rae", "mi"),
+				},
+			},
+		},
+		expectedResults: []v1beta1.PipelineRunResult{{
+			Name:  "pipeline-result-1",
+			Value: *v1beta1.NewArrayOrString("do", "rae", "mi"),
+		}},
+	}, {
+		description: "apply-array-results-nonstar-notation",
+		results: []v1beta1.PipelineResult{{
+			Name:  "pipeline-result-1",
+			Value: *v1beta1.NewArrayOrString("$(tasks.pt1.results.foo)"),
 		}},
 		taskResults: map[string][]v1beta1.TaskRunResult{
 			"pt1": {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds the nonstar reference (tasks.<taskName>.results.<arrayResultName>)
for pipeline array results. Previous to this commit we support nonstar
reference for params array and object, and result object. But doesn't
support the array. Also document the usage and the recommended way to
use it.

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add nonstar reference for pipeline array results. tasks.<taskName>.results.<arrayResultName> can be used to emit pipeline level array result
```
