### PR TITLE
V1: Add conversion for TaskRun.Resources

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -195,9 +195,6 @@ func TestTaskrunConversion(t *testing.T) {
 }
 
 func TestTaskRunConversionFromDeprecated(t *testing.T) {
-	// TODO(#4546): We're just dropping Resources when converting from
-	// v1beta1 to v1. Before moving the stored version to v1, we should
-	// come up with a better strategy
 	versions := []apis.Convertible{&v1.TaskRun{}}
 	tests := []struct {
 		name string
@@ -229,7 +226,19 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			Spec: v1beta1.TaskRunSpec{},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Inputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
 		},
 	}, {
 		name: "output resources",
@@ -257,7 +266,19 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 				Name:      "foo",
 				Namespace: "bar",
 			},
-			Spec: v1beta1.TaskRunSpec{},
+			Spec: v1beta1.TaskRunSpec{
+				Resources: &v1beta1.TaskRunResources{
+					Outputs: []v1beta1.TaskResourceBinding{{
+						PipelineResourceBinding: v1beta1.PipelineResourceBinding{
+							ResourceRef: &v1beta1.PipelineResourceRef{
+								Name: "the-git-with-branch",
+							},
+							Name: "gitspace",
+						},
+						Paths: []string{"test-path"},
+					}},
+				},
+			},
 		},
 	}}
 	for _, test := range tests {


### PR DESCRIPTION
This commit adds support for TaskRun.Resources when converting between
v1beta1 and v1 versions of Tasks. This allows us to release v1 TaskRun
in a backwards compatible way by ensuring that v1beta1 TaskRuns with
Resources serialized into annotations on the v1 TaskRun on conversion.

part of #4985
/kind misc

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
