### PR TITLE
TEP-0114: Clarify the Behavior of Custom Task Retries

### DIFF
--- a/docs/runs.md
+++ b/docs/runs.md
@@ -224,11 +224,8 @@ Supporting retries is optional but recommended.
 
 #### Developer guide for custom controllers supporting `retries`
 
-1. Tekton controllers will use the entire `timeout` duration for exhausting
-    all the retries the custom task is configured to run with. In other words,
-    tekton does not discriminate, if the failure was due to a stuck up process or
-    exhausting all the retries. Custom task developers are recommended to use the
-    same strategy for implementing their timeout for the custom task.
+1. Timeout is for each Custom Task Run retries, meaning if retry balance is
+    not 0 and the run fails because of timeout, it should be retried.
 2. Those custom task who do not wish to support retry, can simply ignore it.
 3. It is recommended, that custom task should update the field `RetriesStatus`
    of a `Run` on each retry performed by the custom task.


### PR DESCRIPTION
# Changes

Prior to this PR, it is not clear enough how retries works when
the custom task run is timeout. This PR refines the developer
guide for custom controllers supporting `retries` to clarify it.

/kind doc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```

