### PR TITLE
Bump TestSidecarTaskSupport test timeout to 2m.

### DIFF
--- a/test/sidecar_test.go
+++ b/test/sidecar_test.go
@@ -96,7 +96,7 @@ metadata:
 spec:
   taskRef:
     name: %s
-  timeout: 1m
+  timeout: 2m
 `, sidecarTaskRunName, namespace, sidecarTaskName))
 
 			t.Logf("Creating Task %q", sidecarTaskName)


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

The sidecar tests have been fairly flaky. :(
While in upstream we've added more compute at the prow clusters to
help, this has still been noticable in other CI environments.

Bumping this for the time being to help the pain. It'd probably be worth
looking into if there's room for improvement for why these are taking so
long to schedule.

/kind flake

Related: https://github.com/tektoncd/pipeline/issues/2656

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
