### PR TITLE
Add V1 version of Pipeline CRD

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -57,7 +57,8 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	v1beta1.SchemeGroupVersion.WithKind("TaskRun"):     &v1beta1.TaskRun{},
 	v1beta1.SchemeGroupVersion.WithKind("PipelineRun"): &v1beta1.PipelineRun{},
 	// v1
-	v1.SchemeGroupVersion.WithKind("Task"): &v1.Task{},
+	v1.SchemeGroupVersion.WithKind("Task"):     &v1.Task{},
+	v1.SchemeGroupVersion.WithKind("Pipeline"): &v1.Pipeline{},
 }
 
 func newDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
@@ -148,6 +149,14 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 				Zygotes: map[string]conversion.ConvertibleObject{
 					v1beta1GroupVersion: &v1beta1.Task{},
 					v1GroupVersion:      &v1.Task{},
+				},
+			},
+			v1.Kind("Pipeline"): {
+				DefinitionName: pipeline.PipelineResource.String(),
+				HubVersion:     v1beta1GroupVersion,
+				Zygotes: map[string]conversion.ConvertibleObject{
+					v1beta1GroupVersion: &v1beta1.Pipeline{},
+					v1GroupVersion:      &v1.Pipeline{},
 				},
 			},
 		},

--- a/config/300-pipeline.yaml
+++ b/config/300-pipeline.yaml
@@ -28,8 +28,6 @@ spec:
   - name: v1beta1
     served: true
     storage: true
-    # Opt into the status subresource so metadata.generation
-    # starts to increment
     subresources:
       status: {}
     schema:
@@ -43,6 +41,24 @@ spec:
         # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
         # See issue: https://github.com/knative/serving/issues/912
         x-kubernetes-preserve-unknown-fields: true
+  - name: v1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # OpenAPIV3 schema allows Kubernetes to perform validation on the schema fields
+        # and use the schema in tooling such as `kubectl explain`.
+        # Using "x-kubernetes-preserve-unknown-fields: true"
+        # at the root of the schema (or within it) allows arbitrary fields.
+        # We currently perform our own validation separately.
+        # See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema
+        # for more info.
+        x-kubernetes-preserve-unknown-fields: true
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: Pipeline
     plural: pipelines
@@ -54,7 +70,7 @@ spec:
   conversion:
     strategy: Webhook
     webhook:
-      conversionReviewVersions: ["v1beta1"]
+      conversionReviewVersions: ["v1beta1", "v1"]
       clientConfig:
         service:
           name: tekton-pipelines-webhook


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit adds a v1 version of the Pipeline CRD, and support to the webhook.
Since this version is not served, it will not be available to users.

Part of #4986 

/kind misc
<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
