### PR TITLE
Updates Default Fields When Creating a GKE Cluster

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -323,13 +323,12 @@ optional: As a convenience, the [Tekton plumbing project](https://github.com/tek
      --no-issue-client-certificate \
      --project=$PROJECT_ID \
      --region=us-central1 \
-     --machine-type=n1-standard-4 \
-     --image-type=cos \
+     --machine-type=e2-standard-4 \
      --num-nodes=1 \
      --cluster-version=1.21
     ```
 
-    > **Note**: The recommended [GCE machine type](https://cloud.google.com/compute/docs/machine-types) is `'n1-standard-4'`.
+    > **Note**: The recommended [GCE machine type](https://cloud.google.com/compute/docs/machine-types) is `'e2-standard-4'`.
 
     > **Note**: [The `'--scopes'` argument](https://cloud.google.com/sdk/gcloud/reference/container/clusters/create#--scopes) on the  `'gcloud container cluster create'` command controls what GCP resources the cluster's default service account has access to; for example, to give the default service account full access to your GCR registry, you can add `'storage-full'` to the `--scopes` arg. See [Authenticating to GCP](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform) for more details.
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR update default fields when creating a GKE Cluster.

1. Removes `--image-type=cos` because "Creation of node pools using node images based on Docker container runtimes is not supported in GKE v1.24+ clusters as Dockershim has been removed in Kubernetes v1.24."
2. Sets default machine type as "e2-standard-4" because it's cost-optimized.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```