### PR TITLE
Make update-reference-docs.sh OSX compatible.

### DIFF
--- a/hack/update-reference-docs.sh
+++ b/hack/update-reference-docs.sh
@@ -23,4 +23,4 @@ go run github.com/ahmetb/gen-crd-api-reference-docs \
     -api-dir "github.com/tektoncd/pipeline/pkg/apis" \
     -template-dir "./hack/reference-docs-template" \
     -out-file "./docs/pipeline-api.md"
-sed -i '1s/^/<!--\n---\ntitle: Pipeline API\nlinkTitle: Pipeline API\nweight: 1000\n---\n-->\n\n/' ./docs/pipeline-api.md
+sed -i".backup" '1s/^/<!--\n---\ntitle: Pipeline API\nlinkTitle: Pipeline API\nweight: 1000\n---\n-->\n\n/' ./docs/pipeline-api.md


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Based on
https://unix.stackexchange.com/questions/663369/invalid-command-code-using-sed-to-replace-characters-inline

Verified this works with OSX 12.5, and Ubuntu 22.04.1.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
