### PR TITLE
support parameterization for `steps[].onError`

### DIFF
--- a/docs/variables.md
+++ b/docs/variables.md
@@ -160,6 +160,7 @@ variable via `resources.inputs.<resourceName>.<variableName>` or
 | `Task` | `spec.steps[].command` |
 | `Task` | `spec.steps[].args` |
 | `Task` | `spec.steps[].script` |
+| `Task` | `spec.steps[].onError` |
 | `Task` | `spec.steps[].env.value` |
 | `Task` | `spec.steps[].env.valuefrom.secretkeyref.name` |
 | `Task` | `spec.steps[].env.valuefrom.secretkeyref.key` |

--- a/examples/v1beta1/pipelineruns/ignore-step-error.yaml
+++ b/examples/v1beta1/pipelineruns/ignore-step-error.yaml
@@ -4,14 +4,24 @@ metadata:
   generateName: pipelinerun-with-failing-step-
 spec:
   serviceAccountName: 'default'
+  params:
+    - name: CONTINUE
+      value: "continue"
   pipelineSpec:
+    params:
+      - name: CONTINUE
     tasks:
       - name: task1
+        params:
+          - name: CONTINUE
+            value: "$(params.CONTINUE)"
         taskSpec:
+          params:
+          - name: CONTINUE
           steps:
             # not really doing anything here, just a hurdle to test the "ignore step error"
             - image: alpine
