### PR TITLE
Move bespoke functionality out of TaskRun API

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1/taskrun_types.go
@@ -407,20 +407,6 @@ func (tr *TaskRun) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}
 }
 
-// IsPartOfPipeline return true if TaskRun is a part of a Pipeline.
-// It also return the name of Pipeline and PipelineRun
-func (tr *TaskRun) IsPartOfPipeline() (bool, string, string) {
-	if tr == nil || len(tr.Labels) == 0 {
-		return false, "", ""
-	}
-
-	if pl, ok := tr.Labels[pipeline.PipelineLabelKey]; ok {
-		return true, pl, tr.Labels[pipeline.PipelineRunLabelKey]
-	}
-
-	return false, "", ""
-}
-
 // HasVolumeClaimTemplate returns true if TaskRun contains volumeClaimTemplates that is
 // used for creating PersistentVolumeClaims with an OwnerReference for each run
 func (tr *TaskRun) HasVolumeClaimTemplate() bool {

--- a/pkg/apis/pipeline/v1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_types_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -220,50 +219,6 @@ func TestTaskRunHasStarted(t *testing.T) {
 			tr.Status = tc.trStatus
 			if tr.HasStarted() != tc.expectedValue {
 				t.Fatalf("Expected taskrun HasStarted() to return %t but got %t", tc.expectedValue, tr.HasStarted())
-			}
-		})
-	}
-}
-
-func TestTaskRunIsOfPipelinerun(t *testing.T) {
-	tests := []struct {
-		name                  string
-		tr                    *v1.TaskRun
-		expectedValue         bool
-		expetectedPipeline    string
-		expetectedPipelineRun string
-	}{{
-		name: "yes",
-		tr: &v1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					pipeline.PipelineLabelKey:    "pipeline",
-					pipeline.PipelineRunLabelKey: "pipelinerun",
-				},
-			},
-		},
-		expectedValue:         true,
-		expetectedPipeline:    "pipeline",
-		expetectedPipelineRun: "pipelinerun",
-	}, {
-		name:          "no",
-		tr:            &v1.TaskRun{},
-		expectedValue: false,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			value, pipeline, pipelineRun := test.tr.IsPartOfPipeline()
-			if value != test.expectedValue {
-				t.Fatalf("Expecting %v got %v", test.expectedValue, value)
-			}
-
-			if pipeline != test.expetectedPipeline {
-				t.Fatalf("Mismatch in pipeline: got %s expected %s", pipeline, test.expetectedPipeline)
-			}
-
-			if pipelineRun != test.expetectedPipelineRun {
-				t.Fatalf("Mismatch in pipelinerun: got %s expected %s", pipelineRun, test.expetectedPipelineRun)
 			}
 		})
 	}

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -468,20 +468,6 @@ func (tr *TaskRun) GetNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Namespace: tr.Namespace, Name: tr.Name}
 }
 
-// IsPartOfPipeline return true if TaskRun is a part of a Pipeline.
-// It also return the name of Pipeline and PipelineRun
-func (tr *TaskRun) IsPartOfPipeline() (bool, string, string) {
-	if tr == nil || len(tr.Labels) == 0 {
-		return false, "", ""
-	}
-
-	if pl, ok := tr.Labels[pipeline.PipelineLabelKey]; ok {
-		return true, pl, tr.Labels[pipeline.PipelineRunLabelKey]
-	}
-
-	return false, "", ""
-}
-
 // HasVolumeClaimTemplate returns true if TaskRun contains volumeClaimTemplates that is
 // used for creating PersistentVolumeClaims with an OwnerReference for each run
 func (tr *TaskRun) HasVolumeClaimTemplate() bool {

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
@@ -212,50 +211,6 @@ func TestTaskRunHasStarted(t *testing.T) {
 			tr.Status = tc.trStatus
 			if tr.HasStarted() != tc.expectedValue {
 				t.Fatalf("Expected taskrun HasStarted() to return %t but got %t", tc.expectedValue, tr.HasStarted())
-			}
-		})
-	}
-}
-
-func TestTaskRunIsOfPipelinerun(t *testing.T) {
-	tests := []struct {
-		name                  string
-		tr                    *v1beta1.TaskRun
-		expectedValue         bool
-		expetectedPipeline    string
-		expetectedPipelineRun string
-	}{{
-		name: "yes",
-		tr: &v1beta1.TaskRun{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					pipeline.PipelineLabelKey:    "pipeline",
-					pipeline.PipelineRunLabelKey: "pipelinerun",
-				},
-			},
-		},
-		expectedValue:         true,
-		expetectedPipeline:    "pipeline",
-		expetectedPipelineRun: "pipelinerun",
-	}, {
-		name:          "no",
-		tr:            &v1beta1.TaskRun{},
-		expectedValue: false,
-	}}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			value, pipeline, pipelineRun := test.tr.IsPartOfPipeline()
-			if value != test.expectedValue {
-				t.Fatalf("Expecting %v got %v", test.expectedValue, value)
-			}
-
-			if pipeline != test.expetectedPipeline {
-				t.Fatalf("Mismatch in pipeline: got %s expected %s", pipeline, test.expetectedPipeline)
-			}
-
-			if pipelineRun != test.expetectedPipelineRun {
-				t.Fatalf("Mismatch in pipelinerun: got %s expected %s", pipelineRun, test.expetectedPipelineRun)
 			}
 		})
 	}

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -309,7 +309,7 @@ func (r *Recorder) DurationAndCount(ctx context.Context, tr *v1beta1.TaskRun, be
 		status = "failed"
 	}
 
