### PR TITLE
Clean up Regexes

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -996,7 +996,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "array param - using the whole variable as a param's value that is intended to be array type",
+		name: "array param - using the whole variable (dot reference) as the value of an array param",
 		params: []ParamSpec{{
 			Name: "myArray",
 			Type: ParamTypeArray,
@@ -1006,6 +1006,45 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param-intended-to-be-array", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.myArray[*])"},
+			}},
+		}},
+	}, {
+		name: "array param - using the whole variable (bracket with single quote) as the value of an array param",
+		params: []ParamSpec{{
+			Name: "myArray",
+			Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-array", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params['myArray'][*])"},
+			}},
+		}},
+	}, {
+		name: "array param - using the whole variable (bracket with double quote) as the value of an array param",
+		params: []ParamSpec{{
+			Name: "myArray",
+			Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-array", Value: ArrayOrString{Type: ParamTypeString, StringVal: `$(params["myArray"][*])`},
+			}},
+		}},
+	}, {
+		name: "array index param - using the value of an array index as a string param",
+		params: []ParamSpec{{
+			Name: "myArray",
+			Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-from-an-array-index", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.myArray[0])"},
 			}},
 		}},
 	}, {
@@ -1083,7 +1122,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "object param - using the whole variable as a param's value that is intended to be object type",
+		name: "object param - using the whole variable (dot notation) as the value of an object param",
 		params: []ParamSpec{{
 			Name: "myObject",
 			Type: ParamTypeObject,
@@ -1097,6 +1136,40 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param-intended-to-be-object", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.myObject[*])"},
+			}},
+		}},
+	}, {
+		name: "object param - using the whole variable (bracket notation with single quote) as the value of an object param",
+		params: []ParamSpec{{
+			Name: "myObject",
+			Type: ParamTypeObject,
+			Properties: map[string]PropertySpec{
+				"key1": {Type: "string"},
+				"key2": {Type: "string"},
+			},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-object", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params['myObject'][*])"},
+			}},
+		}},
+	}, {
+		name: "object param - using the whole variable (bracket notation with double quote) as the value of an object param",
+		params: []ParamSpec{{
+			Name: "myObject",
+			Type: ParamTypeObject,
+			Properties: map[string]PropertySpec{
+				"key1": {Type: "string"},
+				"key2": {Type: "string"},
+			},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-object", Value: ArrayOrString{Type: ParamTypeString, StringVal: `$(params["myObject"][*])`},
 			}},
 		}},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/param_types.go
