### PR TITLE
Unscheduled Runs shouldn't be included in full status

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -7749,3 +7749,94 @@ spec:
 		})
 	}
 }
+
+func TestReconcile_CancelUnscheduled(t *testing.T) {
+	testCases := []struct {
+		name              string
+		embeddedStatusVal string
+	}{
+		{
+			name:              "default embedded status",
+			embeddedStatusVal: config.DefaultEmbeddedStatus,
+		},
+		{
+			name:              "full embedded status",
+			embeddedStatusVal: config.FullEmbeddedStatus,
+		},
+		{
+			name:              "both embedded status",
+			embeddedStatusVal: config.BothEmbeddedStatus,
+		},
+		{
+			name:              "minimal embedded status",
+			embeddedStatusVal: config.MinimalEmbeddedStatus,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pipelineRunName := "cancel-test-run"
+			prs := []*v1beta1.PipelineRun{parse.MustParsePipelineRun(t, `metadata:
+  name: cancel-test-run
+  namespace: foo
+spec:
+  pipelineSpec:
+    tasks:
+      - name: wait-1
+        taskSpec:
+          apiVersion: example.dev/v0
+          kind: Wait
+          params:
+            - name: duration
+              value: 1h
+      - name: wait-2
+        runAfter:
+          - wait-1
+        taskSpec:
+          apiVersion: example.dev/v0
+          kind: Wait
+          params:
+            - name: duration
+              value: 10s
+      - name: wait-3
+        runAfter:
+          - wait-1
+        taskRef:
+          name: hello-world
+`)}
+
+			ts := []*v1beta1.Task{simpleHelloWorldTask}
+
+			cms := []*corev1.ConfigMap{withEmbeddedStatus(withCustomTasks(newFeatureFlagsConfigMap()), tc.embeddedStatusVal)}
+
+			d := test.Data{
+				PipelineRuns: prs,
+				Tasks:        ts,
+				ConfigMaps:   cms,
+			}
+			prt := newPipelineRunTest(d, t)
+			defer prt.Cancel()
+
+			pr, clients := prt.reconcileRun("foo", pipelineRunName, []string{}, false)
+
+			if tc.embeddedStatusVal != config.MinimalEmbeddedStatus {
+				if len(pr.Status.Runs) > 1 {
+					t.Errorf("Expected one Run in status, but found %d", len(pr.Status.Runs))
+				}
+				if len(pr.Status.TaskRuns) > 0 {
+					t.Errorf("Expected no TaskRuns in status, but found %d", len(pr.Status.TaskRuns))
+				}
+			}
+			if tc.embeddedStatusVal != config.FullEmbeddedStatus {
+				if len(pr.Status.ChildReferences) > 1 {
+					t.Errorf("Expected one Run or TaskRun in child references, but found %d", len(pr.Status.ChildReferences))
+				}
+			}
+
+			err := cancelPipelineRun(prt.TestAssets.Ctx, logtesting.TestLogger(t), pr, clients.Pipeline)
+			if err != nil {
+				t.Fatalf("Error found: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -198,10 +198,11 @@ func (state PipelineRunState) GetRunsStatus(pr *v1beta1.PipelineRun) map[string]
 			continue
 		}
 
-		var prrs *v1beta1.PipelineRunRunStatus
-		if rprt.Run != nil {
-			prrs = pr.Status.Runs[rprt.RunName]
+		if rprt.Run == nil {
+			continue
 		}
+
+		prrs := pr.Status.Runs[rprt.RunName]
 
 		if prrs == nil {
 			prrs = &v1beta1.PipelineRunRunStatus{
@@ -209,10 +210,7 @@ func (state PipelineRunState) GetRunsStatus(pr *v1beta1.PipelineRun) map[string]
 				WhenExpressions:  rprt.PipelineTask.WhenExpressions,
 			}
 		}
-
-		if rprt.Run != nil {
-			prrs.Status = &rprt.Run.Status
-		}
+		prrs.Status = &rprt.Run.Status
 
 		status[rprt.RunName] = prrs
 	}

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -2067,6 +2067,15 @@ spec:
 		}},
 		TaskRef: &v1beta1.TaskRef{Name: "unit-test-task"},
 	}
+	unscheduledPipelineTask := v1beta1.PipelineTask{
+		Name: "unit-test-2",
+		WhenExpressions: []v1beta1.WhenExpression{{
+			Input:    "foo",
+			Operator: selection.In,
+			Values:   []string{"foo", "bar"},
+		}},
+		TaskRef: &v1beta1.TaskRef{Name: "unit-test-task"},
+	}
 
 	task := parse.MustParseTask(t, fmt.Sprintf(`
 metadata:
@@ -2101,6 +2110,12 @@ status:
 		PipelineTask: &pipelineTask,
 		TaskRunName:  "test-pipeline-run-success-unit-test-1",
 		TaskRun:      taskrun,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}, {
+		PipelineTask: &unscheduledPipelineTask,
+		TaskRunName:  "test-pipeline-run-success-unit-test-2",
 		ResolvedTaskResources: &resources.ResolvedTaskResources{
 			TaskSpec: &task.Spec,
 		},
@@ -2159,6 +2174,19 @@ spec:
 			Name:       "unit-test-run",
 		},
 	}
+	unscheduledPipelineTask := v1beta1.PipelineTask{
+		Name: "unit-test-2",
+		WhenExpressions: []v1beta1.WhenExpression{{
+			Input:    "foo",
+			Operator: selection.In,
+			Values:   []string{"foo", "bar"},
+		}},
+		TaskRef: &v1beta1.TaskRef{
+			APIVersion: "example.dev/v0",
+			Kind:       "Example",
+			Name:       "unit-test-run",
+		},
+	}
 
 	run := parse.MustParseRun(t, fmt.Sprintf(`
 metadata:
@@ -2175,6 +2203,10 @@ status:
 		CustomTask:   true,
 		RunName:      "test-pipeline-run-success-unit-test-1",
 		Run:          run,
+	}, {
+		PipelineTask: &unscheduledPipelineTask,
+		CustomTask:   true,
+		RunName:      "test-pipeline-run-success-unit-test-2",
 	}}
 	pr.Status.InitializeConditions(testClock)
 	status := state.GetRunsStatus(pr)


### PR DESCRIPTION
Cherry-pick https://github.com/tektoncd/pipeline/pull/5287 on v0.37.x
# Changes

Fixes #5282

When removing conditions, I accidentally made `GetRunsStatus` not skip including custom task `ResolvedPipelineTask`s without `Run`s in the `PipelineRun.Status.Runs` map. This resulted in cancellation failing, because the cancellation logic tries to patch each `Run` or `TaskRun` in the `PipelineRun` status (either in the `Runs` and `TaskRuns` maps for full embedded status, or `ChildReferences` for minimal or both embedded status). Unscheduled `PipelineTask`s for `Task`s were already properly excluded from the status map, and `ChildReferences` was fine either way, but due to the oversight I mentioned above, unscheduled `PipelineTask`s for custom tasks _were_ included in the full embedded status map, and cancellation would error due to that.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix cancellation of PipelineRuns with unscheduled custom tasks.
```

/kind bug