### PR TITLE
Replace time.After with NewTimers

### DIFF
--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -44,11 +44,16 @@ func TestRealWaiterWaitMissingFile(t *testing.T) {
 		}
 		close(doneCh)
 	}()
+
+	delay := time.NewTimer(2 * testWaitPollingInterval)
 	select {
+	case <-delay.C:
+		// Success
 	case <-doneCh:
 		t.Errorf("did not expect Wait() to have detected a file at path %q", tmp.Name())
-	case <-time.After(2 * testWaitPollingInterval):
-		// Success
+		if !delay.Stop() {
+			<-delay.C
+		}
 	}
 }
 
@@ -67,10 +72,11 @@ func TestRealWaiterWaitWithFile(t *testing.T) {
 		}
 		close(doneCh)
 	}()
+	delay := time.NewTimer(2 * testWaitPollingInterval)
 	select {
 	case <-doneCh:
 		// Success
-	case <-time.After(2 * testWaitPollingInterval):
+	case <-delay.C:
 		t.Errorf("expected Wait() to have detected the file's existence by now")
 	}
 }
@@ -90,11 +96,15 @@ func TestRealWaiterWaitMissingContent(t *testing.T) {
 		}
 		close(doneCh)
 	}()
+	delay := time.NewTimer(2 * testWaitPollingInterval)
 	select {
+	case <-delay.C:
+		// Success
 	case <-doneCh:
 		t.Errorf("no data was written to tmp file, did not expect Wait() to have detected a non-zero file size and returned")
-	case <-time.After(2 * testWaitPollingInterval):
-		// Success
+		if !delay.Stop() {
+			<-delay.C
+		}
 	}
 }
 
@@ -116,10 +126,11 @@ func TestRealWaiterWaitWithContent(t *testing.T) {
 	if err := ioutil.WriteFile(tmp.Name(), []byte("😺"), 0700); err != nil {
 		t.Errorf("error writing content to temp file: %v", err)
 	}
+	delay := time.NewTimer(2 * testWaitPollingInterval)
 	select {
 	case <-doneCh:
 		// Success
-	case <-time.After(2 * testWaitPollingInterval):
+	case <-delay.C:
 		t.Errorf("expected Wait() to have detected a non-zero file size by now")
 	}
 }
@@ -146,10 +157,11 @@ func TestRealWaiterWaitWithErrorWaitfile(t *testing.T) {
 			t.Errorf("unexpected error type %T", typ)
 		}
 	}()
+	delay := time.NewTimer(2 * testWaitPollingInterval)
 	select {
 	case <-doneCh:
 		// Success
-	case <-time.After(2 * testWaitPollingInterval):
+	case <-delay.C:
 		t.Errorf("expected Wait() to have detected a non-zero file size by now")
 	}
 }
@@ -171,10 +183,11 @@ func TestRealWaiterWaitWithBreakpointOnFailure(t *testing.T) {
 		}
 		close(doneCh)
 	}()
+	delay := time.NewTimer(2 * testWaitPollingInterval)
 	select {
 	case <-doneCh:
 		// Success
-	case <-time.After(2 * testWaitPollingInterval):
+	case <-delay.C:
 		t.Errorf("expected Wait() to have detected a non-zero file size by now")
 	}
 }

--- a/pkg/pipelinerunmetrics/metrics.go
+++ b/pkg/pipelinerunmetrics/metrics.go
@@ -294,12 +294,16 @@ func (r *Recorder) ReportRunningPipelineRuns(ctx context.Context, lister listers
 	logger := logging.FromContext(ctx)
 
 	for {
+		delay := time.NewTimer(r.ReportingPeriod)
 		select {
 		case <-ctx.Done():
 			// When the context is cancelled, stop reporting.
+			if !delay.Stop() {
+				<-delay.C
+			}
 			return
 
-		case <-time.After(r.ReportingPeriod):
+		case <-delay.C:
 			// Every 30s surface a metric for the number of running pipelines.
 			if err := r.RunningPipelineRuns(lister); err != nil {
 				logger.Warnf("Failed to log the metrics : %v", err)

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -376,12 +376,16 @@ func (r *Recorder) RunningTaskRuns(ctx context.Context, lister listers.TaskRunLi
 func (r *Recorder) ReportRunningTaskRuns(ctx context.Context, lister listers.TaskRunLister) {
 	logger := logging.FromContext(ctx)
 	for {
+		delay := time.NewTimer(r.ReportingPeriod)
 		select {
 		case <-ctx.Done():
 			// When the context is cancelled, stop reporting.
+			if !delay.Stop() {
+				<-delay.C
+			}
 			return
 
-		case <-time.After(r.ReportingPeriod):
+		case <-delay.C:
 			// Every 30s surface a metric for the number of running tasks.
 			if err := r.RunningTaskRuns(ctx, lister); err != nil {
 				logger.Warnf("Failed to log the metrics : %v", err)


### PR DESCRIPTION
# Changes

fixes #5362

See https://www.arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/ for more details.

/kind security

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Replace usages of time.After
```
