### PR TITLE
Add CSI and Projected Workspace to V1

### DIFF
--- a/pkg/apis/pipeline/v1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1/openapi_generated.go
@@ -2451,12 +2451,24 @@ func schema_pkg_apis_pipeline_v1_WorkspaceBinding(ref common.ReferenceCallback) 
 							Ref:         ref("k8s.io/api/core/v1.SecretVolumeSource"),
 						},
 					},
+					"projected": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Projected represents a projected volume that should populate this workspace.",
+							Ref:         ref("k8s.io/api/core/v1.ProjectedVolumeSource"),
+						},
+					},
+					"csi": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+							Ref:         ref("k8s.io/api/core/v1.CSIVolumeSource"),
+						},
+					},
 				},
 				Required: []string{"name"},
 			},
 		},
 		Dependencies: []string{
-			"k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
+			"k8s.io/api/core/v1.CSIVolumeSource", "k8s.io/api/core/v1.ConfigMapVolumeSource", "k8s.io/api/core/v1.EmptyDirVolumeSource", "k8s.io/api/core/v1.PersistentVolumeClaim", "k8s.io/api/core/v1.PersistentVolumeClaimVolumeSource", "k8s.io/api/core/v1.ProjectedVolumeSource", "k8s.io/api/core/v1.SecretVolumeSource"},
 	}
 }
 

--- a/pkg/apis/pipeline/v1/swagger.json
+++ b/pkg/apis/pipeline/v1/swagger.json
@@ -1266,6 +1266,10 @@
           "description": "ConfigMap represents a configMap that should populate this workspace.",
           "$ref": "#/definitions/v1.ConfigMapVolumeSource"
         },
+        "csi": {
+          "description": "CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+          "$ref": "#/definitions/v1.CSIVolumeSource"
+        },
         "emptyDir": {
           "description": "EmptyDir represents a temporary directory that shares a Task's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir Either this OR PersistentVolumeClaim can be used.",
           "$ref": "#/definitions/v1.EmptyDirVolumeSource"
@@ -1278,6 +1282,10 @@
         "persistentVolumeClaim": {
           "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Either this OR EmptyDir can be used.",
           "$ref": "#/definitions/v1.PersistentVolumeClaimVolumeSource"
+        },
+        "projected": {
+          "description": "Projected represents a projected volume that should populate this workspace.",
+          "$ref": "#/definitions/v1.ProjectedVolumeSource"
         },
         "secret": {
           "description": "Secret represents a secret that should populate this workspace.",

--- a/pkg/apis/pipeline/v1/workspace_types.go
+++ b/pkg/apis/pipeline/v1/workspace_types.go
@@ -77,6 +77,12 @@ type WorkspaceBinding struct {
 	// Secret represents a secret that should populate this workspace.
 	// +optional
 	Secret *corev1.SecretVolumeSource `json:"secret,omitempty"`
+	// Projected represents a projected volume that should populate this workspace.
+	// +optional
+	Projected *corev1.ProjectedVolumeSource `json:"projected,omitempty"`
+	// CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
+	// +optional
+	CSI *corev1.CSIVolumeSource `json:"csi,omitempty"`
 }
 
 // WorkspacePipelineDeclaration creates a named slot in a Pipeline that a PipelineRun

--- a/pkg/apis/pipeline/v1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1/workspace_validation.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"knative.dev/pkg/apis"
 )
@@ -36,7 +38,7 @@ var allVolumeSourceFields = []string{
 // Validate looks at the Volume provided in wb and makes sure that it is valid.
 // This means that only one VolumeSource can be specified, and also that the
 // supported VolumeSource is itself valid.
-func (b *WorkspaceBinding) Validate(context.Context) *apis.FieldError {
+func (b *WorkspaceBinding) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if equality.Semantic.DeepEqual(b, &WorkspaceBinding{}) || b == nil {
 		return apis.ErrMissingField(apis.CurrentField)
 	}
@@ -66,6 +68,29 @@ func (b *WorkspaceBinding) Validate(context.Context) *apis.FieldError {
 		return apis.ErrMissingField("secret.secretName")
 	}
 
+	// The projected workspace is only supported when the alpha feature gate is enabled.
+	// For a Projected volume to work, you must provide at least one source.
+	if b.Projected != nil {
+		if err := version.ValidateEnabledAPIFields(ctx, "projected workspace type", config.AlphaAPIFields).ViaField("workspace"); err != nil {
+			return err
+		}
+		if len(b.Projected.Sources) == 0 {
+			return apis.ErrMissingField("projected.sources")
+		}
+	}
+
+	// The csi workspace is only supported when the alpha feature gate is enabled.
+	// For a CSI to work, you must provide and have installed the driver to use.
+	if b.CSI != nil {
+		errs := version.ValidateEnabledAPIFields(ctx, "csi workspace type", config.AlphaAPIFields).ViaField("workspaces")
+		if errs != nil {
+			return errs
+		}
+		if b.CSI.Driver == "" {
+			return apis.ErrMissingField("csi.driver")
+		}
+	}
+
 	return nil
 }
 
@@ -86,6 +111,12 @@ func (b *WorkspaceBinding) numSources() int {
 		n++
 	}
 	if b.Secret != nil {
+		n++
+	}
+	if b.Projected != nil {
+		n++
+	}
+	if b.CSI != nil {
 		n++
 	}
 	return n

--- a/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/pipeline/v1/zz_generated.deepcopy.go
@@ -950,6 +950,16 @@ func (in *WorkspaceBinding) DeepCopyInto(out *WorkspaceBinding) {
 		*out = new(corev1.SecretVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Projected != nil {
+		in, out := &in.Projected, &out.Projected
+		*out = new(corev1.ProjectedVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CSI != nil {
+		in, out := &in.CSI, &out.CSI
+		*out = new(corev1.CSIVolumeSource)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit adds v1 version of the CSI and Projected workspace type.
This is copied from v1beta1 workspace types.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
