### PR TITLE
fix: possible error when 'stepTemplate'  and 'steps' contain the same…

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -856,13 +856,17 @@ overlap occurs.
 
 In the example below, the `Task` specifies a `stepTemplate` field with the environment variable
 `FOO` set to `bar`. The first `Step` in the `Task` uses that value for `FOO`, but the second `Step`
-overrides the value set in the template with `baz`.
+overrides the value set in the template with `baz`. Additional, the `Task` specifies a `stepTemplate`
+field with the environment variable `TOKEN` set to `public`. The last one `Step` in the `Task` uses
+`private` in the referenced secret to override the value set in the template.
 
 ```yaml
 stepTemplate:
   env:
     - name: "FOO"
       value: "bar"
+    - name: "TOKEN"
+      value: "public"
 steps:
   - image: ubuntu
     command: [echo]
@@ -873,6 +877,20 @@ steps:
     env:
       - name: "FOO"
         value: "baz"
+  - image: ubuntu
+    command: [echo]
+    args: ["TOKEN is ${TOKEN}"]
+    env:
+      - name: "TOKEN"
+        valueFrom:
+          secretKeyRef:
+            key: "token"
+            name: "test"
+---
+# The secret 'test' part data is as follows.
+data:
+  # The decoded value of 'cHJpdmF0ZQo=' is 'private'. 
+  token: "cHJpdmF0ZQo="
 ```
 
 ### Specifying `Sidecars`

--- a/pkg/apis/pipeline/v1/merge.go
+++ b/pkg/apis/pipeline/v1/merge.go
@@ -57,6 +57,8 @@ func MergeStepsWithStepTemplate(template *StepTemplate, steps []Step) ([]Step, e
 			merged.Args = []string{}
 		}
 
+		amendConflictingContainerFields(&merged, s)
+
 		// Pass through original step Script, for later conversion.
 		newStep := Step{Script: s.Script, OnError: s.OnError, Timeout: s.Timeout, StdoutConfig: s.StdoutConfig, StderrConfig: s.StderrConfig}
 		newStep.SetContainerFields(merged)
@@ -113,4 +115,25 @@ func mergeObjWithTemplateBytes(md *mergeData, obj, out interface{}) error {
 	}
 	// Unmarshal the merged JSON to a pointer, and return it.
 	return json.Unmarshal(mergedAsJSON, out)
+}
+
+// amendConflictingContainerFields amends conflicting container fields after merge, and overrides conflicting fields
+// by fields in step.
+func amendConflictingContainerFields(container *corev1.Container, step Step) {
+	if container == nil || len(step.Env) == 0 {
+		return
+	}
+
+	envNameToStepEnv := make(map[string]corev1.EnvVar, len(step.Env))
+	for _, e := range step.Env {
+		envNameToStepEnv[e.Name] = e
+	}
+
+	for index, env := range container.Env {
+		if env.ValueFrom != nil && len(env.Value) > 0 {
+			if e, ok := envNameToStepEnv[env.Name]; ok {
+				container.Env[index] = e
+			}
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1/merge_test.go
+++ b/pkg/apis/pipeline/v1/merge_test.go
@@ -127,6 +127,62 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 				MountPath: "/workspace/data",
 			}},
 		}},
+	}, {
+		name: "merge-env-by-step",
+		template: &v1.StepTemplate{
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name: "SOME_KEY_1",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}, {
+				Name:  "SOME_KEY_2",
+				Value: "VALUE_2",
+			}},
+		},
+		steps: []v1.Step{{
+			Env: []corev1.EnvVar{{
+				Name:  "NEW_KEY",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				Value: "VALUE_1",
+			}, {
+				Name: "SOME_KEY_2",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}},
+		}},
+		expected: []v1.Step{{
+			Env: []corev1.EnvVar{{
+				Name:  "NEW_KEY",
+				Value: "A_VALUE",
+			}, {
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				Value: "VALUE_1",
+			}, {
+				Name: "SOME_KEY_2",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}},
+		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := v1.MergeStepsWithStepTemplate(tc.template, tc.steps)

--- a/pkg/apis/pipeline/v1beta1/merge_test.go
+++ b/pkg/apis/pipeline/v1beta1/merge_test.go
@@ -126,6 +126,62 @@ func TestMergeStepsWithStepTemplate(t *testing.T) {
 				MountPath: "/workspace/data",
 			}},
 		}},
+	}, {
+		name: "merge-env-by-step",
+		template: &StepTemplate{
+			Env: []corev1.EnvVar{{
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name: "SOME_KEY_1",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}, {
+				Name:  "SOME_KEY_2",
+				Value: "VALUE_2",
+			}},
+		},
+		steps: []Step{{
+			Env: []corev1.EnvVar{{
+				Name:  "NEW_KEY",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				Value: "VALUE_1",
+			}, {
+				Name: "SOME_KEY_2",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}},
+		}},
+		expected: []Step{{
+			Env: []corev1.EnvVar{{
+				Name:  "NEW_KEY",
+				Value: "A_VALUE",
+			}, {
+				Name:  "KEEP_THIS",
+				Value: "A_VALUE",
+			}, {
+				Name:  "SOME_KEY_1",
+				Value: "VALUE_1",
+			}, {
+				Name: "SOME_KEY_2",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key:                  "A_KEY",
+						LocalObjectReference: corev1.LocalObjectReference{Name: "A_NAME"},
+					},
+				},
+			}},
+		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := MergeStepsWithStepTemplate(tc.template, tc.steps)


### PR DESCRIPTION
possible error when 'stepTemplate' and 'steps' contain the same env key

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Now, when there is a conflict between the env structure of 'stepTemplate' and 'steps', it will eventually be merged according to the value in 'steps'.

Fixs: #5334 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
When stepTemplate and steps contain the same env key, they are finally merged into the env in steps.
```