### PR TITLE
Add a status_msg field to fix issue 5150.

### DIFF
--- a/docs/runs.md
+++ b/docs/runs.md
@@ -192,7 +192,11 @@ Supporting timeouts is optional but recommended.
    (i.e. `Run.Spec.Status == RunCancelled`) and or `Run.HasTimedOut()` and take
    any corresponding actions (i.e. a clean up e.g., cancel a cloud build, stop
    the waiting timer, tear down the approval listener).
-4. Once resources or timers are cleaned up it is good practice to set a
+4. A Custom Task author can differentiate between a Run cancelled by an user from a
+   Run cancellation initiated by a PipelineRun by looking at the `Run.Spec.StatusMessage`.
+   If a Run cancellation has been initiated by a cancellation of a PipelineRun then `Run.Spec.StatusMessage` is
+   `"Run cancelled as the PipelineRun it belongs to has been cancelled."`. 
+5. Once resources or timers are cleaned up it is good practice to set a
    `conditions` on the `Run`'s `status` of `Succeeded/False` with a `Reason`
    of `RunTimedOut`.
 

--- a/pkg/apis/pipeline/v1alpha1/run_types.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types.go
@@ -60,6 +60,10 @@ type RunSpec struct {
 	// +optional
 	Status RunSpecStatus `json:"status,omitempty"`
 
+	// Status message for cancellation.
+	// +optional
+	StatusMessage RunSpecStatusMessage `json:"statusMessage,omitempty"`
+
 	// Used for propagating retries count to custom tasks
 	// +optional
 	Retries int `json:"retries,omitempty"`
@@ -88,6 +92,15 @@ const (
 	// RunSpecStatusCancelled indicates that the user wants to cancel the run,
 	// if not already cancelled or terminated
 	RunSpecStatusCancelled RunSpecStatus = "RunCancelled"
+)
+
+// RunSpecStatusMessage defines human readable status messages for the TaskRun.
+type RunSpecStatusMessage string
+
+const (
+	// RunCancelledByPipelineMsg indicates that the PipelineRun of which part this Run was
+	// has been cancelled.
+	RunCancelledByPipelineMsg RunSpecStatusMessage = "Run cancelled as the PipelineRun it belongs to has been cancelled."
 )
 
 // GetParam gets the Param from the RunSpec with the given name

--- a/pkg/apis/pipeline/v1alpha1/run_types_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_types_test.go
@@ -172,6 +172,27 @@ func TestRunIsCancelled(t *testing.T) {
 	if !run.IsCancelled() {
 		t.Fatal("Expected run status to be cancelled")
 	}
+	expected := ""
+	if string(run.Spec.StatusMessage) != expected {
+		t.Fatalf("Expected StatusMessage is %s but got %s", expected, run.Spec.StatusMessage)
+	}
+}
+
+func TestRunIsCancelledWithMessage(t *testing.T) {
+	expectedStatusMessage := "test message"
+	run := v1alpha1.Run{
+		Spec: v1alpha1.RunSpec{
+			Status:        v1alpha1.RunSpecStatusCancelled,
+			StatusMessage: v1alpha1.RunSpecStatusMessage(expectedStatusMessage),
+		},
+	}
+	if !run.IsCancelled() {
+		t.Fatal("Expected run status to be cancelled")
+	}
+	expected := ""
+	if string(run.Spec.StatusMessage) != expectedStatusMessage {
+		t.Fatalf("Expected StatusMessage is %s but got %s", expected, run.Spec.StatusMessage)
+	}
 }
 
 // TestRunStatusExtraFields tests that extraFields in a RunStatus can be parsed

--- a/pkg/apis/pipeline/v1alpha1/run_validation.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
@@ -65,6 +66,11 @@ func (rs *RunSpec) Validate(ctx context.Context) *apis.FieldError {
 		}
 		if rs.Spec.Kind == "" {
 			return apis.ErrMissingField("spec.spec.kind")
+		}
+	}
+	if rs.Status == "" {
+		if rs.StatusMessage != "" {
+			return apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", rs.StatusMessage), "statusMessage")
 		}
 	}
 	if err := v1beta1.ValidateParameters(ctx, rs.Params).ViaField("spec.params"); err != nil {

--- a/pkg/apis/pipeline/v1alpha1/run_validation_test.go
+++ b/pkg/apis/pipeline/v1alpha1/run_validation_test.go
@@ -18,6 +18,7 @@ package v1alpha1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,6 +32,7 @@ import (
 )
 
 func TestRun_Invalid(t *testing.T) {
+	invalidStatusMessage := "test status message"
 	for _, c := range []struct {
 		name string
 		run  *v1alpha1.Run
@@ -144,6 +146,21 @@ func TestRun_Invalid(t *testing.T) {
 		},
 		want: apis.ErrMissingField("spec.spec.kind"),
 	}, {
+		name: "invalid statusMessage in Spec",
+		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1beta1.TaskRef{
+					APIVersion: "blah",
+					Kind:       "blah",
+				},
+				StatusMessage: v1alpha1.RunSpecStatusMessage(invalidStatusMessage),
+			},
+		},
+		want: apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", invalidStatusMessage), "statusMessage"),
+	}, {
 		name: "non-unique params",
 		run: &v1alpha1.Run{
 			ObjectMeta: metav1.ObjectMeta{
@@ -203,6 +220,21 @@ func TestRun_Valid(t *testing.T) {
 					APIVersion: "blah",
 					Kind:       "blah",
 				},
+			},
+		},
+	}, {
+		name: "unnamed",
+		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "temp",
+			},
+			Spec: v1alpha1.RunSpec{
+				Ref: &v1beta1.TaskRef{
+					APIVersion: "blah",
+					Kind:       "blah",
+				},
+				Status:        v1alpha1.RunSpecStatusCancelled,
+				StatusMessage: v1alpha1.RunSpecStatusMessage("test status vessage"),
 			},
 		},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -4447,6 +4447,13 @@ func schema_pkg_apis_pipeline_v1beta1_TaskRunSpec(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"statusMessage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status message for cancellation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time after which the build times out. Defaults to 1 hour. Specified build timeout should be less than 24h. Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration",

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -2505,6 +2505,10 @@
           "description": "Used for cancelling a taskrun (and maybe more later on)",
           "type": "string"
         },
