### PR TITLE
Prevent infinite recursion in skipBecauseResultReferencesAreMissing

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -412,7 +412,7 @@ func (t *ResolvedPipelineTask) skipBecauseResultReferencesAreMissing(facts *Pipe
 		resolvedResultRefs, pt, err := ResolveResultRefs(facts.State, PipelineRunState{t})
 		rpt := facts.State.ToMap()[pt]
 		if rpt != nil {
-			if err != nil && (t.IsFinalTask(facts) || rpt.Skip(facts).SkippingReason == v1beta1.WhenExpressionsSkip) {
+			if err != nil && (t.IsFinalTask(facts) || rpt.skipBecauseWhenExpressionsEvaluatedToFalse(facts)) {
 				return true
 			}
 		}


### PR DESCRIPTION
# Changes

fixes #5271

While I have not been able to determine why setting `enable-api-fields` to `alpha` while `PipelineRun`s using results are in flight hits this, the immediate symptom in the linked issue is that an infinite recursive loop is hit in `skipBecauseResultReferencesAreMissing`, due to `skipBecauseResultReferencesAreMissing` calling `rpt.Skip(facts)`, which calls `rpt.skip(facts)`, which ends up calling `rpt.skipBecauseResultReferencesAreMissing` again, etc. Changing the call to `rpt.Skip(facts).SkippingReason == v1beta1.WhenExpressionsSkip` to `rpt.skipBecauseWhenExpressionsEvaluatedToFalse(facts)` not only gets rid of the potential for infinite recursion, it also more directly checks the condition we care about there in the first place.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fixes a potential infinite loop when a Pipeline task is missing needed results.
```
