### PR TITLE
Bump go-scm to 1.11.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/jenkins-x/go-scm v1.11.16
+	github.com/jenkins-x/go-scm v1.11.19
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
 	github.com/pkg/errors v0.9.1
@@ -117,7 +117,7 @@ require (
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/tektoncd/resolution v0.0.0-20220331203013-e4203c70c5eb
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -858,8 +858,8 @@ github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/U
 github.com/jcmturner/goidentity/v6 v6.0.1/go.mod h1:X1YW3bgtvwAXju7V3LCIMpY0Gbxyjn/mY9zx4tFonSg=
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/jenkins-x/go-scm v1.11.16 h1:2zo6WysX/KRqs3W9njJzXwd75wPdt3MshNiMPAHz7+U=
-github.com/jenkins-x/go-scm v1.11.16/go.mod h1:GB6XjszezsDOxKTsPoyk4MT/cKw30qkPdJ4tml+MImg=
+github.com/jenkins-x/go-scm v1.11.19 h1:H4CzaM/C/0QcCVLDh603Q6Bv4hqU4G3De2yQntWubqg=
+github.com/jenkins-x/go-scm v1.11.19/go.mod h1:eIcty4+tf6E7ycGOg0cUqnaLP+1LH1Z8zncQFQqRa3E=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jgautheron/goconst v1.5.1/go.mod h1:aAosetZ5zaeC/2EfMeRswtxUFBpe2Hr7HzkgX4fanO4=
@@ -1290,6 +1290,7 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1298,8 +1299,10 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/sylvia7788/contextcheck v1.0.4/go.mod h1:vuPKJMQ7MQ91ZTqfdyreNKwZjyUg6KO+IebVyQDedZQ=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/pullrequest/api.go
+++ b/pkg/pullrequest/api.go
@@ -59,7 +59,7 @@ func (h *Handler) Download(ctx context.Context) (*Resource, error) {
 
 	// Statuses
 	h.logger.Info("finding combined status")
-	status, out, err := h.client.Repositories.ListStatus(ctx, h.repo, pr.Sha, scm.ListOptions{})
+	status, out, err := h.client.Repositories.ListStatus(ctx, h.repo, pr.Sha, &scm.ListOptions{})
 	if err != nil {
 		body, _ := ioutil.ReadAll(out.Body)
 		defer out.Body.Close()
@@ -70,13 +70,13 @@ func (h *Handler) Download(ctx context.Context) (*Resource, error) {
 	// Comments
 	// TODO: Pagination.
 	h.logger.Info("finding comments: %v", h)
-	comments, _, err := h.client.PullRequests.ListComments(ctx, h.repo, h.prNum, scm.ListOptions{})
+	comments, _, err := h.client.PullRequests.ListComments(ctx, h.repo, h.prNum, &scm.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("finding comments for pr %d: %w", h.prNum, err)
 	}
 	h.logger.Info("found comments: %v", comments)
 
-	labels, _, err := h.client.PullRequests.ListLabels(ctx, h.repo, h.prNum, scm.ListOptions{})
+	labels, _, err := h.client.PullRequests.ListLabels(ctx, h.repo, h.prNum, &scm.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("finding labels for pr %d: %w", h.prNum, err)
 	}
@@ -140,7 +140,7 @@ func (h *Handler) uploadLabels(ctx context.Context, manifest Manifest, raw []*sc
 
 	// Fetch current labels associated to the PR. We'll need to keep track of
 	// which labels are new and should not be modified.
-	currentLabels, _, err := h.client.PullRequests.ListLabels(ctx, h.repo, h.prNum, scm.ListOptions{})
+	currentLabels, _, err := h.client.PullRequests.ListLabels(ctx, h.repo, h.prNum, &scm.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("listing labels for pr %d: %w", h.prNum, err)
 	}
@@ -211,7 +211,7 @@ func (h *Handler) uploadComments(ctx context.Context, manifest Manifest, comment
 // SCM and exists in the manifest (therefore was present during resource
 // initialization).
 func (h *Handler) maybeDeleteComments(ctx context.Context, manifest Manifest, comments map[int]*scm.Comment) error {
-	currentComments, _, err := h.client.PullRequests.ListComments(ctx, h.repo, h.prNum, scm.ListOptions{})
+	currentComments, _, err := h.client.PullRequests.ListComments(ctx, h.repo, h.prNum, &scm.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (h *Handler) uploadStatuses(ctx context.Context, statuses []*scm.Status, sh
 	}
 
 	h.logger.Infof("Looking for existing status on %s", sha)
-	cs, _, err := h.client.Repositories.ListStatus(ctx, h.repo, sha, scm.ListOptions{})
+	cs, _, err := h.client.Repositories.ListStatus(ctx, h.repo, sha, &scm.ListOptions{})
 	if err != nil {
 		return err
 	}

--- a/third_party/github.com/benbjohnson/clock/LICENSE
+++ b/third_party/github.com/benbjohnson/clock/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/jenkins-x/go-scm/scm/client.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/client.go
@@ -19,16 +19,16 @@ import (
 
 var (
 	// ErrNotFound indicates a resource is not found.
-	ErrNotFound = errors.New("Not Found")
+	ErrNotFound = errors.New("not Found")
 
 	// ErrNotSupported indicates a resource endpoint is not
 	// supported or implemented.
-	ErrNotSupported = errors.New("Not Supported")
+	ErrNotSupported = errors.New("not Supported")
 
 	// ErrNotAuthorized indicates the request is not
 	// authorized or the user does not have access to the
 	// resource.
-	ErrNotAuthorized = errors.New("Not Authorized")
+	ErrNotAuthorized = errors.New("not Authorized")
 
 	// ErrForbidden indicates the user does not have access to
 	// the resource, this is similar to 401, but in this case,

--- a/vendor/github.com/jenkins-x/go-scm/scm/const.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/const.go
@@ -73,7 +73,7 @@ func ToState(s string) State {
 
 // MarshalJSON marshals State to JSON
 func (s State) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, s.String())), nil
+	return []byte(fmt.Sprintf(`%q`, s.String())), nil
 }
 
 // UnmarshalJSON unmarshals JSON to State

--- a/vendor/github.com/jenkins-x/go-scm/scm/deploy.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/deploy.go
@@ -75,7 +75,7 @@ type (
 		Find(ctx context.Context, repoFullName string, deploymentID string) (*Deployment, *Response, error)
 
 		// List returns a list of deployments.
-		List(ctx context.Context, repoFullName string, opts ListOptions) ([]*Deployment, *Response, error)
+		List(ctx context.Context, repoFullName string, opts *ListOptions) ([]*Deployment, *Response, error)
 
 		// Create creates a new deployment.
 		Create(ctx context.Context, repoFullName string, deployment *DeploymentInput) (*Deployment, *Response, error)
@@ -87,7 +87,7 @@ type (
 		FindStatus(ctx context.Context, repoFullName string, deploymentID string, statusID string) (*DeploymentStatus, *Response, error)
 
 		// List returns a list of deployments.
-		ListStatus(ctx context.Context, repoFullName string, deploymentID string, options ListOptions) ([]*DeploymentStatus, *Response, error)
+		ListStatus(ctx context.Context, repoFullName string, deploymentID string, options *ListOptions) ([]*DeploymentStatus, *Response, error)
 
 		// Create creates a new deployment.
 		CreateStatus(ctx context.Context, repoFullName string, deploymentID string, deployment *DeploymentStatusInput) (*DeploymentStatus, *Response, error)

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/deploy.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/deploy.go
@@ -22,7 +22,7 @@ func (s *deploymentService) Find(ctx context.Context, repoFullName, deploymentID
 	return nil, nil, scm.ErrNotFound
 }
 
-func (s *deploymentService) List(ctx context.Context, repoFullName string, opts scm.ListOptions) ([]*scm.Deployment, *scm.Response, error) {
+func (s *deploymentService) List(ctx context.Context, repoFullName string, opts *scm.ListOptions) ([]*scm.Deployment, *scm.Response, error) {
 	return s.data.Deployments[repoFullName], nil, nil
 }
 
@@ -81,7 +81,7 @@ func (s *deploymentService) FindStatus(ctx context.Context, repoFullName, deploy
 	return nil, nil, scm.ErrNotFound
 }
 
-func (s *deploymentService) ListStatus(ctx context.Context, repoFullName, deploymentID string, opts scm.ListOptions) ([]*scm.DeploymentStatus, *scm.Response, error) {
+func (s *deploymentService) ListStatus(ctx context.Context, repoFullName, deploymentID string, opts *scm.ListOptions) ([]*scm.DeploymentStatus, *scm.Response, error) {
 	key := scm.Join(repoFullName, deploymentID)
 	return s.data.DeploymentStatus[key], nil, nil
 }

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/fake.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/fake.go
@@ -13,7 +13,7 @@ func NewDefault() (*scm.Client, *Data) {
 	data := NewData()
 	data.CurrentUser.Login = "fakeuser"
 	data.CurrentUser.Name = "fakeuser"
-	data.ContentDir = "test_data"
+	data.ContentDir = "testdata"
 
 	client := &wrapper{new(scm.Client)}
 	client.BaseURL = &url.URL{
@@ -35,7 +35,6 @@ func NewDefault() (*scm.Client, *Data) {
 	client.Users = &userService{client: client, data: data}
 
 	client.Username = data.CurrentUser.Login
-	// TODO
 
 	return client.Client, data
 }

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/git.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/git.go
@@ -47,7 +47,7 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	panic("implement me")
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	panic("implement me")
 }
 
@@ -55,14 +55,14 @@ func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.Comm
 	panic("implement me")
 }
 
-func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	panic("implement me")
 }
 
-func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	panic("implement me")
 }
 
-func (s *gitService) ListTags(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListTags(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	panic("implement me")
 }

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/issue.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/issue.go
@@ -21,7 +21,7 @@ func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.Search
 	return nil, nil, nil
 }
 
-func (s *issueService) ListEvents(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+func (s *issueService) ListEvents(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
 	f := s.data
 	return append([]*scm.ListedIssueEvent{}, f.IssueEvents[number]...), nil, nil
 }
@@ -38,7 +38,7 @@ func (s *issueService) Find(ctx context.Context, repo string, number int) (*scm.
 	return nil, nil, nil
 }
 
-func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	f := s.data
 	re := regexp.MustCompile(fmt.Sprintf(`^%s#%d:(.*)$`, repo, number))
 	la := []*scm.Label{}
@@ -125,7 +125,7 @@ func (s *issueService) List(context.Context, string, scm.IssueListOptions) ([]*s
 	panic("implement me")
 }
 
-func (s *issueService) ListComments(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
+func (s *issueService) ListComments(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
 	f := s.data
 	return append([]*scm.Comment{}, f.IssueComments[number]...), nil, nil
 }

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/org.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/org.go
@@ -52,7 +52,7 @@ func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organ
 	return nil, nil, scm.ErrNotFound
 }
 
-func (s *organizationService) List(context.Context, scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
+func (s *organizationService) List(context.Context, *scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
 	orgs := s.data.Organizations
 	if orgs == nil {
 		// Return hardcoded organizations if none specified explicitly
@@ -73,7 +73,7 @@ func (s *organizationService) List(context.Context, scm.ListOptions) ([]*scm.Org
 	return orgs, &scm.Response{}, nil
 }
 
-func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
+func (s *organizationService) ListTeams(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
 	return []*scm.Team{
 		{
 			ID:   0,
@@ -86,7 +86,7 @@ func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm
 	}, nil, nil
 }
 
-func (s *organizationService) ListTeamMembers(ctx context.Context, teamID int, role string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
+func (s *organizationService) ListTeamMembers(ctx context.Context, teamID int, role string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
 	if role != RoleAll {
 		return nil, nil, fmt.Errorf("unsupported role %v (only all supported)", role)
 	}
@@ -101,10 +101,11 @@ func (s *organizationService) ListTeamMembers(ctx context.Context, teamID int, r
 	return members, nil, nil
 }
 
-func (s *organizationService) ListOrgMembers(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
+func (s *organizationService) ListOrgMembers(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
-func (s *organizationService) ListPendingInvitations(_ context.Context, org string, opts scm.ListOptions) ([]*scm.OrganizationPendingInvite, *scm.Response, error) {
+
+func (s *organizationService) ListPendingInvitations(_ context.Context, org string, opts *scm.ListOptions) ([]*scm.OrganizationPendingInvite, *scm.Response, error) {
 	for _, o := range s.data.Organizations {
 		if o.Name == org {
 			return []*scm.OrganizationPendingInvite{{
@@ -117,8 +118,7 @@ func (s *organizationService) ListPendingInvitations(_ context.Context, org stri
 	return nil, nil, scm.ErrNotFound
 }
 
-func (s *organizationService) ListMemberships(ctx context.Context, opts scm.ListOptions) ([]*scm.Membership, *scm.Response, error) {
-
+func (s *organizationService) ListMemberships(ctx context.Context, opts *scm.ListOptions) ([]*scm.Membership, *scm.Response, error) {
 	return []*scm.Membership{
 		{
 			OrganizationName: "test-org1",
@@ -131,7 +131,6 @@ func (s *organizationService) ListMemberships(ctx context.Context, opts scm.List
 			Role:             "member",
 		},
 	}, nil, nil
-
 }
 
 func (s *organizationService) AcceptOrganizationInvitation(_ context.Context, org string) (*scm.Response, error) {

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/pr.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/pr.go
@@ -132,18 +132,18 @@ func filterPullRequests(requests []*scm.PullRequest, opts *scm.PullRequestListOp
 	return returnRequests
 }
 
-func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	f := s.data
 	returnStart, returnEnd := paginated(opts.Page, opts.Size, len(f.PullRequestChanges[number]))
 	return f.PullRequestChanges[number][returnStart:returnEnd], nil, nil
 }
 
-func (s *pullService) ListComments(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
+func (s *pullService) ListComments(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
 	f := s.data
 	return append([]*scm.Comment{}, f.PullRequestComments[number]...), nil, nil
 }
 
-func (s *pullService) ListLabels(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *pullService) ListLabels(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	f := s.data
 	re := regexp.MustCompile(fmt.Sprintf(`^%s#%d:(.*)$`, repo, number))
 	la := []*scm.Label{}
@@ -159,7 +159,7 @@ func (s *pullService) ListLabels(ctx context.Context, repo string, number int, o
 	return la, nil, nil
 }
 
-func (s *pullService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+func (s *pullService) ListEvents(context.Context, string, int, *scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/repo.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/repo.go
@@ -16,7 +16,7 @@ type repositoryService struct {
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	statuses, _, err := s.ListStatus(ctx, repo, ref, scm.ListOptions{})
+	statuses, _, err := s.ListStatus(ctx, repo, ref, &scm.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -47,11 +47,11 @@ func (s *repositoryService) FindPerms(context.Context, string) (*scm.Perm, *scm.
 	panic("implement me")
 }
 
-func (s *repositoryService) ListOrganisation(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) ListOrganisation(context.Context, string, *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	panic("implement me")
 }
 
-func (s *repositoryService) ListUser(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) ListUser(context.Context, string, *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	panic("implement me")
 }
 
@@ -111,7 +111,7 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, login stri
 	return false, nil, nil
 }
 
-func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, ops scm.ListOptions) ([]scm.User, *scm.Response, error) {
+func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, ops *scm.ListOptions) ([]scm.User, *scm.Response, error) {
 	f := s.data
 	result := make([]scm.User, 0, len(f.Collaborators))
 	for _, login := range f.Collaborators {
@@ -129,11 +129,11 @@ func (s *repositoryService) Find(ctx context.Context, fullName string) (*scm.Rep
 	return nil, &scm.Response{Status: 404}, scm.ErrNotFound
 }
 
-func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, opts *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	return s.data.Repositories, nil, nil
 }
 
-func (s *repositoryService) ListLabels(context.Context, string, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *repositoryService) ListLabels(context.Context, string, *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	f := s.data
 	la := []*scm.Label{}
 	for _, l := range f.RepoLabelsExisting {
@@ -142,7 +142,7 @@ func (s *repositoryService) ListLabels(context.Context, string, scm.ListOptions)
 	return la, nil, nil
 }
 
-func (s *repositoryService) ListStatus(ctx context.Context, repo, ref string, opt scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
+func (s *repositoryService) ListStatus(ctx context.Context, repo, ref string, opt *scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
 	f := s.data
 	result := make([]*scm.Status, 0, len(f.Statuses))
 	result = append(result, f.Statuses[ref]...)
@@ -174,7 +174,7 @@ func (s *repositoryService) Fork(ctx context.Context, input *scm.RepositoryInput
 	return s.Create(ctx, input)
 }
 
-func (s *repositoryService) ListHooks(ctx context.Context, fullName string, opts scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
+func (s *repositoryService) ListHooks(ctx context.Context, fullName string, opts *scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
 	return s.data.Hooks[fullName], nil, nil
 }
 

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/review.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/fake/review.go
@@ -12,7 +12,7 @@ type reviewService struct {
 }
 
 func (s *reviewService) Find(ctx context.Context, repo string, number, reviewID int) (*scm.Review, *scm.Response, error) {
-	reviews, r, err := s.List(ctx, repo, number, scm.ListOptions{})
+	reviews, r, err := s.List(ctx, repo, number, &scm.ListOptions{})
 	if err != nil {
 		return nil, r, err
 	}
@@ -24,7 +24,7 @@ func (s *reviewService) Find(ctx context.Context, repo string, number, reviewID 
 	return nil, r, err
 }
 
-func (s *reviewService) List(ctx context.Context, repo string, number int, opt scm.ListOptions) ([]*scm.Review, *scm.Response, error) {
+func (s *reviewService) List(ctx context.Context, repo string, number int, opt *scm.ListOptions) ([]*scm.Review, *scm.Response, error) {
 	f := s.data
 	return append([]*scm.Review{}, f.Reviews[number]...), nil, nil
 }
@@ -45,7 +45,7 @@ func (s *reviewService) Delete(context.Context, string, int, int) (*scm.Response
 	panic("implement me")
 }
 
-func (s *reviewService) ListComments(ctx context.Context, repo string, prID, reviewID int, options scm.ListOptions) ([]*scm.ReviewComment, *scm.Response, error) {
+func (s *reviewService) ListComments(ctx context.Context, repo string, prID, reviewID int, options *scm.ListOptions) ([]*scm.ReviewComment, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/deploy.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/deploy.go
@@ -3,7 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -84,7 +84,7 @@ func (s *deploymentService) Find(ctx context.Context, repoFullName, deploymentID
 	return convertDeployment(out, repoFullName), res, wrapError(res, err)
 }
 
-func (s *deploymentService) List(ctx context.Context, repoFullName string, opts scm.ListOptions) ([]*scm.Deployment, *scm.Response, error) {
+func (s *deploymentService) List(ctx context.Context, repoFullName string, opts *scm.ListOptions) ([]*scm.Deployment, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/deployments?%s", repoFullName, encodeListOptions(opts))
 	out := []*deployment{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -111,7 +111,7 @@ func (s *deploymentService) FindStatus(ctx context.Context, repoFullName, deploy
 	return convertDeploymentStatus(out), res, wrapError(res, err)
 }
 
-func (s *deploymentService) ListStatus(ctx context.Context, repoFullName, deploymentID string, opts scm.ListOptions) ([]*scm.DeploymentStatus, *scm.Response, error) {
+func (s *deploymentService) ListStatus(ctx context.Context, repoFullName, deploymentID string, opts *scm.ListOptions) ([]*scm.DeploymentStatus, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/deployments/%s/statuses?%s", repoFullName, deploymentID, encodeListOptions(opts))
 	out := []*deploymentStatus{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -130,7 +130,7 @@ func wrapError(res *scm.Response, err error) error {
 	if res == nil {
 		return err
 	}
-	data, err2 := ioutil.ReadAll(res.Body)
+	data, err2 := io.ReadAll(res.Body)
 	if err2 != nil {
 		return errors.Wrapf(err, "http status %d", res.Status)
 	}
@@ -151,7 +151,6 @@ func convertDeploymentStatusList(out []*deploymentStatus) []*scm.DeploymentStatu
 		answer = append(answer, convertDeploymentStatus(o))
 	}
 	return answer
-
 }
 
 func convertToDeploymentInput(from *scm.DeploymentInput) *deploymentInput {

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/git.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/git.go
@@ -80,7 +80,7 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/branches?%s", repo, encodeListOptions(opts))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -94,21 +94,21 @@ func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.Comm
 	return convertCommitList(out), res, err
 }
 
-func (s *gitService) ListTags(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+func (s *gitService) ListTags(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/tags?%s", repo, encodeListOptions(opts))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertTagList(out), res, err
 }
 
-func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/commits/%s", repo, ref)
 	out := new(commit)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertChangeList(out.Files), res, err
 }
 
-func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, _ *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	path := fmt.Sprintf("/repos/%s/compare/%s...%s", repo, ref1, ref2)
 	out := new(commit)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/issue.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/issue.go
@@ -125,7 +125,7 @@ func (s *issueService) List(ctx context.Context, repo string, opts scm.IssueList
 	return convertIssueList(out), res, err
 }
 
-func (s *issueService) ListComments(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
+func (s *issueService) ListComments(ctx context.Context, repo string, index int, opts *scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/issues/%d/comments?%s", repo, index, encodeListOptions(opts))
 	out := []*issueComment{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -143,14 +143,14 @@ func (s *issueService) Create(ctx context.Context, repo string, input *scm.Issue
 	return convertIssue(out), res, err
 }
 
-func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/issues/%d/labels?%s", repo, number, encodeListOptions(opts))
 	out := []*label{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertLabelObjects(out), res, err
 }
 
-func (s *issueService) ListEvents(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+func (s *issueService) ListEvents(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/issues/%d/events?%s", repo, number, encodeListOptions(opts))
 	out := []*listedIssueEvent{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/org.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/org.go
@@ -116,22 +116,22 @@ func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organ
 	return convertOrganization(out), res, err
 }
 
-func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
+func (s *organizationService) List(ctx context.Context, opts *scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
 	path := fmt.Sprintf("user/orgs?%s", encodeListOptions(opts))
 	out := []*organization{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertOrganizationList(out), res, err
 }
 
-func (s *organizationService) ListTeams(ctx context.Context, org string, opts scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
+func (s *organizationService) ListTeams(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
 	path := fmt.Sprintf("orgs/%s/teams?%s", org, encodeListOptions(opts))
 	out := []*team{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertTeams(out), res, err
 }
 
-func (s *organizationService) ListOrgMembers(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
-	params := encodeListOptions(ops)
+func (s *organizationService) ListOrgMembers(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
+	params := encodeListOptions(opts)
 
 	req := &scm.Request{
 		Method: http.MethodGet,
@@ -147,7 +147,7 @@ func (s *organizationService) ListOrgMembers(ctx context.Context, org string, op
 	return convertTeamMembers(out), res, err
 }
 
-func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, opts scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
+func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
 	params := encodeListOptionsWith(opts, url.Values{
 		"role": []string{role},
 	})
@@ -168,7 +168,7 @@ func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role 
 
 // ListPendingInvitations lists the pending invitations for an organisation
 // see https://developer.github.com/v3/orgs/members/#list-pending-organization-invitations
-func (s *organizationService) ListPendingInvitations(ctx context.Context, org string, opts scm.ListOptions) ([]*scm.OrganizationPendingInvite, *scm.Response, error) {
+func (s *organizationService) ListPendingInvitations(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.OrganizationPendingInvite, *scm.Response, error) {
 	req := &scm.Request{
 		Method: http.MethodGet,
 		Path:   fmt.Sprintf("orgs/%s/invitations?%s", org, encodeListOptions(opts)),
@@ -180,7 +180,7 @@ func (s *organizationService) ListPendingInvitations(ctx context.Context, org st
 
 // ListMemberships lists organisation memberships for the authenticated user
 // see https://developer.github.com/v3/orgs/members/#list-organization-memberships-for-the-authenticated-user
-func (s *organizationService) ListMemberships(ctx context.Context, opts scm.ListOptions) ([]*scm.Membership, *scm.Response, error) {
+func (s *organizationService) ListMemberships(ctx context.Context, opts *scm.ListOptions) ([]*scm.Membership, *scm.Response, error) {
 	req := &scm.Request{
 		Method: http.MethodGet,
 		Path:   fmt.Sprintf("/user/memberships/orgs?%s", encodeListOptions(opts)),

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/pr.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/pr.go
@@ -37,7 +37,7 @@ func (s *pullService) List(ctx context.Context, repo string, opts *scm.PullReque
 	return convertPullRequestList(out), res, err
 }
 
-func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/pulls/%d/files?%s", repo, number, encodeListOptions(opts))
 	out := []*file{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/repo.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/repo.go
@@ -134,8 +134,8 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 //
 // See 'IsCollaborator' for more details.
 // See https://developer.github.com/v3/repos/collaborators/
-func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, ops scm.ListOptions) ([]scm.User, *scm.Response, error) {
-	params := encodeListOptions(ops)
+func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, opts *scm.ListOptions) ([]scm.User, *scm.Response, error) {
+	params := encodeListOptions(opts)
 
 	req := &scm.Request{
 		Method: http.MethodGet,
@@ -187,7 +187,7 @@ func (s *repositoryService) FindUserPermission(ctx context.Context, repo, user s
 }
 
 // List returns the user repository list.
-func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, opts *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	req := &scm.Request{
 		Method: http.MethodGet,
 		Path:   fmt.Sprintf("user/repos?visibility=all&affiliation=owner&%s", encodeListOptions(opts)),
@@ -203,7 +203,7 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 }
 
 // ListOrganisation returns the repositories for an organisation
-func (s *repositoryService) ListOrganisation(ctx context.Context, org string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) ListOrganisation(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("orgs/%s/repos?%s", org, encodeListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -211,7 +211,7 @@ func (s *repositoryService) ListOrganisation(ctx context.Context, org string, op
 }
 
 // ListUser returns the public repositories for the specified user
-func (s *repositoryService) ListUser(ctx context.Context, user string, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) ListUser(ctx context.Context, user string, opts *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("users/%s/repos?%s", user, encodeListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -219,7 +219,7 @@ func (s *repositoryService) ListUser(ctx context.Context, user string, opts scm.
 }
 
 // ListHooks returns a list or repository hooks.
-func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
+func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/hooks?%s", repo, encodeListOptions(opts))
 	out := []*hook{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -227,7 +227,7 @@ func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts scm
 }
 
 // ListStatus returns a list of commit statuses.
-func (s *repositoryService) ListStatus(ctx context.Context, repo, ref string, opts scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
+func (s *repositoryService) ListStatus(ctx context.Context, repo, ref string, opts *scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/statuses/%s?%s", repo, ref, encodeListOptions(opts))
 	out := []*status{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -244,7 +244,7 @@ func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref st
 	return convertCombinedStatus(out), res, err
 }
 
-func (s *repositoryService) ListLabels(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *repositoryService) ListLabels(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/labels?%s", repo, encodeListOptions(opts))
 	out := []*label{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/review.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/review.go
@@ -23,7 +23,7 @@ func (s *reviewService) Find(ctx context.Context, repo string, number, id int) (
 	return convertReview(out), res, err
 }
 
-func (s *reviewService) List(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Review, *scm.Response, error) {
+func (s *reviewService) List(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Review, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/pulls/%d/reviews?%s", repo, number, encodeListOptions(opts))
 	out := []*review{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
@@ -54,7 +54,7 @@ func (s *reviewService) Delete(ctx context.Context, repo string, number, id int)
 	return s.client.do(ctx, "DELETE", path, nil, nil)
 }
 
-func (s *reviewService) ListComments(ctx context.Context, repo string, prID, reviewID int, options scm.ListOptions) ([]*scm.ReviewComment, *scm.Response, error) {
+func (s *reviewService) ListComments(ctx context.Context, repo string, prID, reviewID int, options *scm.ListOptions) ([]*scm.ReviewComment, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/pulls/%d/reviews/%d/comments?%s", repo, prID, reviewID, encodeListOptions(options))
 	out := []*reviewComment{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/util.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/util.go
@@ -15,11 +15,11 @@ import (
 // NormLogin normalizes GitHub login strings
 var NormLogin = strings.ToLower
 
-func encodeListOptions(opts scm.ListOptions) string {
+func encodeListOptions(opts *scm.ListOptions) string {
 	return encodeListOptionsWith(opts, url.Values{})
 }
 
-func encodeListOptionsWith(opts scm.ListOptions, params url.Values) string {
+func encodeListOptionsWith(opts *scm.ListOptions, params url.Values) string {
 	if opts.Page != 0 {
 		params.Set("page", strconv.Itoa(opts.Page))
 	}

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/github/webhook.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/github/webhook.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
@@ -26,7 +25,7 @@ type webhookService struct {
 }
 
 func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhook, error) {
-	data, err := ioutil.ReadAll(
+	data, err := io.ReadAll(
 		io.LimitReader(req.Body, 10000000),
 	)
 	if err != nil {

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/git.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/git.go
@@ -23,7 +23,6 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	path := fmt.Sprintf("api/v4/projects/%s/repository/commits?ref_name=%s", encode(repo), ref)
 	out := []*commit{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-
 	if err != nil {
 		return "", res, err
 	}
@@ -38,7 +37,6 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 		ref = ref[idx+1:]
 	}
 	return ref, res, err
-
 }
 
 func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
@@ -88,8 +86,8 @@ func (s *gitService) FindTag(ctx context.Context, repo, name string) (*scm.Refer
 	return convertTag(out), res, err
 }
 
-func (s *gitService) ListBranches(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?%s", encode(repo), encodeListOptions(&opts))
+func (s *gitService) ListBranches(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/repository/branches?%s", encode(repo), encodeListOptions(opts))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertBranchList(out), res, err
@@ -102,24 +100,24 @@ func (s *gitService) ListCommits(ctx context.Context, repo string, opts scm.Comm
 	return convertCommitList(out), res, err
 }
 
-func (s *gitService) ListTags(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/tags?%s", encode(repo), encodeListOptions(&opts))
+func (s *gitService) ListTags(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/repository/tags?%s", encode(repo), encodeListOptions(opts))
 	out := []*branch{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertTagList(out), res, err
 }
 
-func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/repository/commits/%s/diff", encode(repo), encode(ref))
 	out := []*change{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertChangeList(out), res, err
 }
 
-func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	opts.From = encode(ref1)
 	opts.To = encode(ref2)
-	path := fmt.Sprintf("api/v4/projects/%s/repository/compare?%s", encode(repo), encodeListOptions(&opts))
+	path := fmt.Sprintf("api/v4/projects/%s/repository/compare?%s", encode(repo), encodeListOptions(opts))
 	out := compare{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertChangeList(out.Diffs), res, err

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/issue.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/issue.go
@@ -80,14 +80,14 @@ func (s *issueService) UnassignIssue(ctx context.Context, repo string, number in
 	return s.setAssignees(ctx, repo, number, assignees)
 }
 
-func (s *issueService) ListEvents(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/issues/%d/resource_label_events?%s", encode(repo), index, encodeListOptions(&opts))
+func (s *issueService) ListEvents(ctx context.Context, repo string, index int, opts *scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/issues/%d/resource_label_events?%s", encode(repo), index, encodeListOptions(opts))
 	out := []*labelEvent{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertLabelEvents(out), res, err
 }
 
-func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	issue, issueResp, err := s.Find(ctx, repo, number)
 	if err != nil {
 		return nil, issueResp, err
@@ -102,7 +102,7 @@ func (s *issueService) ListLabels(ctx context.Context, repo string, number int, 
 }
 
 func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	existingLabels, _, err := s.ListLabels(ctx, repo, number, scm.ListOptions{})
+	existingLabels, _, err := s.ListLabels(ctx, repo, number, &scm.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (s *issueService) setLabels(ctx context.Context, repo string, number int, l
 }
 
 func (s *issueService) DeleteLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	existingLabels, _, err := s.ListLabels(ctx, repo, number, scm.ListOptions{})
+	existingLabels, _, err := s.ListLabels(ctx, repo, number, &scm.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -165,8 +165,8 @@ func (s *issueService) List(ctx context.Context, repo string, opts scm.IssueList
 	return convertIssueList(out), res, err
 }
 
-func (s *issueService) ListComments(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/issues/%d/notes?%s", encode(repo), index, encodeListOptions(&opts))
+func (s *issueService) ListComments(ctx context.Context, repo string, index int, opts *scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/issues/%d/notes?%s", encode(repo), index, encodeListOptions(opts))
 	out := []*issueComment{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertIssueCommentList(out), res, err

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/org.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/org.go
@@ -29,7 +29,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 	var users []scm.User
 	var err error
 	firstRun := false
-	opts := scm.ListOptions{
+	opts := &scm.ListOptions{
 		Page: 1,
 	}
 	for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
@@ -53,18 +53,18 @@ func (s *organizationService) IsAdmin(ctx context.Context, org, user string) (bo
 	return false, nil, nil
 }
 
-func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
+func (s *organizationService) ListTeams(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
 	// TODO implement me
 	return nil, nil, nil
 }
 
-func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
+func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
 	// TODO implement me
 	return nil, nil, nil
 }
 
-func (s *organizationService) ListOrgMembers(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
-	users, res, err := s.ListMemberUsers(ctx, org, ops)
+func (s *organizationService) ListOrgMembers(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
+	users, res, err := s.ListMemberUsers(ctx, org, opts)
 	if err != nil {
 		return nil, res, err
 	}
@@ -75,8 +75,8 @@ func (s *organizationService) ListOrgMembers(ctx context.Context, org string, op
 	return members, res, nil
 }
 
-func (s *organizationService) ListMemberUsers(ctx context.Context, org string, opts scm.ListOptions) ([]scm.User, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/groups/%s/members/all?%s", org, encodeListOptions(&opts))
+func (s *organizationService) ListMemberUsers(ctx context.Context, org string, opts *scm.ListOptions) ([]scm.User, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/groups/%s/members/all?%s", org, encodeListOptions(opts))
 	out := []*user{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertUserList(out), res, err
@@ -89,14 +89,14 @@ func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organ
 	return convertOrganization(out), res, err
 }
 
-func (s *organizationService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/groups?%s", encodeListOptions(&opts))
+func (s *organizationService) List(ctx context.Context, opts *scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/groups?%s", encodeListOptions(opts))
 	out := []*organization{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertOrganizationList(out), res, err
 }
 
-func (s *organizationService) ListPendingInvitations(ctx context.Context, org string, opts scm.ListOptions) ([]*scm.OrganizationPendingInvite, *scm.Response, error) {
+func (s *organizationService) ListPendingInvitations(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.OrganizationPendingInvite, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 
@@ -104,7 +104,7 @@ func (s *organizationService) AcceptOrganizationInvitation(ctx context.Context, 
 	return nil, scm.ErrNotSupported
 }
 
-func (s *organizationService) ListMemberships(ctx context.Context, opts scm.ListOptions) ([]*scm.Membership, *scm.Response, error) {
+func (s *organizationService) ListMemberships(ctx context.Context, opts *scm.ListOptions) ([]*scm.Membership, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/pr.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/pr.go
@@ -55,21 +55,21 @@ func (s *pullService) List(ctx context.Context, repo string, opts *scm.PullReque
 	return convRepos, res, nil
 }
 
-func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/merge_requests/%d/changes?%s", encode(repo), number, encodeListOptions(&opts))
+func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/merge_requests/%d/changes?%s", encode(repo), number, encodeListOptions(opts))
 	out := new(changes)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertChangeList(out.Changes), res, err
 }
 
-func (s *pullService) ListComments(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/merge_requests/%d/notes?%s", encode(repo), index, encodeListOptions(&opts))
+func (s *pullService) ListComments(ctx context.Context, repo string, index int, opts *scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/merge_requests/%d/notes?%s", encode(repo), index, encodeListOptions(opts))
 	out := []*issueComment{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertIssueCommentList(out), res, err
 }
 
-func (s *pullService) ListLabels(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+func (s *pullService) ListLabels(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
 	mr, _, err := s.Find(ctx, repo, number)
 	if err != nil {
 		return nil, nil, err
@@ -78,8 +78,8 @@ func (s *pullService) ListLabels(ctx context.Context, repo string, number int, o
 	return mr.Labels, nil, nil
 }
 
-func (s *pullService) ListEvents(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/merge_requests/%d/resource_label_events?%s", encode(repo), index, encodeListOptions(&opts))
+func (s *pullService) ListEvents(ctx context.Context, repo string, index int, opts *scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/merge_requests/%d/resource_label_events?%s", encode(repo), index, encodeListOptions(opts))
 	out := []*labelEvent{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertLabelEvents(out), res, err

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/repo.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/repo.go
@@ -122,7 +122,6 @@ type member struct {
 	// Fields to be figured out later
 	// expires_at - a yyyy-mm-dd date
 	// group_saml_identity
-
 }
 
 type repositoryService struct {
@@ -183,7 +182,7 @@ func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref st
 	var statusesByPage []*scm.Status
 	var err error
 	firstRun := false
-	opts := scm.ListOptions{
+	opts := &scm.ListOptions{
 		Page: 1,
 	}
 	for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
@@ -216,11 +215,11 @@ func (s *repositoryService) FindUserPermission(ctx context.Context, repo, user s
 	var resp *scm.Response
 	var err error
 	firstRun := false
-	opts := scm.ListOptions{
+	opts := &scm.ListOptions{
 		Page: 1,
 	}
 	for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
-		path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", encode(repo), encodeListOptions(&opts))
+		path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", encode(repo), encodeListOptions(opts))
 		out := []*member{}
 		resp, err = s.client.do(ctx, "GET", path, nil, &out)
 		if err != nil {
@@ -263,7 +262,7 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 	var users []scm.User
 	var err error
 	firstRun := false
-	opts := scm.ListOptions{
+	opts := &scm.ListOptions{
 		Page: 1,
 	}
 	for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
@@ -282,15 +281,15 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 	return false, resp, err
 }
 
-func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, ops scm.ListOptions) ([]scm.User, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", encode(repo), encodeListOptions(&ops))
+func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, opts *scm.ListOptions) ([]scm.User, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", encode(repo), encodeListOptions(opts))
 	out := []*user{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertUserList(out), res, err
 }
 
-func (s *repositoryService) ListLabels(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/labels?%s", encode(repo), encodeListOptions(&opts))
+func (s *repositoryService) ListLabels(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/labels?%s", encode(repo), encodeListOptions(opts))
 	out := []*label{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertLabelObjects(out), res, err
@@ -317,30 +316,30 @@ func (s *repositoryService) FindPerms(ctx context.Context, repo string) (*scm.Pe
 	return convertRepository(out).Perm, res, err
 }
 
-func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) List(ctx context.Context, opts *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects?%s", encodeMemberListOptions(opts))
 	out := []*repository{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertRepositoryList(out), res, err
 }
 
-func (s *repositoryService) ListOrganisation(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) ListOrganisation(context.Context, string, *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *repositoryService) ListUser(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
+func (s *repositoryService) ListUser(context.Context, string, *scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/hooks?%s", encode(repo), encodeListOptions(&opts))
+func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/hooks?%s", encode(repo), encodeListOptions(opts))
 	out := []*hook{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertHookList(out), res, err
 }
 
-func (s *repositoryService) ListStatus(ctx context.Context, repo, ref string, opts scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/commits/%s/statuses?%s", encode(repo), ref, encodeListOptions(&opts))
+func (s *repositoryService) ListStatus(ctx context.Context, repo, ref string, opts *scm.ListOptions) ([]*scm.Status, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/repository/commits/%s/statuses?%s", encode(repo), ref, encodeListOptions(opts))
 	out := []*status{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertStatusList(out), res, err

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/review.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/review.go
@@ -18,7 +18,7 @@ func (s *reviewService) Find(ctx context.Context, repo string, number, id int) (
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *reviewService) List(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Review, *scm.Response, error) {
+func (s *reviewService) List(ctx context.Context, repo string, number int, opts *scm.ListOptions) ([]*scm.Review, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 
@@ -30,7 +30,7 @@ func (s *reviewService) Delete(ctx context.Context, repo string, number, id int)
 	return nil, scm.ErrNotSupported
 }
 
-func (s *reviewService) ListComments(ctx context.Context, repo string, prID, reviewID int, options scm.ListOptions) ([]*scm.ReviewComment, *scm.Response, error) {
+func (s *reviewService) ListComments(ctx context.Context, repo string, prID, reviewID int, options *scm.ListOptions) ([]*scm.ReviewComment, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/user.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/user.go
@@ -36,12 +36,12 @@ func (s *userService) FindLogin(ctx context.Context, login string) (*scm.User, *
 	var resp *scm.Response
 	var err error
 	firstRun := false
-	opts := scm.ListOptions{
+	opts := &scm.ListOptions{
 		Page: 1,
 	}
 	for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
 		out := []*user{}
-		path := fmt.Sprintf("api/v4/users?search=%s&%s", login, encodeListOptions(&opts))
+		path := fmt.Sprintf("api/v4/users?search=%s&%s", login, encodeListOptions(opts))
 		resp, err = s.client.do(ctx, "GET", path, nil, &out)
 		if err != nil {
 			return nil, nil, err

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/util.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/util.go
@@ -36,7 +36,7 @@ func encodeListOptions(opts *scm.ListOptions) string {
 	return params.Encode()
 }
 
-func encodeMemberListOptions(opts scm.ListOptions) string {
+func encodeMemberListOptions(opts *scm.ListOptions) string {
 	params := url.Values{}
 	params.Set("membership", "true")
 	if opts.Page != 0 {

--- a/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/webhook.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/driver/gitlab/webhook.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -30,7 +29,7 @@ type webhookUserService interface {
 }
 
 func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhook, error) {
-	data, err := ioutil.ReadAll(
+	data, err := io.ReadAll(
 		io.LimitReader(req.Body, 10000000),
 	)
 	if err != nil {

--- a/vendor/github.com/jenkins-x/go-scm/scm/git.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/git.go
@@ -69,19 +69,19 @@ type (
 		FindTag(ctx context.Context, repo, name string) (*Reference, *Response, error)
 
 		// ListBranches returns a list of git branches.
-		ListBranches(ctx context.Context, repo string, opts ListOptions) ([]*Reference, *Response, error)
+		ListBranches(ctx context.Context, repo string, opts *ListOptions) ([]*Reference, *Response, error)
 
 		// ListCommits returns a list of git commits.
 		ListCommits(ctx context.Context, repo string, opts CommitListOptions) ([]*Commit, *Response, error)
 
 		// ListChanges returns the changeset between a commit and its parent.
-		ListChanges(ctx context.Context, repo, ref string, opts ListOptions) ([]*Change, *Response, error)
+		ListChanges(ctx context.Context, repo, ref string, opts *ListOptions) ([]*Change, *Response, error)
 
 		// ListChanges returns the changeset between two commits.
-		CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts ListOptions) ([]*Change, *Response, error)
+		CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts *ListOptions) ([]*Change, *Response, error)
 
 		// ListTags returns a list of git tags.
-		ListTags(ctx context.Context, repo string, opts ListOptions) ([]*Reference, *Response, error)
+		ListTags(ctx context.Context, repo string, opts *ListOptions) ([]*Reference, *Response, error)
 
 		// FindRef returns the SHA of the given ref, such as "heads/master".
 		FindRef(ctx context.Context, repo, ref string) (string, *Response, error)

--- a/vendor/github.com/jenkins-x/go-scm/scm/issue.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/issue.go
@@ -98,13 +98,13 @@ type (
 		Search(context.Context, SearchOptions) ([]*SearchIssue, *Response, error)
 
 		// ListComments returns the issue comment list.
-		ListComments(context.Context, string, int, ListOptions) ([]*Comment, *Response, error)
+		ListComments(context.Context, string, int, *ListOptions) ([]*Comment, *Response, error)
 
 		// ListLabels returns the labels on an issue
-		ListLabels(context.Context, string, int, ListOptions) ([]*Label, *Response, error)
+		ListLabels(context.Context, string, int, *ListOptions) ([]*Label, *Response, error)
 
 		// ListEvents returns the events creating and removing the labels on an issue
-		ListEvents(context.Context, string, int, ListOptions) ([]*ListedIssueEvent, *Response, error)
+		ListEvents(context.Context, string, int, *ListOptions) ([]*ListedIssueEvent, *Response, error)
 
 		// Create creates a new issue.
 		Create(context.Context, string, *IssueInput) (*Issue, *Response, error)

--- a/vendor/github.com/jenkins-x/go-scm/scm/org.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/org.go
@@ -79,10 +79,10 @@ type (
 		Delete(context.Context, string) (*Response, error)
 
 		// List returns the user organization list.
-		List(context.Context, ListOptions) ([]*Organization, *Response, error)
+		List(context.Context, *ListOptions) ([]*Organization, *Response, error)
 
 		// ListTeams returns the user organization list.
-		ListTeams(ctx context.Context, org string, ops ListOptions) ([]*Team, *Response, error)
+		ListTeams(ctx context.Context, org string, ops *ListOptions) ([]*Team, *Response, error)
 
 		// IsMember returns true if the user is a member of the organization
 		IsMember(ctx context.Context, org string, user string) (bool, *Response, error)
@@ -91,18 +91,18 @@ type (
 		IsAdmin(ctx context.Context, org string, user string) (bool, *Response, error)
 
 		// ListTeamMembers lists the members of a team with a given role
-		ListTeamMembers(ctx context.Context, id int, role string, ops ListOptions) ([]*TeamMember, *Response, error)
+		ListTeamMembers(ctx context.Context, id int, role string, ops *ListOptions) ([]*TeamMember, *Response, error)
 
 		// ListOrgMembers lists the members of the organization
-		ListOrgMembers(ctx context.Context, org string, ops ListOptions) ([]*TeamMember, *Response, error)
+		ListOrgMembers(ctx context.Context, org string, ops *ListOptions) ([]*TeamMember, *Response, error)
 
 		// ListPendingInvitations lists the pending invitations for an organisation
-		ListPendingInvitations(ctx context.Context, org string, ops ListOptions) ([]*OrganizationPendingInvite, *Response, error)
+		ListPendingInvitations(ctx context.Context, org string, ops *ListOptions) ([]*OrganizationPendingInvite, *Response, error)
 
 		// AcceptPendingInvitation accepts a pending invitation for an organisation
 		AcceptOrganizationInvitation(ctx context.Context, org string) (*Response, error)
 
 		// ListMemberships lists organisation memberships for the authenticated user
-		ListMemberships(ctx context.Context, opts ListOptions) ([]*Membership, *Response, error)
+		ListMemberships(ctx context.Context, opts *ListOptions) ([]*Membership, *Response, error)
 	}
 )

--- a/vendor/github.com/jenkins-x/go-scm/scm/pr.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/pr.go
@@ -134,16 +134,16 @@ type (
 		List(context.Context, string, *PullRequestListOptions) ([]*PullRequest, *Response, error)
 
 		// ListChanges returns the pull request changeset.
-		ListChanges(context.Context, string, int, ListOptions) ([]*Change, *Response, error)
+		ListChanges(context.Context, string, int, *ListOptions) ([]*Change, *Response, error)
 
 		// ListComments returns the pull request comment list.
-		ListComments(context.Context, string, int, ListOptions) ([]*Comment, *Response, error)
+		ListComments(context.Context, string, int, *ListOptions) ([]*Comment, *Response, error)
 
 		// ListLabels returns the labels on a pull request
-		ListLabels(context.Context, string, int, ListOptions) ([]*Label, *Response, error)
+		ListLabels(context.Context, string, int, *ListOptions) ([]*Label, *Response, error)
 
 		// ListEvents returns the events creating and removing the labels on an pull request
-		ListEvents(context.Context, string, int, ListOptions) ([]*ListedIssueEvent, *Response, error)
+		ListEvents(context.Context, string, int, *ListOptions) ([]*ListedIssueEvent, *Response, error)
 
 		// Merge merges the repository pull request.
 		Merge(context.Context, string, int, *PullRequestMergeOptions) (*Response, error)

--- a/vendor/github.com/jenkins-x/go-scm/scm/repo.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/repo.go
@@ -134,22 +134,22 @@ type (
 		FindPerms(context.Context, string) (*Perm, *Response, error)
 
 		// List returns a list of repositories.
-		List(context.Context, ListOptions) ([]*Repository, *Response, error)
+		List(context.Context, *ListOptions) ([]*Repository, *Response, error)
 
 		// List returns a list of repositories for a given organisation
-		ListOrganisation(context.Context, string, ListOptions) ([]*Repository, *Response, error)
+		ListOrganisation(context.Context, string, *ListOptions) ([]*Repository, *Response, error)
 
 		// List returns a list of repositories for a given user.
-		ListUser(context.Context, string, ListOptions) ([]*Repository, *Response, error)
+		ListUser(context.Context, string, *ListOptions) ([]*Repository, *Response, error)
 
 		// ListLabels returns the labels on a repo
-		ListLabels(context.Context, string, ListOptions) ([]*Label, *Response, error)
+		ListLabels(context.Context, string, *ListOptions) ([]*Label, *Response, error)
 
 		// ListHooks returns a list or repository hooks.
-		ListHooks(context.Context, string, ListOptions) ([]*Hook, *Response, error)
+		ListHooks(context.Context, string, *ListOptions) ([]*Hook, *Response, error)
 
 		// ListStatus returns a list of commit statuses.
-		ListStatus(context.Context, string, string, ListOptions) ([]*Status, *Response, error)
+		ListStatus(context.Context, string, string, *ListOptions) ([]*Status, *Response, error)
 
 		// FindCombinedStatus returns the combined status for a ref
 		FindCombinedStatus(ctx context.Context, repo, ref string) (*CombinedStatus, *Response, error)
@@ -179,7 +179,7 @@ type (
 		AddCollaborator(ctx context.Context, repo, user, permission string) (bool, bool, *Response, error)
 
 		// ListCollaborators lists the collaborators on a repository
-		ListCollaborators(ctx context.Context, repo string, ops ListOptions) ([]User, *Response, error)
+		ListCollaborators(ctx context.Context, repo string, ops *ListOptions) ([]User, *Response, error)
 
 		// FindUserPermission returns the user's permission level for a repo
 		FindUserPermission(ctx context.Context, repo string, user string) (string, *Response, error)

--- a/vendor/github.com/jenkins-x/go-scm/scm/review.go
+++ b/vendor/github.com/jenkins-x/go-scm/scm/review.go
@@ -74,7 +74,7 @@ type (
 		Find(context.Context, string, int, int) (*Review, *Response, error)
 
 		// List returns the review list.
-		List(context.Context, string, int, ListOptions) ([]*Review, *Response, error)
+		List(context.Context, string, int, *ListOptions) ([]*Review, *Response, error)
 
 		// Create creates a review.
 		Create(context.Context, string, int, *ReviewInput) (*Review, *Response, error)
@@ -83,7 +83,7 @@ type (
 		Delete(context.Context, string, int, int) (*Response, error)
 
 		// ListComments returns comments from a review
-		ListComments(context.Context, string, int, int, ListOptions) ([]*ReviewComment, *Response, error)
+		ListComments(context.Context, string, int, int, *ListOptions) ([]*ReviewComment, *Response, error)
 
 		// Update updates the body of a review
 		Update(context.Context, string, int, int, string) (*Review, *Response, error)

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare.go
@@ -1,8 +1,10 @@
 package assert
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
+	"time"
 )
 
 type CompareType int
@@ -30,6 +32,9 @@ var (
 	float64Type = reflect.TypeOf(float64(1))
 
 	stringType = reflect.TypeOf("")
+
+	timeType  = reflect.TypeOf(time.Time{})
+	bytesType = reflect.TypeOf([]byte{})
 )
 
 func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
@@ -299,6 +304,47 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 				return compareLess, true
 			}
 		}
+	// Check for known struct types we can check for compare results.
+	case reflect.Struct:
+		{
+			// All structs enter here. We're not interested in most types.
+			if !canConvert(obj1Value, timeType) {
+				break
+			}
+
+			// time.Time can compared!
+			timeObj1, ok := obj1.(time.Time)
+			if !ok {
+				timeObj1 = obj1Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			timeObj2, ok := obj2.(time.Time)
+			if !ok {
+				timeObj2 = obj2Value.Convert(timeType).Interface().(time.Time)
+			}
+
+			return compare(timeObj1.UnixNano(), timeObj2.UnixNano(), reflect.Int64)
+		}
+	case reflect.Slice:
+		{
+			// We only care about the []byte type.
+			if !canConvert(obj1Value, bytesType) {
+				break
+			}
+
+			// []byte can be compared!
+			bytesObj1, ok := obj1.([]byte)
+			if !ok {
+				bytesObj1 = obj1Value.Convert(bytesType).Interface().([]byte)
+
+			}
+			bytesObj2, ok := obj2.([]byte)
+			if !ok {
+				bytesObj2 = obj2Value.Convert(bytesType).Interface().([]byte)
+			}
+
+			return CompareType(bytes.Compare(bytesObj1, bytesObj2)), true
+		}
 	}
 
 	return compareEqual, false
@@ -310,7 +356,10 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 //    assert.Greater(t, float64(2), float64(1))
 //    assert.Greater(t, "b", "a")
 func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // GreaterOrEqual asserts that the first element is greater than or equal to the second
@@ -320,7 +369,10 @@ func Greater(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface
 //    assert.GreaterOrEqual(t, "b", "a")
 //    assert.GreaterOrEqual(t, "b", "b")
 func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareGreater, compareEqual}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Less asserts that the first element is less than the second
@@ -329,7 +381,10 @@ func GreaterOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...in
 //    assert.Less(t, float64(1), float64(2))
 //    assert.Less(t, "a", "b")
 func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // LessOrEqual asserts that the first element is less than or equal to the second
@@ -339,7 +394,10 @@ func Less(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{})
 //    assert.LessOrEqual(t, "a", "b")
 //    assert.LessOrEqual(t, "b", "b")
 func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...interface{}) bool {
-	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return compareTwoValues(t, e1, e2, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }
 
 // Positive asserts that the specified element is positive
@@ -347,8 +405,11 @@ func LessOrEqual(t TestingT, e1 interface{}, e2 interface{}, msgAndArgs ...inter
 //    assert.Positive(t, 1)
 //    assert.Positive(t, 1.23)
 func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareGreater}, "\"%v\" is not positive", msgAndArgs...)
 }
 
 // Negative asserts that the specified element is negative
@@ -356,8 +417,11 @@ func Positive(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
 //    assert.Negative(t, -1)
 //    assert.Negative(t, -1.23)
 func Negative(t TestingT, e interface{}, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
 	zero := reflect.Zero(reflect.TypeOf(e))
-	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs)
+	return compareTwoValues(t, e, zero.Interface(), []CompareType{compareLess}, "\"%v\" is not negative", msgAndArgs...)
 }
 
 func compareTwoValues(t TestingT, e1 interface{}, e2 interface{}, allowedComparesResults []CompareType, failMessage string, msgAndArgs ...interface{}) bool {

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare_can_convert.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare_can_convert.go
@@ -1,0 +1,16 @@
+//go:build go1.17
+// +build go1.17
+
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_go1.17_test.go and
+//       assertion_compare_legacy.go
+
+package assert
+
+import "reflect"
+
+// Wrapper around reflect.Value.CanConvert, for compatibility
+// reasons.
+func canConvert(value reflect.Value, to reflect.Type) bool {
+	return value.CanConvert(to)
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_compare_legacy.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_compare_legacy.go
@@ -1,0 +1,16 @@
+//go:build !go1.17
+// +build !go1.17
+
+// TODO: once support for Go 1.16 is dropped, this file can be
+//       merged/removed with assertion_compare_go1.17_test.go and
+//       assertion_compare_can_convert.go
+
+package assert
+
+import "reflect"
+
+// Older versions of Go does not have the reflect.Value.CanConvert
+// method.
+func canConvert(value reflect.Value, to reflect.Type) bool {
+	return false
+}

--- a/vendor/github.com/stretchr/testify/assert/assertion_format.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_format.go
@@ -123,6 +123,18 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 	return ErrorAs(t, err, target, append([]interface{}{msg}, args...)...)
 }
 
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(t, theError, contains, append([]interface{}{msg}, args...)...)
+}
+
 // ErrorIsf asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func ErrorIsf(t TestingT, err error, target error, msg string, args ...interface{}) bool {
@@ -722,6 +734,16 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 		h.Helper()
 	}
 	return WithinDuration(t, expected, actual, delta, append([]interface{}{msg}, args...)...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinRange(t, actual, start, end, append([]interface{}{msg}, args...)...)
 }
 
 // YAMLEqf asserts that two YAML strings are equivalent.

--- a/vendor/github.com/stretchr/testify/assert/assertion_forward.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_forward.go
@@ -222,6 +222,30 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 	return ErrorAsf(a.t, err, target, msg, args...)
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) bool {
@@ -1435,6 +1459,26 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 		h.Helper()
 	}
 	return WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//   a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//   a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) bool {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	return WithinRangef(a.t, actual, start, end, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/vendor/github.com/stretchr/testify/assert/assertion_order.go
+++ b/vendor/github.com/stretchr/testify/assert/assertion_order.go
@@ -50,7 +50,7 @@ func isOrdered(t TestingT, object interface{}, allowedComparesResults []CompareT
 //    assert.IsIncreasing(t, []float{1, 2})
 //    assert.IsIncreasing(t, []string{"a", "b"})
 func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareLess}, "\"%v\" is not less than \"%v\"", msgAndArgs...)
 }
 
 // IsNonIncreasing asserts that the collection is not increasing
@@ -59,7 +59,7 @@ func IsIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //    assert.IsNonIncreasing(t, []float{2, 1})
 //    assert.IsNonIncreasing(t, []string{"b", "a"})
 func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareEqual, compareGreater}, "\"%v\" is not greater than or equal to \"%v\"", msgAndArgs...)
 }
 
 // IsDecreasing asserts that the collection is decreasing
@@ -68,7 +68,7 @@ func IsNonIncreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) 
 //    assert.IsDecreasing(t, []float{2, 1})
 //    assert.IsDecreasing(t, []string{"b", "a"})
 func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareGreater}, "\"%v\" is not greater than \"%v\"", msgAndArgs...)
 }
 
 // IsNonDecreasing asserts that the collection is not decreasing
@@ -77,5 +77,5 @@ func IsDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) boo
 //    assert.IsNonDecreasing(t, []float{1, 2})
 //    assert.IsNonDecreasing(t, []string{"a", "b"})
 func IsNonDecreasing(t TestingT, object interface{}, msgAndArgs ...interface{}) bool {
-	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs)
+	return isOrdered(t, object, []CompareType{compareLess, compareEqual}, "\"%v\" is not less than or equal to \"%v\"", msgAndArgs...)
 }

--- a/vendor/github.com/stretchr/testify/assert/assertions.go
+++ b/vendor/github.com/stretchr/testify/assert/assertions.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -144,7 +145,8 @@ func CallerInfo() []string {
 		if len(parts) > 1 {
 			dir := parts[len(parts)-2]
 			if (dir != "assert" && dir != "mock" && dir != "require") || file == "mock_test.go" {
-				callers = append(callers, fmt.Sprintf("%s:%d", file, line))
+				path, _ := filepath.Abs(file)
+				callers = append(callers, fmt.Sprintf("%s:%d", path, line))
 			}
 		}
 
@@ -563,16 +565,17 @@ func isEmpty(object interface{}) bool {
 
 	switch objValue.Kind() {
 	// collection types are empty when they have no element
-	case reflect.Array, reflect.Chan, reflect.Map, reflect.Slice:
+	case reflect.Chan, reflect.Map, reflect.Slice:
 		return objValue.Len() == 0
-		// pointers are empty if nil or if the value they point to is empty
+	// pointers are empty if nil or if the value they point to is empty
 	case reflect.Ptr:
 		if objValue.IsNil() {
 			return true
 		}
 		deref := objValue.Elem().Interface()
 		return isEmpty(deref)
-		// for all other types, compare against the zero value
+	// for all other types, compare against the zero value
+	// array types are empty when they match their zero-initialized state
 	default:
 		zero := reflect.Zero(objValue.Type())
 		return reflect.DeepEqual(object, zero.Interface())
@@ -718,10 +721,14 @@ func NotEqualValues(t TestingT, expected, actual interface{}, msgAndArgs ...inte
 // return (false, false) if impossible.
 // return (true, false) if element was not found.
 // return (true, true) if element was found.
-func includeElement(list interface{}, element interface{}) (ok, found bool) {
+func containsElement(list interface{}, element interface{}) (ok, found bool) {
 
 	listValue := reflect.ValueOf(list)
-	listKind := reflect.TypeOf(list).Kind()
+	listType := reflect.TypeOf(list)
+	if listType == nil {
+		return false, false
+	}
+	listKind := listType.Kind()
 	defer func() {
 		if e := recover(); e != nil {
 			ok = false
@@ -764,7 +771,7 @@ func Contains(t TestingT, s, contains interface{}, msgAndArgs ...interface{}) bo
 		h.Helper()
 	}
 
-	ok, found := includeElement(s, contains)
+	ok, found := containsElement(s, contains)
 	if !ok {
 		return Fail(t, fmt.Sprintf("%#v could not be applied builtin len()", s), msgAndArgs...)
 	}
@@ -787,7 +794,7 @@ func NotContains(t TestingT, s, contains interface{}, msgAndArgs ...interface{})
 		h.Helper()
 	}
 
-	ok, found := includeElement(s, contains)
+	ok, found := containsElement(s, contains)
 	if !ok {
 		return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", s), msgAndArgs...)
 	}
@@ -811,7 +818,6 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 		return true // we consider nil to be equal to the nil set
 	}
 
-	subsetValue := reflect.ValueOf(subset)
 	defer func() {
 		if e := recover(); e != nil {
 			ok = false
@@ -821,17 +827,35 @@ func Subset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) (ok
 	listKind := reflect.TypeOf(list).Kind()
 	subsetKind := reflect.TypeOf(subset).Kind()
 
-	if listKind != reflect.Array && listKind != reflect.Slice {
+	if listKind != reflect.Array && listKind != reflect.Slice && listKind != reflect.Map {
 		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", list, listKind), msgAndArgs...)
 	}
 
-	if subsetKind != reflect.Array && subsetKind != reflect.Slice {
+	if subsetKind != reflect.Array && subsetKind != reflect.Slice && listKind != reflect.Map {
 		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", subset, subsetKind), msgAndArgs...)
+	}
+
+	subsetValue := reflect.ValueOf(subset)
+	if subsetKind == reflect.Map && listKind == reflect.Map {
+		listValue := reflect.ValueOf(list)
+		subsetKeys := subsetValue.MapKeys()
+
+		for i := 0; i < len(subsetKeys); i++ {
+			subsetKey := subsetKeys[i]
+			subsetElement := subsetValue.MapIndex(subsetKey).Interface()
+			listElement := listValue.MapIndex(subsetKey).Interface()
+
+			if !ObjectsAreEqual(subsetElement, listElement) {
+				return Fail(t, fmt.Sprintf("\"%s\" does not contain \"%s\"", list, subsetElement), msgAndArgs...)
+			}
+		}
+
+		return true
 	}
 
 	for i := 0; i < subsetValue.Len(); i++ {
 		element := subsetValue.Index(i).Interface()
-		ok, found := includeElement(list, element)
+		ok, found := containsElement(list, element)
 		if !ok {
 			return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", list), msgAndArgs...)
 		}
@@ -852,10 +876,9 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 		h.Helper()
 	}
 	if subset == nil {
-		return Fail(t, fmt.Sprintf("nil is the empty set which is a subset of every set"), msgAndArgs...)
+		return Fail(t, "nil is the empty set which is a subset of every set", msgAndArgs...)
 	}
 
-	subsetValue := reflect.ValueOf(subset)
 	defer func() {
 		if e := recover(); e != nil {
 			ok = false
@@ -865,17 +888,35 @@ func NotSubset(t TestingT, list, subset interface{}, msgAndArgs ...interface{}) 
 	listKind := reflect.TypeOf(list).Kind()
 	subsetKind := reflect.TypeOf(subset).Kind()
 
-	if listKind != reflect.Array && listKind != reflect.Slice {
+	if listKind != reflect.Array && listKind != reflect.Slice && listKind != reflect.Map {
 		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", list, listKind), msgAndArgs...)
 	}
 
-	if subsetKind != reflect.Array && subsetKind != reflect.Slice {
+	if subsetKind != reflect.Array && subsetKind != reflect.Slice && listKind != reflect.Map {
 		return Fail(t, fmt.Sprintf("%q has an unsupported type %s", subset, subsetKind), msgAndArgs...)
+	}
+
+	subsetValue := reflect.ValueOf(subset)
+	if subsetKind == reflect.Map && listKind == reflect.Map {
+		listValue := reflect.ValueOf(list)
+		subsetKeys := subsetValue.MapKeys()
+
+		for i := 0; i < len(subsetKeys); i++ {
+			subsetKey := subsetKeys[i]
+			subsetElement := subsetValue.MapIndex(subsetKey).Interface()
+			listElement := listValue.MapIndex(subsetKey).Interface()
+
+			if !ObjectsAreEqual(subsetElement, listElement) {
+				return true
+			}
+		}
+
+		return Fail(t, fmt.Sprintf("%q is a subset of %q", subset, list), msgAndArgs...)
 	}
 
 	for i := 0; i < subsetValue.Len(); i++ {
 		element := subsetValue.Index(i).Interface()
-		ok, found := includeElement(list, element)
+		ok, found := containsElement(list, element)
 		if !ok {
 			return Fail(t, fmt.Sprintf("\"%s\" could not be applied builtin len()", list), msgAndArgs...)
 		}
@@ -1000,27 +1041,21 @@ func Condition(t TestingT, comp Comparison, msgAndArgs ...interface{}) bool {
 type PanicTestFunc func()
 
 // didPanic returns true if the function passed to it panics. Otherwise, it returns false.
-func didPanic(f PanicTestFunc) (bool, interface{}, string) {
+func didPanic(f PanicTestFunc) (didPanic bool, message interface{}, stack string) {
+	didPanic = true
 
-	didPanic := false
-	var message interface{}
-	var stack string
-	func() {
-
-		defer func() {
-			if message = recover(); message != nil {
-				didPanic = true
-				stack = string(debug.Stack())
-			}
-		}()
-
-		// call the target function
-		f()
-
+	defer func() {
+		message = recover()
+		if didPanic {
+			stack = string(debug.Stack())
+		}
 	}()
 
-	return didPanic, message, stack
+	// call the target function
+	f()
+	didPanic = false
 
+	return
 }
 
 // Panics asserts that the code inside the specified PanicTestFunc panics.
@@ -1111,6 +1146,27 @@ func WithinDuration(t TestingT, expected, actual time.Time, delta time.Duration,
 	return true
 }
 
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual, start, end time.Time, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	if end.Before(start) {
+		return Fail(t, "Start should be before end", msgAndArgs...)
+	}
+
+	if actual.Before(start) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is before the range", actual, start, end), msgAndArgs...)
+	} else if actual.After(end) {
+		return Fail(t, fmt.Sprintf("Time %v expected to be in time range %v to %v, but is after the range", actual, start, end), msgAndArgs...)
+	}
+
+	return true
+}
+
 func toFloat(x interface{}) (float64, bool) {
 	var xf float64
 	xok := true
@@ -1161,11 +1217,15 @@ func InDelta(t TestingT, expected, actual interface{}, delta float64, msgAndArgs
 	bf, bok := toFloat(actual)
 
 	if !aok || !bok {
-		return Fail(t, fmt.Sprintf("Parameters must be numerical"), msgAndArgs...)
+		return Fail(t, "Parameters must be numerical", msgAndArgs...)
+	}
+
+	if math.IsNaN(af) && math.IsNaN(bf) {
+		return true
 	}
 
 	if math.IsNaN(af) {
-		return Fail(t, fmt.Sprintf("Expected must not be NaN"), msgAndArgs...)
+		return Fail(t, "Expected must not be NaN", msgAndArgs...)
 	}
 
 	if math.IsNaN(bf) {
@@ -1188,7 +1248,7 @@ func InDeltaSlice(t TestingT, expected, actual interface{}, delta float64, msgAn
 	if expected == nil || actual == nil ||
 		reflect.TypeOf(actual).Kind() != reflect.Slice ||
 		reflect.TypeOf(expected).Kind() != reflect.Slice {
-		return Fail(t, fmt.Sprintf("Parameters must be slice"), msgAndArgs...)
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
 	actualSlice := reflect.ValueOf(actual)
@@ -1250,18 +1310,18 @@ func InDeltaMapValues(t TestingT, expected, actual interface{}, delta float64, m
 
 func calcRelativeError(expected, actual interface{}) (float64, error) {
 	af, aok := toFloat(expected)
-	if !aok {
-		return 0, fmt.Errorf("expected value %q cannot be converted to float", expected)
+	bf, bok := toFloat(actual)
+	if !aok || !bok {
+		return 0, fmt.Errorf("Parameters must be numerical")
+	}
+	if math.IsNaN(af) && math.IsNaN(bf) {
+		return 0, nil
 	}
 	if math.IsNaN(af) {
 		return 0, errors.New("expected value must not be NaN")
 	}
 	if af == 0 {
 		return 0, fmt.Errorf("expected value must have a value other than zero to calculate the relative error")
-	}
-	bf, bok := toFloat(actual)
-	if !bok {
-		return 0, fmt.Errorf("actual value %q cannot be converted to float", actual)
 	}
 	if math.IsNaN(bf) {
 		return 0, errors.New("actual value must not be NaN")
@@ -1298,7 +1358,7 @@ func InEpsilonSlice(t TestingT, expected, actual interface{}, epsilon float64, m
 	if expected == nil || actual == nil ||
 		reflect.TypeOf(actual).Kind() != reflect.Slice ||
 		reflect.TypeOf(expected).Kind() != reflect.Slice {
-		return Fail(t, fmt.Sprintf("Parameters must be slice"), msgAndArgs...)
+		return Fail(t, "Parameters must be slice", msgAndArgs...)
 	}
 
 	actualSlice := reflect.ValueOf(actual)
@@ -1372,6 +1432,27 @@ func EqualError(t TestingT, theError error, errString string, msgAndArgs ...inte
 			"expected: %q\n"+
 			"actual  : %q", expected, actual), msgAndArgs...)
 	}
+	return true
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if !Error(t, theError, msgAndArgs...) {
+		return false
+	}
+
+	actual := theError.Error()
+	if !strings.Contains(actual, contains) {
+		return Fail(t, fmt.Sprintf("Error %#v does not contain %#v", actual, contains), msgAndArgs...)
+	}
+
 	return true
 }
 
@@ -1588,12 +1669,17 @@ func diff(expected interface{}, actual interface{}) string {
 	}
 
 	var e, a string
-	if et != reflect.TypeOf("") {
-		e = spewConfig.Sdump(expected)
-		a = spewConfig.Sdump(actual)
-	} else {
+
+	switch et {
+	case reflect.TypeOf(""):
 		e = reflect.ValueOf(expected).String()
 		a = reflect.ValueOf(actual).String()
+	case reflect.TypeOf(time.Time{}):
+		e = spewConfigStringerEnabled.Sdump(expected)
+		a = spewConfigStringerEnabled.Sdump(actual)
+	default:
+		e = spewConfig.Sdump(expected)
+		a = spewConfig.Sdump(actual)
 	}
 
 	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
@@ -1622,6 +1708,14 @@ var spewConfig = spew.ConfigState{
 	DisableCapacities:       true,
 	SortKeys:                true,
 	DisableMethods:          true,
+	MaxDepth:                10,
+}
+
+var spewConfigStringerEnabled = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
 	MaxDepth:                10,
 }
 

--- a/vendor/github.com/stretchr/testify/require/require.go
+++ b/vendor/github.com/stretchr/testify/require/require.go
@@ -280,6 +280,36 @@ func ErrorAsf(t TestingT, err error, target interface{}, msg string, args ...int
 	t.FailNow()
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContains(t, err,  expectedErrorSubString)
+func ErrorContains(t TestingT, theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContains(t, theError, contains, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   assert.ErrorContainsf(t, err,  expectedErrorSubString, "error message %s", "formatted")
+func ErrorContainsf(t TestingT, theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.ErrorContainsf(t, theError, contains, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func ErrorIs(t TestingT, err error, target error, msgAndArgs ...interface{}) {
@@ -1829,6 +1859,32 @@ func WithinDurationf(t TestingT, expected time.Time, actual time.Time, delta tim
 		h.Helper()
 	}
 	if assert.WithinDurationf(t, expected, actual, delta, msg, args...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinRange(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func WithinRange(t TestingT, actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRange(t, actual, start, end, msgAndArgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//   assert.WithinRangef(t, time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func WithinRangef(t TestingT, actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	if assert.WithinRangef(t, actual, start, end, msg, args...) {
 		return
 	}
 	t.FailNow()

--- a/vendor/github.com/stretchr/testify/require/require_forward.go
+++ b/vendor/github.com/stretchr/testify/require/require_forward.go
@@ -223,6 +223,30 @@ func (a *Assertions) ErrorAsf(err error, target interface{}, msg string, args ..
 	ErrorAsf(a.t, err, target, msg, args...)
 }
 
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContains(err,  expectedErrorSubString)
+func (a *Assertions) ErrorContains(theError error, contains string, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContains(a.t, theError, contains, msgAndArgs...)
+}
+
+// ErrorContainsf asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+//
+//   actualObj, err := SomeFunction()
+//   a.ErrorContainsf(err,  expectedErrorSubString, "error message %s", "formatted")
+func (a *Assertions) ErrorContainsf(theError error, contains string, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	ErrorContainsf(a.t, theError, contains, msg, args...)
+}
+
 // ErrorIs asserts that at least one of the errors in err's chain matches target.
 // This is a wrapper for errors.Is.
 func (a *Assertions) ErrorIs(err error, target error, msgAndArgs ...interface{}) {
@@ -1436,6 +1460,26 @@ func (a *Assertions) WithinDurationf(expected time.Time, actual time.Time, delta
 		h.Helper()
 	}
 	WithinDurationf(a.t, expected, actual, delta, msg, args...)
+}
+
+// WithinRange asserts that a time is within a time range (inclusive).
+//
+//   a.WithinRange(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second))
+func (a *Assertions) WithinRange(actual time.Time, start time.Time, end time.Time, msgAndArgs ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRange(a.t, actual, start, end, msgAndArgs...)
+}
+
+// WithinRangef asserts that a time is within a time range (inclusive).
+//
+//   a.WithinRangef(time.Now(), time.Now().Add(-time.Second), time.Now().Add(time.Second), "error message %s", "formatted")
+func (a *Assertions) WithinRangef(actual time.Time, start time.Time, end time.Time, msg string, args ...interface{}) {
+	if h, ok := a.t.(tHelper); ok {
+		h.Helper()
+	}
+	WithinRangef(a.t, actual, start, end, msg, args...)
 }
 
 // YAMLEq asserts that two YAML strings are equivalent.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -334,8 +334,8 @@ github.com/hashicorp/golang-lru/simplelru
 # github.com/imdario/mergo v0.3.12
 ## explicit; go 1.13
 github.com/imdario/mergo
-# github.com/jenkins-x/go-scm v1.11.16
-## explicit; go 1.17
+# github.com/jenkins-x/go-scm v1.11.19
+## explicit; go 1.18
 github.com/jenkins-x/go-scm/pkg/hmac
 github.com/jenkins-x/go-scm/scm
 github.com/jenkins-x/go-scm/scm/driver/fake
@@ -437,7 +437,7 @@ github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 ## explicit; go 1.12
 github.com/spf13/pflag
-# github.com/stretchr/testify v1.7.0
+# github.com/stretchr/testify v1.8.0
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require


### PR DESCRIPTION
# Changes

Dependabot keeps trying to upgrade go-scm past 1.11.16, but there's a signature change, so it needed to be done manually.

Replaces #5211 

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
