### PR TITLE
Move validation from `pipelinespec` to `pipelinerunspec` when propagating parameters

### DIFF
--- a/pkg/apis/config/contexts.go
+++ b/pkg/apis/config/contexts.go
@@ -23,8 +23,8 @@ import (
 // isSubstituted is used for associating the parameter substitution inside the context.Context.
 type isSubstituted struct{}
 
-// validateEmbeddedVariables is used for deciding whether to validate or skip parameters and workspaces inside the contect.Context.
-type validateEmbeddedVariables string
+// validatePropagatedVariables is used for deciding whether to validate or skip parameters and workspaces inside the contect.Context.
+type validatePropagatedVariables string
 
 // WithinSubstituted is used to note that it is calling within
 // the context of a substitute variable operation.
@@ -37,12 +37,12 @@ func IsSubstituted(ctx context.Context) bool {
 	return ctx.Value(isSubstituted{}) != nil
 }
 
-// SetValidateParameterVariablesAndWorkspaces sets the context to skip validation of parameters when embedded vs referenced to true or false.
-func SetValidateParameterVariablesAndWorkspaces(ctx context.Context, validate bool) context.Context {
-	return context.WithValue(ctx, validateEmbeddedVariables("ValidateParameterVariablesAndWorkspaces"), validate)
+// SkipValidationDueToPropagatedParametersAndWorkspaces sets the context to skip validation of parameters when embedded vs referenced to true or false.
+func SkipValidationDueToPropagatedParametersAndWorkspaces(ctx context.Context, skip bool) context.Context {
+	return context.WithValue(ctx, validatePropagatedVariables("ValidatePropagatedParameterVariablesAndWorkspaces"), !skip)
 }
 
 // ValidateParameterVariablesAndWorkspaces indicates if validation of paramater variables and workspaces should be conducted.
 func ValidateParameterVariablesAndWorkspaces(ctx context.Context) bool {
-	return ctx.Value(validateEmbeddedVariables("ValidateParameterVariablesAndWorkspaces")) == true
+	return ctx.Value(validatePropagatedVariables("ValidatePropagatedParameterVariablesAndWorkspaces")) == true
 }

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -224,6 +224,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 				cfg.FeatureFlags.EnableAPIFields = config.AlphaAPIFields
 			}
 			ctx = config.ToContext(ctx, cfg)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := tt.tasks.validateTask(ctx)
 			if err != nil {
 				t.Errorf("PipelineTask.validateTask() returned error for valid pipeline task: %v", err)
@@ -282,7 +283,8 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.task.validateTask(context.Background())
+			ctx := config.SkipValidationDueToPropagatedParametersAndWorkspaces(context.Background(), false)
+			err := tt.task.validateTask(ctx)
 			if err == nil {
 				t.Error("PipelineTask.validateTask() did not return error for invalid pipeline task")
 			}
@@ -317,6 +319,7 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := tt.p.Validate(ctx)
 			if err == nil {
 				t.Error("PipelineTask.Validate() did not return error for invalid pipeline task")

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
 	"github.com/tektoncd/pipeline/pkg/substitution"
@@ -38,6 +39,7 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 	return errs.Also(p.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -56,7 +56,7 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
-	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -126,7 +126,7 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 			}
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -1263,7 +1263,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := ts.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
@@ -1368,7 +1368,7 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 			err := ts.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
@@ -1420,7 +1420,7 @@ func TestStepOnError(t *testing.T) {
 			}
 			ctx := context.Background()
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 			err := ts.Validate(ctx)
 			if tt.expectedError == nil && err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
@@ -1515,7 +1515,7 @@ func TestIncompatibleAPIVersions(t *testing.T) {
 					ctx = config.EnableAlphaAPIFields(ctx)
 				}
 				ts.SetDefaults(ctx)
-				ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+				ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 				err := ts.Validate(ctx)
 
 				if tt.requiredVersion != version && err == nil {
@@ -1599,7 +1599,7 @@ func TestSubstitutedContext(t *testing.T) {
 			}
 			ctx := context.Background()
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			if tt.fields.SubstitutionContext {
 				ctx = config.WithinSubstituted(ctx)
 			}

--- a/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/cluster_task_validation.go
@@ -32,6 +32,6 @@ func (t *ClusterTask) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
-	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -279,6 +279,7 @@ func TestPipelineTask_ValidateRegularTask_Success(t *testing.T) {
 				cfg.FeatureFlags.EnableTektonOCIBundles = true
 			}
 			ctx = config.ToContext(ctx, cfg)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := tt.tasks.validateTask(ctx)
 			if err != nil {
 				t.Errorf("PipelineTask.validateTask() returned error for valid pipeline task: %v", err)
@@ -344,7 +345,8 @@ func TestPipelineTask_ValidateRegularTask_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.task.validateTask(context.Background())
+			ctx := config.SkipValidationDueToPropagatedParametersAndWorkspaces(context.Background(), false)
+			err := tt.task.validateTask(ctx)
 			if err == nil {
 				t.Error("PipelineTask.validateTask() did not return error for invalid pipeline task")
 			}
@@ -390,6 +392,7 @@ func TestPipelineTask_Validate_Failure(t *testing.T) {
 			if tt.wc != nil {
 				ctx = tt.wc(ctx)
 			}
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := tt.p.Validate(ctx)
 			if err == nil {
 				t.Error("PipelineTask.Validate() did not return error for invalid pipeline task")
@@ -735,6 +738,7 @@ func TestPipelineTaskList_Validate(t *testing.T) {
 				ctx = tt.wc(ctx)
 			}
 			taskNames := sets.String{}
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := tt.tasks.Validate(ctx, taskNames, tt.path)
 			if tt.expectedError != nil && err == nil {
 				t.Error("PipelineTaskList.Validate() did not return error for invalid pipeline tasks")

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag"
@@ -39,6 +40,7 @@ func (p *Pipeline) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(p.GetObjectMeta()).ViaField("metadata")
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 	return errs.Also(p.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -56,7 +56,7 @@ func (t *Task) Validate(ctx context.Context) *apis.FieldError {
 		return nil
 	}
 	errs := validate.ObjectMetadata(t.GetObjectMeta()).ViaField("metadata")
-	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 	return errs.Also(t.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
 }
 

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -142,7 +142,7 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 			}
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -1373,7 +1373,7 @@ func TestTaskSpecValidateError(t *testing.T) {
 			}
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := ts.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
@@ -1421,7 +1421,7 @@ func TestStepAndSidecarWorkspaces(t *testing.T) {
 			}
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 			if err := ts.Validate(ctx); err != nil {
 				t.Errorf("TaskSpec.Validate() = %v", err)
 			}
@@ -1479,7 +1479,7 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 
 			ctx := config.EnableAlphaAPIFields(context.Background())
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 			err := ts.Validate(ctx)
 			if err == nil {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
@@ -1555,7 +1555,7 @@ func TestStepOnError(t *testing.T) {
 			}
 			ctx := context.Background()
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			err := ts.Validate(ctx)
 			if tt.expectedError == nil && err != nil {
 				t.Errorf("No error expected from TaskSpec.Validate() but got = %v", err)
@@ -1653,7 +1653,7 @@ func TestIncompatibleAPIVersions(t *testing.T) {
 					ctx = config.EnableAlphaAPIFields(ctx)
 				}
 				ts.SetDefaults(ctx)
-				ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+				ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 				err := ts.Validate(ctx)
 
 				if tt.requiredVersion != version && err == nil {
@@ -1737,7 +1737,7 @@ func TestSubstitutedContext(t *testing.T) {
 			}
 			ctx := context.Background()
 			ts.SetDefaults(ctx)
-			ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 			if tt.fields.SubstitutionContext {
 				ctx = config.WithinSubstituted(ctx)
 			}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -56,7 +56,7 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	// Validate TaskSpec if it's present.
 	if ts.TaskSpec != nil {
 		// skip validation of parameter and workspaces variables since we validate them via taskrunspec below.
-		ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, false)
+		ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 		errs = errs.Also(ts.TaskSpec.Validate(ctx).ViaField("taskSpec"))
 	}
 
@@ -135,7 +135,7 @@ func (ts *TaskRunSpec) validateInlineParameters(ctx context.Context) (errs *apis
 		}
 	}
 	if ts.TaskSpec != nil && ts.TaskSpec.Steps != nil {
-		errs = errs.Also(ValidateParameterVariables(config.SetValidateParameterVariablesAndWorkspaces(ctx, true), ts.TaskSpec.Steps, paramSpec))
+		errs = errs.Also(ValidateParameterVariables(config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false), ts.TaskSpec.Steps, paramSpec))
 	}
 	return errs
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -392,6 +392,9 @@ func (c *Reconciler) reconcile(ctx context.Context, pr *v1beta1.PipelineRun, get
 		return controller.NewPermanentError(err)
 	}
 
+	// Because of parameter propagation, we skip validating it inside the pipelineSpec since it may
+	// not have the full list of defined parameters
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, true)
 	if err := pipelineSpec.Validate(ctx); err != nil {
 		// This Run has failed, so we need to mark it as failed and stop reconciling it
 		pr.Status.MarkFailed(ReasonFailedValidation,

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -706,7 +706,7 @@ func (c *Reconciler) createPod(ctx context.Context, ts *v1beta1.TaskSpec, tr *v1
 
 	// By this time, params and workspaces should be propagated down so we can
 	// validate that all parameter variables and workspaces used in the TaskSpec are declared by the Task.
-	ctx = config.SetValidateParameterVariablesAndWorkspaces(ctx, true)
+	ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
 	if validateErr := ts.Validate(ctx); validateErr != nil {
 		logger.Errorf("Failed to create a pod for taskrun: %s due to task validation error %v", tr.Name, validateErr)
 		return nil, validateErr


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Prior to this, propagating parameters only skipped webhook validation for params defined in script. As a result, when users tried to propagate params to other fields like `args` or `command`, etc. an webhook validation was raised. This PR address issue https://github.com/tektoncd/pipeline/issues/5141. This PR addresses validations in `pipelinespec` and `pipelinerunspec`. The changes for validations in `taskspec` and `taskrunspec` are in a separate [PR](https://github.com/tektoncd/pipeline/pull/5143).

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Move parameter validation from `pipelinespec` to `pipelinerunspec` when propagating parameters
```
