### PR TITLE
TEP-0116: Referencing Finally Task Results in Pipeline Results

### DIFF
--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -39,6 +39,7 @@ weight: 400
     - [Specifying `Parameters` in `finally` tasks](#specifying-parameters-in-finally-tasks)
     - [Specifying `matrix` in `finally` tasks](#specifying-matrix-in-finally-tasks)
     - [Consuming `Task` execution results in `finally`](#consuming-task-execution-results-in-finally)
+    - [Consuming `Pipeline` result with `finally`](#consuming-pipeline-result-with-finally)
     - [`PipelineRun` Status with `finally`](#pipelinerun-status-with-finally)
     - [Using Execution `Status` of `pipelineTask`](#using-execution-status-of-pipelinetask)
     - [Using Aggregate Execution `Status` of All `Tasks`](#using-aggregate-execution-status-of-all-tasks)
@@ -50,7 +51,6 @@ weight: 400
     - [Known Limitations](#known-limitations)
       - [Specifying `Resources` in `finally` tasks](#specifying-resources-in-finally-tasks)
       - [Cannot configure the `finally` task execution order](#cannot-configure-the-finally-task-execution-order)
-      - [Cannot configure `Pipeline` result with `finally`](#cannot-configure-pipeline-result-with-finally)
   - [Using Custom Tasks](#using-custom-tasks)
     - [Specifying the target Custom Task](#specifying-the-target-custom-task)
     - [Specifying a Custom Task Spec in-line (or embedded)](#specifying-a-custom-task-spec-in-line-or-embedded)
@@ -1268,6 +1268,24 @@ uninitialized task result `commit`, the `finally` Task `discover-git-commit` wil
 `skippedTasks` and continues executing rest of the `finally` tasks. The pipeline exits with `completion` instead of
 `success` if a `finally` task is added to the list of `skippedTasks`.
 
+### Consuming `Pipeline` result with `finally`
+
+`finally` tasks can emit `Results` and these results emitted from the `finally` tasks can be configured in the
+[Pipeline Results](#emitting-results-from-a-pipeline). References of `Results` from `finally` will follow the same naming conventions as referencing `Results` from `tasks`: ```$(finally.<finally-pipelinetask-name>.result.<result-name>)```.
+
+```yaml
+results:
+  - name: comment-count-validate
+    value: $(finally.check-count.results.comment-count-validate)
+finally:
+  - name: check-count
+    taskRef: 
+      name: example-task-name
+```
+
+In this example, `pipelineResults` in `status` will show the name-value pair for the result `comment-count-validate` which is produced in the `Task` `example-task-name`.
+
+
 ### `PipelineRun` Status with `finally`
 
 With `finally`, `PipelineRun` status is calculated based on `PipelineTasks` under `tasks` section and `finally` tasks.
@@ -1543,21 +1561,6 @@ spec:
 It's not possible to configure or modify the execution order of the `finally` tasks. Unlike `Tasks` in a `Pipeline`,
 all `finally` tasks run simultaneously and start executing once all `PipelineTasks` under `tasks` have settled which means
 no `runAfter` can be specified in `finally` tasks.
-
-#### Cannot configure `Pipeline` result with `finally`
-
-`finally` tasks can emit `Results` but results emitted from the `finally` tasks can not be configured in the
-[Pipeline Results](#emitting-results-from-a-pipeline). We are working on adding support for this
-(tracked in issue [#2710](https://github.com/tektoncd/pipeline/issues/2710)).
-
-```yaml
-results:
-  - name: comment-count-validate
-    value: $(finally.check-count.results.comment-count-validate)
-```
-
-In this example, `pipelineResults` in `status` will exclude the name-value pair for that result `comment-count-validate`.
-
 
 ## Using Custom Tasks
 

--- a/examples/v1beta1/pipelineruns/pipelinerun-with-final-results.yaml
+++ b/examples/v1beta1/pipelineruns/pipelinerun-with-final-results.yaml
@@ -1,0 +1,77 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: sum-and-multiply-pipeline
+spec:
+  params:
+    - name: a
+      type: string
+      default: "1"
+    - name: b
+      type: string
+      default: "1"
+  results:
+    - name: task-result
+      description: "grabbing results from the tasks section"
+      value: $(tasks.multiply-inputs.results.product)
+    - name: finally-result
+      description: "grabbing results from the finally section"
+      value: $(finally.exponent.results.product)
+  tasks:
+    - name: multiply-inputs
+      taskRef:
+        name: multiply
+      params:
+        - name: a
+          value: "$(params.a)"
+        - name: b
+          value: "$(params.b)"
+  finally:
+    - name: exponent
+      taskRef:
+        name: multiply
+      params:
+        - name: a
+          value: "$(tasks.multiply-inputs.results.product)$(tasks.multiply-inputs.results.product)"
+        - name: b
+          value: "$(tasks.multiply-inputs.results.product)$(tasks.multiply-inputs.results.product)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: multiply
+  annotations:
+    description: |
+      A simple task that multiplies the two provided integers
+spec:
+  params:
+    - name: a
+      type: string
+      default: "1"
+      description: The first integer
+    - name: b
+      type: string
+      default: "1"
+      description: The second integer
+  results:
+    - name: product
+      description: The product of the two provided integers
+  steps:
+    - name: product
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        echo -n $(( "$(params.a)" * "$(params.b)" )) | tee $(results.product.path)
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: sum-and-multiply-pipeline-run-
+spec:
+  pipelineRef:
+    name: sum-and-multiply-pipeline
+  params:
+    - name: a
+      value: "2"
+    - name: b
+      value: "1"

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -69,7 +69,7 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validatePipelineWorkspacesUsage(ps.Workspaces, ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validatePipelineWorkspacesUsage(ps.Workspaces, ps.Finally).ViaField("finally"))
 	// Validate the pipeline's results
-	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks))
+	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
 	errs = errs.Also(validateFinalTasks(ps.Tasks, ps.Finally))
 	errs = errs.Also(validateWhenExpressions(ps.Tasks, ps.Finally))
@@ -255,8 +255,9 @@ func filter(arr []string, cond func(string) bool) []string {
 }
 
 // validatePipelineResults ensure that pipeline result variables are properly configured
-func validatePipelineResults(results []PipelineResult, tasks []PipelineTask) (errs *apis.FieldError) {
+func validatePipelineResults(results []PipelineResult, tasks []PipelineTask, finally []PipelineTask) (errs *apis.FieldError) {
 	pipelineTaskNames := getPipelineTasksNames(tasks)
+	pipelineFinallyTaskNames := getPipelineTasksNames(finally)
 	for idx, result := range results {
 		expressions, ok := GetVarSubstitutionExpressionsForPipelineResult(result)
 		if !ok {
@@ -276,7 +277,7 @@ func validatePipelineResults(results []PipelineResult, tasks []PipelineTask) (er
 				"value").ViaFieldIndex("results", idx))
 		}
 
-		if !taskContainsResult(result.Value.StringVal, pipelineTaskNames) {
+		if !taskContainsResult(result.Value.StringVal, pipelineTaskNames, pipelineFinallyTaskNames) {
 			errs = errs.Also(apis.ErrInvalidValue("referencing a nonexistent task",
 				"value").ViaFieldIndex("results", idx))
 		}
@@ -297,16 +298,26 @@ func getPipelineTasksNames(pipelineTasks []PipelineTask) sets.String {
 
 // taskContainsResult ensures the result value is referenced within the
 // task names
-func taskContainsResult(resultExpression string, pipelineTaskNames sets.String) bool {
+func taskContainsResult(resultExpression string, pipelineTaskNames sets.String, pipelineFinallyTaskNames sets.String) bool {
 	// split incase of multiple resultExpressions in the same result.Value string
 	// i.e "$(task.<task-name).result.<result-name>) - $(task2.<task2-name).result2.<result2-name>)"
 	split := strings.Split(resultExpression, "$")
 	for _, expression := range split {
 		if expression != "" {
-			pipelineTaskName, _, _, _, _ := parseExpression(stripVarSubExpression("$" + expression))
-			if !pipelineTaskNames.Has(pipelineTaskName) {
+			value := stripVarSubExpression("$" + expression)
+			pipelineTaskName, _, _, _, err := parseExpression(value)
+
+			if err != nil {
 				return false
 			}
+
+			if strings.HasPrefix(value, "tasks") && !pipelineTaskNames.Has(pipelineTaskName) {
+				return false
+			}
+			if strings.HasPrefix(value, "finally") && !pipelineFinallyTaskNames.Has(pipelineTaskName) {
+				return false
+			}
+
 		}
 	}
 	return true

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -39,6 +39,8 @@ const (
 	objectResultExpressionFormat = "tasks.<taskName>.results.<objectResultName>.<individualAttribute>"
 	// ResultTaskPart Constant used to define the "tasks" part of a pipeline result reference
 	ResultTaskPart = "tasks"
+	// ResultFinallyPart Constant used to define the "finally" part of a pipeline result reference
+	ResultFinallyPart = "finally"
 	// ResultResultPart Constant used to define the "results" part of a pipeline result reference
 	ResultResultPart = "results"
 	// TODO(#2462) use one regex across all substitutions
@@ -99,7 +101,7 @@ func LooksLikeContainsResultRefs(expressions []string) bool {
 // looksLikeResultRef attempts to check if the given string looks like it contains any
 // result references. Returns true if it does, false otherwise
 func looksLikeResultRef(expression string) bool {
-	return strings.HasPrefix(expression, "task") && strings.Contains(expression, ".result")
+	return (strings.HasPrefix(expression, "task") || strings.HasPrefix(expression, "finally")) && strings.Contains(expression, ".result")
 }
 
 // GetVarSubstitutionExpressionsForParam extracts all the value between "$(" and ")"" for a parameter
@@ -172,7 +174,7 @@ func parseExpression(substitutionExpression string) (string, string, int, string
 
 	// For string result: tasks.<taskName>.results.<stringResultName>
 	// For array result: tasks.<taskName>.results.<arrayResultName>[index]
-	if len(subExpressions) == 4 && subExpressions[0] == ResultTaskPart && subExpressions[2] == ResultResultPart {
+	if len(subExpressions) == 4 && (subExpressions[0] == ResultTaskPart || subExpressions[0] == ResultFinallyPart) && subExpressions[2] == ResultResultPart {
 		resultName, stringIdx := ParseResultName(subExpressions[3])
 		if stringIdx != "" {
 			intIdx, _ := strconv.Atoi(stringIdx)
@@ -182,11 +184,11 @@ func parseExpression(substitutionExpression string) (string, string, int, string
 	}
 
 	// For object type result: tasks.<taskName>.results.<objectResultName>.<individualAttribute>
-	if len(subExpressions) == 5 && subExpressions[0] == ResultTaskPart && subExpressions[2] == ResultResultPart {
+	if len(subExpressions) == 5 && (subExpressions[0] == ResultTaskPart || subExpressions[0] == ResultFinallyPart) && subExpressions[2] == ResultResultPart {
 		return subExpressions[1], subExpressions[3], 0, subExpressions[4], nil
 	}
 
-	return "", "", 0, "", fmt.Errorf("Must be one of the form 1). %q; 2). %q", resultExpressionFormat, objectResultExpressionFormat)
+	return "", "", 0, "", fmt.Errorf("must be one of the form 1). %q; 2). %q", resultExpressionFormat, objectResultExpressionFormat)
 }
 
 // ParseResultName parse the input string to extract resultName and result index.

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -87,6 +87,7 @@ var (
 	ignoreTypeMeta           = cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion")
 	ignoreLastTransitionTime = cmpopts.IgnoreFields(apis.Condition{}, "LastTransitionTime.Inner.Time")
 	ignoreStartTime          = cmpopts.IgnoreFields(v1beta1.PipelineRunStatusFields{}, "StartTime")
+	ignoreCompletionTime     = cmpopts.IgnoreFields(v1beta1.PipelineRunStatusFields{}, "CompletionTime")
 	trueb                    = true
 	simpleHelloWorldTask     = &v1beta1.Task{ObjectMeta: baseObjectMeta("hello-world", "foo")}
 	simpleSomeTask           = &v1beta1.Task{ObjectMeta: baseObjectMeta("some-task", "foo")}
@@ -4776,8 +4777,365 @@ func TestReconcileWithPipelineResults(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			runTestReconcileWithPipelineResults(t, tc.embeddedVal)
+			runTestReconcileWithFinallyResults(t, tc.embeddedVal)
 		})
 	}
+}
+
+func runTestReconcileWithFinallyResults(t *testing.T, embeddedStatus string) {
+	names.TestingSeed()
+	ps := []*v1beta1.Pipeline{parse.MustParsePipeline(t, `
+metadata:
+  name: test-pipeline
+  namespace: foo
+spec:
+  results:
+    - description: pipeline result
+      name: result
+      value: $(finally.a-task.results.a-Result)
+    - description: custom task pipeline result
+      name: custom-result
+      value: $(finally.b-task.results.b-Result)
+  tasks:
+    - name: c-task
+      taskRef:
+        name: c-task
+  finally:
+    - name: a-task
+      taskRef:
+        name: a-task
+    - name: b-task
+      taskRef:
+        name: b-task
+`)}
+	trs := []*v1beta1.TaskRun{mustParseTaskRunWithObjectMeta(t,
+		taskRunObjectMeta("test-pipeline-run-finally-results-task-run-a", "foo",
+			"test-pipeline-run-finally-results", "test-pipeline", "a-task", true),
+		`
+spec:
+  taskRef:
+    name: hello-world
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  taskResults:
+  - name: a-Result
+    value: aResultValue
+`), mustParseTaskRunWithObjectMeta(t,
+		taskRunObjectMeta("test-pipeline-run-finally-results-task-run-b", "foo",
+			"test-pipeline-run-finally-results", "test-pipeline", "b-task", true),
+		`
+spec:
+  taskRef:
+    name: hello-world
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+  taskResults:
+  - name: b-Result
+    value: bResultValue
+`), mustParseTaskRunWithObjectMeta(t,
+		taskRunObjectMeta("test-pipeline-run-finally-results-task-run-c", "foo",
+			"test-pipeline-run-finally-results", "test-pipeline", "c-task", true),
+		`
+spec:
+  taskRef:
+    name: hello-world
+status:
+  conditions:
+  - status: "True"
+    type: Succeeded
+`)}
+	prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `
+metadata:
+  name: test-pipeline-run-finally-results
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+status:
+  conditions:
+  - status: "Unknown"
+    type: Succeeded
+    reason: Succeeded
+`)}
+	ts := []*v1beta1.Task{
+		parse.MustParseTask(t, `
+metadata:
+  name: b-task
+  namespace: foo
+spec:
+  taskRef:
+    apiVersion: example.dev/v0
+    kind: Example
+  results:
+  - name: b-Result
+`),
+		parse.MustParseTask(t, `
+metadata:
+  name: a-task
+  namespace: foo
+spec:
+  results:
+  - name: a-Result
+`),
+		parse.MustParseTask(t, `
+metadata:
+  name: c-task
+  namespace: foo
+spec:
+  steps:
+  - image: ubuntu
+    script: |
+      #!/usr/bin/env bash
+      echo "Hello from bash!"
+  
+`),
+	}
+
+	d := test.Data{
+		PipelineRuns: prs,
+		Pipelines:    ps,
+		Tasks:        ts,
+		TaskRuns:     trs,
+		ConfigMaps:   []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)},
+	}
+	prt := newPipelineRunTest(d, t)
+	defer prt.Cancel()
+	reconciledRun, _ := prt.reconcileRun("foo", "test-pipeline-run-finally-results", []string{}, false)
+
+	expectedPrFullStatus := parse.MustParsePipelineRun(t, `
+metadata:
+  name: test-pipeline-run-finally-results
+  namespace: foo
+  labels:
+    tekton.dev/pipeline: test-pipeline
+  annotations: {}
+spec:
+  pipelineRef:
+    name: test-pipeline
+status:
+  runs: {}
+  pipelineSpec: 
+    results:
+    - description: pipeline result
+      name: result
+      value: $(finally.a-task.results.a-Result)
+    - description: custom task pipeline result
+      name: custom-result
+      value: $(finally.b-task.results.b-Result)
+    tasks:
+    - name: c-task
+      taskRef:
+        name: c-task
+        kind: Task
+    finally:
+    - name: a-task
+      taskRef:
+        name: a-task
+        kind: Task
+    - name: b-task
+      taskRef:
+        name: b-task
+        kind: Task    
+  conditions:
+  - status: "True"
+    type: Succeeded
+    reason: Succeeded
+    message: "Tasks Completed: 3 (Failed: 0, Cancelled 0), Skipped: 0"
+  pipelineResults:
+  - name: result
+    value: aResultValue
+  - name: custom-result
+    value: bResultValue
+  taskRuns:
+    test-pipeline-run-finally-results-task-run-a:
+      pipelineTaskName: a-task
+      status:
+        conditions:
+        - status: "True"
+          type: Succeeded
+        taskResults:
+        - name: a-Result
+          value: aResultValue
+    test-pipeline-run-finally-results-task-run-b:
+      pipelineTaskName: b-task
+      status:
+        conditions:
+        - status: "True"
+          type: Succeeded
+        taskResults:
+        - name: b-Result
+          value: bResultValue
+    test-pipeline-run-finally-results-task-run-c:
+      pipelineTaskName: c-task
+      status:
+        conditions:
+        - status: "True"
+          type: Succeeded
+`)
+
+	expectedPrBothStatus := parse.MustParsePipelineRun(t, `
+metadata:
+  name: test-pipeline-run-finally-results
+  namespace: foo
+  labels:
+    tekton.dev/pipeline: test-pipeline
+  annotations: {}
+spec:
+  pipelineRef:
+    name: test-pipeline
+status:
+  runs: {}
+  pipelineSpec: 
+    results:
+    - description: pipeline result
+      name: result
+      value: $(finally.a-task.results.a-Result)
+    - description: custom task pipeline result
+      name: custom-result
+      value: $(finally.b-task.results.b-Result)
+    tasks:
+    - name: c-task
+      taskRef:
+        name: c-task
+        kind: Task
+    finally:
+    - name: a-task
+      taskRef:
+        name: a-task
+        kind: Task
+    - name: b-task
+      taskRef: 
+        name: b-task
+        kind: Task
+  conditions:
+  - status: "True"
+    type: Succeeded
+    reason: Succeeded
+    message: "Tasks Completed: 3 (Failed: 0, Cancelled 0), Skipped: 0"
+  pipelineResults:
+  - name: result
+    value: aResultValue
+  - name: custom-result
+    value: bResultValue
+  childReferences:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: test-pipeline-run-finally-results-task-run-c
+    pipelineTaskName: c-task
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: test-pipeline-run-finally-results-task-run-a
+    pipelineTaskName: a-task
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: test-pipeline-run-finally-results-task-run-b
+    pipelineTaskName: b-task
+  taskRuns:
+    test-pipeline-run-finally-results-task-run-a:
+      pipelineTaskName: a-task
+      status:
+        conditions:
+        - status: "True"
+          type: Succeeded
+        taskResults:
+        - name: a-Result
+          value: aResultValue
+    test-pipeline-run-finally-results-task-run-b:
+      pipelineTaskName: b-task
+      status:
+        conditions:
+        - status: "True"
+          type: Succeeded
+        taskResults:
+        - name: b-Result
+          value: bResultValue
+    test-pipeline-run-finally-results-task-run-c:
+      pipelineTaskName: c-task
+      status:
+        conditions:
+        - status: "True"
+          type: Succeeded
+`)
+
+	expectedPrMinimalStatus := parse.MustParsePipelineRun(t, `
+metadata:
+  name: test-pipeline-run-finally-results
+  namespace: foo
+  labels:
+    tekton.dev/pipeline: test-pipeline
+  annotations: {}
+spec:
+  pipelineRef:
+    name: test-pipeline
+status:
+  runs: {}
+  pipelineSpec: 
+    results:
+    - description: pipeline result
+      name: result
+      value: $(finally.a-task.results.a-Result)
+    - description: custom task pipeline result
+      name: custom-result
+      value: $(finally.b-task.results.b-Result)
+    tasks:
+    - name: c-task
+      taskRef:
+        name: c-task
+        kind: Task
+    finally:
+    - name: a-task
+      taskRef:
+        name: a-task
+        kind: Task
+    - name: b-task
+      taskRef: 
+        name: b-task
+        kind: Task
+  conditions:
+  - status: "True"
+    type: Succeeded
+    reason: Succeeded
+    message: "Tasks Completed: 3 (Failed: 0, Cancelled 0), Skipped: 0"
+  pipelineResults:
+  - name: result
+    value: aResultValue
+  - name: custom-result
+    value: bResultValue
+  taskRuns: {}
+  childReferences:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: test-pipeline-run-finally-results-task-run-c
+    pipelineTaskName: c-task
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: test-pipeline-run-finally-results-task-run-a
+    pipelineTaskName: a-task
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    name: test-pipeline-run-finally-results-task-run-b
+    pipelineTaskName: b-task
+`)
+	var expectedPr *v1beta1.PipelineRun
+	switch {
+	case embeddedStatus == config.BothEmbeddedStatus:
+		expectedPr = expectedPrBothStatus
+	case embeddedStatus == config.DefaultEmbeddedStatus:
+		expectedPr = expectedPrFullStatus
+	case embeddedStatus == config.FullEmbeddedStatus:
+		expectedPr = expectedPrFullStatus
+	case embeddedStatus == config.MinimalEmbeddedStatus:
+		expectedPr = expectedPrMinimalStatus
+	}
+
+	if d := cmp.Diff(expectedPr, reconciledRun, ignoreResourceVersion, ignoreLastTransitionTime, ignoreCompletionTime, ignoreStartTime); d != "" {
+		t.Errorf("expected to see pipeline run results created. Diff %s", diff.PrintWantGot(d))
+	}
+
 }
 
 func runTestReconcileWithPipelineResults(t *testing.T, embeddedStatus string) {

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -282,7 +282,7 @@ func ApplyTaskResultsToPipelineResults(
 				continue
 			}
 			variableParts := strings.Split(variable, ".")
-			if variableParts[0] != v1beta1.ResultTaskPart || variableParts[2] != v1beta1.ResultResultPart {
+			if (variableParts[0] != v1beta1.ResultTaskPart && variableParts[0] != v1beta1.ResultFinallyPart) || variableParts[2] != v1beta1.ResultResultPart {
 				validPipelineResult = false
 				invalidPipelineResults = append(invalidPipelineResults, pipelineResult.Name)
 				continue


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Feature Request

This issue will track implementation of [TEP-0116: Referencing Finally Task Results in Pipeline Results](https://github.com/tektoncd/community/pull/746).

# Changes

Previously, `finally` fields could not propagate `Results`
to `Pipeline`, whereas `PipelineTasks` in the `Tasks` field could. 
To improve the parity between `finally` field and `tasks`, this
issue supports referencing `Results` from `finally` in 
`Pipeline Results`.

This PR adds `finally` to the `v1beta1` `const` field, updates logic,
adds unit tests to allow `$(finally.<pipelinetask-name>.result.<result-name>)`
to be valid, adds validation, and updates documentation.

/kind feature
/cc @jerop 
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Allow users to use `results` from `finally` in `PipelineResults` using `$(finally.<pipelinetask-name>.result.<result-name>)`
```
