### PR TITLE
Use step.ImageID instead of looking into status.TaskSpec

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -197,16 +197,16 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, tr *v1beta1.TaskRun) pkg
 }
 
 func (c *Reconciler) checkPodFailed(tr *v1beta1.TaskRun) (bool, v1beta1.TaskRunReason, string) {
-	for index, step := range tr.Status.Steps {
+	for _, step := range tr.Status.Steps {
 		if step.Waiting != nil && step.Waiting.Reason == "ImagePullBackOff" {
-			image := tr.Status.TaskSpec.Steps[index].Image
+			image := step.ImageID
 			message := fmt.Sprintf(`The step %q in TaskRun %q failed to pull the image %q. The pod errored with the message: "%s."`, step.Name, tr.Name, image, step.Waiting.Message)
 			return true, v1beta1.TaskRunReasonImagePullFailed, message
 		}
 	}
-	for index, sidecar := range tr.Status.Sidecars {
+	for _, sidecar := range tr.Status.Sidecars {
 		if sidecar.Waiting != nil && sidecar.Waiting.Reason == "ImagePullBackOff" {
-			image := tr.Status.TaskSpec.Sidecars[index].Image
+			image := sidecar.ImageID
 			message := fmt.Sprintf(`The sidecar %q in TaskRun %q failed to pull the image %q. The pod errored with the message: "%s."`, sidecar.Name, tr.Name, image, sidecar.Waiting.Message)
 			return true, v1beta1.TaskRunReasonImagePullFailed, message
 		}

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -2160,6 +2160,7 @@ status:
   steps:
   - container: step-unnamed-0
     name: unnamed-0
+    imageID: whatever
     waiting:
       message: Back-off pulling image "whatever"
       reason: ImagePullBackOff
@@ -2223,6 +2224,7 @@ status:
       startedAt: "2022-06-09T10:13:41Z"
   - container: step-unnamed-1
     name: unnamed-1
+    imageID: whatever
     waiting:
       message: Back-off pulling image "whatever"
       reason: ImagePullBackOff


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`tr.Status.TaskSpec.Steps` can be out-of-sync with
`tr.Status.Steps`. As we already have the image information (through
`ImageID`) in the struct we are getting from our iteration, we don't
need to look into another array, with the risk of getting a panic.

The same goes for sidecars.

We managed to get multiple panics on the controller prior to this change.

```
panic: runtime error: index out of range [1] with length 1
goroutine 197 [running]:
github.com/tektoncd/pipeline/pkg/reconciler/taskrun.(*Reconciler).checkPodFailed(0x400004d4a0, {0x1e11968, 0x4000cb8d20}, 0x400082d080)
/go/src/github.com/tektoncd/pipeline/pkg/reconciler/taskrun/taskrun.go:202 +0x42c
github.com/tektoncd/pipeline/pkg/reconciler/taskrun.(*Reconciler).ReconcileKind(0x400004d4a0, {0x1e11968, 0x4000cb8ba0}, 0x400082d080)
/go/src/github.com/tektoncd/pipeline/pkg/reconciler/taskrun/taskrun.go:161 +0x6e8
github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/taskrun.(*reconcilerImpl).Reconcile(0x4000355860, {0x1e11968, 0x4000cb8ae0}, {0x4000a273b0, 0x4c})
/go/src/github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/taskrun/reconciler.go:235 +0x5a8
knative.dev/pkg/controller.(*Impl).processNextWorkItem(0x400052b380)
/go/src/github.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller/controller.go:542 +0x490
knative.dev/pkg/controller.(*Impl).RunContext.func3(0x4000b42094, 0x400052b380)
/go/src/github.com/tektoncd/pipeline/vendor/knative.dev/pkg/controller/controller.go:491 +0x50
created by knative.dev/pkg/controller.(*Impl).RunContext
```

See https://github.com/tektoncd/pipeline/pull/4952 for the initial implementation.
See https://issues.redhat.com/browse/SRVKP-2380

This affects v0.37.x and v0.38.x, and probably need a cherry-pick on both (and another bugfix release)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @dibyom @lbernick @abayer 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Do not panic on `ImagePullBackOff` in case of status being not fully populated *yet*
```
