### PR TITLE
Propagating object params

### DIFF
--- a/docs/taskruns.md
+++ b/docs/taskruns.md
@@ -15,6 +15,7 @@ weight: 300
   - [Remote Tasks](#remote-tasks)
   - [Specifying `Parameters`](#specifying-parameters)
     - [Propagated Parameters](#propagated-parameters)
+    - [Propagated Object Parameters](#propagated-object-parameters)
     - [Extra Parameters](#extra-parameters)
   - [Specifying `Resources`](#specifying-resources)
   - [Specifying `Resource` limits](#specifying-resource-limits)
@@ -263,6 +264,85 @@ status:
       resources: {}
       script: |
         echo "hello world!"
+```
+
+#### Propagated Object Parameters
+**([alpha only](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#alpha-features))**
+
+When using an inlined `taskSpec`, object parameters from the parent `TaskRun` will be
+available to the `Task` without needing to be explicitly defined.
+
+
+**Note:** If an object parameter is being defined explicitly then you must define the spec of the object in `Properties`.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: object-param-result-
+spec:
+  params:
+  - name: gitrepo
+    value:
+      commit: sha123
+      url: xyz.com
+  taskSpec:
+    steps:
+    - name: echo-object-params
+      image: bash
+      args:
+      - echo
+      - --url=$(params.gitrepo.url)
+      - --commit=$(params.gitrepo.commit)
+```
+
+On executing the task run, the object parameters will be interpolated during resolution.
+The specifications are not mutated before storage and so it remains the same.
+The status is updated.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: object-param-result-vlnmb
+  ...
+spec:
+  params:
+  - name: gitrepo
+    value:
+      commit: sha123
+      url: xyz.com
+  serviceAccountName: default
+  taskSpec:
+    steps:
+    - args:
+      - echo
+      - --url=$(params.gitrepo.url)
+      - --commit=$(params.gitrepo.commit)
+      image: bash
+      name: echo-object-params
+      resources: {}
+status:
+  completionTime: "2022-09-08T17:09:37Z"
+  conditions:
+  - lastTransitionTime: "2022-09-08T17:09:37Z"
+    message: All Steps have completed executing
+    reason: Succeeded
+    status: "True"
+    type: Succeeded
+    ...
+  steps:
+  - container: step-echo-object-params
+    ...
+  taskSpec:
+    steps:
+    - args:
+      - echo
+      - --url=xyz.com
+      - --commit=sha123
+      image: bash
+      name: echo-object-params
+      resources: {}
 ```
 
 #### Extra Parameters

--- a/examples/v1beta1/pipelineruns/alpha/propagated-pipeline-object-param.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagated-pipeline-object-param.yaml
@@ -1,0 +1,28 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: pipelinerun-object-param-result
+spec:
+  params:
+    - name: gitrepo
+      value:
+        url: abc.com
+        commit: sha123
+  pipelineSpec:
+    tasks:
+      - name: task1
+        params:
+          - name: gitrepo
+            value:
+              branch: main
+              url: xyz.com
+        taskSpec:
+          steps:
+            - name: write-result
+              image: bash
+              args: [
+                "echo",
+                "--url=$(params.gitrepo.url)",
+                "--commit=$(params.gitrepo.commit)",
+                "--branch=$(params.gitrepo.branch)",
+              ]

--- a/examples/v1beta1/taskruns/alpha/propagated-object-parameters.yaml
+++ b/examples/v1beta1/taskruns/alpha/propagated-object-parameters.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: object-param-result-
+spec:
+  params:
+    - name: gitrepo
+      value:
+        url: "xyz.com"
+        commit: "sha123"
+  taskSpec:
+    steps:
+      - name: echo-object-params
+        image: bash
+        args: [
+          "echo",
+          "--url=$(params.gitrepo.url)",
+          "--commit=$(params.gitrepo.commit)",
+        ]

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -1132,9 +1132,10 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := config.EnableAlphaAPIFields(context.Background())
-			err := validatePipelineParameterVariables(ctx, tt.tasks, tt.params)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err != nil {
-				t.Errorf("Pipeline.validatePipelineParameterVariables() returned error for valid pipeline parameters: %v", err)
+				t.Errorf("Pipeline.ValidatePipelineParameterVariables() returned error for valid pipeline parameters: %v", err)
 			}
 		})
 	}
@@ -1535,9 +1536,10 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 			if tt.api == "alpha" {
 				ctx = config.EnableAlphaAPIFields(context.Background())
 			}
-			err := validatePipelineParameterVariables(ctx, tt.tasks, tt.params)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err == nil {
-				t.Errorf("Pipeline.validatePipelineParameterVariables() did not return error for invalid pipeline parameters")
+				t.Errorf("Pipeline.ValidatePipelineParameterVariables() did not return error for invalid pipeline parameters")
 			}
 			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("PipelineSpec.Validate() errors diff %s", diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -277,13 +277,13 @@ func ValidateParameterTypes(ctx context.Context, params []ParamSpec) (errs *apis
 			// when the enable-api-fields feature gate is not "alpha".
 			errs = errs.Also(version.ValidateEnabledAPIFields(ctx, "object type parameter", config.AlphaAPIFields))
 		}
-		errs = errs.Also(p.ValidateType())
+		errs = errs.Also(p.ValidateType(ctx))
 	}
 	return errs
 }
 
 // ValidateType checks that the type of a ParamSpec is allowed and its default value matches that type
-func (p ParamSpec) ValidateType() *apis.FieldError {
+func (p ParamSpec) ValidateType(ctx context.Context) *apis.FieldError {
 	// Ensure param has a valid type.
 	validType := false
 	for _, allowedType := range AllParamTypes {
@@ -308,17 +308,20 @@ func (p ParamSpec) ValidateType() *apis.FieldError {
 	}
 
 	// Check object type and its PropertySpec type
-	return p.ValidateObjectType()
+	return p.ValidateObjectType(ctx)
 }
 
 // ValidateObjectType checks that object type parameter does not miss the
 // definition of `properties` section and the type of a PropertySpec is allowed.
 // (Currently, only string is allowed)
-func (p ParamSpec) ValidateObjectType() *apis.FieldError {
+func (p ParamSpec) ValidateObjectType(ctx context.Context) *apis.FieldError {
 	if p.Type == ParamTypeObject && p.Properties == nil {
-		return apis.ErrMissingField(fmt.Sprintf("%s.properties", p.Name))
+		// If this we are not skipping validation checks due to propagated params
+		// then properties field is required.
+		if config.ValidateParameterVariablesAndWorkspaces(ctx) == true {
+			return apis.ErrMissingField(fmt.Sprintf("%s.properties", p.Name))
+		}
 	}
-
 	invalidKeys := []string{}
 	for key, propertySpec := range p.Properties {
 		if propertySpec.Type != ParamTypeString {
@@ -363,9 +366,9 @@ func ValidateParameterVariables(ctx context.Context, steps []Step, params []Para
 	errs = errs.Also(validateNameFormat(stringParameterNames.Insert(arrayParameterNames.List()...), objectParamSpecs))
 	if config.ValidateParameterVariablesAndWorkspaces(ctx) == true {
 		errs = errs.Also(validateVariables(ctx, steps, "params", allParameterNames))
+		errs = errs.Also(validateObjectUsage(ctx, steps, objectParamSpecs))
 	}
-	errs = errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
-	return errs.Also(validateObjectUsage(ctx, steps, objectParamSpecs))
+	return errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
 }
 
 func validateTaskContextVariables(ctx context.Context, steps []Step) *apis.FieldError {

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -102,6 +102,17 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "propagating object params valid step with script skip validation",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:  "propagatingobjectparams",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env bash
+				$(params.message.foo)`,
+			}},
+		},
+	}, {
 		name: "propagating params valid step with args",
 		fields: fields{
 			Steps: []v1.Step{{
@@ -109,6 +120,16 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 				Image:   "my-image",
 				Command: []string{"$(params.command)"},
 				Args:    []string{"$(params.message)"},
+			}},
+		},
+	}, {
+		name: "propagating object params valid step with args",
+		fields: fields{
+			Steps: []v1.Step{{
+				Name:    "propagatingobjectparams",
+				Image:   "my-image",
+				Command: []string{"$(params.command.foo)"},
+				Args:    []string{"$(params.message.bar)"},
 			}},
 		},
 	}}
@@ -409,6 +430,16 @@ func TestTaskSpecValidate(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "the spec of object type parameter misses the definition of properties",
+		fields: fields{
+			Params: []v1.ParamSpec{{
+				Name:        "task",
+				Type:        v1.ParamTypeObject,
+				Description: "param",
+			}},
+			Steps: validSteps,
+		},
+	}, {
 		name: "valid task name context",
 		fields: fields{
 			Steps: []v1.Step{{
@@ -668,17 +699,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Message: `"object" type does not match default value's type: "string"`,
 			Paths:   []string{"params.task.type", "params.task.default.type"},
 		},
-	}, {
-		name: "the spec of object type parameter misses the definition of properties",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name:        "task",
-				Type:        v1.ParamTypeObject,
-				Description: "param",
-			}},
-			Steps: validSteps,
-		},
-		expectedError: *apis.ErrMissingField("params.task.properties"),
 	}, {
 		name: "PropertySpec type is set with unsupported type",
 		fields: fields{

--- a/pkg/apis/pipeline/v1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation.go
@@ -113,30 +113,80 @@ func (ts *TaskRunSpec) validateInlineParameters(ctx context.Context) (errs *apis
 	if ts.TaskSpec == nil {
 		return errs
 	}
-	var paramSpec []ParamSpec
+	paramSpecForValidation := make(map[string]ParamSpec)
 	for _, p := range ts.Params {
-		pSpec := ParamSpec{
-			Name:    p.Name,
-			Default: &p.Value,
-		}
-		paramSpec = append(paramSpec, pSpec)
+		paramSpecForValidation = createParamSpecFromParam(p, paramSpecForValidation)
 	}
+
 	for _, p := range ts.TaskSpec.Params {
-		skip := false
-		for _, ps := range paramSpec {
-			if ps.Name == p.Name {
-				skip = true
-				break
-			}
+		var err *apis.FieldError
+		paramSpecForValidation, err = combineParamSpec(p, paramSpecForValidation)
+		if err != nil {
+			errs = errs.Also(err)
 		}
-		if !skip {
-			paramSpec = append(paramSpec, p)
-		}
+	}
+	var paramSpec []ParamSpec
+	for _, v := range paramSpecForValidation {
+		paramSpec = append(paramSpec, v)
 	}
 	if ts.TaskSpec != nil && ts.TaskSpec.Steps != nil {
+		errs = errs.Also(ValidateParameterTypes(ctx, paramSpec))
 		errs = errs.Also(ValidateParameterVariables(config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false), ts.TaskSpec.Steps, paramSpec))
 	}
 	return errs
+}
+
+func createParamSpecFromParam(p Param, paramSpecForValidation map[string]ParamSpec) map[string]ParamSpec {
+	value := p.Value
+	pSpec := ParamSpec{
+		Name:    p.Name,
+		Default: &value,
+		Type:    p.Value.Type,
+	}
+	if p.Value.ObjectVal != nil {
+		pSpec.Properties = make(map[string]PropertySpec)
+		prop := make(map[string]PropertySpec)
+		for k := range p.Value.ObjectVal {
+			prop[k] = PropertySpec{Type: ParamTypeString}
+		}
+		pSpec.Properties = prop
+	}
+	paramSpecForValidation[p.Name] = pSpec
+	return paramSpecForValidation
+}
+
+func combineParamSpec(p ParamSpec, paramSpecForValidation map[string]ParamSpec) (map[string]ParamSpec, *apis.FieldError) {
+	if pSpec, ok := paramSpecForValidation[p.Name]; ok {
+		// Merge defaults with provided values in the taskrun.
+		if p.Default != nil && p.Default.ObjectVal != nil {
+			for k, v := range p.Default.ObjectVal {
+				if pSpec.Default.ObjectVal == nil {
+					pSpec.Default.ObjectVal = map[string]string{k: v}
+				} else {
+					pSpec.Default.ObjectVal[k] = v
+				}
+			}
+			// If Default values of object type are provided then Properties must also be fully declared.
+			if p.Properties == nil {
+				return paramSpecForValidation, apis.ErrMissingField(fmt.Sprintf("%s.properties", p.Name))
+			}
+		}
+
+		// Properties must be defined if paramSpec is of object Type
+		if pSpec.Type == ParamTypeObject {
+			if p.Properties == nil {
+				return paramSpecForValidation, apis.ErrMissingField(fmt.Sprintf("%s.properties", p.Name))
+			}
+			// Expect Properties to be complete
+			pSpec.Properties = p.Properties
+		}
+		paramSpecForValidation[p.Name] = pSpec
+	} else {
+		// No values provided by task run but found a paramSpec declaration.
+		// Expect it to be fully speced out.
+		paramSpecForValidation[p.Name] = p
+	}
+	return paramSpecForValidation, nil
 }
 
 // validateDebug

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -61,8 +61,8 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateGraph(ps.Tasks))
 	errs = errs.Also(validateParamResults(ps.Tasks))
 	// The parameter variables should be valid
-	errs = errs.Also(validatePipelineParameterVariables(ctx, ps.Tasks, ps.Params).ViaField("tasks"))
-	errs = errs.Also(validatePipelineParameterVariables(ctx, ps.Finally, ps.Params).ViaField("finally"))
+	errs = errs.Also(ValidatePipelineParameterVariables(ctx, ps.Tasks, ps.Params).ViaField("tasks"))
+	errs = errs.Also(ValidatePipelineParameterVariables(ctx, ps.Finally, ps.Params).ViaField("finally"))
 	errs = errs.Also(validatePipelineContextVariables(ps.Tasks).ViaField("tasks"))
 	errs = errs.Also(validatePipelineContextVariables(ps.Finally).ViaField("finally"))
 	errs = errs.Also(validateExecutionStatusVariables(ps.Tasks, ps.Finally))
@@ -124,10 +124,10 @@ func validatePipelineWorkspacesUsage(wss []PipelineWorkspaceDeclaration, pts []P
 	return errs
 }
 
-// validatePipelineParameterVariables validates parameters with those specified by each pipeline task,
+// ValidatePipelineParameterVariables validates parameters with those specified by each pipeline task,
 // (1) it validates the type of parameter is either string or array (2) parameter default value matches
 // with the type of that param (3) ensures that the referenced param variable is defined is part of the param declarations
-func validatePipelineParameterVariables(ctx context.Context, tasks []PipelineTask, params []ParamSpec) (errs *apis.FieldError) {
+func ValidatePipelineParameterVariables(ctx context.Context, tasks []PipelineTask, params []ParamSpec) (errs *apis.FieldError) {
 	parameterNames := sets.NewString()
 	arrayParameterNames := sets.NewString()
 	objectParameterNameKeys := map[string][]string{}
@@ -151,7 +151,10 @@ func validatePipelineParameterVariables(ctx context.Context, tasks []PipelineTas
 			}
 		}
 	}
-	return errs.Also(validatePipelineParametersVariables(tasks, "params", parameterNames, arrayParameterNames, objectParameterNameKeys))
+	if config.ValidateParameterVariablesAndWorkspaces(ctx) == true {
+		errs = errs.Also(validatePipelineParametersVariables(tasks, "params", parameterNames, arrayParameterNames, objectParameterNameKeys))
+	}
+	return errs
 }
 
 func validatePipelineParametersVariables(tasks []PipelineTask, prefix string, paramNames sets.String, arrayParamNames sets.String, objectParamNameKeys map[string][]string) (errs *apis.FieldError) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -1673,9 +1673,10 @@ func TestValidatePipelineParameterVariables_Success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := config.EnableAlphaAPIFields(context.Background())
-			err := validatePipelineParameterVariables(ctx, tt.tasks, tt.params)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err != nil {
-				t.Errorf("Pipeline.validatePipelineParameterVariables() returned error for valid pipeline parameters: %v", err)
+				t.Errorf("Pipeline.ValidatePipelineParameterVariables() returned error for valid pipeline parameters: %v", err)
 			}
 		})
 	}
