### PR TITLE
Add conversion for v1 TaskRun

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1/taskrun_conversion.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+var _ apis.Convertible = (*TaskRun)(nil)
+
+// ConvertTo implements apis.Convertible
+func (tr *TaskRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (tr *TaskRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/pipeline/v1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_conversion_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Tetkon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func TestTaskRunConversionBadType(t *testing.T) {
+	good, bad := &v1.TaskRun{}, &v1.Task{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion.go
@@ -20,23 +20,167 @@ import (
 	"context"
 	"fmt"
 
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"knative.dev/pkg/apis"
 )
 
 var _ apis.Convertible = (*TaskRun)(nil)
 
 // ConvertTo implements apis.Convertible
-func (tr *TaskRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+func (tr *TaskRun) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+	switch sink := to.(type) {
+	case *v1.TaskRun:
+		sink.ObjectMeta = tr.ObjectMeta
+		return tr.Spec.ConvertTo(ctx, &sink.Spec)
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
+	}
+}
+
+// ConvertTo implements apis.Convertible
+func (trs *TaskRunSpec) ConvertTo(ctx context.Context, sink *v1.TaskRunSpec) error {
+	if trs.Debug != nil {
+		sink.Debug = &v1.TaskRunDebug{}
+		trs.Debug.convertTo(ctx, sink.Debug)
+	}
+	sink.Params = nil
+	for _, p := range trs.Params {
+		new := v1.Param{}
+		p.convertTo(ctx, &new)
+		sink.Params = append(sink.Params, new)
+	}
+	sink.ServiceAccountName = trs.ServiceAccountName
+	if trs.TaskRef != nil {
+		sink.TaskRef = &v1.TaskRef{}
+		trs.TaskRef.convertTo(ctx, sink.TaskRef)
+	}
+	if trs.TaskSpec != nil {
+		sink.TaskSpec = &v1.TaskSpec{}
+		err := trs.TaskSpec.ConvertTo(ctx, sink.TaskSpec)
+		if err != nil {
+			return err
+		}
+	}
+	sink.Status = v1.TaskRunSpecStatus(trs.Status)
+	sink.StatusMessage = v1.TaskRunSpecStatusMessage(trs.StatusMessage)
+	sink.Timeout = trs.Timeout
+	sink.PodTemplate = trs.PodTemplate
+	sink.Workspaces = nil
+	for _, w := range trs.Workspaces {
+		new := v1.WorkspaceBinding{}
+		w.convertTo(ctx, &new)
+		sink.Workspaces = append(sink.Workspaces, new)
+	}
+	sink.StepOverrides = nil
+	for _, so := range trs.StepOverrides {
+		new := v1.TaskRunStepOverride{}
+		so.convertTo(ctx, &new)
+		sink.StepOverrides = append(sink.StepOverrides, new)
+	}
+	sink.SidecarOverrides = nil
+	for _, so := range trs.SidecarOverrides {
+		new := v1.TaskRunSidecarOverride{}
+		so.convertTo(ctx, &new)
+		sink.SidecarOverrides = append(sink.SidecarOverrides, new)
+	}
+	sink.ComputeResources = trs.ComputeResources
+	return nil
 }
 
 // ConvertFrom implements apis.Convertible
-func (tr *TaskRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+func (tr *TaskRun) ConvertFrom(ctx context.Context, from apis.Convertible) error {
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+	switch source := from.(type) {
+	case *v1.TaskRun:
+		tr.ObjectMeta = source.ObjectMeta
+		return tr.Spec.ConvertFrom(ctx, &source.Spec)
+	default:
+		return fmt.Errorf("unknown version, got: %T", tr)
+	}
+}
+
+// ConvertFrom implements apis.Convertible
+func (trs *TaskRunSpec) ConvertFrom(ctx context.Context, source *v1.TaskRunSpec) error {
+	if source.Debug != nil {
+		newDebug := TaskRunDebug{}
+		newDebug.convertFrom(ctx, *source.Debug)
+		trs.Debug = &newDebug
+	}
+	trs.Params = nil
+	for _, p := range source.Params {
+		new := Param{}
+		new.convertFrom(ctx, p)
+		trs.Params = append(trs.Params, new)
+	}
+	trs.ServiceAccountName = source.ServiceAccountName
+	if source.TaskRef != nil {
+		newTaskRef := TaskRef{}
+		newTaskRef.convertFrom(ctx, *source.TaskRef)
+		trs.TaskRef = &newTaskRef
+	}
+	if source.TaskSpec != nil {
+		newTaskSpec := TaskSpec{}
+		err := newTaskSpec.ConvertFrom(ctx, source.TaskSpec)
+		if err != nil {
+			return err
+		}
+		trs.TaskSpec = &newTaskSpec
+	}
+	trs.Status = TaskRunSpecStatus(source.Status)
+	trs.StatusMessage = TaskRunSpecStatusMessage(source.StatusMessage)
+	trs.Timeout = source.Timeout
+	trs.PodTemplate = source.PodTemplate
+	trs.Workspaces = nil
+	for _, w := range source.Workspaces {
+		new := WorkspaceBinding{}
+		new.convertFrom(ctx, w)
+		trs.Workspaces = append(trs.Workspaces, new)
+	}
+	trs.StepOverrides = nil
+	for _, so := range source.StepOverrides {
+		new := TaskRunStepOverride{}
+		new.convertFrom(ctx, so)
+		trs.StepOverrides = append(trs.StepOverrides, new)
+	}
+	trs.SidecarOverrides = nil
+	for _, so := range source.SidecarOverrides {
+		new := TaskRunSidecarOverride{}
+		new.convertFrom(ctx, so)
+		trs.SidecarOverrides = append(trs.SidecarOverrides, new)
+	}
+	trs.ComputeResources = source.ComputeResources
+	return nil
+}
+
+func (trd TaskRunDebug) convertTo(ctx context.Context, sink *v1.TaskRunDebug) {
+	sink.Breakpoint = trd.Breakpoint
+}
+
+func (trd *TaskRunDebug) convertFrom(ctx context.Context, source v1.TaskRunDebug) {
+	trd.Breakpoint = source.Breakpoint
+}
+
+func (trso TaskRunStepOverride) convertTo(ctx context.Context, sink *v1.TaskRunStepOverride) {
+	sink.Name = trso.Name
+	sink.Resources = trso.Resources
+}
+
+func (trso *TaskRunStepOverride) convertFrom(ctx context.Context, source v1.TaskRunStepOverride) {
+	trso.Name = source.Name
+	trso.Resources = source.Resources
+}
+
+func (trso TaskRunSidecarOverride) convertTo(ctx context.Context, sink *v1.TaskRunSidecarOverride) {
+	sink.Name = trso.Name
+	sink.Resources = trso.Resources
+}
+
+func (trso *TaskRunSidecarOverride) convertFrom(ctx context.Context, source v1.TaskRunSidecarOverride) {
+	trso.Name = source.Name
+	trso.Resources = source.Resources
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -14,15 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package v1beta1_test
 
 import (
 	"context"
 	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	pod "github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/test/diff"
+	corev1 "k8s.io/api/core/v1"
+	corev1resources "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+const (
+	breakpointOnFailure = "onFailure"
 )
 
 func TestTaskRunConversionBadType(t *testing.T) {
-	good, bad := &TaskRun{}, &Task{}
+	good, bad := &v1beta1.TaskRun{}, &v1beta1.Task{}
 
 	if err := good.ConvertTo(context.Background(), bad); err == nil {
 		t.Errorf("ConvertTo() = %#v, wanted error", bad)
@@ -30,5 +45,238 @@ func TestTaskRunConversionBadType(t *testing.T) {
 
 	if err := good.ConvertFrom(context.Background(), bad); err == nil {
 		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}
+
+func TestTaskrunConversion(t *testing.T) {
+	versions := []apis.Convertible{&v1.TaskRun{}}
+
+	tests := []struct {
+		name string
+		in   *v1beta1.TaskRun
+	}{{
+		name: "simple taskrun",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{Name: "test-task"},
+			},
+		},
+	}, {
+		name: "taskrun conversion all non deprecated fields",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Debug: &v1beta1.TaskRunDebug{
+					Breakpoint: []string{breakpointOnFailure},
+				},
+				Params: []v1beta1.Param{{
+					Name: "param-task-1",
+					Value: v1beta1.ParamValue{
+						ArrayVal: []string{"value-task-1"},
+					},
+				}},
+				ServiceAccountName: "test-sa",
+				TaskRef:            &v1beta1.TaskRef{Name: "test-task"},
+				TaskSpec: &v1beta1.TaskSpec{
+					Params: []v1beta1.ParamSpec{{
+						Name: "param-name",
+					}},
+				},
+				Status:        "test-task-run-spec-status",
+				StatusMessage: v1beta1.TaskRunSpecStatusMessage("test-status-message"),
+				Timeout:       &metav1.Duration{Duration: 5 * time.Second},
+				PodTemplate: &pod.Template{
+					NodeSelector: map[string]string{
+						"label": "value",
+					},
+				},
+				Workspaces: []v1beta1.WorkspaceBinding{{
+					Name:    "workspace-volumeclaimtemplate",
+					SubPath: "/foo/bar/baz",
+					VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{},
+					},
+				}, {
+					Name:                  "workspace-pvc",
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{},
+				}, {
+					Name:     "workspace-emptydir",
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}, {
+					Name: "workspace-configmap",
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "configbar",
+						},
+					},
+				}, {
+					Name:   "workspace-secret",
+					Secret: &corev1.SecretVolumeSource{SecretName: "sname"},
+				}, {
+					Name: "workspace-projected",
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{{
+							ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "projected-configmap",
+								},
+							},
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "projected-secret",
+								},
+							},
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience: "projected-sat",
+							},
+						}},
+					},
+				}, {
+					Name: "workspace-csi",
+					CSI: &corev1.CSIVolumeSource{
+						NodePublishSecretRef: &corev1.LocalObjectReference{
+							Name: "projected-csi",
+						},
+						VolumeAttributes: map[string]string{"key": "attribute-val"},
+					},
+				},
+				},
+				StepOverrides: []v1beta1.TaskRunStepOverride{{
+					Name: "task-1",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
+					}},
+				},
+				SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{
+					Name: "task-1",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
+					}},
+				},
+				ComputeResources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceMemory: corev1resources.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+	}}
+
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+					t.Errorf("ConvertTo() = %v", err)
+					return
+				}
+				t.Logf("ConvertTo() =%v", ver)
+				got := &v1beta1.TaskRun{}
+				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+					t.Errorf("ConvertFrom() = %v", err)
+				}
+				t.Logf("ConvertFrom() =%v", got)
+				if d := cmp.Diff(test.in, got); d != "" {
+					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
+				}
+			})
+		}
+	}
+}
+
+func TestTaskRunConversionFromDeprecated(t *testing.T) {
+	// TODO(#4546): We're just dropping Resources when converting from
+	// v1beta1 to v1. Before moving the stored version to v1, we should
+	// come up with a better strategy
+	versions := []apis.Convertible{&v1.TaskRun{}}
+	tests := []struct {
+		name string
+		in   *v1beta1.TaskRun
+		want *v1beta1.TaskRun
+	}{{
+		name: "input resources",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Inputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{},
+		},
+	}, {
+		name: "output resources",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Outputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{},
+		},
+	}}
+	for _, test := range tests {
+		for _, version := range versions {
+			t.Run(test.name, func(t *testing.T) {
+				ver := version
+				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+					t.Errorf("ConvertTo() = %v", err)
+				}
+				t.Logf("ConvertTo() = %#v", ver)
+				got := &v1beta1.TaskRun{}
+				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+					t.Errorf("ConvertFrom() = %v", err)
+				}
+				t.Logf("ConvertFrom() = %#v", got)
+				if d := cmp.Diff(test.want, got); d != "" {
+					t.Errorf("roundtrip %s", diff.PrintWantGot(d))
+				}
+			})
+		}
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/workspace_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/workspace_conversion.go
@@ -55,3 +55,27 @@ func (w *WorkspacePipelineTaskBinding) convertFrom(ctx context.Context, source v
 	w.Workspace = source.Workspace
 	w.SubPath = source.SubPath
 }
