### PR TITLE
Make sure that OpenAPI rules violations errors show up in Prow build logs

### DIFF
--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -52,7 +52,7 @@ do
   violations=$(diff --changed-group-format='%>' --unchanged-group-format='' <(sort "hack/ignored-openapi-violations.list") <(sort "${TMP_DIFFROOT}/api-report") || echo "")
   if [ -n "${violations}" ]; then
     echo ""
-    echo "New API rule violations found which are not present in hack/ignored-openapi-violations.list. Please fix these violations:"
+    echo "ERROR: New API rule violations found which are not present in hack/ignored-openapi-violations.list. Please fix these violations:"
     echo ""
     echo "${violations}"
     echo ""


### PR DESCRIPTION
# Changes

I noticed recently that `pull-tekton-pipeline-build-tests` will properly fail for a new OpenAPI rules violation, but the failure doesn't get shown on the Prow page for the job unless you expand to see the full log. This is because the error message doesn't contain any of the strings Spyglass/Prow are searching for in the logs to identify errors/failures. So let's add `ERROR:` to the message.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
