### PR TITLE
Move step and sidecar replacements to new package

### DIFF
--- a/pkg/container/container_replacements.go
+++ b/pkg/container/container_replacements.go
@@ -14,22 +14,23 @@
  limitations under the License.
 */
 
-package v1beta1
+package container
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // applyStepReplacements returns a StepContainer with variable interpolation applied.
-func applyStepReplacements(step *Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+func applyStepReplacements(step *v1beta1.Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	c := step.ToK8sContainer()
 	applyContainerReplacements(c, stringReplacements, arrayReplacements)
 	step.SetContainerFields(*c)
 }
 
 // applySidecarReplacements returns a SidecarContainer with variable interpolation applied.
-func applySidecarReplacements(sidecar *Sidecar, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+func applySidecarReplacements(sidecar *v1beta1.Sidecar, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	c := sidecar.ToK8sContainer()
 	applyContainerReplacements(c, stringReplacements, arrayReplacements)
 	sidecar.SetContainerFields(*c)

--- a/pkg/container/sidecar_replacements.go
+++ b/pkg/container/sidecar_replacements.go
@@ -14,14 +14,15 @@
  limitations under the License.
 */
 
-package v1beta1
+package container
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 )
 
 // ApplySidecarReplacements applies variable interpolation on a Sidecar.
-func ApplySidecarReplacements(sidecar *Sidecar, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+func ApplySidecarReplacements(sidecar *v1beta1.Sidecar, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	sidecar.Script = substitution.ApplyReplacements(sidecar.Script, stringReplacements)
 	applySidecarReplacements(sidecar, stringReplacements, arrayReplacements)
 }

--- a/pkg/container/sidecar_replacements_test.go
+++ b/pkg/container/sidecar_replacements_test.go
@@ -14,13 +14,14 @@
  limitations under the License.
 */
 
-package v1beta1_test
+package container_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/container"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -120,7 +121,7 @@ func TestApplySidecarReplacements(t *testing.T) {
 			SubPath:   "replaced!",
 		}},
 	}
-	v1beta1.ApplySidecarReplacements(&s, replacements, arrayReplacements)
+	container.ApplySidecarReplacements(&s, replacements, arrayReplacements)
 	if d := cmp.Diff(s, expected); d != "" {
 		t.Errorf("Container replacements failed: %s", d)
 	}

--- a/pkg/container/step_replacements.go
+++ b/pkg/container/step_replacements.go
@@ -14,14 +14,15 @@
  limitations under the License.
 */
 
-package v1beta1
+package container
 
 import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 )
 
 // ApplyStepReplacements applies variable interpolation on a Step.
-func ApplyStepReplacements(step *Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+func ApplyStepReplacements(step *v1beta1.Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	step.Script = substitution.ApplyReplacements(step.Script, stringReplacements)
 	if step.StdoutConfig != nil {
 		step.StdoutConfig.Path = substitution.ApplyReplacements(step.StdoutConfig.Path, stringReplacements)
@@ -33,7 +34,7 @@ func ApplyStepReplacements(step *Step, stringReplacements map[string]string, arr
 }
 
 // ApplyStepTemplateReplacements applies variable interpolation on a StepTemplate (aka a container)
-func ApplyStepTemplateReplacements(stepTemplate *StepTemplate, stringReplacements map[string]string, arrayReplacements map[string][]string) {
+func ApplyStepTemplateReplacements(stepTemplate *v1beta1.StepTemplate, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	container := stepTemplate.ToK8sContainer()
 	applyContainerReplacements(container, stringReplacements, arrayReplacements)
 	stepTemplate.SetContainerFields(*container)

--- a/pkg/container/step_replacements_test.go
+++ b/pkg/container/step_replacements_test.go
@@ -14,13 +14,14 @@
  limitations under the License.
 */
 
-package v1beta1_test
+package container_test
 
 import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/container"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -133,7 +134,7 @@ func TestApplyStepReplacements(t *testing.T) {
 			Path: "/workspace/data/stderr.txt",
 		},
 	}
-	v1beta1.ApplyStepReplacements(&s, replacements, arrayReplacements)
+	container.ApplyStepReplacements(&s, replacements, arrayReplacements)
 	if d := cmp.Diff(s, expected); d != "" {
 		t.Errorf("Container replacements failed: %s", d)
 	}

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -28,6 +28,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/container"
 	"github.com/tektoncd/pipeline/pkg/pod"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 )
@@ -202,7 +203,7 @@ func applyWorkspaceMountPath(variable string, spec *v1beta1.TaskSpec, declaratio
 		for _, usage := range step.Workspaces {
 			if usage.Name == declaration.Name && usage.MountPath != "" {
 				stringReplacements[variable] = usage.MountPath
-				v1beta1.ApplyStepReplacements(step, stringReplacements, emptyArrayReplacements)
+				container.ApplyStepReplacements(step, stringReplacements, emptyArrayReplacements)
 			}
 		}
 	}
@@ -212,7 +213,7 @@ func applyWorkspaceMountPath(variable string, spec *v1beta1.TaskSpec, declaratio
 		for _, usage := range sidecar.Workspaces {
 			if usage.Name == declaration.Name && usage.MountPath != "" {
 				stringReplacements[variable] = usage.MountPath
-				v1beta1.ApplySidecarReplacements(sidecar, stringReplacements, emptyArrayReplacements)
+				container.ApplySidecarReplacements(sidecar, stringReplacements, emptyArrayReplacements)
 			}
 		}
 	}
@@ -269,12 +270,12 @@ func ApplyReplacements(spec *v1beta1.TaskSpec, stringReplacements map[string]str
 	// Apply variable expansion to steps fields.
 	steps := spec.Steps
 	for i := range steps {
-		v1beta1.ApplyStepReplacements(&steps[i], stringReplacements, arrayReplacements)
+		container.ApplyStepReplacements(&steps[i], stringReplacements, arrayReplacements)
 	}
 
 	// Apply variable expansion to stepTemplate fields.
 	if spec.StepTemplate != nil {
-		v1beta1.ApplyStepTemplateReplacements(spec.StepTemplate, stringReplacements, arrayReplacements)
+		container.ApplyStepTemplateReplacements(spec.StepTemplate, stringReplacements, arrayReplacements)
 	}
 
 	// Apply variable expansion to the build's volumes
@@ -329,7 +330,7 @@ func ApplyReplacements(spec *v1beta1.TaskSpec, stringReplacements map[string]str
 	// Apply variable substitution to the sidecar definitions
 	sidecars := spec.Sidecars
 	for i := range sidecars {
-		v1beta1.ApplySidecarReplacements(&sidecars[i], stringReplacements, arrayReplacements)
+		container.ApplySidecarReplacements(&sidecars[i], stringReplacements, arrayReplacements)
 	}
 
 	return spec


### PR DESCRIPTION
# Changes
This commit moves logic related to variable replacement in Steps and Sidecars
out of pkg/apis into its own package. This will prevent this code from being
duplicated in the v1 api package. No functional changes.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

-  n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
