### PR TITLE
Fix a typo in 5080-entrypoint-init-regression.yaml

### DIFF
--- a/examples/v1beta1/taskruns/5080-entrypoint-init-regression.yaml
+++ b/examples/v1beta1/taskruns/5080-entrypoint-init-regression.yaml
@@ -14,7 +14,7 @@ spec:
       Test consuming args, acts as a regression test for bug 5080
     params:
     - name: ARGS
-      description: The terraform cli commands to tun
+      description: The terraform cli commands to run
       type: array
       default:
       - "--help"


### PR DESCRIPTION
fix typo

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Fix a typo in 5080-entrypoint-init-regression.yaml

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] ~Follows the [commit message standard]~(https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] ~Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)~
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] ~Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)~
- [x] ~Release notes contains the string "action required" if the change requires additional action from users switching to the new release~

# Release Notes

``` release-note
NONE
```
