### PR TITLE
Include Windows image builds in CI build tests

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -99,6 +99,7 @@ spec:
         mcr.microsoft.com/windows/nanoserver:ltsc2022 \
         ${CONTAINER_REGISTRY}/$(params.package)/combined-base-image:latest)
 
+      # NOTE: Make sure this list of images to use the combined base image is in sync with what's in test/presubmit-tests.sh's 'ko_resolve' function.
       cat <<EOF > ${PROJECT_ROOT}/.ko.yaml
       # This matches the value configured in .ko.yaml
       defaultBaseImage: ghcr.io/distroless/static

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -59,6 +59,19 @@ function check_yaml_lint() {
 
 function ko_resolve() {
   header "Running `ko resolve`"
+
+  cat <<EOF > .ko.yaml
+    defaultBaseImage: ghcr.io/distroless/static
+    baseImageOverrides:
+      # Use the combined base image for images that should include Windows support.
+      # NOTE: Make sure this list of images to use the combined base image is in sync with what's in tekton/publish.yaml's 'create-ko-yaml' Task.
+      github.com/tektoncd/pipeline/cmd/entrypoint: gcr.io/tekton-releases/github.com/tektoncd/pipeline/combined-base-image:latest
+      github.com/tektoncd/pipeline/cmd/nop: gcr.io/tekton-releases/github.com/tektoncd/pipeline/combined-base-image:latest
+      github.com/tektoncd/pipeline/cmd/workingdirinit: gcr.io/tekton-releases/github.com/tektoncd/pipeline/combined-base-image:latest
+
+      github.com/tektoncd/pipeline/cmd/git-init: ghcr.io/distroless/git
+EOF
+
   KO_DOCKER_REPO=example.com ko resolve --platform=all --push=false -R -f config 1>/dev/null
 }
 


### PR DESCRIPTION
# Changes

closes #5177

Note that this PR will fail `pull-tekton-pipeline-build-tests` (assuming the change does what it's supposed to!) until #5174 is dealt with.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
