### PR TITLE
Support parameter substitution for resolver params

### DIFF
--- a/pkg/apis/pipeline/v1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1/taskref_validation_test.go
@@ -123,6 +123,41 @@ func TestTaskRef_Invalid(t *testing.T) {
 		},
 		wantErr: apis.ErrMultipleOneOf("name", "params").Also(apis.ErrMissingField("resolver")),
 		wc:      config.EnableAlphaAPIFields,
+	}, {
+		name: "taskref param array not allowed",
+		taskRef: &v1.TaskRef{
+			ResolverRef: v1.ResolverRef{
+				Resolver: "some-resolver",
+				Params: []v1.Param{{
+					Name: "foo",
+					Value: v1.ParamValue{
+						Type:     v1.ParamTypeArray,
+						ArrayVal: []string{"bar", "baz"},
+					},
+				}},
+			},
+		},
+		wantErr: apis.ErrGeneric("remote resolution parameter type must be string, not array").
+			Also(apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")).
+			Also(apis.ErrGeneric("params requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
+	}, {
+		name: "taskref param object requires alpha",
+		taskRef: &v1.TaskRef{
+			ResolverRef: v1.ResolverRef{
+				Resolver: "some-resolver",
+				Params: []v1.Param{{
+					Name: "foo",
+					Value: v1.ParamValue{
+						Type:      v1.ParamTypeObject,
+						ObjectVal: map[string]string{"bar": "baz"},
+					},
+				}},
+			},
+		},
+		wantErr: apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").
+			Also(apis.ErrGeneric("remote resolution parameter type must be string, not object")).
+			Also(apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")).
+			Also(apis.ErrGeneric("params requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
 	}}
 	for _, ts := range tests {
 		t.Run(ts.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation.go
@@ -55,6 +55,7 @@ func (ref *PipelineRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 				errs = errs.Also(apis.ErrMissingField("resolver"))
 			}
 			errs = errs.Also(ValidateParameters(ctx, ref.Params))
+			errs = errs.Also(validateResolutionParamTypes(ref.Params).ViaField("params"))
 		}
 	} else {
 		if ref.Name == "" {
@@ -78,4 +79,15 @@ func validateBundleFeatureFlag(ctx context.Context, featureName string, wantValu
 		return errs.Also(apis.ErrGeneric(message))
 	}
 	return nil
+}
+
+func validateResolutionParamTypes(params []Param) (errs *apis.FieldError) {
+	for i, p := range params {
+		if p.Value.Type == ParamTypeArray || p.Value.Type == ParamTypeObject {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("remote resolution parameter type must be %s, not %s",
+				string(ParamTypeString), string(p.Value.Type))).ViaIndex(i))
+		}
+	}
+
+	return errs
 }

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -140,7 +140,24 @@ func TestPipelineRef_Invalid(t *testing.T) {
 		wantErr:     apis.ErrMultipleOneOf("bundle", "params").Also(apis.ErrMissingField("resolver")),
 		withContext: config.EnableAlphaAPIFields,
 	}, {
-		name: "pipelineref param object requires alpha",
+		name: "pipelineref param array not allowed",
+		ref: &v1beta1.PipelineRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "some-resolver",
+				Params: []v1beta1.Param{{
+					Name: "foo",
+					Value: v1beta1.ParamValue{
+						Type:     v1beta1.ParamTypeArray,
+						ArrayVal: []string{"bar", "baz"},
+					},
+				}},
+			},
+		},
+		wantErr: apis.ErrGeneric("remote resolution parameter type must be string, not array").
+			Also(apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")).
+			Also(apis.ErrGeneric("params requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
+	}, {
+		name: "pipelineref param object not allowed",
 		ref: &v1beta1.PipelineRef{
 			ResolverRef: v1beta1.ResolverRef{
 				Resolver: "some-resolver",
@@ -154,6 +171,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").
+			Also(apis.ErrGeneric("remote resolution parameter type must be string, not object")).
 			Also(apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")).
 			Also(apis.ErrGeneric("params requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
 	}}

--- a/pkg/apis/pipeline/v1beta1/taskref_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation.go
@@ -54,6 +54,7 @@ func (ref *TaskRef) Validate(ctx context.Context) (errs *apis.FieldError) {
 				errs = errs.Also(apis.ErrMissingField("resolver"))
 			}
 			errs = errs.Also(ValidateParameters(ctx, ref.Params))
+			errs = errs.Also(validateResolutionParamTypes(ref.Params).ViaField("params"))
 		}
 	} else {
 		if ref.Name == "" {

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -187,6 +187,23 @@ func TestTaskRef_Invalid(t *testing.T) {
 		wantErr: apis.ErrMultipleOneOf("bundle", "params").Also(apis.ErrMissingField("resolver")),
 		wc:      config.EnableAlphaAPIFields,
 	}, {
+		name: "taskref param array not allowed",
+		taskRef: &v1beta1.TaskRef{
+			ResolverRef: v1beta1.ResolverRef{
+				Resolver: "some-resolver",
+				Params: []v1beta1.Param{{
+					Name: "foo",
+					Value: v1beta1.ParamValue{
+						Type:     v1beta1.ParamTypeArray,
+						ArrayVal: []string{"bar", "baz"},
+					},
+				}},
+			},
+		},
+		wantErr: apis.ErrGeneric("remote resolution parameter type must be string, not array").
+			Also(apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")).
+			Also(apis.ErrGeneric("params requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
+	}, {
 		name: "taskref param object requires alpha",
 		taskRef: &v1beta1.TaskRef{
 			ResolverRef: v1beta1.ResolverRef{
@@ -201,6 +218,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 			},
 		},
 		wantErr: apis.ErrGeneric("object type parameter requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"").
+			Also(apis.ErrGeneric("remote resolution parameter type must be string, not object")).
 			Also(apis.ErrGeneric("resolver requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")).
 			Also(apis.ErrGeneric("params requires \"enable-api-fields\" feature gate to be \"alpha\" but it is \"stable\"")),
 	}}

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -73,7 +73,9 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 	case cfg.FeatureFlags.EnableAPIFields == config.AlphaAPIFields && pr != nil && pr.Resolver != "" && requester != nil:
 		return func(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
 			params := map[string]string{}
-			for _, p := range pr.Params {
+			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(ctx, pipelineRun)
+			replacedParams := replaceParamValues(pr.Params, stringReplacements, arrayReplacements, objectReplacements)
+			for _, p := range replacedParams {
 				params[p.Name] = p.Value.StringVal
 			}
 			resolver := resolution.NewResolver(requester, pipelineRun, string(pr.Resolver), "", "", params)

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -105,7 +105,17 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 		// casting it to a TaskObject.
 		return func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
 			params := map[string]string{}
-			for _, p := range tr.Params {
+			var replacedParams []v1beta1.Param
+			if ownerAsTR, ok := owner.(*v1beta1.TaskRun); ok {
+				stringReplacements, arrayReplacements := paramsFromTaskRun(ctx, ownerAsTR)
+				for _, p := range tr.Params {
+					p.Value.ApplyReplacements(stringReplacements, arrayReplacements, nil)
+					replacedParams = append(replacedParams, p)
+				}
+			} else {
+				replacedParams = append(replacedParams, tr.Params...)
+			}
+			for _, p := range replacedParams {
 				params[p.Name] = p.Value.StringVal
 			}
 			resolver := resolution.NewResolver(requester, owner, string(tr.Resolver), trName, namespace, params)

--- a/test/resolution.go
+++ b/test/resolution.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"fmt"
 
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
 )
@@ -37,12 +38,28 @@ type Requester struct {
 	ResolvedResource resolution.ResolvedResource
 	// An error to return when a request is submitted.
 	SubmitErr error
+	// Params that should match those on the request in order to return the resolved resource
+	Params map[string]string
 }
 
 // Submit implements resolution.Requester, accepting the name of a
 // resolver and a request for a specific remote file, and then returns
 // whatever mock data was provided on initialization.
 func (r *Requester) Submit(ctx context.Context, resolverName resolution.ResolverName, req resolution.Request) (resolution.ResolvedResource, error) {
+	if len(r.Params) == 0 {
+		return r.ResolvedResource, r.SubmitErr
+	}
+	reqParams := make(map[string]string)
+	for k, v := range req.Params() {
+		reqParams[k] = v
+	}
+
+	for k, v := range r.Params {
+		if reqValue, ok := reqParams[k]; !ok || reqValue != v {
+			return nil, fmt.Errorf("expected %s param to be %s, but was %s", k, v, reqValue)
+		}
+	}
+
 	return r.ResolvedResource, r.SubmitErr
 }
 


### PR DESCRIPTION
# Changes

Part of #4710

Until we do `v1beta1` of `ResolutionRequest`, it will still have parameters of `map[string]string`, so we're only doing limited substitution.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