-              onError: continue
+              onError: $(params.CONTINUE)
               name: exit-with-1
               script: |
                 exit 1

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1424,24 +1424,36 @@ func TestStepAndSidecarWorkspacesErrors(t *testing.T) {
 func TestStepOnError(t *testing.T) {
 	tests := []struct {
 		name          string
+		params        []v1beta1.ParamSpec
 		steps         []v1beta1.Step
 		expectedError *apis.FieldError
 	}{{
-		name: "valid step - valid onError usage - set to continue - alpha API",
+		name: "valid step - valid onError usage - set to continue",
 		steps: []v1beta1.Step{{
 			OnError: "continue",
 			Image:   "image",
 			Args:    []string{"arg"},
 		}},
 	}, {
-		name: "valid step - valid onError usage - set to stopAndFail - alpha API",
+		name: "valid step - valid onError usage - set to stopAndFail",
 		steps: []v1beta1.Step{{
 			OnError: "stopAndFail",
 			Image:   "image",
 			Args:    []string{"arg"},
 		}},
 	}, {
-		name: "invalid step - onError set to invalid value - alpha API",
+		name: "valid step - valid onError usage - set to a task parameter",
+		params: []v1beta1.ParamSpec{{
+			Name:    "CONTINUE",
+			Default: &v1beta1.ArrayOrString{Type: v1beta1.ParamTypeString, StringVal: "continue"},
+		}},
+		steps: []v1beta1.Step{{
+			OnError: "$(params.CONTINUE)",
+			Image:   "image",
+			Args:    []string{"arg"},
+		}},
+	}, {
+		name: "invalid step - onError set to invalid value",
 		steps: []v1beta1.Step{{
 			OnError: "onError",
 			Image:   "image",
@@ -1449,26 +1461,41 @@ func TestStepOnError(t *testing.T) {
 		}},
 		expectedError: &apis.FieldError{
 			Message: fmt.Sprintf("invalid value: onError"),
-			Paths:   []string{"onError"},
+			Paths:   []string{"steps[0].onError"},
 			Details: "Task step onError must be either continue or stopAndFail",
+		},
+	}, {
+		name: "invalid step - invalid onError usage - set to a parameter which does not exist in the task",
+		steps: []v1beta1.Step{{
+			OnError: "$(params.CONTINUE)",
+			Image:   "image",
+			Args:    []string{"arg"},
+		}},
+		expectedError: &apis.FieldError{
+			Message: "non-existent variable in \"$(params.CONTINUE)\"",
+			Paths:   []string{"steps[0].onError"},
 		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := &v1beta1.TaskSpec{
-				Steps: tt.steps,
+				Params: tt.params,
+				Steps:  tt.steps,
 			}
 			ctx := context.Background()
 			ts.SetDefaults(ctx)
 			err := ts.Validate(ctx)
 			if tt.expectedError == nil && err != nil {
-				t.Errorf("TaskSpec.Validate() = %v", err)
-			} else if tt.expectedError != nil && err == nil {
-				t.Errorf("TaskSpec.Validate() = %v", err)
+				t.Errorf("No error expected from TaskSpec.Validate() but got = %v", err)
+			} else if tt.expectedError != nil {
+				if err == nil {
+					t.Errorf("Expected error from TaskSpec.Validate() = %v, but got none", tt.expectedError)
+				} else if d := cmp.Diff(tt.expectedError.Error(), err.Error()); d != "" {
+					t.Errorf("returned error from TaskSpec.Validate() does not match with the expected error: %s", diff.PrintWantGot(d))
+				}
 			}
 		})
 	}
-
 }
 
 // TestIncompatibleAPIVersions exercises validation of fields that

--- a/pkg/container/step_replacements.go
+++ b/pkg/container/step_replacements.go
@@ -24,6 +24,7 @@ import (
 // ApplyStepReplacements applies variable interpolation on a Step.
 func ApplyStepReplacements(step *v1beta1.Step, stringReplacements map[string]string, arrayReplacements map[string][]string) {
 	step.Script = substitution.ApplyReplacements(step.Script, stringReplacements)
+	step.OnError = substitution.ApplyReplacements(step.OnError, stringReplacements)
 	if step.StdoutConfig != nil {
 		step.StdoutConfig.Path = substitution.ApplyReplacements(step.StdoutConfig.Path, stringReplacements)
 	}

--- a/pkg/container/step_replacements_test.go
+++ b/pkg/container/step_replacements_test.go
@@ -42,6 +42,7 @@ func TestApplyStepReplacements(t *testing.T) {
 		Command:    []string{"$(array.replace.me)"},
 		Args:       []string{"$(array.replace.me)"},
 		WorkingDir: "$(replace.me)",
+		OnError:    "$(replace.me)",
 		EnvFrom: []corev1.EnvFromSource{{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -92,6 +93,7 @@ func TestApplyStepReplacements(t *testing.T) {
 		Command:    []string{"val1", "val2"},
 		Args:       []string{"val1", "val2"},
 		WorkingDir: "replaced!",
+		OnError:    "replaced!",
 		EnvFrom: []corev1.EnvFromSource{{
 			ConfigMapRef: &corev1.ConfigMapEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/entrypoint"
 	"gomodules.xyz/jsonpatch/v2"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -137,6 +138,10 @@ func orderContainers(commonExtraEntrypointArgs []string, steps []corev1.Containe
 		if taskSpec != nil {
 			if taskSpec.Steps != nil && len(taskSpec.Steps) >= i+1 {
 				if taskSpec.Steps[i].OnError != "" {
+					if taskSpec.Steps[i].OnError != entrypoint.ContinueOnError && taskSpec.Steps[i].OnError != entrypoint.FailOnError {
+						return nil, fmt.Errorf("task step onError must be either %s or %s but it is set to an invalid value %s",
+							entrypoint.ContinueOnError, entrypoint.FailOnError, taskSpec.Steps[i].OnError)
+					}
 					argsForEntrypoint = append(argsForEntrypoint, "-on_error", taskSpec.Steps[i].OnError)
 				}
 				if taskSpec.Steps[i].Timeout != nil {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In addition to the static values supported (`continue` and `stopAndFail`) for `onError`, allow specifying these valid values as a task parameter for example, `onError: $(params.CONTINUE)`. Also, validate the specified value is supported otherwise return an error for an invalid value.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Support variables in steps[].onError, for example, $(params.CONTINUE)
```

/kind feature
