### PR TITLE
Add conversion for v1 Pipeline

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1/pipeline_conversion.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+var _ apis.Convertible = (*Pipeline)(nil)
+
+// ConvertTo implements apis.Convertible
+func (p *Pipeline) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (p *Pipeline) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/pipeline/v1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_conversion_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Tetkon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func TestPipelineConversionBadType(t *testing.T) {
+	good, bad := &v1.Pipeline{}, &v1.Task{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/param_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/param_conversion.go
@@ -45,3 +45,31 @@ func (p *ParamSpec) convertFrom(ctx context.Context, source v1.ParamSpec) {
 		}
 	}
 }
+
+func (p Param) convertTo(ctx context.Context, sink *v1.Param) {
+	sink.Name = p.Name
+	newValue := v1.ArrayOrString{}
+	p.Value.convertTo(ctx, &newValue)
+	sink.Value = newValue
+}
+
+func (p *Param) convertFrom(ctx context.Context, source v1.Param) {
+	p.Name = source.Name
+	newValue := ArrayOrString{}
+	newValue.convertFrom(ctx, source.Value)
+	p.Value = newValue
+}
+
+func (aos ArrayOrString) convertTo(ctx context.Context, sink *v1.ArrayOrString) {
+	sink.Type = v1.ParamType(aos.Type)
+	sink.StringVal = aos.StringVal
+	sink.ArrayVal = aos.ArrayVal
+	sink.ObjectVal = aos.ObjectVal
+}
+
+func (aos *ArrayOrString) convertFrom(ctx context.Context, source v1.ArrayOrString) {
+	aos.Type = ParamType(source.Type)
+	aos.StringVal = source.StringVal
+	aos.ArrayVal = source.ArrayVal
+	aos.ObjectVal = source.ObjectVal
+}

--- a/pkg/apis/pipeline/v1beta1/resolver_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/resolver_conversion.go
@@ -1,0 +1,37 @@
+package v1beta1
+
+import (
+	"context"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func (rr ResolverRef) convertTo(ctx context.Context, sink *v1.ResolverRef) {
+	sink.Resolver = v1.ResolverName(rr.Resolver)
+	sink.Resource = nil
+	for _, r := range rr.Resource {
+		new := v1.ResolverParam{}
+		r.convertTo(ctx, &new)
+		sink.Resource = append(sink.Resource, new)
+	}
+}
+
+func (rr *ResolverRef) convertFrom(ctx context.Context, source v1.ResolverRef) {
+	rr.Resolver = ResolverName(source.Resolver)
+	rr.Resource = nil
+	for _, r := range source.Resource {
+		new := ResolverParam{}
+		new.convertFrom(ctx, r)
+		rr.Resource = append(rr.Resource, new)
+	}
+}
+
+func (rp ResolverParam) convertTo(ctx context.Context, sink *v1.ResolverParam) {
+	sink.Name = rp.Name
+	sink.Value = rp.Value
+}
+
+func (rp *ResolverParam) convertFrom(ctx context.Context, source v1.ResolverParam) {
+	rp.Name = source.Name
+	rp.Value = source.Value
+}

--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -1,0 +1,27 @@
+package v1beta1
+
+import (
+	"context"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func (tr TaskRef) convertTo(ctx context.Context, sink *v1.TaskRef) {
+	sink.Name = tr.Name
+	sink.Kind = v1.TaskKind(tr.Kind)
+	sink.APIVersion = tr.APIVersion
+	// TODO: handle bundle in #4546
+	new := v1.ResolverRef{}
+	tr.ResolverRef.convertTo(ctx, &new)
+	sink.ResolverRef = new
+}
+
+func (tr *TaskRef) convertFrom(ctx context.Context, source v1.TaskRef) {
+	tr.Name = source.Name
+	tr.Kind = TaskKind(source.Kind)
+	tr.APIVersion = source.APIVersion
+	// TODO: handle bundle in #4546
+	new := ResolverRef{}
+	new.convertFrom(ctx, source.ResolverRef)
+	tr.ResolverRef = new
+}

--- a/pkg/apis/pipeline/v1beta1/workspace_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_conversion.go
@@ -31,3 +31,27 @@ func (w *WorkspaceUsage) convertFrom(ctx context.Context, source v1.WorkspaceUsa
 	w.Name = source.Name
 	w.MountPath = source.MountPath
 }
+
+func (w PipelineWorkspaceDeclaration) convertTo(ctx context.Context, sink *v1.PipelineWorkspaceDeclaration) {
+	sink.Name = w.Name
+	sink.Description = w.Description
+	sink.Optional = w.Optional
+}
+
+func (w *PipelineWorkspaceDeclaration) convertFrom(ctx context.Context, source v1.PipelineWorkspaceDeclaration) {
+	w.Name = source.Name
+	w.Description = source.Description
+	w.Optional = source.Optional
+}
+
+func (w WorkspacePipelineTaskBinding) convertTo(ctx context.Context, sink *v1.WorkspacePipelineTaskBinding) {
+	sink.Name = w.Name
+	sink.Workspace = w.Workspace
+	sink.SubPath = w.SubPath
+}
+
+func (w *WorkspacePipelineTaskBinding) convertFrom(ctx context.Context, source v1.WorkspacePipelineTaskBinding) {
+	w.Name = source.Name
+	w.Workspace = source.Workspace
+	w.SubPath = source.SubPath
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit adds conversion functions between v1beta1 and v1 Pipeline.
It does not handle fields deprecated in v1beta1 that will not be present in v1.
It implements ConvertTo and ConvertFrom for v1beta1 Pipeline, and leaves
these functions unimplemented for v1 Pipeline, since it is the highest known version.

Conversions for all types are basically deep copies, rather than using the same struct
definition for both API versions. This will allow us to iterate on v1 without making additional
changes to v1beta1, after v1 is the stored version.

Handle `resources` regarding #5253

Part of #4986
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
