### PR TITLE
Clarify error message for verify-codegen.sh

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -52,6 +52,6 @@ if [[ $ret -eq 0 ]]
 then
   echo "${REPO_ROOT_DIR} up to date."
 else
-  echo "${REPO_ROOT_DIR} is out of date. Please run hack/update-codegen.sh and hack/update-openapigen.sh"
+  echo "${REPO_ROOT_DIR} is out of date. Please run hack/update-codegen.sh."
   exit 1
 fi


### PR DESCRIPTION
# Changes

It currently says to run both `hack/update-codegen.sh` and `hack/update-openapigen.sh`, but `hack/update-codegen.sh` actually calls `hack/update-openapigen.sh`. So let's make the message actually match all that you need to do.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
