### PR TITLE
Fix docs and remove redundant code for LimitRanges

### DIFF
--- a/docs/compute-resources.md
+++ b/docs/compute-resources.md
@@ -158,23 +158,18 @@ will be applied to the init containers that Tekton injects into a `TaskRun`'s po
 
 ### Requests
 
-If a container does not have requests defined, the resulting container's requests are the larger of:
-- the LimitRange minimum resource requests 
-- the LimitRange default resource requests (for init and Sidecar containers) or the LimitRange default resource requests divided by the number of Step containers (for Step containers)
+If a Step container does not have requests defined, Tekton will divide a LimitRange's `defaultRequests` by the number of Step containers and apply these requests to the Steps.
+This results in a TaskRun with overall requests equal to LimitRange `defaultRequests`.
+If this value is less than the LimitRange minimum, the LimitRange minimum will be used instead.
+LimitRange `defaultRequests` are applied as-is to init containers or Sidecar containers that don't specify requests.
 
-If a container has requests defined, the resulting container's requests are the larger of:
-- the container's requests
-- the LimitRange minimum resource requests
+Containers that do specify requests will not be modified. If these requests are lower than LimitRange minimums, Kubernetes will reject the resulting TaskRun's pod.
 
 ### Limits
 
-If a container does not have limits defined, the resulting container's limits are the smaller of:
-- the LimitRange maximum resource limits 
-- the LimitRange default resource limits
-
-If a container has limits defined, the resulting container's limits are the smaller of:
-- the container's limits
-- the LimitRange maximum resource limits
+Tekton does not adjust container limits, regardless of whether a container is a Step, Sidecar, or init container.
+If a container does not have limits defined, Kubernetes will apply the LimitRange `default` to the container's limits.
+If a container does define limits, and they are less than the LimitRange `default`, Kubernetes will reject the resulting TaskRun's pod.
 
 ### Examples
 

--- a/pkg/internal/computeresources/transformer_test.go
+++ b/pkg/internal/computeresources/transformer_test.go
@@ -88,22 +88,10 @@ func TestTransformerOneContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 		},
 	}, {
@@ -128,13 +116,7 @@ func TestTransformerOneContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
@@ -173,26 +155,10 @@ func TestTransformerOneContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -228,26 +194,10 @@ func TestTransformerOneContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -298,11 +248,9 @@ func TestTransformerOneContainer(t *testing.T) {
 			InitContainers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4"),
-						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceCPU: resource.MustParse("4"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("400Mi"),
 					},
 				},
@@ -314,8 +262,8 @@ func TestTransformerOneContainer(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("1"),
 						corev1.ResourceMemory: resource.MustParse("400Mi"),
+						corev1.ResourceCPU:    resource.MustParse("1"),
 					},
 				},
 			}},
@@ -357,26 +305,10 @@ func TestTransformerOneContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -460,9 +392,6 @@ func TestTransformerOneContainer(t *testing.T) {
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU: resource.MustParse("1"),
-					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("800m"),
 					},
@@ -470,11 +399,11 @@ func TestTransformerOneContainer(t *testing.T) {
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU: resource.MustParse("1"),
-					},
 					Limits: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("800m"),
+					},
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
 					},
 				},
 			}},
@@ -557,18 +486,12 @@ func TestTransformerOneContainer(t *testing.T) {
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("3"),
 					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU: resource.MustParse("2"),
-					},
 				},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("3"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU: resource.MustParse("2"),
 					},
 				},
 			}},
@@ -658,30 +581,12 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}, {
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 		},
 	}, {
@@ -709,13 +614,7 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1000m"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
@@ -765,26 +664,10 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -793,11 +676,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -836,26 +714,10 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -864,11 +726,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("1"),
 						corev1.ResourceMemory:           resource.MustParse("100Mi"),
@@ -917,26 +774,10 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("700m"),
 						corev1.ResourceMemory:           resource.MustParse("70Mi"),
@@ -945,11 +786,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				},
 			}, {
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("700m"),
 						corev1.ResourceMemory:           resource.MustParse("70Mi"),
@@ -991,27 +827,11 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Name: "step-foo",
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -1021,11 +841,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 			}, {
 				Name: "step-bar",
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -1033,19 +848,8 @@ func TestTransformerMultipleContainer(t *testing.T) {
 					},
 				},
 			}, {
-				Name: "sidecar-fizz",
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Name:      "sidecar-fizz",
+				Resources: corev1.ResourceRequirements{},
 			}},
 		},
 	}, {
@@ -1089,27 +893,11 @@ func TestTransformerMultipleContainer(t *testing.T) {
 		},
 		want: corev1.PodSpec{
 			InitContainers: []corev1.Container{{
-				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("100Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+				Resources: corev1.ResourceRequirements{},
 			}},
 			Containers: []corev1.Container{{
 				Name: "step-foo",
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -1119,11 +907,6 @@ func TestTransformerMultipleContainer(t *testing.T) {
 			}, {
 				Name: "step-bar",
 				Resources: corev1.ResourceRequirements{
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
-					},
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              resource.MustParse("500m"),
 						corev1.ResourceMemory:           resource.MustParse("50Mi"),
@@ -1134,16 +917,11 @@ func TestTransformerMultipleContainer(t *testing.T) {
 				Name: "sidecar-fizz",
 				Resources: corev1.ResourceRequirements{
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("4"),
-						corev1.ResourceMemory:           resource.MustParse("200Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
+						corev1.ResourceCPU: resource.MustParse("4"),
 					},
 					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("1"),
-						corev1.ResourceMemory:           resource.MustParse("400Mi"),
-						corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
-					},
-				},
+						corev1.ResourceMemory: resource.MustParse("400Mi"),
+					}},
 			}},
 		},
 	}} {


### PR DESCRIPTION
# Changes
Prior to this commit, LimitRange transformer behavior did not match our documentation.
Our documentation stated that Tekton adjusts compute resources of containers to fit within
LimitRange minimum requests and maximum limits. This is not true. Instead, Tekton divides LimitRange
defaultRequests among Step containers, and considers the minimum only if the defaultRequest divided
by the number of Steps would be less than the minimum.

In addition, the LimitRange transformer does several things that would be done by Kubernetes anyway,
which are removed by this commit.
When a LimitRange is created, Kubernetes automatically sets defaults and defaultRequests to the max
if a user did not specify them. Kubernetes will automatically apply these defaults and defaultRequests
to any pods created. Therefore, there is no need for Tekton to set container limits to the default limits
(or in fact, to consider limits at all). There's also no need for Tekton to consider defaults/defaultRequests
for Sidecars and init containers, as we are happy to accept Kubernetes' default behavior here.
The only resource requirements we need to modify are to split a LimitRange's defaultRequests among Steps that
don't specify requests, so all other LimitRange-based transformations are removed in this commit.

Note that Tekton makes no guarantees that a TaskRun's pod will be valid (i.e. requests <= limits).
If a user configures a TaskRun in a way that is inconsistent with any LimitRanges, we allow Kubernetes
to reject the resulting pod.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
[Bug fix] Clarify limitrange documentation and remove functionality that's provided by k8s anyway
```
