### PR TITLE
Add V1 version to Task CRD

### DIFF
--- a/config/300-task.yaml
+++ b/config/300-task.yaml
@@ -43,6 +43,25 @@ spec:
     # starts to increment
     subresources:
       status: {}
+  - name: v1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # TODO(#1461): Add OpenAPIV3 schema
+        # OpenAPIV3 schema allows Kubernetes to perform validation on the schema fields
+        # and use the schema in tooling such as `kubectl explain`.
+        # Using "x-kubernetes-preserve-unknown-fields: true"
+        # at the root of the schema (or within it) allows arbitrary fields.
+        # We currently perform our own validation separately.
+        # See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
+        # for more info.
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: Task
     plural: tasks
@@ -54,7 +73,7 @@ spec:
   conversion:
     strategy: Webhook
     webhook:
-      conversionReviewVersions: ["v1beta1"]
+      conversionReviewVersions: ["v1beta1", "v1"]
       clientConfig:
         service:
           name: tekton-pipelines-webhook


### PR DESCRIPTION
# Changes

This commit adds a v1 version of the Task CRD, and support to the webhook.
Since this version is not served, it will not be available to users.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
