### PR TITLE
Metrics: Nil Derefence when TR/PR not found

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -262,8 +262,9 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, pr *v1beta1.Pi
 		if err != nil && !kerrors.IsNotFound(err) {
 			logger.Errorf("Error getting PipelineRun %s when updating metrics: %w", pr.Name, err)
 			return
-		} else if kerrors.IsNotFound(err) {
+		} else if kerrors.IsNotFound(err) || newPr == nil {
 			logger.Debugf("Pipelinerun %s not found when updating metrics: %w", pr.Name, err)
+			return
 		}
 
 		before := newPr.Status.GetCondition(apis.ConditionSucceeded)

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -221,8 +221,9 @@ func (c *Reconciler) durationAndCountMetrics(ctx context.Context, tr *v1beta1.Ta
 		if err != nil && !k8serrors.IsNotFound(err) {
 			logger.Errorf("Error getting TaskRun %s when updating metrics: %w", tr.Name, err)
 			return
-		} else if k8serrors.IsNotFound(err) {
+		} else if k8serrors.IsNotFound(err) || newTr == nil {
 			logger.Debugf("TaskRun %s not found when updating metrics: %w", tr.Name, err)
+			return
 		}
 
 		before := newTr.Status.GetCondition(apis.ConditionSucceeded)


### PR DESCRIPTION
We dereference a nil pointer when TR/PR is not found or
somehow taskrun or pipelinerun pointer is nil.
This was catch by @Epsilon314  [here](https://github.com/tektoncd/pipeline/pull/5166/files/26e452bc4232c0a48660bc3968fc86eec0f2f369#r956867723)
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
