### PR TITLE
Add validation for results object properties types

### DIFF
--- a/pkg/apis/pipeline/v1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1/result_validation_test.go
@@ -44,7 +44,7 @@ func TestResultsValidate(t *testing.T) {
 		name: "valid result type string",
 		Result: v1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "string",
+			Type:        v1.ResultsTypeString,
 			Description: "my great result",
 		},
 
@@ -53,7 +53,7 @@ func TestResultsValidate(t *testing.T) {
 		name: "valid result type array",
 		Result: v1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "array",
+			Type:        v1.ResultsTypeArray,
 			Description: "my great result",
 		},
 
@@ -62,10 +62,10 @@ func TestResultsValidate(t *testing.T) {
 		name: "valid result type object",
 		Result: v1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "array",
+			Type:        v1.ResultsTypeObject,
 			Description: "my great result",
+			Properties:  map[string]v1.PropertySpec{"hello": {Type: v1.ParamTypeString}},
 		},
-
 		apiFields: "alpha",
 	}}
 	for _, tt := range tests {
@@ -117,7 +117,7 @@ func TestResultsValidateError(t *testing.T) {
 		name: "invalid array result type in stable",
 		Result: v1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "array",
+			Type:        v1.ResultsTypeArray,
 			Description: "my great result",
 		},
 		apiFields: "stable",
@@ -128,12 +128,38 @@ func TestResultsValidateError(t *testing.T) {
 		name: "invalid object result type in stable",
 		Result: v1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "object",
+			Type:        v1.ResultsTypeObject,
 			Description: "my great result",
+			Properties:  map[string]v1.PropertySpec{"hello": {Type: v1.ParamTypeString}},
 		},
 		apiFields: "stable",
 		expectedError: apis.FieldError{
 			Message: "results type requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"",
+		},
+	}, {
+		name: "invalid object properties type",
+		Result: v1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        v1.ResultsTypeObject,
+			Description: "my great result",
+			Properties:  map[string]v1.PropertySpec{"hello": {Type: "wrong type"}},
+		},
+		apiFields: "alpha",
+		expectedError: apis.FieldError{
+			Message: "The value type specified for these keys [hello] is invalid, the type must be string",
+			Paths:   []string{"MY-RESULT.properties"},
+		},
+	}, {
+		name: "invalid object properties empty",
+		Result: v1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        v1.ResultsTypeObject,
+			Description: "my great result",
+		},
+		apiFields: "alpha",
+		expectedError: apis.FieldError{
+			Message: "missing field(s)",
+			Paths:   []string{"MY-RESULT.properties"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -328,6 +328,10 @@ func TestTaskSpecValidate(t *testing.T) {
 				Name:        "MY-RESULT",
 				Type:        v1.ResultsTypeObject,
 				Description: "my great result",
+				Properties: map[string]v1.PropertySpec{
+					"url":    {"string"},
+					"commit": {"string"},
+				},
 			}},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/result_validation.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation.go
@@ -29,7 +29,9 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 	}
 	// Array and Object is alpha feature
 	if tr.Type == ResultsTypeArray || tr.Type == ResultsTypeObject {
-		return errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.AlphaAPIFields))
+		errs := validateObjectResult(tr)
+		errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "results type", config.AlphaAPIFields))
+		return errs
 	}
 
 	// Resources created before the result. Type was introduced may not have Type set
@@ -43,5 +45,28 @@ func (tr TaskResult) Validate(ctx context.Context) (errs *apis.FieldError) {
 		return apis.ErrInvalidValue(tr.Type, "type", fmt.Sprintf("type must be string"))
 	}
 
