### PR TITLE
V1: Add conversion for Pipeline.Resources

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -170,7 +170,6 @@ func TestPipelineConversion(t *testing.T) {
 	}
 }
 
-// TODO handle resources and bundles in #4546
 func TestPipelineConversionFromDeprecated(t *testing.T) {
 	versions := []apis.Convertible{&v1.Pipeline{}}
 	tests := []struct {
@@ -185,18 +184,36 @@ func TestPipelineConversionFromDeprecated(t *testing.T) {
 				Namespace: "bar",
 			},
 			Spec: v1beta1.PipelineSpec{
-				Resources: []v1beta1.PipelineDeclaredResource{{
-					Name:     "pipeline resource",
-					Type:     v1beta1.PipelineResourceTypeGit,
-					Optional: true,
-				}},
+				Resources: []v1beta1.PipelineDeclaredResource{
+					{
+						Name:     "1st pipeline resource",
+						Type:     v1beta1.PipelineResourceTypeGit,
+						Optional: true,
+					}, {
+						Name:     "2nd pipeline resource",
+						Type:     v1beta1.PipelineResourceTypeGit,
+						Optional: false,
+					},
+				},
 			}},
 		want: &v1beta1.Pipeline{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			Spec: v1beta1.PipelineSpec{},
+			Spec: v1beta1.PipelineSpec{
+				Resources: []v1beta1.PipelineDeclaredResource{
+					{
+						Name:     "1st pipeline resource",
+						Type:     v1beta1.PipelineResourceTypeGit,
+						Optional: true,
+					}, {
+						Name:     "2nd pipeline resource",
+						Type:     v1beta1.PipelineResourceTypeGit,
+						Optional: false,
+					},
+				},
+			},
 		},
 	}}
 

--- a/pkg/apis/version/conversion_test.go
+++ b/pkg/apis/version/conversion_test.go
@@ -52,3 +52,28 @@ func TestSerializationRoundTrip(t *testing.T) {
 		t.Errorf("Unexpected diff after serialization/deserialization round trip: %s", d)
 	}
 }
+
+func TestSliceSerializationRoundTrip(t *testing.T) {
+	meta := metav1.ObjectMeta{}
+	source := []testStruct{{Field: "foo"}, {Field: "bar"}}
+	key := "my-key"
+	err := version.SerializeToMetadata(&meta, source, key)
+	if err != nil {
+		t.Fatalf("Serialization error: %s", err)
+	}
+
+	sink := []testStruct{}
+	err = version.DeserializeFromMetadata(&meta, &sink, key)
+	if err != nil {
+		t.Fatalf("Deserialization error: %s", err)
+	}
+
+	_, ok := meta.Annotations[key]
+	if ok {
+		t.Errorf("Expected key %s not to be present in annotations but it was", key)
+	}
+
+	if d := cmp.Diff(source, sink); d != "" {
+		t.Errorf("Unexpected diff after serialization/deserialization round trip: %s", d)
+	}
+}


### PR DESCRIPTION
This commit adds support for Pipeline.Resources when converting between v1beta1 and v1
versions of Pipelines. This will allow us to release v1 Pipeline in a backwards compatible way,
by ensuring that v1beta1 Pipelines with Resources will have the Resources serialized into
annotations on the v1 Pipeline on conversion.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds support for Pipeline.Resources when converting between v1beta1 and v1
versions of Pipelines. This will allow us to release v1 Pipeline in a backwards compatible way,
by ensuring that v1beta1 Pipelines with Resources will have the Resources serialized into
annotations on the v1 Pipeline on conversion.

Part of #4986 
/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
