### PR TITLE
TEP-0115: Update Git Resolver example to use revision and pathInRepo fields

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -178,7 +178,7 @@ so long as the artifact adheres to the [contract](tekton-bundle-contracts.md).
 
 A `pipelineRef` field may specify a Pipeline in a remote location such as git.
 Support for specific types of remote will depend on the Resolvers your
-cluster's operator has installed. The below example demonstrates
+cluster's operator has installed. For more information please check the [Tekton resolution repo](https://github.com/tektoncd/resolution). The below example demonstrates
 referencing a Pipeline in git:
 
 ```yaml
@@ -188,9 +188,9 @@ spec:
     resource:
     - name: url
       value: https://github.com/tektoncd/catalog.git
-    - name: commit
+    - name: revision
       value: abc123
-    - name: path
+    - name: pathInRepo
       value: /pipeline/buildpacks/0.1/buildpacks.yaml
 ```
 

--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -169,7 +169,7 @@ cli *(coming soon)*.
 
 A `taskRef` field may specify a Task in a remote location such as git.
 Support for specific types of remote will depend on the Resolvers your
-cluster's operator has installed. The below example demonstrates
+cluster's operator has installed. For more information please check the [Tekton resolution repo](https://github.com/tektoncd/resolution). The below example demonstrates
 referencing a Task in git:
 
 ```yaml
@@ -179,9 +179,9 @@ spec:
     resource:
     - name: url
       value: https://github.com/tektoncd/catalog.git
-    - name: commit
+    - name: revision
       value: abc123
-    - name: path
+    - name: pathInRepo
       value: /task/golang-build/0.3/golang-build.yaml
 ```
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Part of TEP-0115

Update Git Resolver example to use ```revision``` and ```pathInRepo``` fields to reflect the changes in [TEP-0115: Add git revision resolution suppot in Git Resolver](https://github.com/tektoncd/resolution/pull/75) and [Add core Reconciler testing and fake resolver framework functions](https://github.com/tektoncd/resolution/pull/51)

# Changes
/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
None
```
