### PR TITLE
V1: Add conversion for TaskRunSpec.TaskRef.Bundle

### DIFF
--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -10,18 +10,38 @@ func (tr TaskRef) convertTo(ctx context.Context, sink *v1.TaskRef) {
 	sink.Name = tr.Name
 	sink.Kind = v1.TaskKind(tr.Kind)
 	sink.APIVersion = tr.APIVersion
-	// TODO: handle bundle in #4546
 	new := v1.ResolverRef{}
 	tr.ResolverRef.convertTo(ctx, &new)
 	sink.ResolverRef = new
+	tr.convertBundleToResolver(sink)
 }
 
 func (tr *TaskRef) convertFrom(ctx context.Context, source v1.TaskRef) {
 	tr.Name = source.Name
 	tr.Kind = TaskKind(source.Kind)
 	tr.APIVersion = source.APIVersion
-	// TODO: handle bundle in #4546
 	new := ResolverRef{}
 	new.convertFrom(ctx, source.ResolverRef)
 	tr.ResolverRef = new
+}
+
+// convertBundleToResolver converts v1beta1 bundle string to a remote reference with the bundle resolver in v1.
+// The conversion from Resolver to Bundle is not being supported since remote resolution would be turned on by
+// default and it will be in beta before the stored version of CRD getting swapped to v1.
+func (tr TaskRef) convertBundleToResolver(sink *v1.TaskRef) {
+	if tr.Bundle != "" {
+		sink.ResolverRef = v1.ResolverRef{
+			Resolver: "bundles",
+			Params: []v1.Param{{
+				Name:  "bundle",
+				Value: v1.ParamValue{StringVal: tr.Bundle},
+			}, {
+				Name:  "name",
+				Value: v1.ParamValue{StringVal: tr.Name},
+			}, {
+				Name:  "kind",
+				Value: v1.ParamValue{StringVal: "Task"},
+			}},
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -280,6 +280,39 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "bundle",
+		in: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name:   "test-bundle-name",
+					Bundle: "test-bundle",
+				},
+			},
+		},
+		want: &v1beta1.TaskRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.TaskRunSpec{
+				TaskRef: &v1beta1.TaskRef{
+					Name: "test-bundle-name",
+					ResolverRef: v1beta1.ResolverRef{
+						Resolver: "bundles",
+						Params: []v1beta1.Param{
+							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle"}},
+							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name"}},
+							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task"}},
+						},
+					},
+				},
+			},
+		},
 	}}
 	for _, test := range tests {
 		for _, version := range versions {


### PR DESCRIPTION
This commit adds support for TaskRef.Bundle when converting between
v1beta1 and v1 versions of TaskRef. This allows us to release v1 TaskRun
 in a backwards compatible way by ensuring that v1beta1 TaskRuns and
PipelineRuns with Bundle converted to v1 TaskRuns conversion.

part of #4985 
/kind misc

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
