### PR TITLE
Add "beta" value to `enable-api-fields`

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -76,7 +76,7 @@ data:
   # an alpha feature.
   enable-custom-tasks: "false"
   # Setting this flag will determine which gated features are enabled.
-  # Acceptable values are "stable" or "alpha".
+  # Acceptable values are "stable", "beta", or "alpha".
   enable-api-fields: "stable"
   # Setting this flag to "true" enables CloudEvents for Runs, as long as a
   # CloudEvents sink is configured in the config-defaults config map

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,6 +23,7 @@ This guide explains how to install Tekton Pipelines. It covers the following top
 - [Customizing basic execution parameters](#customizing-basic-execution-parameters)
     - [Customizing the Pipelines Controller behavior](#customizing-the-pipelines-controller-behavior)
     - [Alpha Features](#alpha-features)
+    - [Beta Features](#beta-features)
 - [Configuring High Availability](#configuring-high-availability)
 - [Configuring tekton pipeline controller performance](#configuring-tekton-pipeline-controller-performance)
 - [Creating a custom release of Tekton Pipelines](#creating-a-custom-release-of-tekton-pipelines)
@@ -450,6 +451,7 @@ Alpha features are still in development and their syntax is subject to change.
 To enable these, set the `enable-api-fields` feature flag to `"alpha"` in
 the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via
 `kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"alpha"}}'`.
+Setting `enable-api-fields` to "alpha" also enables [beta features](#beta-features).
 
 Features currently in "alpha" are:
 
@@ -471,6 +473,15 @@ Features currently in "alpha" are:
 | [CSI Workspace Type](workspaces.md#csi)                                                               | N/A                                                                                                                        | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
 | [Object Params and Results](pipelineruns.md#specifying-parameters)                                    | [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md)                     | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
 | [Array Results](pipelineruns.md#specifying-parameters)                                                | [TEP-0076](https://github.com/tektoncd/community/blob/main/teps/0076-array-result-types.md)                                | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
+
+### Beta Features
+
+Beta features are fields of stable CRDs that follow our "beta" [compatibility policy](../api_compatibility_policy.md).
+To enable these features, set the `enable-api-fields` feature flag to `"beta"` in
+the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via
+`kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"beta"}}'`.
+
+For beta versions of Tekton CRDs, setting `enable-api-fields` to "beta" is the same as setting it to "stable".
 
 ## Configuring High Availability
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -31,6 +31,8 @@ const (
 	StableAPIFields = "stable"
 	// AlphaAPIFields is the value used for "enable-api-fields" when alpha APIs should be usable as well.
 	AlphaAPIFields = "alpha"
+	// BetaAPIFields is the value used for "enable-api-fields" when beta APIs should be usable as well.
+	BetaAPIFields = "beta"
 	// FullEmbeddedStatus is the value used for "embedded-status" when the full statuses of TaskRuns and Runs should be
 	// embedded in PipelineRunStatusFields, but ChildReferences should not be used.
 	FullEmbeddedStatus = "full"
@@ -167,7 +169,7 @@ func setEnabledAPIFields(cfgMap map[string]string, defaultValue string, feature 
 		value = strings.ToLower(cfg)
 	}
 	switch value {
-	case AlphaAPIFields, StableAPIFields:
+	case AlphaAPIFields, BetaAPIFields, StableAPIFields:
 		*feature = value
 	default:
 		return fmt.Errorf("invalid value for feature flag %q: %q", enableAPIFields, value)
@@ -196,10 +198,19 @@ func NewFeatureFlagsFromConfigMap(config *corev1.ConfigMap) (*FeatureFlags, erro
 	return NewFeatureFlagsFromMap(config.Data)
 }
 
-// EnableAlphaAPIFields enables alpha feature in an existing context (for use in testing)
+// EnableAlphaAPIFields enables alpha features in an existing context (for use in testing)
 func EnableAlphaAPIFields(ctx context.Context) context.Context {
+	return setEnableAPIFields(ctx, "alpha")
+}
+
+// EnableBetaAPIFields enables beta features in an existing context (for use in testing)
+func EnableBetaAPIFields(ctx context.Context) context.Context {
+	return setEnableAPIFields(ctx, "beta")
+}
+
+func setEnableAPIFields(ctx context.Context, want string) context.Context {
 	featureFlags, _ := NewFeatureFlagsFromMap(map[string]string{
-		"enable-api-fields": "alpha",
+		"enable-api-fields": want,
 	})
 	cfg := &Config{
 		Defaults: &Defaults{

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -96,6 +96,22 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			},
 			fileName: "feature-flags-bundles-and-custom-tasks",
 		},
+		{
+			expectedConfig: &config.FeatureFlags{
+				EnableAPIFields: "beta",
+
+				EnableTektonOCIBundles:           config.DefaultEnableTektonOciBundles,
+				EnableCustomTasks:                config.DefaultEnableCustomTasks,
+				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
+				DisableCredsInit:                 config.DefaultDisableCredsInit,
+				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+				RequireGitSSHSecretKnownHosts:    config.DefaultRequireGitSSHSecretKnownHosts,
+				SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
+				EmbeddedStatus:                   config.DefaultEmbeddedStatus,
+			},
+			fileName: "feature-flags-beta-api-fields",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/apis/config/testdata/feature-flags-beta-api-fields.yaml
+++ b/pkg/apis/config/testdata/feature-flags-beta-api-fields.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  enable-api-fields: "beta"


### PR DESCRIPTION
# Changes

Add "beta" value to `enable-api-fields`
This commit continues the implementation plan described in
[TEP-0033](https://github.com/tektoncd/community/blob/main/teps/0033-tekton-feature-gates.md)
by adding a "beta" option to the "enable-api-fields" feature flag.

Features moving from "alpha" to "beta" stability should be gated behind the "beta" value of
this feature flag in v1 until they are ready to move to a "stable" stability level.
Maintainers can make exceptions to this policy on a case-by-case basis.
While the Tekton community may decide to make changes to the API versioning process,
features should follow this "graduation" process until the new process, if any,
is reflected in a TEP.

No functional changes.
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
