### PR TITLE
Move version validation tests into separate package

### DIFF
--- a/pkg/apis/version/version_validation_test.go
+++ b/pkg/apis/version/version_validation_test.go
@@ -14,19 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package version_test
 
 import (
 	"context"
 	"testing"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 )
 
 func TestValidateEnabledAPIFields(t *testing.T) {
-	version := "alpha"
+	testVersion := "alpha"
 	flags, err := config.NewFeatureFlagsFromMap(map[string]string{
-		"enable-api-fields": version,
+		"enable-api-fields": testVersion,
 	})
 	if err != nil {
 		t.Fatalf("error creating feature flags from map: %v", err)
@@ -35,7 +36,7 @@ func TestValidateEnabledAPIFields(t *testing.T) {
 		FeatureFlags: flags,
 	}
 	ctx := config.ToContext(context.Background(), cfg)
-	if err := ValidateEnabledAPIFields(ctx, "test feature", version); err != nil {
+	if err := version.ValidateEnabledAPIFields(ctx, "test feature", testVersion); err != nil {
 		t.Errorf("unexpected error for compatible feature gates: %q", err)
 	}
 }
@@ -51,7 +52,7 @@ func TestValidateEnabledAPIFieldsError(t *testing.T) {
 		FeatureFlags: flags,
 	}
 	ctx := config.ToContext(context.Background(), cfg)
-	err = ValidateEnabledAPIFields(ctx, "test feature", "alpha")
+	err = version.ValidateEnabledAPIFields(ctx, "test feature", "alpha")
 
 	if err == nil {
 		t.Errorf("error expected for incompatible feature gates")


### PR DESCRIPTION
# Changes
This commit cleans up tests in pkg/apis/version by moving them
into a separate package. This encourages black-box testing.
No functional changes.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
