### PR TITLE
Merge affinity from podtempalte and affinity-assistant

### DIFF
--- a/pkg/internal/affinityassistant/transformer_test.go
+++ b/pkg/internal/affinityassistant/transformer_test.go
@@ -88,3 +88,156 @@ func TestNewTransformer(t *testing.T) {
 		})
 	}
 }
+
+func TestNewTransformerWithNodeAffinity(t *testing.T) {
+
+	nodeAffinity := &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{{
+				MatchFields: []corev1.NodeSelectorRequirement{{
+					Key:      "kubernetes.io/hostname",
+					Operator: corev1.NodeSelectorOpNotIn,
+					Values:   []string{"192.0.0.1"},
+				}},
+			}},
+		},
+	}
+
+	podAffinityTerm := &corev1.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"from": "podtemplate",
+			},
+		},
+		TopologyKey: "kubernetes.io/hostname",
+	}
+
+	for _, tc := range []struct {
+		description string
+		annotations map[string]string
+		pod         *corev1.Pod
+		expected    *corev1.Affinity
+	}{{
+		description: "no affinity annotation and pod contains nodeAffinity",
+		annotations: map[string]string{
+			"foo": "bar",
+		},
+		pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: nodeAffinity,
+				},
+			},
+		},
+		expected: &corev1.Affinity{
+			NodeAffinity: nodeAffinity,
+		},
+	}, {
+		description: "affinity annotation and pod contains nodeAffinity",
+		annotations: map[string]string{
+			"foo": "bar",
+			workspace.AnnotationAffinityAssistantName: "baz",
+		},
+		pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Affinity: &corev1.Affinity{
+					NodeAffinity: nodeAffinity,
+				},
+			},
+		},
+
+		expected: &corev1.Affinity{
+			NodeAffinity: nodeAffinity,
+			PodAffinity: &corev1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							workspace.LabelInstance:  "baz",
+							workspace.LabelComponent: workspace.ComponentNameAffinityAssistant,
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				}},
+			},
+		},
+	}, {
+		description: "affinity annotation with a different name and pod contains podAffinity",
+		annotations: map[string]string{
+			workspace.AnnotationAffinityAssistantName: "helloworld",
+		},
+		pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Affinity: &corev1.Affinity{PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution:  []corev1.PodAffinityTerm{*podAffinityTerm},
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{100, *podAffinityTerm}},
+				}},
+			},
+		},
+
+		expected: &corev1.Affinity{
+			PodAffinity: &corev1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{*podAffinityTerm, {
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							workspace.LabelInstance:  "helloworld",
+							workspace.LabelComponent: workspace.ComponentNameAffinityAssistant,
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				}},
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					{100, *podAffinityTerm},
+				},
+			},
+		},
+	}, {
+		description: "affinity annotation with a different name and pod contains podAffinity and nodeAffinity",
+		annotations: map[string]string{
+			workspace.AnnotationAffinityAssistantName: "helloworld",
+		},
+		pod: &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Affinity: &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution:  []corev1.PodAffinityTerm{*podAffinityTerm},
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{100, *podAffinityTerm}},
+					},
+					NodeAffinity: nodeAffinity},
+			},
+		},
+
+		expected: &corev1.Affinity{
+			PodAffinity: &corev1.PodAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					*podAffinityTerm,
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								workspace.LabelInstance:  "helloworld",
+								workspace.LabelComponent: workspace.ComponentNameAffinityAssistant,
+							},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					{100, *podAffinityTerm},
+				},
+			},
+			NodeAffinity: nodeAffinity,
+		},
+	},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			ctx := context.Background()
+			f := affinityassistant.NewTransformer(ctx, tc.annotations)
+			got, err := f(tc.pod)
+			if err != nil {
+				t.Fatalf("Transformer failed: %v", err)
+			}
+			if d := cmp.Diff(tc.expected, got.Spec.Affinity); d != "" {
+				t.Errorf("AffinityAssistant diff: %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
No matter user provide affinity in podtemplate or not the
affinity-assistant will overwrite the affinity in pod.

However if user set affinity in podtemplate merge
podtemplate's affinity with affinity-assistant's affinity
is better way.

So we inject the affinity of the affinity-assitant into the
affinity of the podtempalte as the affinity of the pod to
make sure that all the affinities work properly.

Related Issue: https://github.com/tektoncd/pipeline/issues/5241
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
If the user provide affinity in podtempalte it will merge with affinity-assistant's affinity

action required: Need to check podtemplate make sure the change will not cause unexpected behaviour
```
