### PR TITLE
Log namespaces left in place after e2e testing.

### DIFF
--- a/test/init_test.go
+++ b/test/init_test.go
@@ -117,6 +117,8 @@ func tearDown(ctx context.Context, t *testing.T, cs *clients, namespace string) 
 		if err := cs.KubeClient.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{}); err != nil {
 			t.Errorf("Failed to delete namespace %s: %s", namespace, err)
 		}
+	} else {
+		t.Logf("Not deleting namespace %s", namespace)
 	}
 }
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Context from [slack msg](https://tektoncd.slack.com/archives/CJ480GNDN/p1661353949809779):

```
Not sure where to ask this, but someone on my team found these namespaces, and it seeeeeemmmsss to be related to tekton? but i also cant find these definitions anywhere ?
 k get ns | grep arendelle                                                                                                                                
arendelle-ktg6c                        Active        92d
arendelle-pvrms                        Active        92d
arendelle-vdcdv                        Active        92d
arendelle-vq2gw                        Active        92d
arendelle-zg554                        Active        92d
arendelle-zvxn5                        Active        92d
```

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
e2e tests log when a namespace is not deleted at test completion.
```