@@ -2151,9 +2152,10 @@ func TestValidatePipelineParameterVariables_Failure(t *testing.T) {
 			if tt.api == "alpha" {
 				ctx = config.EnableAlphaAPIFields(context.Background())
 			}
-			err := validatePipelineParameterVariables(ctx, tt.tasks, tt.params)
+			ctx = config.SkipValidationDueToPropagatedParametersAndWorkspaces(ctx, false)
+			err := ValidatePipelineParameterVariables(ctx, tt.tasks, tt.params)
 			if err == nil {
-				t.Errorf("Pipeline.validatePipelineParameterVariables() did not return error for invalid pipeline parameters")
+				t.Errorf("Pipeline.ValidatePipelineParameterVariables() did not return error for invalid pipeline parameters")
 			}
 			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
 				t.Errorf("PipelineSpec.Validate() errors diff %s", diff.PrintWantGot(d))

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -120,6 +120,17 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 			}},
 		},
 	}, {
+		name: "propagating object params valid step with script skip validation",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Name:  "propagatingobjectparams",
+				Image: "my-image",
+				Script: `
+				#!/usr/bin/env bash
+				$(params.message.foo)`,
+			}},
+		},
+	}, {
 		name: "propagating params valid step with args",
 		fields: fields{
 			Steps: []v1beta1.Step{{
@@ -127,6 +138,16 @@ func TestTaskSpecValidatePropagatedParamsAndWorkspaces(t *testing.T) {
 				Image:   "my-image",
 				Command: []string{"$(params.command)"},
 				Args:    []string{"$(params.message)"},
+			}},
+		},
+	}, {
+		name: "propagating object params valid step with args",
+		fields: fields{
+			Steps: []v1beta1.Step{{
+				Name:    "propagatingobjectparams",
+				Image:   "my-image",
+				Command: []string{"$(params.command.foo)"},
+				Args:    []string{"$(params.message.bar)"},
 			}},
 		},
 	}}