+        "statusMessage": {
+          "description": "Status message for cancellation.",
+          "type": "string"
+        },
         "stepOverrides": {
           "description": "Overrides to apply to Steps in this TaskRun. If a field is specified in both a Step and a StepOverride, the value from the StepOverride will be used. This field is only supported when the alpha feature gate is enabled.",
           "type": "array",

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -52,6 +52,9 @@ type TaskRunSpec struct {
 	// Used for cancelling a taskrun (and maybe more later on)
 	// +optional
 	Status TaskRunSpecStatus `json:"status,omitempty"`
+	// Status message for cancellation.
+	// +optional
+	StatusMessage TaskRunSpecStatusMessage `json:"statusMessage,omitempty"`
 	// Time after which the build times out. Defaults to 1 hour.
 	// Specified build timeout should be less than 24h.
 	// Refer Go's ParseDuration documentation for expected format: https://golang.org/pkg/time/#ParseDuration
@@ -88,6 +91,15 @@ const (
 	// TaskRunSpecStatusCancelled indicates that the user wants to cancel the task,
 	// if not already cancelled or terminated
 	TaskRunSpecStatusCancelled = "TaskRunCancelled"
+)
+
+// TaskRunSpecStatusMessage defines human readable status messages for the TaskRun.
+type TaskRunSpecStatusMessage string
+
+const (
+	// TaskRunCancelledByPipelineMsg indicates that the PipelineRun of which this
+	// TaskRun was a part of has been cancelled.
+	TaskRunCancelledByPipelineMsg TaskRunSpecStatusMessage = "TaskRun cancelled as the PipelineRun it belongs to has been cancelled."
 )
 
 // TaskRunDebug defines the breakpoint config for a particular TaskRun

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -133,6 +133,27 @@ func TestTaskRunIsCancelled(t *testing.T) {
 	if !tr.IsCancelled() {
 		t.Fatal("Expected pipelinerun status to be cancelled")
 	}
+	expected := ""
+	if string(tr.Spec.StatusMessage) != expected {
+		t.Fatalf("Expected StatusMessage is %s but got %s", expected, tr.Spec.StatusMessage)
+	}
+}
+
+func TestTaskRunIsCancelledWithMessage(t *testing.T) {
+	expectedStatusMessage := "test message"
+	tr := &v1beta1.TaskRun{
+		Spec: v1beta1.TaskRunSpec{
+			Status:        v1beta1.TaskRunSpecStatusCancelled,
+			StatusMessage: v1beta1.TaskRunSpecStatusMessage(expectedStatusMessage),
+		},
+	}
+	if !tr.IsCancelled() {
+		t.Fatal("Expected pipelinerun status to be cancelled")
+	}
+
+	if string(tr.Spec.StatusMessage) != expectedStatusMessage {
+		t.Fatalf("Expected StatusMessage is %s but got %s", v1beta1.TaskRunCancelledByPipelineMsg, tr.Spec.StatusMessage)
+	}
 }
 
 func TestTaskRunHasVolumeClaimTemplate(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -83,6 +83,12 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("%s should be %s", ts.Status, TaskRunSpecStatusCancelled), "status"))
 		}
 	}
