### PR TITLE
Add V1 version of TaskRun CRD

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -60,6 +60,7 @@ var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	// v1
 	v1.SchemeGroupVersion.WithKind("Task"):     &v1.Task{},
 	v1.SchemeGroupVersion.WithKind("Pipeline"): &v1.Pipeline{},
+	v1.SchemeGroupVersion.WithKind("TaskRun"):  &v1.TaskRun{},
 
 	// resolution
 	// v1alpha1
@@ -162,6 +163,14 @@ func newConversionController(ctx context.Context, cmw configmap.Watcher) *contro
 				Zygotes: map[string]conversion.ConvertibleObject{
 					v1beta1GroupVersion: &v1beta1.Pipeline{},
 					v1GroupVersion:      &v1.Pipeline{},
+				},
+			},
+			v1.Kind("TaskRun"): {
+				DefinitionName: pipeline.TaskRunResource.String(),
+				HubVersion:     v1beta1GroupVersion,
+				Zygotes: map[string]conversion.ConvertibleObject{
+					v1beta1GroupVersion: &v1beta1.TaskRun{},
+					v1GroupVersion:      &v1.TaskRun{},
 				},
 			},
 		},

--- a/config/300-taskrun.yaml
+++ b/config/300-taskrun.yaml
@@ -56,6 +56,37 @@ spec:
     # starts to increment
     subresources:
       status: {}
+  - name: v1
+    served: false
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        # One can use x-kubernetes-preserve-unknown-fields: true
+        # at the root of the schema (and inside any properties, additionalProperties)
+        # to get the traditional CRD behaviour that nothing is pruned, despite
+        # setting spec.preserveUnknownProperties: false.
+        #
+        # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+        # See issue: https://github.com/knative/serving/issues/912
+        x-kubernetes-preserve-unknown-fields: true
+    additionalPrinterColumns:
+    - name: Succeeded
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+    - name: Reason
+      type: string
+      jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+    - name: StartTime
+      type: date
+      jsonPath: .status.startTime
+    - name: CompletionTime
+      type: date
+      jsonPath: .status.completionTime
+    # Opt into the status subresource so metadata.generation
+    # starts to increment
+    subresources:
+      status: {}
   names:
     kind: TaskRun
     plural: taskruns
@@ -70,7 +101,7 @@ spec:
   conversion:
     strategy: Webhook
     webhook:
-      conversionReviewVersions: ["v1beta1"]
+      conversionReviewVersions: ["v1beta1", "v1"]
       clientConfig:
         service:
           name: tekton-pipelines-webhook


### PR DESCRIPTION
This commit adds a v1 version of the TaskRun CRD, and support to the webhook.
Since this version is not served, it will not be available to users.

part of #4985 
kind /misc

needs #5378 #5381 

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