+
+func (w WorkspaceBinding) convertTo(ctx context.Context, sink *v1.WorkspaceBinding) {
+	sink.Name = w.Name
+	sink.SubPath = w.SubPath
+	sink.VolumeClaimTemplate = w.VolumeClaimTemplate
+	sink.PersistentVolumeClaim = w.PersistentVolumeClaim
+	sink.EmptyDir = w.EmptyDir
+	sink.ConfigMap = w.ConfigMap
+	sink.Secret = w.Secret
+	sink.Projected = w.Projected
+	sink.CSI = w.CSI
+}
+
+func (w *WorkspaceBinding) convertFrom(ctx context.Context, source v1.WorkspaceBinding) {
+	w.Name = source.Name
+	w.SubPath = source.SubPath
+	w.VolumeClaimTemplate = source.VolumeClaimTemplate
+	w.PersistentVolumeClaim = source.PersistentVolumeClaim
+	w.EmptyDir = source.EmptyDir
+	w.ConfigMap = source.ConfigMap
+	w.Secret = source.Secret
+	w.Projected = source.Projected
+	w.CSI = source.CSI
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit adds conversion functions between v1beta1 and v1 TaskRun.
It does not handle fields deprecated in v1beta1 that will not be present in v1.
It implements ConvertTo and ConvertFrom for v1beta1 TaskRun, and leaves
these functions unimplemented for v1 TaskRun, since it is the highest known version.

needs #5272 #5354

Part of #4985
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
