### PR TITLE
fix: possible error when 'stepTemplate'  and 'steps' contain the same…

### DIFF
--- a/pkg/apis/pipeline/v1beta1/merge.go
+++ b/pkg/apis/pipeline/v1beta1/merge.go
@@ -58,6 +58,8 @@ func MergeStepsWithStepTemplate(template *StepTemplate, steps []Step) ([]Step, e
 			merged.Args = []string{}
 		}
 
+		amendConflictingContainerFields(&merged, s)
+
 		// Pass through original step Script, for later conversion.
 		newStep := Step{Script: s.Script, OnError: s.OnError, Timeout: s.Timeout, StdoutConfig: s.StdoutConfig, StderrConfig: s.StderrConfig}
 		newStep.SetContainerFields(merged)
@@ -173,4 +175,25 @@ func mergeObjWithTemplateBytes(md *mergeData, obj, out interface{}) error {
 	}
 	// Unmarshal the merged JSON to a pointer, and return it.
 	return json.Unmarshal(mergedAsJSON, out)
+}
+
+// amendConflictingContainerFields amends conflicting container fields after merge, and overrides conflicting fields
+// by fields in step.
+func amendConflictingContainerFields(container *corev1.Container, step Step) {
+	if container == nil || len(step.Env) == 0 {
+		return
+	}
+
+	envNameToStepEnv := make(map[string]corev1.EnvVar, len(step.Env))
+	for _, e := range step.Env {
+		envNameToStepEnv[e.Name] = e
+	}
+
+	for index, env := range container.Env {
+		if env.ValueFrom != nil && len(env.Value) >= 0 {
+			if e, ok := envNameToStepEnv[env.Name]; ok {
+				container.Env[index] = e
+			}
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/merge_test.go
+++ b/pkg/apis/pipeline/v1beta1/merge_test.go
@@ -126,6 +126,62 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 				MountPath: "/workspace/data",
 			}},
 		}},
+	}, {
+		name: "merge-and-remove",
+		template: &StepTemplate{
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key: "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}, {
+				Name:  "SOME_KEY_2",
+				Value: "VALUE_2",
+			}},
+		},
+		steps: []Step{{
+			Env: []corev1.EnvVar{{
+				Name:  "NEW_KEY",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				Value: "VALUE_1",
+			}, {
+				Name:  "SOME_KEY_2",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key: "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}},
+		}},
+		expected: []Step{{
+			Env: []corev1.EnvVar{{
+				Name:  "NEW_KEY",
+				Value: "A_VALUE",
+			}, {
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				Value: "VALUE_1",
+			}, {
+				Name: "SOME_KEY_2",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}},
+		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := MergeStepsWithStepTemplate(tc.template, tc.steps)


### PR DESCRIPTION
possible error when 'stepTemplate'  and 'steps' contain the same env key

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Now, when there is a conflict between the env structure of 'stepTemplate' and 'steps', it will eventually be merged according to the value in 'steps'.

Fixs: #5334 

# Submitter Checklist


- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
When stepTemplate and steps contain the same env key, they are finally merged into the env in steps.
```
