### PR TITLE
Fail steps on Windows with StdoutPath or StderrPath set

### DIFF
--- a/cmd/entrypoint/runner_windows.go
+++ b/cmd/entrypoint/runner_windows.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 
@@ -32,11 +33,16 @@ import (
 
 // realRunner actually runs commands.
 type realRunner struct {
+	stdoutPath string
+	stderrPath string
 }
 
 var _ entrypoint.Runner = (*realRunner)(nil)
 
 func (rr *realRunner) Run(ctx context.Context, args ...string) error {
+	if rr.stdoutPath != "" || rr.stderrPath != "" {
+		return errors.New("step.StdoutPath and step.StderrPath not supported on Windows")
+	}
 	if len(args) == 0 {
 		return nil
 	}


### PR DESCRIPTION
# Changes

closes #5174

This fixes the release pipeline issue with building `cmd/entrypoint` on Windows, and returns an error if `StdoutPath` or `StderrPath` are specified in a Windows step.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