-	if ok, pipeline, pipelinerun := isPartOfPipeline(tr); ok {
+	if ok, pipeline, pipelinerun := IsPartOfPipeline(tr); ok {
 		ctx, err := tag.New(
 			ctx,
 			append([]tag.Mutator{tag.Insert(namespaceTag, tr.Namespace),
@@ -446,7 +446,7 @@ func (r *Recorder) CloudEvents(ctx context.Context, tr *v1beta1.TaskRun) error {
 		status = "failed"
 	}
 
-	if ok, pipeline, pipelinerun := isPartOfPipeline(tr); ok {
+	if ok, pipeline, pipelinerun := IsPartOfPipeline(tr); ok {
 		ctx, err := tag.New(
 			ctx,
 			append([]tag.Mutator{tag.Insert(namespaceTag, tr.Namespace),
@@ -474,9 +474,9 @@ func (r *Recorder) CloudEvents(ctx context.Context, tr *v1beta1.TaskRun) error {
 	return nil
 }
 
-// isPartOfPipeline return true if TaskRun is a part of a Pipeline.
+// IsPartOfPipeline return true if TaskRun is a part of a Pipeline.
 // It also return the name of Pipeline and PipelineRun
-func isPartOfPipeline(tr *v1beta1.TaskRun) (bool, string, string) {
+func IsPartOfPipeline(tr *v1beta1.TaskRun) (bool, string, string) {
 	pipelineLabel, hasPipelineLabel := tr.Labels[pipeline.PipelineLabelKey]
 	pipelineRunLabel, hasPipelineRunLabel := tr.Labels[pipeline.PipelineRunLabelKey]
 

--- a/pkg/taskrunmetrics/metrics.go
+++ b/pkg/taskrunmetrics/metrics.go
@@ -474,6 +474,8 @@ func (r *Recorder) CloudEvents(ctx context.Context, tr *v1beta1.TaskRun) error {
 	return nil
 }
 
+// isPartOfPipeline return true if TaskRun is a part of a Pipeline.
+// It also return the name of Pipeline and PipelineRun
 func isPartOfPipeline(tr *v1beta1.TaskRun) (bool, string, string) {
 	pipelineLabel, hasPipelineLabel := tr.Labels[pipeline.PipelineLabelKey]
 	pipelineRunLabel, hasPipelineRunLabel := tr.Labels[pipeline.PipelineRunLabelKey]

--- a/pkg/taskrunmetrics/metrics_test.go
+++ b/pkg/taskrunmetrics/metrics_test.go
@@ -493,6 +493,50 @@ func TestRecordPodLatency(t *testing.T) {
 
 }
 
+func TestTaskRunIsOfPipelinerun(t *testing.T) {
+	tests := []struct {
+		name                  string
+		tr                    *v1beta1.TaskRun
+		expectedValue         bool
+		expetectedPipeline    string
+		expetectedPipelineRun string
+	}{{
+		name: "yes",
+		tr: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					pipeline.PipelineLabelKey:    "pipeline",
+					pipeline.PipelineRunLabelKey: "pipelinerun",
+				},
+			},
+		},
+		expectedValue:         true,
+		expetectedPipeline:    "pipeline",
+		expetectedPipelineRun: "pipelinerun",
+	}, {
+		name:          "no",
+		tr:            &v1beta1.TaskRun{},
+		expectedValue: false,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, pipeline, pipelineRun := IsPartOfPipeline(test.tr)
+			if value != test.expectedValue {
+				t.Fatalf("Expecting %v got %v", test.expectedValue, value)
+			}
+
+			if pipeline != test.expetectedPipeline {
+				t.Fatalf("Mismatch in pipeline: got %s expected %s", pipeline, test.expetectedPipeline)
+			}
+
+			if pipelineRun != test.expetectedPipelineRun {
+				t.Fatalf("Mismatch in pipelinerun: got %s expected %s", pipelineRun, test.expetectedPipelineRun)
+			}
+		})
+	}
+}
+
 func TestRecordCloudEvents(t *testing.T) {
 	for _, c := range []struct {
 		name          string


### PR DESCRIPTION
The TaskRun API was maintaining a `isPartOfPipeline`
function, which was only consumed by a single package (taskrunmetrics).

As the only consumer, taskrunmetrics should own this interface, and
pull the taskrun meta data it needs on its own,
rather than depending on the package to maintain a compatible API
for its bespoke use case.

closes https://github.com/tektoncd/pipeline/issues/5320

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
