### PR TITLE
Do not validate anything on delete ✂

### DIFF
--- a/pkg/apis/pipeline/v1beta1/cluster_task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_conversion.go
@@ -27,10 +27,16 @@ var _ apis.Convertible = (*ClusterTask)(nil)
 
 // ConvertTo implements api.Convertible
 func (ct *ClusterTask) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
 func (ct *ClusterTask) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -27,9 +27,9 @@ var _ apis.Validatable = (*ClusterTask)(nil)
 
 // Validate performs validation of the metadata and spec of this ClusterTask.
 func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -27,10 +27,16 @@ var _ apis.Convertible = (*Pipeline)(nil)
 
 // ConvertTo implements api.Convertible
 func (p *Pipeline) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
 func (p *Pipeline) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -35,10 +35,10 @@ var _ apis.Validatable = (*Pipeline)(nil)
 // Validate checks that the Pipeline structure is valid but does not validate
 // that any references resources exist, that is done at run time.
 func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(p.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+	errs := validate.ObjectMetadata(p.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(p.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -27,10 +27,16 @@ var _ apis.Convertible = (*PipelineRun)(nil)
 
 // ConvertTo implements api.Convertible
 func (pr *PipelineRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
 func (pr *PipelineRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -32,11 +32,11 @@ var _ apis.Validatable = (*PipelineRun)(nil)
 
 // Validate pipelinerun
 func (pr *PipelineRun) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(pr.GetObjectMeta()).ViaField("metadata")
-
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+
+	errs := validate.ObjectMetadata(pr.GetObjectMeta()).ViaField("metadata")
 
 	if pr.IsPending() && pr.HasStarted() {
 		errs = errs.Also(apis.ErrInvalidValue("PipelineRun cannot be Pending after it is started", "spec.status"))

--- a/pkg/apis/pipeline/v1beta1/task_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion.go
@@ -27,10 +27,16 @@ var _ apis.Convertible = (*Task)(nil)
 
 // ConvertTo implements api.Convertible
 func (t *Task) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
 func (t *Task) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -52,10 +52,10 @@ var objectVariableNameFormatRegex = regexp.MustCompile(objectVariableNameFormat)
 
 // Validate implements apis.Validatable
 func (t *Task) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -27,10 +27,16 @@ var _ apis.Convertible = (*TaskRun)(nil)
 
 // ConvertTo implements api.Convertible
 func (tr *TaskRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements api.Convertible
 func (tr *TaskRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
 	return fmt.Errorf("v1beta1 is the highest know version, got: %T", source)
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -33,10 +33,10 @@ var _ apis.Validatable = (*TaskRun)(nil)
 
 // Validate taskrun
 func (tr *TaskRun) Validate(ctx context.Context) *apis.FieldError {
-	errs := validate.ObjectMetadata(tr.GetObjectMeta()).ViaField("metadata")
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+	errs := validate.ObjectMetadata(tr.GetObjectMeta()).ViaField("metadata")
 	return errs.Also(tr.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In case of deletion, we do not want to validate anything (to allow a
wronq object to be deleted).

We will also not try to convert anything on deletion, again, to allow
deleting an object that cannot be converted.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @lbernick (for #5202)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Do not try to convert object on deletion, and do not validate names on deletion as well.
```
