### PR TITLE
Remove not supported results and params variables doc

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -19,21 +19,16 @@ For instructions on using variable substitutions see the relevant section of [th
 | `params.<param name>` | The value of the parameter at runtime. |
 | `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
+| `params.<param name>[*]` | Get the whole param array or object.|
+| `params['<param name>'][*]` | (see above) |
+| `params["<param name>"][*]` | (see above) |
 | `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
 | `params['<param name>'][i]` | (see above) |
 | `params["<param name>"][i]` | (see above) |
 | `tasks.<taskName>.results.<resultName>` | The value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`.) |
-| `tasks.<taskName>.results['<resultName>']` | (see above)) |
-| `tasks.<taskName>.results["<resultName>"]` | (see above)) |
 | `tasks.<taskName>.results.<resultName>[i]` | The ith value of the `Task's` array result. Can alter `Task` execution order within a `Pipeline`.) |
-| `tasks.<taskName>.results['<resultName>'][i]` | (see above)) |
-| `tasks.<taskName>.results["<resultName>"][i]` | (see above)) |
 | `tasks.<taskName>.results.<resultName>[*]` | The array value of the `Task's` result. Can alter `Task` execution order within a `Pipeline`. Cannot be used in `script`.) |
-| `tasks.<taskName>.results['<resultName>'][*]` | (see above)) |
-| `tasks.<taskName>.results["<resultName>"][*]` | (see above)) |
 | `tasks.<taskName>.results.<resultName>.key` | The `key` value of the `Task's` object result. Can alter `Task` execution order within a `Pipeline`.) |
-| `tasks.<taskName>.results['<resultName>'][key]` | (see above)) |
-| `tasks.<taskName>.results["<resultName>"][key]` | (see above)) |
 | `workspaces.<workspaceName>.bound` | Whether a `Workspace` has been bound or not. "false" if the `Workspace` declaration has `optional: true` and the Workspace binding was omitted by the PipelineRun. |
 | `context.pipelineRun.name` | The name of the `PipelineRun` that this `Pipeline` is running in. |
 | `context.pipelineRun.namespace` | The namespace of the `PipelineRun` that this `Pipeline` is running in. |
@@ -50,6 +45,9 @@ For instructions on using variable substitutions see the relevant section of [th
 | `params.<param name>` | The value of the parameter at runtime. |
 | `params['<param name>']` | (see above) |
 | `params["<param name>"]` | (see above) |
+| `params.<param name>[*]` | Get the whole param array or object.|
+| `params['<param name>'][*]` | (see above) |
+| `params["<param name>"][*]` | (see above) |
 | `params.<param name>[i]` | Get the i-th element of param array. This is alpha feature, set `enable-api-fields` to `alpha`  to use it.|
 | `params['<param name>'][i]` | (see above) |
 | `params["<param name>"][i]` | (see above) |


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit updates the results and params related variables doc. In the
doc for results, the square bracket reference is not currently supported
for all types of results, these should be removed to avoid user
confusion before issue #4910 is done. Meanwhile we add star notation for
param reference as a whole.

/kind documentation

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
