### PR TITLE
Check and/or add to sent cloud event cache in one operation

### DIFF
--- a/pkg/reconciler/events/cache/cache.go
+++ b/pkg/reconciler/events/cache/cache.go
@@ -31,21 +31,8 @@ type eventData struct {
 	Run *v1alpha1.Run `json:"run,omitempty"`
 }
 
-// AddEventSentToCache adds the particular object to cache marking it as sent
-func AddEventSentToCache(cacheClient *lru.Cache, event *cloudevents.Event) error {
-	if cacheClient == nil {
-		return errors.New("cache client is nil")
-	}
-	eventKey, err := EventKey(event)
-	if err != nil {
-		return err
-	}
-	cacheClient.Add(eventKey, nil)
-	return nil
-}
-
-// IsCloudEventSent checks if the event exists in the cache
-func IsCloudEventSent(cacheClient *lru.Cache, event *cloudevents.Event) (bool, error) {
+// ContainsOrAddCloudEvent checks if the event exists in the cache
+func ContainsOrAddCloudEvent(cacheClient *lru.Cache, event *cloudevents.Event) (bool, error) {
 	if cacheClient == nil {
 		return false, errors.New("cache client is nil")
 	}
@@ -53,7 +40,8 @@ func IsCloudEventSent(cacheClient *lru.Cache, event *cloudevents.Event) (bool, e
 	if err != nil {
 		return false, err
 	}
-	return cacheClient.Contains(eventKey), nil
+	isPresent, _ := cacheClient.ContainsOrAdd(eventKey, nil)
+	return isPresent, nil
 }
 
 // EventKey defines whether an event is considered different from another

--- a/pkg/reconciler/events/cache/cache_test.go
+++ b/pkg/reconciler/events/cache/cache_test.go
@@ -146,8 +146,8 @@ func TestAddCheckEvent(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			testCache, _ := lru.New(10)
-			AddEventSentToCache(testCache, tc.firstEvent)
-			found, _ := IsCloudEventSent(testCache, tc.secondEvent)
+			_, _ = ContainsOrAddCloudEvent(testCache, tc.firstEvent)
+			found, _ := ContainsOrAddCloudEvent(testCache, tc.secondEvent)
 			if d := cmp.Diff(tc.wantFound, found); d != "" {
 				t.Errorf("Cache check failure %s", diff.PrintWantGot(d))
 			}

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -149,7 +149,7 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 		logger.Debugf("Sending cloudevent of type %q", event.Type())
 		// In case of Run event, check cache if cloudevent is already sent
 		if isRun {
-			cloudEventSent, err := cache.IsCloudEventSent(cacheClient, event)
+			cloudEventSent, err := cache.ContainsOrAddCloudEvent(cacheClient, event)
 			if err != nil {
 				logger.Errorf("error while checking cache: %s", err)
 			}
@@ -163,14 +163,9 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 			recorder := controller.GetEventRecorder(ctx)
 			if recorder == nil {
 				logger.Warnf("No recorder in context, cannot emit error event")
+				return
 			}
 			recorder.Event(object, corev1.EventTypeWarning, "Cloud Event Failure", result.Error())
-		}
-		// In case of Run event, add to the cache to avoid duplicate events
-		if isRun {
-			if err := cache.AddEventSentToCache(cacheClient, event); err != nil {
-				logger.Errorf("error while adding sent event to cache: %s", err)
-			}
 		}
 	}()
 

--- a/test/events/events.go
+++ b/test/events/events.go
@@ -26,6 +26,8 @@ import (
 // in the same order.
 func CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wantEvents []string) error {
 	t.Helper()
+	// Sleep 50ms to make sure events have delivered
+	time.Sleep(50 * time.Millisecond)
 	err := eventsFromChannel(eventChan, wantEvents)
 	if err != nil {
 		return fmt.Errorf("error in test %s: %v", testName, err)
@@ -37,6 +39,8 @@ func CheckEventsOrdered(t *testing.T, eventChan chan string, testName string, wa
 // were received via the given chan, in any order.
 func CheckEventsUnordered(t *testing.T, eventChan chan string, testName string, wantEvents []string) error {
 	t.Helper()
+	// Sleep 50ms to make sure events have delivered
+	time.Sleep(50 * time.Millisecond)
 	err := eventsFromChannelUnordered(eventChan, wantEvents)
 	if err != nil {
 		return fmt.Errorf("error in test %s: %v", testName, err)


### PR DESCRIPTION
# Changes

fixes (hopefully) #5160

At least some of the `TestReconcile_CloudEvents` failures in `pkg/reconciler/run/run_test.go` we've been seeing are due to a race condition around the event cache used to prevent double-sending `Run` events. This is because we check the cache, then send the event, and finally write to the cache, creating a race where an initial attempt to send an event may not get to writing to the cache until after a second attempt has gotten past checking the cache. This fixes that by writing to the cache immediately after checking the cache.

In my test bed, with this fix (and a 50ms sleep added to `CheckEventsOrdered` and `CheckEventsUnordered` to make sure that we leave some leeway for asynchronous event delivery to complete before checking events), `TestReconcile_CloudEvents` went from failing a relatively consistent one out of every ten or so runs to failing 20 times out of 1,800 runs over the weekend. So there's still some flakiness there, but much, much less than there was previously

/kind flake

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
