### PR TITLE
Add Tep 75&76 to install doc

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -318,7 +318,7 @@ The example below customizes the following:
 - the default Pod template to include a node selector to select the node where the Pod will be scheduled by default. A list of supported fields is available [here](https://github.com/tektoncd/pipeline/blob/main/docs/podtemplates.md#supported-fields).
   For more information, see [`PodTemplate` in `TaskRuns`](./taskruns.md#specifying-a-pod-template) or [`PodTemplate` in `PipelineRuns`](./pipelineruns.md#specifying-a-pod-template).
 - the default `Workspace` configuration can be set for any `Workspaces` that a Task declares but that a TaskRun does not explicitly provide
-- the default maximum combinations of `Parameters` in a `Matrix` that can be used to fan out a `PipelineTask`. For 
+- the default maximum combinations of `Parameters` in a `Matrix` that can be used to fan out a `PipelineTask`. For
 more information, see [`Matrix`](matrix.md).
 
 ```yaml
@@ -396,9 +396,9 @@ use of custom tasks in pipelines.
 most stable features to be used. Set it to "alpha" to allow [alpha
 features](#alpha-features) to be used.
 
-- `embedded-status`: set this flag to "full" to enable full embedding of `TaskRun` and `Run` statuses in the 
+- `embedded-status`: set this flag to "full" to enable full embedding of `TaskRun` and `Run` statuses in the
  `PipelineRun` status. Set it to "minimal" to populate the `ChildReferences` field in the `PipelineRun` status with
-  name, kind, and API version information for each `TaskRun` and `Run` in the `PipelineRun` instead. Set it to "both" to 
+  name, kind, and API version information for each `TaskRun` and `Run` in the `PipelineRun` instead. Set it to "both" to
   do both. For more information, see [Configuring usage of `TaskRun` and `Run` embedded statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses).
 
 For example:
@@ -436,6 +436,8 @@ Features currently in "alpha" are:
 | [Task-level Resource Requirements](compute-resources.md#task-level-compute-resources-configuration)   | [TEP-0104](https://github.com/tektoncd/community/blob/main/teps/0104-tasklevel-resource-requirements.md)             |                                                                      |                             |
 | [Projected Workspace Type](workspaces.md#projected)                                                   |                  |                                                                |                             |
 | [CSI Workspace Type](workspaces.md#csi)                                                               |                  |                                                                |                             |
+| [Object Params and Results](pipelineruns.md#specifying-parameters)                                                               | [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md)                  |                [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0)                                                |                             |
+| [Array Results](pipelineruns.md#specifying-parameters)                                                               |            [TEP-0076](https://github.com/tektoncd/community/blob/main/teps/0076-array-result-types.md)       |       [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0)                                                           |                |
 
 ## Configuring High Availability
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Tep 75&76 are implemented in release v0.38.0, so need to add them into
the install doc's alpha feature section.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