+	return nil
+}
+
+// validateObjectResult validates the object result and check if the Properties is missing
+// for Properties values it will check if the type is string.
+func validateObjectResult(tr TaskResult) (errs *apis.FieldError) {
+	if ParamType(tr.Type) == ParamTypeObject && tr.Properties == nil {
+		return apis.ErrMissingField(fmt.Sprintf("%s.properties", tr.Name))
+	}
+
+	invalidKeys := []string{}
+	for key, propertySpec := range tr.Properties {
+		if propertySpec.Type != ParamTypeString {
+			invalidKeys = append(invalidKeys, key)
+		}
+	}
+
+	if len(invalidKeys) != 0 {
+		return &apis.FieldError{
+			Message: fmt.Sprintf("The value type specified for these keys %v is invalid, the type must be string", invalidKeys),
+			Paths:   []string{fmt.Sprintf("%s.properties", tr.Name)},
+		}
+	}
 	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/result_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/result_validation_test.go
@@ -44,7 +44,7 @@ func TestResultsValidate(t *testing.T) {
 		name: "valid result type string",
 		Result: v1beta1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "string",
+			Type:        v1beta1.ResultsTypeString,
 			Description: "my great result",
 		},
 
@@ -53,7 +53,7 @@ func TestResultsValidate(t *testing.T) {
 		name: "valid result type array",
 		Result: v1beta1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "array",
+			Type:        v1beta1.ResultsTypeArray,
 			Description: "my great result",
 		},
 
@@ -62,10 +62,10 @@ func TestResultsValidate(t *testing.T) {
 		name: "valid result type object",
 		Result: v1beta1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "array",
+			Type:        v1beta1.ResultsTypeObject,
 			Description: "my great result",
+			Properties:  map[string]v1beta1.PropertySpec{"hello": {Type: v1beta1.ParamTypeString}},
 		},
-
 		apiFields: "alpha",
 	}}
 	for _, tt := range tests {
@@ -117,7 +117,7 @@ func TestResultsValidateError(t *testing.T) {
 		name: "invalid array result type in stable",
 		Result: v1beta1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "array",
+			Type:        v1beta1.ResultsTypeArray,
 			Description: "my great result",
 		},
 		apiFields: "stable",
@@ -128,12 +128,38 @@ func TestResultsValidateError(t *testing.T) {
 		name: "invalid object result type in stable",
 		Result: v1beta1.TaskResult{
 			Name:        "MY-RESULT",
-			Type:        "object",
+			Type:        v1beta1.ResultsTypeObject,
 			Description: "my great result",
+			Properties:  map[string]v1beta1.PropertySpec{"hello": {Type: v1beta1.ParamTypeString}},
 		},
 		apiFields: "stable",
 		expectedError: apis.FieldError{
 			Message: "results type requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"",
+		},
+	}, {
+		name: "invalid object properties type",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        v1beta1.ResultsTypeObject,
+			Description: "my great result",
+			Properties:  map[string]v1beta1.PropertySpec{"hello": {Type: "wrong type"}},
+		},
+		apiFields: "alpha",
+		expectedError: apis.FieldError{
+			Message: "The value type specified for these keys [hello] is invalid, the type must be string",
+			Paths:   []string{"MY-RESULT.properties"},
+		},
+	}, {
+		name: "invalid object properties empty",
+		Result: v1beta1.TaskResult{
+			Name:        "MY-RESULT",
+			Type:        v1beta1.ResultsTypeObject,
+			Description: "my great result",
+		},
+		apiFields: "alpha",
+		expectedError: apis.FieldError{
+			Message: "missing field(s)",
+			Paths:   []string{"MY-RESULT.properties"},
 		},
 	}}
 	for _, tt := range tests {

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -359,6 +359,10 @@ func TestTaskSpecValidate(t *testing.T) {
 				Name:        "MY-RESULT",
 				Type:        v1beta1.ResultsTypeObject,
 				Description: "my great result",
+				Properties: map[string]v1beta1.PropertySpec{
+					"url":    {"string"},
+					"commit": {"string"},
+				},
 			}},
 		},
 	}, {


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds the validation for results object properties types.
Right now we only support string types, so if the type is not string we
should validate and return err for this.
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
