### PR TITLE
TEP-0090: Matrix - Retries

### DIFF
--- a/docs/matrix.md
+++ b/docs/matrix.md
@@ -19,6 +19,7 @@ weight: 11
 - [Fan Out](#fan-out)
   - [`PipelineTasks` with `Tasks`](#pipelinetasks-with-tasks)
   - [`PipelineTasks` with `Custom Tasks`](#pipelinetasks-with-custom-tasks)
+- [Retries](#retries)
 
 ## Overview
 
@@ -521,6 +522,47 @@ status:
       pipelineTaskName: platforms-and-browsers
 ```
 
+## Retries
+
+The `retries` field is used to specify the number of times a `PipelineTask` should be retried when its `TaskRun` or 
+`Run` fails, see the [documentation][retries] for further details. When a `PipelineTask` is fanned out using `Matrix`, 
+a given `TaskRun` or `Run` executed will be retried as much as the field in the `retries` field of the `PipelineTask`.
+
+For example, the `PipelineTask` in this `PipelineRun` will be fanned out into three `TaskRuns` each of which will be 
+retried once:
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: matrixed-pr-with-retries-
+spec:
+  pipelineSpec:
+    tasks:
+      - name: matrix-and-params
+        matrix:
+          - name: platform
+            value:
+              - linux
+              - mac
+              - windows
+        params:
+          - name: browser
+            value: chrome
+        retries: 1
+        taskSpec:
+          params:
+            - name: platform
+            - name: browser
+          steps:
+            - name: echo
+              image: alpine
+              script: |
+                echo "$(params.platform) and $(params.browser)"
+                exit 1
+```
+
 [cel]: https://github.com/tektoncd/experimental/tree/1609827ea81d05c8d00f8933c5c9d6150cd36989/cel
 [pr-with-matrix]: ../examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix.yaml
 [pr-with-matrix-and-results]: ../examples/v1beta1/pipelineruns/alpha/pipelinerun-with-matrix-and-results.yaml
+[retries]: pipelines.md#using-the-retries-field

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -808,6 +808,10 @@ func (c *Reconciler) createTaskRun(ctx context.Context, taskRunName string, para
 
 	tr, _ := c.taskRunLister.TaskRuns(pr.Namespace).Get(taskRunName)
 	if tr != nil {
+		// retry should happen only when the taskrun has failed
+		if !tr.Status.GetCondition(apis.ConditionSucceeded).IsFalse() {
+			return tr, nil
+		}
 		// Don't modify the lister cache's copy.
 		tr = tr.DeepCopy()
 		// is a retry


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

[TEP-0090: Matrix][tep-0090] proposed executing a `PipelineTask` in parallel `TaskRuns` and `Runs` with substitutions from combinations of `Parameters` in a `Matrix`.

Today, a matrixed `PipelineTask` that has retries will reattempt each matrixed `TaskRun` when one of them fails. In this change, we fix this issue such that each retry is completed for each matrixed `TaskRun`. That is, each retry for each `TaskRun` is completed before it is reattempted; failure in one matrixed `TaskRun` no longer affects retries for other matrixed `TaskRuns` from the same `PipelineTask`.

Many thanks to @AlanGreene for [catching](https://tektoncd.slack.com/archives/CK3HBG7CM/p1659626154695289) this issue! 

[tep-0090]: https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Each retry for each matrixed `TaskRun` is completed before it is reattempted; failure in one matrixed `TaskRun` no longer affects retries for other matrixed `TaskRuns` from the same `PipelineTask`.
```