+	if ts.Status == "" {
+		if ts.StatusMessage != "" {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", ts.StatusMessage), "statusMessage"))
+		}
+	}
+
 	if ts.Timeout != nil {
 		// timeout should be a valid duration of at least 0.
 		if ts.Timeout.Duration < 0 {

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -18,6 +18,7 @@ package v1beta1_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -148,6 +149,7 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 }
 
 func TestTaskRunSpec_Invalidate(t *testing.T) {
+	invalidStatusMessage := "status message without status"
 	tests := []struct {
 		name    string
 		spec    v1beta1.TaskRunSpec
@@ -189,6 +191,15 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 			Status: "TaskRunCancell",
 		},
 		wantErr: apis.ErrInvalidValue("TaskRunCancell should be TaskRunCancelled", "status"),
+	}, {
+		name: "incorrectly set statusMesage",
+		spec: v1beta1.TaskRunSpec{
+			TaskRef: &v1beta1.TaskRef{
+				Name: "taskrefname",
+			},
+			StatusMessage: v1beta1.TaskRunSpecStatusMessage(invalidStatusMessage),
+		},
+		wantErr: apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", invalidStatusMessage), "statusMessage"),
 	}, {
 		name: "invalid taskspec",
 		spec: v1beta1.TaskRunSpec{

--- a/pkg/reconciler/pipelinerun/cancel.go
+++ b/pkg/reconciler/pipelinerun/cancel.go
@@ -41,19 +41,31 @@ var cancelTaskRunPatchBytes, cancelRunPatchBytes []byte
 
 func init() {
 	var err error
-	cancelTaskRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{{
-		Operation: "add",
-		Path:      "/spec/status",
-		Value:     v1beta1.TaskRunSpecStatusCancelled,
-	}})
+	cancelTaskRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/status",
+			Value:     v1beta1.TaskRunSpecStatusCancelled,
+		},
+		{
+			Operation: "add",
+			Path:      "/spec/statusMessage",
+			Value:     v1beta1.TaskRunCancelledByPipelineMsg,
+		}})
 	if err != nil {
 		log.Fatalf("failed to marshal TaskRun cancel patch bytes: %v", err)
 	}
-	cancelRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{{
-		Operation: "add",
-		Path:      "/spec/status",
-		Value:     v1alpha1.RunSpecStatusCancelled,
-	}})
+	cancelRunPatchBytes, err = json.Marshal([]jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/spec/status",
+			Value:     v1alpha1.RunSpecStatusCancelled,
+		},
+		{
+			Operation: "add",
+			Path:      "/spec/statusMessage",
+			Value:     v1alpha1.RunCancelledByPipelineMsg,
+		}})
 	if err != nil {
 		log.Fatalf("failed to marshal Run cancel patch bytes: %v", err)
 	}

--- a/pkg/reconciler/pipelinerun/cancel_test.go
+++ b/pkg/reconciler/pipelinerun/cancel_test.go
@@ -248,6 +248,10 @@ func TestCancelPipelineRun(t *testing.T) {
 						if tr.Spec.Status != v1beta1.TaskRunSpecStatusCancelled {
 							t.Errorf("expected task %q to be marked as cancelled, was %q", tr.Name, tr.Spec.Status)
 						}
+						expectedStatusMessage := v1beta1.TaskRunCancelledByPipelineMsg
+						if tr.Spec.StatusMessage != expectedStatusMessage {
+							t.Errorf("expected task %q to have status message %s but was %s", tr.Name, expectedStatusMessage, tr.Spec.StatusMessage)
+						}
 					}
 				}
 				if tc.runs != nil {
@@ -258,6 +262,10 @@ func TestCancelPipelineRun(t *testing.T) {
 						}
 						if r.Spec.Status != v1alpha1.RunSpecStatusCancelled {
 							t.Errorf("expected task %q to be marked as cancelled, was %q", r.Name, r.Spec.Status)
+						}
+						expectedStatusMessage := v1alpha1.RunCancelledByPipelineMsg
+						if r.Spec.StatusMessage != expectedStatusMessage {
+							t.Errorf("expected task %q to have status message %s but was %s", r.Name, expectedStatusMessage, r.Spec.StatusMessage)
 						}
 					}
 				}

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -1690,6 +1690,10 @@ status:
 		Operation: "add",
 		Path:      "/spec/status",
 		Value:     "RunCancelled",
