### PR TITLE
Update GCR IAM settings in Tekton development doc

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -195,7 +195,20 @@ for your `KO_DOCKER_REPO` if required. To be able to push images to
 ```shell
 gcloud auth configure-docker
 ```
-The [example GKE setup](#using-gke) in this guide grants service accounts permissions to push and pull GCR images in the same project.
+
+To be able to pull images from `gcr.io/<project>`, please follow the instructions [here](https://cloud.google.com/container-registry/docs/access-control#grant) to configure IAM policies for the services that will pull iamges from your GCR. 
+
+If you choose to run GKE and GCR in the same GCP project, please follow the [example GKE setup](#using-gke) and make sure to add ```storage-full``` to the ```--scopes``` args in the example to give the GKE default service account full access to your GCR. Alternatively, you can grant the GKE default service account read access to your GCR by running:
+
+```
+gcloud projects add-iam-policy-binding <project-number> \
+--member='serviceAccount:<project-number>-compute@developer.gserviceaccount.com' \
+--role='roles/storage.objectViewer'
+```
+
+For more information about GCP Compute Engine default service accounts, please check [here](https://cloud.google.com/compute/docs/access/service-accounts)
+
+After configuring IAM policy of your GCR, the [example GKE setup](#using-gke) in this guide now has permissions to push and pull images from your GCR.
 If you choose to use a different setup with fewer default permissions, or your GKE cluster that will run Tekton
 is in a different project than your GCR registry, you will need to provide the Tekton pipelines
 controller and webhook service accounts with GCR credentials.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
The current settings of GCR in the development doc does not include instructions to configure GCR IAM policies. This results in ```ErrImagePull``` issue when pulling images from GCR to run Tekton project (due to missing permission). This commits adds the missing IAM policy setup instructions under the [using Google Container Registry (GCR)](https://github.com/QuanZhang-William/pipeline/blob/update-onboarding-foc-grc-settings/DEVELOPMENT.md#using-google-container-registry-gcr) section.

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```
