### PR TITLE
Refactor compute resources compare functions

### DIFF
--- a/pkg/internal/computeresources/compare/compare.go
+++ b/pkg/internal/computeresources/compare/compare.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package compare
+
+import (
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// IsZero returns true if the resource quantity has a zero value
+func IsZero(q resource.Quantity) bool {
+	return (&q).IsZero()
+}
+
+// MaxRequest returns the largest resource request
+// A zero request is considered the smallest request
+func MaxRequest(quantities ...resource.Quantity) resource.Quantity {
+	max := resource.Quantity{}
+	for _, q := range quantities {
+		if q.Cmp(max) > 0 {
+			max = q
+		}
+	}
+	return max
+}
+
+// MinLimit returns the smallest resource limit
+// A zero limit is considered higher than any other resource limit.
+func MinLimit(quantities ...resource.Quantity) resource.Quantity {
+	min := resource.Quantity{}
+	for _, q := range quantities {
+		if min.IsZero() {
+			min = q
+		} else if q.Cmp(min) < 0 {
+			min = q
+		}
+	}
+	return min
+}
+
+// ResourceQuantityCmp allows resource quantities to be compared in tests
+var ResourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
+	return x.Cmp(y) == 0
+})
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmptyResourceList returns a comparison option that will equate resource lists
+// if neither contains non-empty resource quantities.
+func EquateEmptyResourceList() cmp.Option {
+	return cmp.FilterValues(func(x, y corev1.ResourceList) bool { return IsEmpty(x) && IsEmpty(y) }, cmp.Comparer(equateAlways))
+}
+
+// IsEmpty returns false if the ResourceList contains non-empty resource quantities.
+func IsEmpty(x corev1.ResourceList) bool {
+	if len(x) == 0 {
+		return true
+	}
+	for _, q := range x {
+		if !q.IsZero() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/internal/computeresources/limitrange/limitrange_test.go
+++ b/pkg/internal/computeresources/limitrange/limitrange_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/internal/computeresources/compare"
 	"github.com/tektoncd/pipeline/pkg/internal/computeresources/limitrange"
 	ttesting "github.com/tektoncd/pipeline/pkg/reconciler/testing"
 	"github.com/tektoncd/pipeline/test"
@@ -276,33 +277,11 @@ func TestGetVirtualLimitRange(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error %s", err)
 			}
-			if d := cmp.Diff(tc.want, got, resourceQuantityCmp, equateEmpty()); d != "" {
+			if d := cmp.Diff(tc.want, got, compare.ResourceQuantityCmp, compare.EquateEmptyResourceList()); d != "" {
 				t.Errorf("Unexpected output for virtual limit range: %s", d)
 			}
 		})
 	}
-}
-
-var resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
-	return x.Cmp(y) == 0
-})
-
-func equateAlways(_, _ interface{}) bool { return true }
-
-func equateEmpty() cmp.Option {
-	return cmp.FilterValues(func(x, y corev1.ResourceList) bool { return isEmpty(x) && isEmpty(y) }, cmp.Comparer(equateAlways))
-}
-
-func isEmpty(x corev1.ResourceList) bool {
-	if len(x) == 0 {
-		return true
-	}
-	for _, q := range x {
-		if !q.IsZero() {
-			return false
-		}
-	}
-	return true
 }
 
 func createResourceList(multiple int) corev1.ResourceList {

--- a/pkg/internal/computeresources/transformer_test.go
+++ b/pkg/internal/computeresources/transformer_test.go
@@ -19,15 +19,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/internal/computeresources/compare"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-var resourceQuantityCmp = cmp.Comparer(func(x, y resource.Quantity) bool {
-	return x.Cmp(y) == 0
-})
 
 func TestTransformerOneContainer(t *testing.T) {
 	for _, tc := range []struct {
@@ -989,7 +986,7 @@ func cmpRequestsAndLimits(t *testing.T, want, got corev1.PodSpec) {
 				}
 			}
 
-			if d := cmp.Diff(want.InitContainers[i].Resources, c.Resources, resourceQuantityCmp); d != "" {
+			if d := cmp.Diff(want.InitContainers[i].Resources, c.Resources, compare.ResourceQuantityCmp); d != "" {
 				t.Errorf("Diff initcontainers[%d] %s", i, diff.PrintWantGot(d))
 			}
 		}
@@ -1008,7 +1005,7 @@ func cmpRequestsAndLimits(t *testing.T, want, got corev1.PodSpec) {
 				}
 			}
 
-			if d := cmp.Diff(want.Containers[i].Resources, c.Resources, resourceQuantityCmp); d != "" {
+			if d := cmp.Diff(want.Containers[i].Resources, c.Resources, compare.ResourceQuantityCmp); d != "" {
 				t.Errorf("Diff containers[%d] %s", i, diff.PrintWantGot(d))
 			}
 		}


### PR DESCRIPTION
# Changes
This commit creates a new package for comparison of compute resources
and refactors limitrange-related tests to use these comparison helpers.
This refactoring will make upcoming changes to compute resource code
easier to write. No functional changes.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