+	}, {
+		Operation: "add",
+		Path:      "/spec/statusMessage",
+		Value:     "Run cancelled as the PipelineRun it belongs to has been cancelled.",
 	}}
 	if d := cmp.Diff(got, want); d != "" {
 		t.Fatalf("Expected cancel patch operation, but got a mismatch %s", diff.PrintWantGot(d))
@@ -1802,6 +1806,10 @@ status:
 				Operation: "add",
 				Path:      "/spec/status",
 				Value:     "RunCancelled",
+			}, {
+				Operation: "add",
+				Path:      "/spec/statusMessage",
+				Value:     string(v1alpha1.RunCancelledByPipelineMsg),
 			}}
 			if d := cmp.Diff(got, want); d != "" {
 				t.Fatalf("Expected RunCancelled patch operation, but got a mismatch %s", diff.PrintWantGot(d))

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -144,7 +144,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1beta1.TaskRun) pkg
 
 	// If the TaskRun is cancelled, kill resources and update status
 	if tr.IsCancelled() {
-		message := fmt.Sprintf("TaskRun %q was cancelled", tr.Name)
+		message := fmt.Sprintf("TaskRun %q was cancelled. %s", tr.Name, tr.Spec.StatusMessage)
 		err := c.failTaskRun(ctx, tr, v1beta1.TaskRunReasonCancelled, message)
 		return c.finishReconcileUpdateEmitEvents(ctx, tr, before, err)
 	}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2075,6 +2075,7 @@ metadata:
   namespace: foo
 spec:
   status: TaskRunCancelled
+  statusMessage: "Test cancellation message."
   taskRef:
     name: test-task
 status:
@@ -2110,7 +2111,7 @@ status:
 		Type:    apis.ConditionSucceeded,
 		Status:  corev1.ConditionFalse,
 		Reason:  "TaskRunCancelled",
-		Message: `TaskRun "test-taskrun-run-cancelled" was cancelled`,
+		Message: `TaskRun "test-taskrun-run-cancelled" was cancelled. Test cancellation message.`,
 	}
 	if d := cmp.Diff(expectedStatus, newTr.Status.GetCondition(apis.ConditionSucceeded), ignoreLastTransitionTime); d != "" {
 		t.Fatalf("Did not get expected condition %s", diff.PrintWantGot(d))
@@ -3621,6 +3622,7 @@ metadata:
   namespace: foo
 spec:
   status: TaskRunCancelled
+  statusMessage: "Test cancellation message."
   taskRef:
     name: test-task
 status:
@@ -3672,6 +3674,7 @@ metadata:
   namespace: foo
 spec:
   status: TaskRunCancelled
+  statusMessage: "Test cancellation message."
   taskRef:
     name: test-task
 status:
@@ -3688,12 +3691,12 @@ status:
 			Name:      "foo-is-bar",
 		}},
 		reason:  v1beta1.TaskRunReasonCancelled,
-		message: "TaskRun test-taskrun-run-cancel was cancelled",
+		message: "TaskRun test-taskrun-run-cancel was cancelled. Test cancellation message.",
 		expectedStatus: apis.Condition{
 			Type:    apis.ConditionSucceeded,
 			Status:  corev1.ConditionFalse,
 			Reason:  v1beta1.TaskRunReasonCancelled.String(),
-			Message: "TaskRun test-taskrun-run-cancel was cancelled",
+			Message: "TaskRun test-taskrun-run-cancel was cancelled. Test cancellation message.",
 		},
 		expectedStepStates: []v1beta1.StepState{
 			{

--- a/test/cancel_test.go
+++ b/test/cancel_test.go
@@ -145,6 +145,13 @@ spec:
 			}
 			for _, taskrunItem := range taskrunList.Items {
 				trName = append(trName, taskrunItem.Name)
+				if taskrunItem.Spec.Status != v1beta1.TaskRunSpecStatusCancelled {
+					t.Fatalf("Status is %s while it should have been %s", taskrunItem.Spec.Status, v1beta1.TaskRunSpecStatusCancelled)
+				}
+				if taskrunItem.Spec.StatusMessage != v1beta1.TaskRunCancelledByPipelineMsg {
+					t.Fatalf("Status message is set to %s while it should be %s.", taskrunItem.Spec.StatusMessage, v1beta1.TaskRunCancelledByPipelineMsg)
+				}
+
 			}
 
 			matchKinds := map[string][]string{"PipelineRun": {pipelineRun.Name}}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

- Adds a new field status_msg to taskrun spec and run spec. This field adds an user_defined / pre-defined messages for run status. 
- status_msg is used to propagate pipeline run cancellations to taskruns and tasks.

/kind bug
fixes #5150


# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Users can now differentiate if a TaskRun was cancelled by the user or by cancellation of a PipelineRun of which the TaskRun was a part of, by looking at the TaskRun's spec.StatusMessage field.
```
