### PR TITLE
[cherry-pick: v0.38] Do not serve v1alpha1 for CRDs that do not exists anymore

### DIFF
--- a/config/300-clustertask.yaml
+++ b/config/300-clustertask.yaml
@@ -25,24 +25,6 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   - name: v1beta1
     served: true
     storage: true

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -25,24 +25,6 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
   - name: v1beta1
     served: true
     storage: true

--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -25,37 +25,6 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    additionalPrinterColumns:
-    - name: Succeeded
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
-    - name: StartTime
-      type: date
-      jsonPath: .status.startTime
-    - name: CompletionTime
-      type: date
-      jsonPath: .status.completionTime
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   - name: v1beta1
     served: true
     storage: true

--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -25,24 +25,6 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   - name: v1beta1
     served: true
     storage: true

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -25,37 +25,6 @@ spec:
   group: tekton.dev
   preserveUnknownFields: false
   versions:
-  - name: v1alpha1
-    served: true
-    storage: false
-    schema:
-      openAPIV3Schema:
-        type: object
-        # One can use x-kubernetes-preserve-unknown-fields: true
-        # at the root of the schema (and inside any properties, additionalProperties)
-        # to get the traditional CRD behaviour that nothing is pruned, despite
-        # setting spec.preserveUnknownProperties: false.
-        #
-        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
-        # See issue: https://github.com/knative/serving/issues/912
-        x-kubernetes-preserve-unknown-fields: true
-    additionalPrinterColumns:
-    - name: Succeeded
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
-    - name: Reason
-      type: string
-      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
-    - name: StartTime
-      type: date
-      jsonPath: .status.startTime
-    - name: CompletionTime
-      type: date
-      jsonPath: .status.completionTime
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
-    subresources:
-      status: {}
   - name: v1beta1
     served: true
     storage: true


### PR DESCRIPTION
# Changes

Cherry-picked from #5215

We removed v1alpha1 support for some types (Task, ClusterTask,
Pipeline, TaskRun and PipelineRun). But, somehow, we are still serving
them.

This is most likely going to cause problems of conversion and for old clients.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Do not serve removed object from v1alpha1 (Task, ClusterTask, Pipeline, TaskRun and PipelineRun)
```
