### PR TITLE
Test feature flags

### DIFF
--- a/test/featureflags.go
+++ b/test/featureflags.go
@@ -31,7 +31,7 @@ func requireAnyGate(gates map[string]string) func(context.Context, *testing.T, *
 			}
 			pairs = append(pairs, fmt.Sprintf("%q: %q", name, value))
 		}
-		t.Skipf("No feature flag matching %s", strings.Join(pairs, " or "))
+		t.Skipf("No feature flag in namespace %q matching %s\nExisting feature flag: %#v", system.Namespace(), strings.Join(pairs, " or "), featureFlagsCM.Data)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
Adds more info the the error message when feature flags are missing.

Originally the error message only contains the expected feature flags, this pr adds the expected namespace, and current feature flags information to ease the debugging process.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