@@ -443,6 +464,16 @@ func TestTaskSpecValidate(t *testing.T) {
 					"commit": {"string"},
 				},
 			}},
+		},
+	}, {
+		name: "the spec of object type parameter misses the definition of properties",
+		fields: fields{
+			Params: []v1beta1.ParamSpec{{
+				Name:        "task",
+				Type:        v1beta1.ParamTypeObject,
+				Description: "param",
+			}},
+			Steps: validSteps,
 		},
 	}, {
 		name: "valid task name context",
@@ -780,17 +811,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 			Message: `"object" type does not match default value's type: "string"`,
 			Paths:   []string{"params.task.type", "params.task.default.type"},
 		},
-	}, {
-		name: "the spec of object type parameter misses the definition of properties",
-		fields: fields{
-			Params: []v1beta1.ParamSpec{{
-				Name:        "task",
-				Type:        v1beta1.ParamTypeObject,
-				Description: "param",
-			}},
-			Steps: validSteps,
-		},
-		expectedError: *apis.ErrMissingField(fmt.Sprintf("params.task.properties")),
 	}, {
 		name: "PropertySpec type is set with unsupported type",
 		fields: fields{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Prior to this, object parameters were not being propagated down the spec during resolution.
After following the same logic applied for propagating parameters in PRs https://github.com/tektoncd/pipeline/pull/5291 and https://github.com/tektoncd/pipeline/pull/5143, we can not also propagate object params. This PR address issue https://github.com/tektoncd/pipeline/issues/5140

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Propagating object params
```
