### PR TITLE
Fix flaky test by sorting slices

### DIFF
--- a/pkg/apis/pipeline/v1beta1/resultref_test.go
+++ b/pkg/apis/pipeline/v1beta1/resultref_test.go
@@ -754,10 +754,13 @@ func TestGetVarSubstitutionExpressionsForPipelineResult(t *testing.T) {
 		want: []string{"tasks.task1.results.result1", "tasks.task2.results.result2", "tasks.task3.results.result3"},
 	},
 	}
+	var sortStrings = func(x, y string) bool {
+		return x < y
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			get, _ := v1beta1.GetVarSubstitutionExpressionsForPipelineResult(tt.result)
-			if d := cmp.Diff(tt.want, get); d != "" {
+			if d := cmp.Diff(tt.want, get, cmpopts.SortSlices(sortStrings)); d != "" {
 				t.Error(diff.PrintWantGot(d))
 			}
 		})


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

TestGetVarSubstitutionExpressionsForPipelineResult was flaky since the expected
test output was in a fixed order while the function under test was iterating
through a map where order is not guaranteed. This commit fixes it by sorting
the inputs to cmp.Diff

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