+++ b/pkg/apis/pipeline/v1beta1/param_types.go
@@ -221,7 +221,7 @@ func (arrayOrString *ArrayOrString) applyOrCorrect(stringReplacements map[string
 
 	// if the stringVal is a string literal or a string that mixed with var references
 	// just do the normal string replacement
-	if !exactVariableSubstitutionRegex.MatchString(stringVal) {
+	if !isolatedResultVariableSubstitutionRegex.MatchString(stringVal) && !substitution.IsIsolatedArrayOrObjectParamRef(stringVal) {
 		arrayOrString.StringVal = substitution.ApplyReplacements(arrayOrString.StringVal, stringReplacements)
 		return
 	}
@@ -338,7 +338,7 @@ func validateParamStringValue(param Param, prefix string, paramNames sets.String
 	stringValue := param.Value.StringVal
 
 	// if the provided param value is an isolated reference to the whole array/object, we just check if the param name exists.
-	isIsolated, errs := substitution.ValidateWholeArrayOrObjectRefInStringVariable(param.Name, stringValue, prefix, paramNames)
+	isIsolated, errs := substitution.ValidateIsolatedArrayOrObjectRefInStringVariable(param.Name, stringValue, prefix, paramNames)
 	if isIsolated {
 		return errs
 	}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1517,7 +1517,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "array param - using the whole variable as a param's value that is intended to be array type",
+		name: "array param - using the whole variable (dot reference) as the value of an array param",
 		params: []ParamSpec{{
 			Name: "myArray",
 			Type: ParamTypeArray,
@@ -1527,6 +1527,45 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param-intended-to-be-array", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.myArray[*])"},
+			}},
+		}},
+	}, {
+		name: "array param - using the whole variable (bracket with single quote) as the value of an array param",
+		params: []ParamSpec{{
+			Name: "myArray",
+			Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-array", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params['myArray'][*])"},
+			}},
+		}},
+	}, {
+		name: "array param - using the whole variable (bracket with double quote) as the value of an array param",
+		params: []ParamSpec{{
+			Name: "myArray",
+			Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-array", Value: ArrayOrString{Type: ParamTypeString, StringVal: `$(params["myArray"][*])`},
+			}},
+		}},
+	}, {
+		name: "array index param - using the value of an array index as a string param",
+		params: []ParamSpec{{
+			Name: "myArray",
+			Type: ParamTypeArray,
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-from-an-array-index", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.myArray[0])"},
 			}},
 		}},
 	}, {
@@ -1621,7 +1660,7 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			}},
 		}},
 	}, {
-		name: "object param - using the whole variable as a param's value that is intended to be object type",
+		name: "object param - using the whole variable (dot notation) as the value of an object param",
 		params: []ParamSpec{{
 			Name: "myObject",
 			Type: ParamTypeObject,
@@ -1635,6 +1674,40 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 			TaskRef: &TaskRef{Name: "bar-task"},
 			Params: []Param{{
 				Name: "a-param-intended-to-be-object", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params.myObject[*])"},
+			}},
+		}},
+	}, {
+		name: "object param - using the whole variable (bracket notation with single quote) as the value of an object param",
+		params: []ParamSpec{{
+			Name: "myObject",
+			Type: ParamTypeObject,
+			Properties: map[string]PropertySpec{
+				"key1": {Type: "string"},
+				"key2": {Type: "string"},
+			},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-object", Value: ArrayOrString{Type: ParamTypeString, StringVal: "$(params['myObject'][*])"},
+			}},
+		}},
+	}, {
+		name: "object param - using the whole variable (bracket notation with double quote) as the value of an object param",
+		params: []ParamSpec{{
+			Name: "myObject",
+			Type: ParamTypeObject,
+			Properties: map[string]PropertySpec{
+				"key1": {Type: "string"},
+				"key2": {Type: "string"},
+			},
+		}},
+		tasks: []PipelineTask{{
+			Name:    "bar",
+			TaskRef: &TaskRef{Name: "bar-task"},
+			Params: []Param{{
+				Name: "a-param-intended-to-be-object", Value: ArrayOrString{Type: ParamTypeString, StringVal: `$(params["myObject"][*])`},
 			}},
 		}},
 	}, {

--- a/pkg/apis/pipeline/v1beta1/resultref.go
+++ b/pkg/apis/pipeline/v1beta1/resultref.go
@@ -44,20 +44,20 @@ const (
 	// ResultResultPart Constant used to define the "results" part of a pipeline result reference
 	ResultResultPart = "results"
 	// TODO(#2462) use one regex across all substitutions
-	// variableSubstitutionFormat matches format like $result.resultname, $result.resultname[int] and $result.resultname[*]
-	variableSubstitutionFormat = `\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*(\[([0-9]+|\*)\])?\)`
-	// exactVariableSubstitutionFormat matches strings that only contain a single reference to result or param variables, but nothing else
+	// resultVariableSubstitutionFormat matches format like $result.resultname, $result.resultname[int] and $result.resultname[*]
+	resultVariableSubstitutionFormat = `\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*(\[([0-9]+|\*)\])?\)`
+	// isolatedResultVariableSubstitutionFormat matches strings that only contain a single reference to result or param variables, but nothing else
 	// i.e. `$(result.resultname)` is a match, but `foo $(result.resultname)` is not.
-	exactVariableSubstitutionFormat = `^\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*(\[([0-9]+|\*)\])?\)$`
+	isolatedResultVariableSubstitutionFormat = `^\$\([_a-zA-Z0-9.-]+(\.[_a-zA-Z0-9.-]+)*(\[([0-9]+|\*)\])?\)$`
 	// arrayIndexing will match all `[int]` and `[*]` for parseExpression
 	arrayIndexing = `\[([0-9])*\*?\]`
 	// ResultNameFormat Constant used to define the the regex Result.Name should follow
 	ResultNameFormat = `^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`
 )
 
-// VariableSubstitutionRegex is a regex to find all result matching substitutions
-var VariableSubstitutionRegex = regexp.MustCompile(variableSubstitutionFormat)
-var exactVariableSubstitutionRegex = regexp.MustCompile(exactVariableSubstitutionFormat)
+// ResultVariableSubstitutionRegex is a regex to find all result matching substitutions
+var ResultVariableSubstitutionRegex = regexp.MustCompile(resultVariableSubstitutionFormat)
+var isolatedResultVariableSubstitutionRegex = regexp.MustCompile(isolatedResultVariableSubstitutionFormat)
 var resultNameFormatRegex = regexp.MustCompile(ResultNameFormat)
 
 // arrayIndexingRegex is used to match `[int]` and `[*]`
@@ -140,7 +140,7 @@ func GetVarSubstitutionExpressionsForPipelineResult(result PipelineResult) ([]st
 }
 
 func validateString(value string) []string {
-	expressions := VariableSubstitutionRegex.FindAllString(value, -1)
+	expressions := ResultVariableSubstitutionRegex.FindAllString(value, -1)
 	if expressions == nil {
 		return nil
 	}

--- a/pkg/reconciler/pipelinerun/resources/validate_params.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params.go
@@ -184,7 +184,7 @@ func findInvalidParamArrayReference(paramReference string, arrayParams map[strin
 	for _, val := range list {
 		indexString := substitution.ExtractIndexString(paramReference)
 		idx, _ := substitution.ExtractIndex(indexString)
-		v := substitution.TrimArrayIndex(val)
+		v := substitution.TrimTailOperator(val)
 		if paramLength, ok := arrayParams[v]; ok {
 			if idx >= paramLength {
 				outofBoundParams.Insert(val)

--- a/pkg/reconciler/taskrun/validate_resources.go
+++ b/pkg/reconciler/taskrun/validate_resources.go
@@ -148,7 +148,7 @@ func wrongTypeParamsNames(params []v1beta1.Param, matrix []v1beta1.Param, needed
 		// to pass array result to array param, yet in yaml format this will be
 		// unmarshalled to string for ArrayOrString. So we need to check and skip this validation.
 		// Please refer issue #4879 for more details and examples.
-		if param.Value.Type == v1beta1.ParamTypeString && (neededParamsTypes[param.Name] == v1beta1.ParamTypeArray || neededParamsTypes[param.Name] == v1beta1.ParamTypeObject) && v1beta1.VariableSubstitutionRegex.MatchString(param.Value.StringVal) {
+		if param.Value.Type == v1beta1.ParamTypeString && (neededParamsTypes[param.Name] == v1beta1.ParamTypeArray || neededParamsTypes[param.Name] == v1beta1.ParamTypeObject) && v1beta1.ResultVariableSubstitutionRegex.MatchString(param.Value.StringVal) {
 			continue
 		}
 		if param.Value.Type != neededParamsTypes[param.Name] {
@@ -428,7 +428,7 @@ func extractParamIndex(paramReference string, arrayParams map[string]int, outofB
 	for _, val := range list {
 		indexString := substitution.ExtractIndexString(paramReference)
 		idx, _ := substitution.ExtractIndex(indexString)
-		v := substitution.TrimArrayIndex(val)
+		v := substitution.TrimTailOperator(val)
 		if paramLength, ok := arrayParams[v]; ok {
 			if idx >= paramLength {
 				outofBoundParams.Insert(val)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Prior to this commit, the regexes in substitution.go file were hard to
understand and hard to reuse because of the complexity of the regexes.
For example, we have to consider
  - all the three notations (dot notation, bracket with single quote,
  and bracket with double quote)
  - the operator suffix including star `[*]` operator and
  int indexing that was not considerd before.
Also the old regex coupled each notation part with the operator
part, which leads to extra step to be done in the extract-related functions
i.e. have to trim the [*] every time.

This PR
  - cleans up the regexes and make it as much reable and reuseble as possible
  - makes the method `extractVariablesFromString` be capable of extracting
  both variable name and the operator (indexing operator or star operator)
  examples:
    - $(params.myString)       - name: "myString", operator: ""
    - $(params['myArray'][2])  - name: "myArray", operator: "1"
    - $(params.myObject[\*])    - name: "myObject", operator: "*"

Enabling `extractVariablesFromString` to extract both name and operator
is particularly useful for array indexing validation. There will be more
PRs to come to clean up considering the complexity of the all regexes.
Also results-related regexes in resultref.go file need cleanup too.

/kind cleanup

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
