### PR TITLE
Unscheduled Runs shouldn't be included in full status

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -199,10 +199,11 @@ func (state PipelineRunState) GetRunsStatus(pr *v1beta1.PipelineRun) map[string]
 			continue
 		}
 
-		var prrs *v1beta1.PipelineRunRunStatus
-		if rpt.Run != nil {
-			prrs = pr.Status.Runs[rpt.RunName]
+		if rpt.Run == nil {
+			continue
 		}
+
+		prrs := pr.Status.Runs[rpt.RunName]
 
 		if prrs == nil {
 			prrs = &v1beta1.PipelineRunRunStatus{
@@ -210,10 +211,7 @@ func (state PipelineRunState) GetRunsStatus(pr *v1beta1.PipelineRun) map[string]
 				WhenExpressions:  rpt.PipelineTask.WhenExpressions,
 			}
 		}
-
-		if rpt.Run != nil {
-			prrs.Status = &rpt.Run.Status
-		}
+		prrs.Status = &rpt.Run.Status
 
 		status[rpt.RunName] = prrs
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2381,6 +2381,15 @@ spec:
 		}},
 		TaskRef: &v1beta1.TaskRef{Name: "unit-test-task"},
 	}
+	unscheduledPipelineTask := v1beta1.PipelineTask{
+		Name: "unit-test-2",
+		WhenExpressions: []v1beta1.WhenExpression{{
+			Input:    "foo",
+			Operator: selection.In,
+			Values:   []string{"foo", "bar"},
+		}},
+		TaskRef: &v1beta1.TaskRef{Name: "unit-test-task"},
+	}
 
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
@@ -2415,6 +2424,12 @@ status:
 		PipelineTask: &pipelineTask,
 		TaskRunName:  "test-pipeline-run-success-unit-test-1",
 		TaskRun:      taskrun,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		PipelineTask: &unscheduledPipelineTask,
+		TaskRunName:  "test-pipeline-run-success-unit-test-2",
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskSpec: &task.Spec,
 		},
@@ -2473,6 +2488,19 @@ spec:
 			Name:       "unit-test-run",
 		},
 	}
+	unscheduledPipelineTask := v1beta1.PipelineTask{
+		Name: "unit-test-2",
+		WhenExpressions: []v1beta1.WhenExpression{{
+			Input:    "foo",
+			Operator: selection.In,
+			Values:   []string{"foo", "bar"},
+		}},
+		TaskRef: &v1beta1.TaskRef{
+			APIVersion: "example.dev/v0",
+			Kind:       "Example",
+			Name:       "unit-test-run",
+		},
+	}
 
 	run := parse.MustParseRun(t, fmt.Sprintf(`
 metadata:
@@ -2489,6 +2517,10 @@ status:
 		CustomTask:   true,
 		RunName:      "test-pipeline-run-success-unit-test-1",
 		Run:          run,
+	}, {
+		PipelineTask: &unscheduledPipelineTask,
+		CustomTask:   true,
+		RunName:      "test-pipeline-run-success-unit-test-2",
 	}}
 	pr.Status.InitializeConditions(testClock)
 	status := state.GetRunsStatus(pr)


### PR DESCRIPTION
# Changes

Fixes #5282

When removing conditions, I accidentally made `GetRunsStatus` not skip including custom task `ResolvedPipelineTask`s without `Run`s in the `PipelineRun.Status.Runs` map. This resulted in cancellation failing, because the cancellation logic tries to patch each `Run` or `TaskRun` in the `PipelineRun` status (either in the `Runs` and `TaskRuns` maps for full embedded status, or `ChildReferences` for minimal or both embedded status). Unscheduled `PipelineTask`s for `Task`s were already properly excluded from the status map, and `ChildReferences` was fine either way, but due to the oversight I mentioned above, unscheduled `PipelineTask`s for custom tasks _were_ included in the full embedded status map, and cancellation would error due to that.

This will need to be cherry-picked to v0.37.x and v0.38.x, since the issue was a regression.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix cancellation of PipelineRuns with unscheduled custom tasks.
```
