### PR TITLE
TEP-0114: Remove enable-custom-task and alpha feature flag

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -70,11 +70,6 @@ data:
   # This is an experimental feature and thus should still be considered
   # an alpha feature.
   enable-tekton-oci-bundles: "false"
-  # Setting this flag to "true" enables the use of custom tasks from
-  # within pipelines.
-  # This is an experimental feature and thus should still be considered
-  # an alpha feature.
-  enable-custom-tasks: "false"
   # Setting this flag will determine which gated features are enabled.
   # Acceptable values are "stable" or "alpha".
   enable-api-fields: "stable"

--- a/docs/install.md
+++ b/docs/install.md
@@ -389,9 +389,6 @@ not running.
 and use Workspaces to mount credentials from Secrets instead.
 The default is `false`. For more information, see the [associated issue](https://github.com/tektoncd/pipeline/issues/3399).
 
-- `enable-custom-tasks`: set this flag to `"true"` to enable the
-use of custom tasks in pipelines.
-
 - `enable-api-fields`: set this flag to "stable" to allow only the
 most stable features to be used. Set it to "alpha" to allow [alpha
 features](#alpha-features) to be used.
@@ -423,7 +420,6 @@ Features currently in "alpha" are:
 | Feature                                                                                               | TEP                                                                                                                  | Release                                                              | Individual Flag             |
 |:------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:----------------------------|
 | [Bundles ](./pipelineruns.md#tekton-bundles)                                                          | [TEP-0005](https://github.com/tektoncd/community/blob/main/teps/0005-tekton-oci-bundles.md)                          | [v0.18.0](https://github.com/tektoncd/pipeline/releases/tag/v0.18.0) | `enable-tekton-oci-bundles` |
-| [`Runs` and `Custom Tasks`](./runs.md)                                                                | [TEP-0002](https://github.com/tektoncd/community/blob/main/teps/0002-custom-tasks.md)                                | [v0.19.0](https://github.com/tektoncd/pipeline/releases/tag/v0.19.0) | `enable-custom-tasks`       |
 | [Isolated `Step` & `Sidecar` `Workspaces`](./workspaces.md#isolated-workspaces)                       | [TEP-0029](https://github.com/tektoncd/community/blob/main/teps/0029-step-workspaces.md)                             | [v0.24.0](https://github.com/tektoncd/pipeline/releases/tag/v0.24.0) |                             |
 | [Hermetic Execution Mode](./hermetic.md)                                                              | [TEP-0025](https://github.com/tektoncd/community/blob/main/teps/0025-hermekton.md)                                   | [v0.25.0](https://github.com/tektoncd/pipeline/releases/tag/v0.25.0) |                             |
 | [Propagated `Parameters`](./taskruns.md#propagated-parameters)                                        | [TEP-0107](https://github.com/tektoncd/community/blob/main/teps/0107-propagating-parameters.md)                      | [v0.36.0](https://github.com/tektoncd/pipeline/releases/tag/v0.36.0) |                             |

--- a/docs/pipelines.md
+++ b/docs/pipelines.md
@@ -1561,9 +1561,6 @@ In this example, `pipelineResults` in `status` will exclude the name-value pair 
 
 ## Using Custom Tasks
 
-**Note: This is only allowed if `enable-custom-tasks` is set to
-`"true"` in the `feature-flags` configmap, see [`install.md`](./install.md#customizing-the-pipelines-controller-behavior)**
-
 [Custom Tasks](https://github.com/tektoncd/community/blob/main/teps/0002-custom-tasks.md)
 can implement behavior that doesn't correspond directly to running a workload in a `Pod` on the cluster.
 For example, a custom task might execute some operation outside of the cluster and wait for its execution to complete.

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -52,8 +52,6 @@ const (
 	DefaultRequireGitSSHSecretKnownHosts = false
 	// DefaultEnableTektonOciBundles is the default value for "enable-tekton-oci-bundles".
 	DefaultEnableTektonOciBundles = false
-	// DefaultEnableCustomTasks is the default value for "enable-custom-tasks".
-	DefaultEnableCustomTasks = false
 	// DefaultEnableAPIFields is the default value for "enable-api-fields".
 	DefaultEnableAPIFields = StableAPIFields
 	// DefaultSendCloudEventsForRuns is the default value for "send-cloudevents-for-runs".
@@ -67,7 +65,6 @@ const (
 	awaitSidecarReadinessKey            = "await-sidecar-readiness"
 	requireGitSSHSecretKnownHostsKey    = "require-git-ssh-secret-known-hosts" // nolint: gosec
 	enableTektonOCIBundles              = "enable-tekton-oci-bundles"
-	enableCustomTasks                   = "enable-custom-tasks"
 	enableAPIFields                     = "enable-api-fields"
 	sendCloudEventsForRuns              = "send-cloudevents-for-runs"
 	embeddedStatus                      = "embedded-status"
@@ -81,7 +78,6 @@ type FeatureFlags struct {
 	RunningInEnvWithInjectedSidecars bool
 	RequireGitSSHSecretKnownHosts    bool
 	EnableTektonOCIBundles           bool
-	EnableCustomTasks                bool
 	ScopeWhenExpressionsToTask       bool
 	EnableAPIFields                  string
 	SendCloudEventsForRuns           bool
@@ -147,12 +143,8 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 	// defeat the purpose of having a single shared gate for all alpha features.
 	if tc.EnableAPIFields == AlphaAPIFields {
 		tc.EnableTektonOCIBundles = true
-		tc.EnableCustomTasks = true
 	} else {
 		if err := setFeature(enableTektonOCIBundles, DefaultEnableTektonOciBundles, &tc.EnableTektonOCIBundles); err != nil {
-			return nil, err
-		}
-		if err := setFeature(enableCustomTasks, DefaultEnableCustomTasks, &tc.EnableCustomTasks); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -42,7 +42,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				DisableCredsInit:       config.DefaultDisableCredsInit,
 				AwaitSidecarReadiness:  config.DefaultAwaitSidecarReadiness,
 				EnableTektonOCIBundles: config.DefaultEnableTektonOciBundles,
-				EnableCustomTasks:      config.DefaultEnableCustomTasks,
 				EnableAPIFields:        config.DefaultEnableAPIFields,
 				SendCloudEventsForRuns: config.DefaultSendCloudEventsForRuns,
 				EmbeddedStatus:         config.DefaultEmbeddedStatus,
@@ -56,7 +55,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				AwaitSidecarReadiness:            false,
 				RequireGitSSHSecretKnownHosts:    true,
 				EnableTektonOCIBundles:           true,
-				EnableCustomTasks:                true,
 				EnableAPIFields:                  "alpha",
 				SendCloudEventsForRuns:           true,
 				EmbeddedStatus:                   "both",
@@ -69,7 +67,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				// These are prescribed as true by enabling "alpha" API fields, even
 				// if the submitted text value is "false".
 				EnableTektonOCIBundles: true,
-				EnableCustomTasks:      true,
 
 				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
 				DisableCredsInit:                 config.DefaultDisableCredsInit,
@@ -85,7 +82,6 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			expectedConfig: &config.FeatureFlags{
 				EnableAPIFields:        "stable",
 				EnableTektonOCIBundles: true,
-				EnableCustomTasks:      true,
 
 				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
 				DisableCredsInit:                 config.DefaultDisableCredsInit,
@@ -117,7 +113,6 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
 		RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
 		EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
-		EnableCustomTasks:                config.DefaultEnableCustomTasks,
 		EnableAPIFields:                  config.DefaultEnableAPIFields,
 		SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 		EmbeddedStatus:                   config.DefaultEmbeddedStatus,

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -23,7 +23,6 @@ data:
   await-sidecar-readiness: "false"
   require-git-ssh-secret-known-hosts: "true"
   enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
   enable-api-fields: "alpha"
   send-cloudevents-for-runs: "true"
   embedded-status: "both"

--- a/pkg/apis/config/testdata/feature-flags-bundles-and-custom-tasks.yaml
+++ b/pkg/apis/config/testdata/feature-flags-bundles-and-custom-tasks.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: tekton-pipelines
 data:
   enable-tekton-oci-bundles: "true"
-  enable-custom-tasks: "true"
   enable-api-fields: "stable"

--- a/pkg/apis/config/testdata/feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks.yaml
+++ b/pkg/apis/config/testdata/feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks.yaml
@@ -5,5 +5,4 @@ metadata:
   namespace: tekton-pipelines
 data:
   enable-tekton-oci-bundles: "false"
-  enable-custom-tasks: "false"
   enable-api-fields: "alpha"

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -494,12 +494,12 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(pt.validateEmbeddedOrType())
 
 	cfg := config.FromContextOrDefaults(ctx)
-	// If EnableCustomTasks feature flag is on, validate custom task specifications
-	// pipeline task having taskRef with APIVersion is classified as custom task
+	// Validate custom task specifications pipeline task having taskRef
+	// with APIVersion is classified as custom task
 	switch {
-	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
+	case pt.TaskRef != nil && pt.TaskRef.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
-	case cfg.FeatureFlags.EnableCustomTasks && pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
+	case pt.TaskSpec != nil && pt.TaskSpec.APIVersion != "":
 		errs = errs.Also(pt.validateCustomTask())
 		// If EnableTektonOCIBundles feature flag is on, validate bundle specifications
 	case cfg.FeatureFlags.EnableTektonOCIBundles && pt.TaskRef != nil && pt.TaskRef.Bundle != "":

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -371,7 +371,6 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 			Message: `invalid value: custom task ref must specify kind`,
 			Paths:   []string{"taskRef.kind"},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}, {
 		name: "invalid bundle without bundle name",
 		p: PipelineTask{
@@ -678,7 +677,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 			TaskRef: &TaskRef{Name: "task"},
 		}},
 		path: "tasks",
-		wc:   enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc:   enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}, {
 		name: "validate list of tasks with valid custom task and bundle but invalid regular task",
 		tasks: PipelineTaskList{{
@@ -693,7 +692,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 		}},
 		path:          "tasks",
 		expectedError: apis.ErrGeneric(`invalid value: taskRef must specify name`, "tasks[2].taskRef.name"),
-		wc:            enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc:            enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}, {
 		name: "validate list of tasks with valid custom task but invalid bundle and invalid regular task",
 		tasks: PipelineTaskList{{
@@ -709,7 +708,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 		path: "tasks",
 		expectedError: apis.ErrGeneric(`invalid value: taskRef must specify name`, "tasks[2].taskRef.name").Also(
 			apis.ErrGeneric(`missing field(s)`, "tasks[1].taskRef.name")),
-		wc: enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc: enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}, {
 		name: "validate all three invalid tasks - custom task, bundle and regular task",
 		tasks: PipelineTaskList{{
@@ -726,7 +725,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 		expectedError: apis.ErrGeneric(`invalid value: taskRef must specify name`, "tasks[2].taskRef.name").Also(
 			apis.ErrGeneric(`missing field(s)`, "tasks[1].taskRef.name")).Also(
 			apis.ErrGeneric(`invalid value: custom task ref must specify kind`, "tasks[0].taskRef.kind")),
-		wc: enableFeatures(t, []string{"enable-custom-tasks", "enable-tekton-oci-bundles"}),
+		wc: enableFeatures(t, []string{"enable-tekton-oci-bundles"}),
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -55,7 +55,6 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				Tasks: []PipelineTask{{Name: "foo", TaskRef: &TaskRef{APIVersion: "example.dev/v0", Kind: "Example", Name: ""}}},
 			},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}, {
 		name: "pipelinetask custom task spec",
 		p: &Pipeline{
@@ -73,7 +72,6 @@ func TestPipeline_Validate_Success(t *testing.T) {
 				}},
 			},
 		},
-		wc: enableFeatures(t, []string{"enable-custom-tasks"}),
 	}, {
 		name: "valid pipeline with params, resources, workspaces, task results, and pipeline results",
 		p: &Pipeline{
@@ -726,27 +724,6 @@ func TestValidatePipelineTasks_Failure(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: `expected exactly one, got both`,
 			Paths:   []string{"tasks[1].name"},
-		},
-	}, {
-		name: "apiVersion with steps",
-		tasks: []PipelineTask{{
-			Name: "foo",
-			TaskSpec: &EmbeddedTask{
-				TypeMeta: runtime.TypeMeta{
-					APIVersion: "tekton.dev/v1beta1",
-				},
-				TaskSpec: TaskSpec{
-					Steps: []Step{{
-						Name:  "some-step",
-						Image: "some-image",
-					}},
-				},
-			},
-		}},
-		finalTasks: nil,
-		expectedError: apis.FieldError{
-			Message: "taskSpec.apiVersion cannot be specified when using taskSpec.steps",
-			Paths:   []string{"tasks[0].taskSpec.apiVersion"},
 		},
 	}, {
 		name: "kind with steps",

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -41,14 +41,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -41,14 +41,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/resource/clientset/versioned/fake/register.go
+++ b/pkg/client/resource/clientset/versioned/fake/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/client/resource/clientset/versioned/scheme/register.go
+++ b/pkg/client/resource/clientset/versioned/scheme/register.go
@@ -37,14 +37,14 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition
 // of clientsets, like in:
 //
-//   import (
-//     "k8s.io/client-go/kubernetes"
-//     clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-//     aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
-//   )
+//	import (
+//	  "k8s.io/client-go/kubernetes"
+//	  clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+//	  aggregatorclientsetscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+//	)
 //
-//   kclientset, _ := kubernetes.NewForConfig(c)
-//   _ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
+//	kclientset, _ := kubernetes.NewForConfig(c)
+//	_ = aggregatorclientsetscheme.AddToScheme(clientsetscheme.Scheme)
 //
 // After this, RawExtensions in Kubernetes types will serialize kube-aggregator types
 // correctly.

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -219,7 +219,7 @@ func TestCancelPipelineRun(t *testing.T) {
 			}
 			ctx, _ := ttesting.SetupFakeContext(t)
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
+			cfg.OnConfigChanged(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus))
 			ctx = cfg.ToContext(ctx)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -391,7 +391,7 @@ func TestGetChildObjectsFromPRStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, _ := ttesting.SetupFakeContext(t)
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cfg.OnConfigChanged(withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus)))
+			cfg.OnConfigChanged(withEmbeddedStatus(newFeatureFlagsConfigMap(), tc.embeddedStatus))
 			ctx = cfg.ToContext(ctx)
 
 			trNames, runNames, err := getChildObjectsFromPRStatus(ctx, tc.prStatus)

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -107,7 +107,6 @@ var (
 
 const (
 	apiFieldsFeatureFlag           = "enable-api-fields"
-	customTasksFeatureFlag         = "enable-custom-tasks"
 	ociBundlesFeatureFlag          = "enable-tekton-oci-bundles"
 	embeddedStatusFeatureFlag      = "embedded-status"
 	maxMatrixCombinationsCountFlag = "default-max-matrix-combinations-count"
@@ -752,7 +751,7 @@ spec:
 			if embeddedStatus == "" {
 				embeddedStatus = config.DefaultEmbeddedStatus
 			}
-			cms := []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
+			cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)}
 
 			d := test.Data{
 				PipelineRuns: []*v1beta1.PipelineRun{tc.pr},
@@ -1497,12 +1496,6 @@ func withEnabledAlphaAPIFields(cm *corev1.ConfigMap) *corev1.ConfigMap {
 	return newCM
 }
 
-func withCustomTasks(cm *corev1.ConfigMap) *corev1.ConfigMap {
-	newCM := cm.DeepCopy()
-	newCM.Data[customTasksFeatureFlag] = "true"
-	return newCM
-}
-
 func withOCIBundles(cm *corev1.ConfigMap) *corev1.ConfigMap {
 	newCM := cm.DeepCopy()
 	newCM.Data[ociBundlesFeatureFlag] = "true"
@@ -1651,7 +1644,7 @@ status:
     type: Succeeded
   startTime: "2021-12-31T23:58:59Z"
 `)}
-	cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+	cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -1741,7 +1734,7 @@ status:
 			prs[0].Spec.Timeout = tc.timeout
 			prs[0].Spec.Timeouts = tc.timeouts
 
-			cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+			cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 			d := test.Data{
 				PipelineRuns: prs,
 				Pipelines:    ps,
@@ -2981,7 +2974,7 @@ spec:
     pipelineTaskName: hello-world-1
 `)}
 
-	cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+	cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -3575,7 +3568,7 @@ spec:
     taskServiceAccountName: custom-sa
 `)}
 
-	cms := []*corev1.ConfigMap{withCustomTasks(newFeatureFlagsConfigMap())}
+	cms := []*corev1.ConfigMap{newFeatureFlagsConfigMap()}
 	d := test.Data{
 		PipelineRuns: prs,
 		Pipelines:    ps,
@@ -5224,7 +5217,7 @@ status:
 	trs := []*v1beta1.TaskRun{taskRunDone, taskRunOrphaned}
 	runs := []*v1alpha1.Run{orphanedRun}
 
-	cms := []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
+	cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)}
 
 	d := test.Data{
 		PipelineRuns: prs,
@@ -5423,7 +5416,7 @@ spec:
         name: some-custom-task
 `)
 
-	cms := []*corev1.ConfigMap{withCustomTasks(withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus))}
+	cms := []*corev1.ConfigMap{withEmbeddedStatus(newFeatureFlagsConfigMap(), embeddedStatus)}
 
 	d := test.Data{
 		PipelineRuns: []*v1beta1.PipelineRun{pr},

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -539,14 +538,13 @@ func ValidateTaskRunSpecs(p *v1beta1.PipelineSpec, pr *v1beta1.PipelineRun) erro
 	return nil
 }
 
-func isCustomTask(ctx context.Context, rpt ResolvedPipelineTask) bool {
+func isCustomTask(rpt ResolvedPipelineTask) bool {
 	invalidSpec := rpt.PipelineTask.TaskRef != nil && rpt.PipelineTask.TaskSpec != nil
 	isTaskRefCustomTask := rpt.PipelineTask.TaskRef != nil && rpt.PipelineTask.TaskRef.APIVersion != "" &&
 		rpt.PipelineTask.TaskRef.Kind != ""
 	isTaskSpecCustomTask := rpt.PipelineTask.TaskSpec != nil && rpt.PipelineTask.TaskSpec.APIVersion != "" &&
 		rpt.PipelineTask.TaskSpec.Kind != ""
-	cfg := config.FromContextOrDefaults(ctx)
-	return cfg.FeatureFlags.EnableCustomTasks && !invalidSpec && (isTaskRefCustomTask || isTaskSpecCustomTask)
+	return !invalidSpec && (isTaskRefCustomTask || isTaskSpecCustomTask)
 }
 
 // ResolvePipelineTask retrieves a single Task's instance using the getTask to fetch
@@ -565,7 +563,7 @@ func ResolvePipelineTask(
 	rpt := ResolvedPipelineTask{
 		PipelineTask: &pipelineTask,
 	}
-	rpt.CustomTask = isCustomTask(ctx, rpt)
+	rpt.CustomTask = isCustomTask(rpt)
 	switch {
 	case rpt.IsCustomTask() && rpt.IsMatrixed():
 		rpt.RunNames = getNamesOfRuns(pipelineRun.Status.ChildReferences, pipelineTask.Name, pipelineRun.Name, pipelineTask.GetMatrixCombinationsCount())

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution_test.go
@@ -1969,12 +1969,6 @@ func TestResolvePipelineRun_CustomTask(t *testing.T) {
 	pipelineState := PipelineRunState{}
 	ctx := context.Background()
 	cfg := config.NewStore(logtesting.TestLogger(t))
-	cfg.OnConfigChanged(&corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-		Data: map[string]string{
-			"enable-custom-tasks": "true",
-		},
-	})
 	ctx = cfg.ToContext(ctx)
 	for _, task := range pts {
 		ps, err := ResolvePipelineTask(ctx, pr, nopGetTask, nopGetTaskRun, getRun, task, nil)
@@ -2742,12 +2736,6 @@ func TestIsCustomTask(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			cfg := config.NewStore(logtesting.TestLogger(t))
-			cfg.OnConfigChanged(&corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-				Data: map[string]string{
-					"enable-custom-tasks": "true",
-				},
-			})
 			ctx = cfg.ToContext(ctx)
 			rpt, err := ResolvePipelineTask(ctx, pr, getTask, getTaskRun, getRun, tc.pt, nil)
 			if err != nil {

--- a/test/custom_task_test.go
+++ b/test/custom_task_test.go
@@ -49,16 +49,11 @@ const (
 	kind       = "Example"
 )
 
-var supportedFeatureGates = map[string]string{
-	"enable-custom-tasks": "true",
-	"enable-api-fields":   "alpha",
-}
-
 func TestCustomTask(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	c, namespace := setup(ctx, t, requireAnyGate(supportedFeatureGates))
+	c, namespace := setup(ctx, t)
 	knativetest.CleanupOnInterrupt(func() { tearDown(ctx, t, c, namespace) }, t.Logf)
 	defer tearDown(ctx, t, c, namespace)
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commits remove the `enable-custom-task` and alpha feature flag for the
custom task feature gates.

/kind feature
Fixes: #5155 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
