### PR TITLE
Fix taskrun_validation_test Version

### DIFF
--- a/pkg/apis/pipeline/v1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskrun_validation_test.go
@@ -24,8 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	resource "github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	corev1resources "k8s.io/apimachinery/pkg/api/resource"
@@ -36,21 +35,21 @@ import (
 func TestTaskRun_Invalidate(t *testing.T) {
 	tests := []struct {
 		name    string
-		taskRun *v1beta1.TaskRun
+		taskRun *v1.TaskRun
 		want    *apis.FieldError
 		wc      func(context.Context) context.Context
 	}{{
 		name:    "invalid taskspec",
-		taskRun: &v1beta1.TaskRun{},
+		taskRun: &v1.TaskRun{},
 		want: apis.ErrMissingOneOf("spec.taskRef", "spec.taskSpec").Also(
 			apis.ErrGeneric(`invalid resource name "": must be a valid DNS label`, "metadata.name")),
 	}, {
 		name: "propagating params not provided but used by step",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
-			Spec: v1beta1.TaskRunSpec{
-				TaskSpec: &v1beta1.TaskSpec{
-					Steps: []v1beta1.Step{{
+			Spec: v1.TaskRunSpec{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
 						Name:    "echo",
 						Image:   "ubuntu",
 						Command: []string{"echo"},
@@ -82,27 +81,27 @@ func TestTaskRun_Invalidate(t *testing.T) {
 func TestTaskRun_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
-		taskRun *v1beta1.TaskRun
+		taskRun *v1.TaskRun
 		wc      func(context.Context) context.Context
 	}{{
 		name: "do not validate spec on delete",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "taskrname"},
 		},
 		wc: apis.WithinDelete,
 	}, {
 		name: "propagating params with taskrun",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
-			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+			Spec: v1.TaskRunSpec{
+				Params: []v1.Param{{
 					Name: "task-words",
-					Value: v1beta1.ParamValue{
+					Value: v1.ParamValue{
 						ArrayVal: []string{"hello", "task run"},
 					},
 				}},
-				TaskSpec: &v1beta1.TaskSpec{
-					Steps: []v1beta1.Step{{
+				TaskSpec: &v1.TaskSpec{
+					Steps: []v1.Step{{
 						Name:    "echo",
 						Image:   "ubuntu",
 						Command: []string{"echo"},
@@ -114,21 +113,21 @@ func TestTaskRun_Validate(t *testing.T) {
 		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating partial params with different provided and default names",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
-			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+			Spec: v1.TaskRunSpec{
+				Params: []v1.Param{{
 					Name: "task-words",
-					Value: v1beta1.ParamValue{
+					Value: v1.ParamValue{
 						ArrayVal: []string{"hello", "task run"},
 					},
 				}},
-				TaskSpec: &v1beta1.TaskSpec{
-					Params: []v1beta1.ParamSpec{{
+				TaskSpec: &v1.TaskSpec{
+					Params: []v1.ParamSpec{{
 						Name: "task-words-2",
-						Type: v1beta1.ParamTypeArray,
+						Type: v1.ParamTypeArray,
 					}},
-					Steps: []v1beta1.Step{{
+					Steps: []v1.Step{{
 						Name:    "task-echo",
 						Image:   "ubuntu",
 						Command: []string{"echo"},
@@ -145,24 +144,24 @@ func TestTaskRun_Validate(t *testing.T) {
 		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating partial params in taskrun",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
-			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+			Spec: v1.TaskRunSpec{
+				Params: []v1.Param{{
 					Name: "task-words",
-					Value: v1beta1.ParamValue{
+					Value: v1.ParamValue{
 						ArrayVal: []string{"hello", "task run"},
 					},
 				}},
-				TaskSpec: &v1beta1.TaskSpec{
-					Params: []v1beta1.ParamSpec{{
+				TaskSpec: &v1.TaskSpec{
+					Params: []v1.ParamSpec{{
 						Name: "task-words-2",
-						Type: v1beta1.ParamTypeArray,
+						Type: v1.ParamTypeArray,
 					}, {
 						Name: "task-words",
-						Type: v1beta1.ParamTypeArray,
+						Type: v1.ParamTypeArray,
 					}},
-					Steps: []v1beta1.Step{{
+					Steps: []v1.Step{{
 						Name:    "echo",
 						Image:   "ubuntu",
 						Command: []string{"echo"},
@@ -179,21 +178,21 @@ func TestTaskRun_Validate(t *testing.T) {
 		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "propagating params with taskrun same names",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
-			Spec: v1beta1.TaskRunSpec{
-				Params: []v1beta1.Param{{
+			Spec: v1.TaskRunSpec{
+				Params: []v1.Param{{
 					Name: "task-words",
-					Value: v1beta1.ParamValue{
+					Value: v1.ParamValue{
 						ArrayVal: []string{"hello", "task run"},
 					},
 				}},
-				TaskSpec: &v1beta1.TaskSpec{
-					Params: []v1beta1.ParamSpec{{
+				TaskSpec: &v1.TaskSpec{
+					Params: []v1.ParamSpec{{
 						Name: "task-words",
-						Type: v1beta1.ParamTypeArray,
+						Type: v1.ParamTypeArray,
 					}},
-					Steps: []v1beta1.Step{{
+					Steps: []v1.Step{{
 						Name:    "echo",
 						Image:   "ubuntu",
 						Command: []string{"echo"},
@@ -205,17 +204,17 @@ func TestTaskRun_Validate(t *testing.T) {
 		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "alpha feature: valid step and sidecar overrides",
-		taskRun: &v1beta1.TaskRun{
+		taskRun: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "tr"},
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "task"},
-				StepOverrides: []v1beta1.TaskRunStepOverride{{
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{Name: "task"},
+				StepOverrides: []v1.TaskRunStepOverride{{
 					Name: "foo",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
 					},
 				}},
-				SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{
+				SidecarOverrides: []v1.TaskRunSidecarOverride{{
 					Name: "bar",
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
@@ -241,15 +240,15 @@ func TestTaskRun_Validate(t *testing.T) {
 func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 	tests := []struct {
 		name    string
-		tr      *v1beta1.TaskRun
+		tr      *v1.TaskRun
 		wantErr *apis.FieldError
 	}{{
 		name: "make sure WorkspaceBinding validation invoked",
-		tr: &v1beta1.TaskRun{
+		tr: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "taskname"},
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "task"},
-				Workspaces: []v1beta1.WorkspaceBinding{{
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{Name: "task"},
+				Workspaces: []v1.WorkspaceBinding{{
 					Name:                  "workspace",
 					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{},
 				}},
@@ -258,11 +257,11 @@ func TestTaskRun_Workspaces_Invalid(t *testing.T) {
 		wantErr: apis.ErrMissingField("spec.workspaces[0].persistentvolumeclaim.claimname"),
 	}, {
 		name: "bind same workspace twice",
-		tr: &v1beta1.TaskRun{
+		tr: &v1.TaskRun{
 			ObjectMeta: metav1.ObjectMeta{Name: "taskname"},
-			Spec: v1beta1.TaskRunSpec{
-				TaskRef: &v1beta1.TaskRef{Name: "task"},
-				Workspaces: []v1beta1.WorkspaceBinding{{
+			Spec: v1.TaskRunSpec{
+				TaskRef: &v1.TaskRef{Name: "task"},
+				Workspaces: []v1.WorkspaceBinding{{
 					Name:     "workspace",
 					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				}, {
@@ -290,21 +289,21 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 	invalidStatusMessage := "status message without status"
 	tests := []struct {
 		name    string
-		spec    v1beta1.TaskRunSpec
+		spec    v1.TaskRunSpec
 		wantErr *apis.FieldError
 		wc      func(context.Context) context.Context
 	}{{
 		name:    "invalid taskspec",
-		spec:    v1beta1.TaskRunSpec{},
+		spec:    v1.TaskRunSpec{},
 		wantErr: apis.ErrMissingOneOf("taskRef", "taskSpec"),
 	}, {
 		name: "invalid taskref and taskspec together",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "taskrefname",
 			},
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
 					Name:  "mystep",
 					Image: "myimage",
 				}},
@@ -313,8 +312,8 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrMultipleOneOf("taskRef", "taskSpec"),
 	}, {
 		name: "negative pipeline timeout",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "taskrefname",
 			},
 			Timeout: &metav1.Duration{Duration: -48 * time.Hour},
@@ -322,8 +321,8 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrInvalidValue("-48h0m0s should be >= 0", "timeout"),
 	}, {
 		name: "wrong taskrun cancel",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "taskrefname",
 			},
 			Status: "TaskRunCancell",
@@ -331,18 +330,18 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrInvalidValue("TaskRunCancell should be TaskRunCancelled", "status"),
 	}, {
 		name: "incorrectly set statusMesage",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "taskrefname",
 			},
-			StatusMessage: v1beta1.TaskRunSpecStatusMessage(invalidStatusMessage),
+			StatusMessage: v1.TaskRunSpecStatusMessage(invalidStatusMessage),
 		},
 		wantErr: apis.ErrInvalidValue(fmt.Sprintf("statusMessage should not be set if status is not set, but it is currently set to %s", invalidStatusMessage), "statusMessage"),
 	}, {
 		name: "invalid taskspec",
-		spec: v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
+		spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
 					Name:  "invalid-name-with-$weird-char/%",
 					Image: "myimage",
 				}},
@@ -355,62 +354,62 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		},
 	}, {
 		name: "invalid params - exactly same names",
-		spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+		spec: v1.TaskRunSpec{
+			Params: []v1.Param{{
 				Name:  "myname",
-				Value: *v1beta1.NewStructuredValues("value"),
+				Value: *v1.NewStructuredValues("value"),
 			}, {
 				Name:  "myname",
-				Value: *v1beta1.NewStructuredValues("value"),
+				Value: *v1.NewStructuredValues("value"),
 			}},
-			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
+			TaskRef: &v1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("params[myname].name"),
 	}, {
 		name: "invalid params - same names but different case",
-		spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+		spec: v1.TaskRunSpec{
+			Params: []v1.Param{{
 				Name:  "FOO",
-				Value: *v1beta1.NewStructuredValues("value"),
+				Value: *v1.NewStructuredValues("value"),
 			}, {
 				Name:  "foo",
-				Value: *v1beta1.NewStructuredValues("value"),
+				Value: *v1.NewStructuredValues("value"),
 			}},
-			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
+			TaskRef: &v1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("params[foo].name"),
 	}, {
 		name: "invalid params (object type) - same names but different case",
-		spec: v1beta1.TaskRunSpec{
-			Params: []v1beta1.Param{{
+		spec: v1.TaskRunSpec{
+			Params: []v1.Param{{
 				Name:  "MYOBJECTPARAM",
-				Value: *v1beta1.NewObject(map[string]string{"key1": "val1", "key2": "val2"}),
+				Value: *v1.NewObject(map[string]string{"key1": "val1", "key2": "val2"}),
 			}, {
 				Name:  "myobjectparam",
-				Value: *v1beta1.NewObject(map[string]string{"key1": "val1", "key2": "val2"}),
+				Value: *v1.NewObject(map[string]string{"key1": "val1", "key2": "val2"}),
 			}},
-			TaskRef: &v1beta1.TaskRef{Name: "mytask"},
+			TaskRef: &v1.TaskRef{Name: "mytask"},
 		},
 		wantErr: apis.ErrMultipleOneOf("params[myobjectparam].name"),
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "using debug when apifields stable",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "my-task",
 			},
-			Debug: &v1beta1.TaskRunDebug{
+			Debug: &v1.TaskRunDebug{
 				Breakpoint: []string{"onFailure"},
 			},
 		},
 		wantErr: apis.ErrGeneric("debug requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "invalid breakpoint",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "my-task",
 			},
-			Debug: &v1beta1.TaskRunDebug{
+			Debug: &v1.TaskRunDebug{
 				Breakpoint: []string{"breakito"},
 			},
 		},
@@ -418,11 +417,11 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "stepOverride disallowed without alpha feature gate",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "foo",
 			},
-			StepOverrides: []v1beta1.TaskRunStepOverride{{
+			StepOverrides: []v1.TaskRunStepOverride{{
 				Name: "foo",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
@@ -432,11 +431,11 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrGeneric("stepOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "sidecarOverride disallowed without alpha feature gate",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "foo",
 			},
-			SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{
+			SidecarOverrides: []v1.TaskRunSidecarOverride{{
 				Name: "foo",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
@@ -446,9 +445,9 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wantErr: apis.ErrGeneric("sidecarOverrides requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\""),
 	}, {
 		name: "duplicate stepOverride names",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			StepOverrides: []v1beta1.TaskRunStepOverride{{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
+			StepOverrides: []v1.TaskRunStepOverride{{
 				Name: "foo",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
@@ -464,9 +463,9 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "missing stepOverride names",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			StepOverrides: []v1beta1.TaskRunStepOverride{{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
+			StepOverrides: []v1.TaskRunStepOverride{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
 				},
@@ -476,9 +475,9 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "duplicate sidecarOverride names",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
+			SidecarOverrides: []v1.TaskRunSidecarOverride{{
 				Name: "bar",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
@@ -494,9 +493,9 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "missing sidecarOverride names",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
+			SidecarOverrides: []v1.TaskRunSidecarOverride{{
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{corev1.ResourceMemory: corev1resources.MustParse("1Gi")},
 				},
@@ -506,9 +505,9 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wc:      config.EnableAlphaAPIFields,
 	}, {
 		name: "invalid both step-level (stepOverrides.resources) and task-level (spec.computeResources) resource requirements",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
-			StepOverrides: []v1beta1.TaskRunStepOverride{{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
+			StepOverrides: []v1.TaskRunStepOverride{{
 				Name: "stepOverride",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -529,8 +528,8 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "computeResources disallowed without alpha feature gate",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{
 				Name: "foo",
 			},
 			ComputeResources: &corev1.ResourceRequirements{
@@ -559,13 +558,13 @@ func TestTaskRunSpec_Invalidate(t *testing.T) {
 func TestTaskRunSpec_Validate(t *testing.T) {
 	tests := []struct {
 		name string
-		spec v1beta1.TaskRunSpec
+		spec v1.TaskRunSpec
 		wc   func(context.Context) context.Context
 	}{{
 		name: "taskspec without a taskRef",
-		spec: v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
+		spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
 					Name:  "mystep",
 					Image: "myimage",
 				}},
@@ -573,10 +572,10 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		},
 	}, {
 		name: "no timeout",
-		spec: v1beta1.TaskRunSpec{
+		spec: v1.TaskRunSpec{
 			Timeout: &metav1.Duration{Duration: 0},
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
 					Name:  "mystep",
 					Image: "myimage",
 				}},
@@ -584,14 +583,14 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		},
 	}, {
 		name: "parameters",
-		spec: v1beta1.TaskRunSpec{
+		spec: v1.TaskRunSpec{
 			Timeout: &metav1.Duration{Duration: 0},
-			Params: []v1beta1.Param{{
+			Params: []v1.Param{{
 				Name:  "name",
-				Value: *v1beta1.NewStructuredValues("value"),
+				Value: *v1.NewStructuredValues("value"),
 			}},
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
 					Name:  "mystep",
 					Image: "myimage",
 				}},
@@ -599,9 +598,9 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		},
 	}, {
 		name: "task spec with credentials.path variable",
-		spec: v1beta1.TaskRunSpec{
-			TaskSpec: &v1beta1.TaskSpec{
-				Steps: []v1beta1.Step{{
+		spec: v1.TaskRunSpec{
+			TaskSpec: &v1.TaskSpec{
+				Steps: []v1.Step{{
 					Name:   "mystep",
 					Image:  "myimage",
 					Script: `echo "creds-init writes to $(credentials.path)"`,
@@ -610,8 +609,8 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		},
 	}, {
 		name: "valid task-level (spec.resources) resource requirements",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
 			ComputeResources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: corev1resources.MustParse("2Gi"),
@@ -621,14 +620,14 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 		wc: config.EnableAlphaAPIFields,
 	}, {
 		name: "valid sidecar and task-level (spec.resources) resource requirements",
-		spec: v1beta1.TaskRunSpec{
-			TaskRef: &v1beta1.TaskRef{Name: "task"},
+		spec: v1.TaskRunSpec{
+			TaskRef: &v1.TaskRef{Name: "task"},
 			ComputeResources: &corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceMemory: corev1resources.MustParse("2Gi"),
 				},
 			},
-			SidecarOverrides: []v1beta1.TaskRunSidecarOverride{{
+			SidecarOverrides: []v1.TaskRunSidecarOverride{{
 				Name: "sidecar",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -648,239 +647,6 @@ func TestTaskRunSpec_Validate(t *testing.T) {
 			}
 			if err := ts.spec.Validate(ctx); err != nil {
 				t.Error(err)
-			}
-		})
-	}
-}
-
-func TestResources_Validate(t *testing.T) {
-	tests := []struct {
-		name      string
-		resources *v1beta1.TaskRunResources
-	}{{
-		name: "no resources is valid",
-	}, {
-		name: "inputs only",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource",
-					},
-					Name: "workspace",
-				},
-			}},
-		},
-	}, {
-		name: "multiple inputs only",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource1",
-					},
-					Name: "workspace1",
-				},
-			}, {
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource2",
-					},
-					Name: "workspace2",
-				},
-			}},
-		},
-	}, {
-		name: "outputs only",
-		resources: &v1beta1.TaskRunResources{
-			Outputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource",
-					},
-					Name: "workspace",
-				},
-			}},
-		},
-	}, {
-		name: "multiple outputs only",
-		resources: &v1beta1.TaskRunResources{
-			Outputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource1",
-					},
-					Name: "workspace1",
-				},
-			}, {
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource2",
-					},
-					Name: "workspace2",
-				},
-			}},
-		},
-	}, {
-		name: "inputs and outputs",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource",
-					},
-					Name: "workspace",
-				},
-			}},
-			Outputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource",
-					},
-					Name: "workspace",
-				},
-			}},
-		},
-	}}
-	for _, ts := range tests {
-		t.Run(ts.name, func(t *testing.T) {
-			if err := ts.resources.Validate(context.Background()); err != nil {
-				t.Errorf("TaskRunInputs.Validate() error = %v", err)
-			}
-		})
-	}
-
-}
-
-func TestResources_Invalidate(t *testing.T) {
-	tests := []struct {
-		name      string
-		resources *v1beta1.TaskRunResources
-		wantErr   *apis.FieldError
-	}{{
-		name: "duplicate task inputs",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource1",
-					},
-					Name: "workspace",
-				},
-			}, {
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource2",
-					},
-					Name: "workspace",
-				},
-			}},
-		},
-		wantErr: apis.ErrMultipleOneOf("spec.resources.inputs.name"),
-	}, {
-		name: "duplicate resource ref and resource spec",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource",
-					},
-					ResourceSpec: &resource.PipelineResourceSpec{
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-					Name: "resource-dup",
-				},
-			}},
-		},
-		wantErr: apis.ErrDisallowedFields("spec.resources.inputs.name.resourceRef", "spec.resources.inputs.name.resourceSpec"),
-	}, {
-		name: "invalid resource spec",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceSpec: &resource.PipelineResourceSpec{
-						Type: "non-existent",
-					},
-					Name: "resource-inv",
-				},
-			}},
-		},
-		wantErr: apis.ErrInvalidValue("spec.type", "non-existent"),
-	}, {
-		name: "no resource ref", // and resource spec
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					Name: "resource",
-				},
-			}},
-		},
-		wantErr: apis.ErrMissingField("spec.resources.inputs.name.resourceRef", "spec.resources.inputs.name.resourceSpec"),
-	}, {
-		name: "duplicate task outputs",
-		resources: &v1beta1.TaskRunResources{
-			Outputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource1",
-					},
-					Name: "workspace",
-				},
-			}, {
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource2",
-					},
-					Name: "workspace",
-				},
-			}},
-		},
-		wantErr: apis.ErrMultipleOneOf("spec.resources.outputs.name"),
-	}, {
-		name: "duplicate resource ref and resource spec",
-		resources: &v1beta1.TaskRunResources{
-			Outputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceRef: &v1beta1.PipelineResourceRef{
-						Name: "testresource",
-					},
-					ResourceSpec: &resource.PipelineResourceSpec{
-						Type: v1beta1.PipelineResourceTypeGit,
-					},
-					Name: "resource-dup",
-				},
-			}},
-		},
-		wantErr: apis.ErrDisallowedFields("spec.resources.outputs.name.resourceRef", "spec.resources.outputs.name.resourceSpec"),
-	}, {
-		name: "invalid resource spec",
-		resources: &v1beta1.TaskRunResources{
-			Inputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					ResourceSpec: &resource.PipelineResourceSpec{
-						Type: "non-existent",
-					},
-					Name: "resource-inv",
-				},
-			}},
-		},
-		wantErr: apis.ErrInvalidValue("spec.type", "non-existent"),
-	}, {
-		name: "no resource ref ", // and resource spec
-		resources: &v1beta1.TaskRunResources{
-			Outputs: []v1beta1.TaskResourceBinding{{
-				PipelineResourceBinding: v1beta1.PipelineResourceBinding{
-					Name: "resource",
-				},
-			}},
-		},
-		wantErr: apis.ErrMissingField("spec.resources.outputs.name.resourceRef", "spec.resources.outputs.name.resourceSpec"),
-	}}
-	for _, ts := range tests {
-		t.Run(ts.name, func(t *testing.T) {
-			err := ts.resources.Validate(context.Background())
-			if d := cmp.Diff(err.Error(), ts.wantErr.Error()); d != "" {
-				t.Error(diff.PrintWantGot(d))
 			}
 		})
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
This commit fixes the version misplace of the test in taskrun_validation for v1.

cc @lbernick @chitrangpatel 
/kind bug

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
