### PR TITLE
Add TerminationMessagePolicy in container conversion

### DIFF
--- a/pkg/apis/pipeline/v1/container_types.go
+++ b/pkg/apis/pipeline/v1/container_types.go
@@ -476,27 +476,28 @@ type Sidecar struct {
 // ToK8sContainer converts the Sidecar to a Kubernetes Container struct
 func (s *Sidecar) ToK8sContainer() *corev1.Container {
 	return &corev1.Container{
-		Name:                   s.Name,
-		Image:                  s.Image,
-		Command:                s.Command,
-		Args:                   s.Args,
-		WorkingDir:             s.WorkingDir,
-		Ports:                  s.Ports,
-		EnvFrom:                s.EnvFrom,
-		Env:                    s.Env,
-		Resources:              s.Resources,
-		VolumeMounts:           s.VolumeMounts,
-		VolumeDevices:          s.VolumeDevices,
-		LivenessProbe:          s.LivenessProbe,
-		ReadinessProbe:         s.ReadinessProbe,
-		StartupProbe:           s.StartupProbe,
-		Lifecycle:              s.Lifecycle,
-		TerminationMessagePath: s.TerminationMessagePath,
-		ImagePullPolicy:        s.ImagePullPolicy,
-		SecurityContext:        s.SecurityContext,
-		Stdin:                  s.Stdin,
-		StdinOnce:              s.StdinOnce,
-		TTY:                    s.TTY,
+		Name:                     s.Name,
+		Image:                    s.Image,
+		Command:                  s.Command,
+		Args:                     s.Args,
+		WorkingDir:               s.WorkingDir,
+		Ports:                    s.Ports,
+		EnvFrom:                  s.EnvFrom,
+		Env:                      s.Env,
+		Resources:                s.Resources,
+		VolumeMounts:             s.VolumeMounts,
+		VolumeDevices:            s.VolumeDevices,
+		LivenessProbe:            s.LivenessProbe,
+		ReadinessProbe:           s.ReadinessProbe,
+		StartupProbe:             s.StartupProbe,
+		Lifecycle:                s.Lifecycle,
+		TerminationMessagePath:   s.TerminationMessagePath,
+		TerminationMessagePolicy: s.TerminationMessagePolicy,
+		ImagePullPolicy:          s.ImagePullPolicy,
+		SecurityContext:          s.SecurityContext,
+		Stdin:                    s.Stdin,
+		StdinOnce:                s.StdinOnce,
+		TTY:                      s.TTY,
 	}
 }
 
@@ -518,6 +519,7 @@ func (s *Sidecar) SetContainerFields(c corev1.Container) {
 	s.StartupProbe = c.StartupProbe
 	s.Lifecycle = c.Lifecycle
 	s.TerminationMessagePath = c.TerminationMessagePath
+	s.TerminationMessagePolicy = c.TerminationMessagePolicy
 	s.ImagePullPolicy = c.ImagePullPolicy
 	s.SecurityContext = c.SecurityContext
 	s.Stdin = c.Stdin

--- a/pkg/apis/pipeline/v1beta1/container_types.go
+++ b/pkg/apis/pipeline/v1beta1/container_types.go
@@ -228,27 +228,28 @@ type StepOutputConfig struct {
 // ToK8sContainer converts the Step to a Kubernetes Container struct
 func (s *Step) ToK8sContainer() *corev1.Container {
 	return &corev1.Container{
-		Name:                   s.Name,
-		Image:                  s.Image,
-		Command:                s.Command,
-		Args:                   s.Args,
-		WorkingDir:             s.WorkingDir,
-		Ports:                  s.DeprecatedPorts,
-		EnvFrom:                s.EnvFrom,
-		Env:                    s.Env,
-		Resources:              s.Resources,
-		VolumeMounts:           s.VolumeMounts,
-		VolumeDevices:          s.VolumeDevices,
-		LivenessProbe:          s.DeprecatedLivenessProbe,
-		ReadinessProbe:         s.DeprecatedReadinessProbe,
-		StartupProbe:           s.DeprecatedStartupProbe,
-		Lifecycle:              s.DeprecatedLifecycle,
-		TerminationMessagePath: s.DeprecatedTerminationMessagePath,
-		ImagePullPolicy:        s.ImagePullPolicy,
-		SecurityContext:        s.SecurityContext,
-		Stdin:                  s.DeprecatedStdin,
-		StdinOnce:              s.DeprecatedStdinOnce,
-		TTY:                    s.DeprecatedTTY,
+		Name:                     s.Name,
+		Image:                    s.Image,
+		Command:                  s.Command,
+		Args:                     s.Args,
+		WorkingDir:               s.WorkingDir,
+		Ports:                    s.DeprecatedPorts,
+		EnvFrom:                  s.EnvFrom,
+		Env:                      s.Env,
+		Resources:                s.Resources,
+		VolumeMounts:             s.VolumeMounts,
+		VolumeDevices:            s.VolumeDevices,
+		LivenessProbe:            s.DeprecatedLivenessProbe,
+		ReadinessProbe:           s.DeprecatedReadinessProbe,
+		StartupProbe:             s.DeprecatedStartupProbe,
+		Lifecycle:                s.DeprecatedLifecycle,
+		TerminationMessagePath:   s.DeprecatedTerminationMessagePath,
+		TerminationMessagePolicy: s.DeprecatedTerminationMessagePolicy,
+		ImagePullPolicy:          s.ImagePullPolicy,
+		SecurityContext:          s.SecurityContext,
+		Stdin:                    s.DeprecatedStdin,
+		StdinOnce:                s.DeprecatedStdinOnce,
+		TTY:                      s.DeprecatedTTY,
 	}
 }
 
@@ -270,6 +271,7 @@ func (s *Step) SetContainerFields(c corev1.Container) {
 	s.DeprecatedStartupProbe = c.StartupProbe
 	s.DeprecatedLifecycle = c.Lifecycle
 	s.DeprecatedTerminationMessagePath = c.TerminationMessagePath
+	s.DeprecatedTerminationMessagePolicy = c.TerminationMessagePolicy
 	s.ImagePullPolicy = c.ImagePullPolicy
 	s.SecurityContext = c.SecurityContext
 	s.DeprecatedStdin = c.Stdin
@@ -474,6 +476,7 @@ func (s *StepTemplate) SetContainerFields(c corev1.Container) {
 	s.DeprecatedStartupProbe = c.StartupProbe
 	s.DeprecatedLifecycle = c.Lifecycle
 	s.DeprecatedTerminationMessagePath = c.TerminationMessagePath
+	s.DeprecatedTerminationMessagePolicy = c.TerminationMessagePolicy
 	s.ImagePullPolicy = c.ImagePullPolicy
 	s.SecurityContext = c.SecurityContext
 	s.DeprecatedStdin = c.Stdin
@@ -484,27 +487,28 @@ func (s *StepTemplate) SetContainerFields(c corev1.Container) {
 // ToK8sContainer converts the StepTemplate to a Kubernetes Container struct
 func (s *StepTemplate) ToK8sContainer() *corev1.Container {
 	return &corev1.Container{
-		Name:                   s.DeprecatedName,
-		Image:                  s.Image,
-		Command:                s.Command,
-		Args:                   s.Args,
-		WorkingDir:             s.WorkingDir,
-		Ports:                  s.DeprecatedPorts,
-		EnvFrom:                s.EnvFrom,
-		Env:                    s.Env,
-		Resources:              s.Resources,
-		VolumeMounts:           s.VolumeMounts,
-		VolumeDevices:          s.VolumeDevices,
-		LivenessProbe:          s.DeprecatedLivenessProbe,
-		ReadinessProbe:         s.DeprecatedReadinessProbe,
-		StartupProbe:           s.DeprecatedStartupProbe,
-		Lifecycle:              s.DeprecatedLifecycle,
-		TerminationMessagePath: s.DeprecatedTerminationMessagePath,
-		ImagePullPolicy:        s.ImagePullPolicy,
-		SecurityContext:        s.SecurityContext,
-		Stdin:                  s.DeprecatedStdin,
-		StdinOnce:              s.DeprecatedStdinOnce,
-		TTY:                    s.DeprecatedTTY,
+		Name:                     s.DeprecatedName,
+		Image:                    s.Image,
+		Command:                  s.Command,
+		Args:                     s.Args,
+		WorkingDir:               s.WorkingDir,
+		Ports:                    s.DeprecatedPorts,
+		EnvFrom:                  s.EnvFrom,
+		Env:                      s.Env,
+		Resources:                s.Resources,
+		VolumeMounts:             s.VolumeMounts,
+		VolumeDevices:            s.VolumeDevices,
+		LivenessProbe:            s.DeprecatedLivenessProbe,
+		ReadinessProbe:           s.DeprecatedReadinessProbe,
+		StartupProbe:             s.DeprecatedStartupProbe,
+		Lifecycle:                s.DeprecatedLifecycle,
+		TerminationMessagePath:   s.DeprecatedTerminationMessagePath,
+		TerminationMessagePolicy: s.DeprecatedTerminationMessagePolicy,
+		ImagePullPolicy:          s.ImagePullPolicy,
+		SecurityContext:          s.SecurityContext,
+		Stdin:                    s.DeprecatedStdin,
+		StdinOnce:                s.DeprecatedStdinOnce,
+		TTY:                      s.DeprecatedTTY,
 	}
 }
 
@@ -696,27 +700,28 @@ type Sidecar struct {
 // ToK8sContainer converts the Sidecar to a Kubernetes Container struct
 func (s *Sidecar) ToK8sContainer() *corev1.Container {
 	return &corev1.Container{
-		Name:                   s.Name,
-		Image:                  s.Image,
-		Command:                s.Command,
-		Args:                   s.Args,
-		WorkingDir:             s.WorkingDir,
-		Ports:                  s.Ports,
-		EnvFrom:                s.EnvFrom,
-		Env:                    s.Env,
-		Resources:              s.Resources,
-		VolumeMounts:           s.VolumeMounts,
-		VolumeDevices:          s.VolumeDevices,
-		LivenessProbe:          s.LivenessProbe,
-		ReadinessProbe:         s.ReadinessProbe,
-		StartupProbe:           s.StartupProbe,
-		Lifecycle:              s.Lifecycle,
-		TerminationMessagePath: s.TerminationMessagePath,
-		ImagePullPolicy:        s.ImagePullPolicy,
-		SecurityContext:        s.SecurityContext,
-		Stdin:                  s.Stdin,
-		StdinOnce:              s.StdinOnce,
-		TTY:                    s.TTY,
+		Name:                     s.Name,
+		Image:                    s.Image,
+		Command:                  s.Command,
+		Args:                     s.Args,
+		WorkingDir:               s.WorkingDir,
+		Ports:                    s.Ports,
+		EnvFrom:                  s.EnvFrom,
+		Env:                      s.Env,
+		Resources:                s.Resources,
+		VolumeMounts:             s.VolumeMounts,
+		VolumeDevices:            s.VolumeDevices,
+		LivenessProbe:            s.LivenessProbe,
+		ReadinessProbe:           s.ReadinessProbe,
+		StartupProbe:             s.StartupProbe,
+		Lifecycle:                s.Lifecycle,
+		TerminationMessagePath:   s.TerminationMessagePath,
+		TerminationMessagePolicy: s.TerminationMessagePolicy,
+		ImagePullPolicy:          s.ImagePullPolicy,
+		SecurityContext:          s.SecurityContext,
+		Stdin:                    s.Stdin,
+		StdinOnce:                s.StdinOnce,
+		TTY:                      s.TTY,
 	}
 }
 
@@ -738,6 +743,7 @@ func (s *Sidecar) SetContainerFields(c corev1.Container) {
 	s.StartupProbe = c.StartupProbe
 	s.Lifecycle = c.Lifecycle
 	s.TerminationMessagePath = c.TerminationMessagePath
+	s.TerminationMessagePolicy = c.TerminationMessagePolicy
 	s.ImagePullPolicy = c.ImagePullPolicy
 	s.SecurityContext = c.SecurityContext
 	s.Stdin = c.Stdin


### PR DESCRIPTION
# Changes
The "TerminationMessagePolicy" field for v1beta1 Step, StepTemplate,
and Sidecar, and v1 Sidecar, should be used when converting to and from
the Kubernetes container struct. They were omitted by accident, and
this commit adds them in.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[Bug fix] Apply the TerminationMessagePolicy field for container types
```
