### PR TITLE
Update the release cheatsheet to include release resources

### DIFF
--- a/tekton/release-cheat-sheet.md
+++ b/tekton/release-cheat-sheet.md
@@ -14,6 +14,12 @@ the pipelines repo, a terminal window and a text editor.
    most recent commit at https://github.com/tektoncd/pipeline/commits/main
    and note the commit's full (40-digit) hash.
 
+1. Ensure the correct version of the release pipeline is installed on the cluster:
+
+    ```bash
+    kustomize build tekton | kubectl --context dogfooding replace -f -
+    ```
+
 1. Create environment variables for bash scripts in later steps.
 
     ```bash


### PR DESCRIPTION
# Changes

Before performing a release, we need to make sure that the
correct version of the release pipeline is installed. The latest
is always available in the tekton-nightly namespace, but the
one needed in the default namespace depends on the release
that it's being made, which could be the latest or a point
release on an old branch.

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```

/kind documentation