### PR TITLE
Populate the `*Run.Status.Provenance.ConfigSource` field

### DIFF
--- a/pkg/internal/resolution/resolved_meta.go
+++ b/pkg/internal/resolution/resolved_meta.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolution
+
+import (
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResolvedObjectMeta contains both ObjectMeta and the metadata that identifies the source where the resource came from.
+type ResolvedObjectMeta struct {
+	*metav1.ObjectMeta `json:",omitempty"`
+	// ConfigSource identifies where the spec came from.
+	ConfigSource *v1beta1.ConfigSource `json:",omitempty"`
+}

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
@@ -22,32 +22,37 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GetPipeline is a function used to retrieve Pipelines.
-type GetPipeline func(context.Context, string) (v1beta1.PipelineObject, error)
+type GetPipeline func(context.Context, string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error)
 
 // GetPipelineData will retrieve the Pipeline metadata and Spec associated with the
 // provided PipelineRun. This can come from a reference Pipeline or from the PipelineRun's
 // metadata and embedded PipelineSpec.
-func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getPipeline GetPipeline) (*metav1.ObjectMeta, *v1beta1.PipelineSpec, error) {
+func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getPipeline GetPipeline) (*resolutionutil.ResolvedObjectMeta, *v1beta1.PipelineSpec, error) {
 	pipelineMeta := metav1.ObjectMeta{}
+	var configSource *v1beta1.ConfigSource
 	pipelineSpec := v1beta1.PipelineSpec{}
 	switch {
 	case pipelineRun.Spec.PipelineRef != nil && pipelineRun.Spec.PipelineRef.Name != "":
 		// Get related pipeline for pipelinerun
-		t, err := getPipeline(ctx, pipelineRun.Spec.PipelineRef.Name)
+		p, source, err := getPipeline(ctx, pipelineRun.Spec.PipelineRef.Name)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error when listing pipelines for pipelineRun %s: %w", pipelineRun.Name, err)
 		}
-		pipelineMeta = t.PipelineMetadata()
-		pipelineSpec = t.PipelineSpec()
+		pipelineMeta = p.PipelineMetadata()
+		pipelineSpec = p.PipelineSpec()
+		configSource = source
 	case pipelineRun.Spec.PipelineSpec != nil:
 		pipelineMeta = pipelineRun.ObjectMeta
 		pipelineSpec = *pipelineRun.Spec.PipelineSpec
+		// TODO: if we want to set source for embedded pipeline, set it here.
+		// https://github.com/tektoncd/pipeline/issues/5522
 	case pipelineRun.Spec.PipelineRef != nil && pipelineRun.Spec.PipelineRef.Resolver != "":
-		pipeline, err := getPipeline(ctx, "")
+		pipeline, source, err := getPipeline(ctx, "")
 		switch {
 		case err != nil:
 			return nil, nil, err
@@ -57,10 +62,14 @@ func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getP
 			pipelineMeta = pipeline.PipelineMetadata()
 			pipelineSpec = pipeline.PipelineSpec()
 		}
+		configSource = source
 	default:
 		return nil, nil, fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
 	}
 
 	pipelineSpec.SetDefaults(ctx)
-	return &pipelineMeta, &pipelineSpec, nil
+	return &resolutionutil.ResolvedObjectMeta{
+		ObjectMeta:   &pipelineMeta,
+		ConfigSource: configSource,
+	}, &pipelineSpec, nil
 }

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -44,36 +44,42 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 	cfg := config.FromContextOrDefaults(ctx)
 	pr := pipelineRun.Spec.PipelineRef
 	namespace := pipelineRun.Namespace
-	// if the spec is already in the status, do not try to fetch it again, just use it as source of truth
+	// if the spec is already in the status, do not try to fetch it again, just use it as source of truth.
+	// Same for the Source field in the Status.Provenance.
 	if pipelineRun.Status.PipelineSpec != nil {
-		return func(_ context.Context, name string) (v1beta1.PipelineObject, error) {
+		return func(_ context.Context, name string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+			var configSource *v1beta1.ConfigSource
+			if pipelineRun.Status.Provenance != nil {
+				configSource = pipelineRun.Status.Provenance.ConfigSource
+			}
 			return &v1beta1.Pipeline{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: namespace,
 				},
 				Spec: *pipelineRun.Status.PipelineSpec,
-			}, nil
+			}, configSource, nil
 		}, nil
 	}
+
 	switch {
 	case cfg.FeatureFlags.EnableTektonOCIBundles && pr != nil && pr.Bundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a PipelineObject.
-		return func(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
+		return func(ctx context.Context, name string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
 			// If there is a bundle url at all, construct an OCI resolver to fetch the pipeline.
 			kc, err := k8schain.New(ctx, k8s, k8schain.Options{
 				Namespace:          namespace,
 				ServiceAccountName: pipelineRun.Spec.ServiceAccountName,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to get keychain: %w", err)
+				return nil, nil, fmt.Errorf("failed to get keychain: %w", err)
 			}
 			resolver := oci.NewResolver(pr.Bundle, kc)
 			return resolvePipeline(ctx, resolver, name, k8s)
 		}, nil
 	case pr != nil && pr.Resolver != "" && requester != nil:
-		return func(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
+		return func(ctx context.Context, name string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
 			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(ctx, pipelineRun)
 			for k, v := range getContextReplacements("", pipelineRun) {
 				stringReplacements[k] = v
@@ -102,40 +108,42 @@ type LocalPipelineRefResolver struct {
 
 // GetPipeline will resolve a Pipeline from the local cluster using a versioned Tekton client. It will
 // return an error if it can't find an appropriate Pipeline for any reason.
-func (l *LocalPipelineRefResolver) GetPipeline(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
+// TODO: if we want to set source for in-cluster pipeline, set it here.
+// https://github.com/tektoncd/pipeline/issues/5522
+func (l *LocalPipelineRefResolver) GetPipeline(ctx context.Context, name string) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {
-		return nil, fmt.Errorf("Must specify namespace to resolve reference to pipeline %s", name)
+		return nil, nil, fmt.Errorf("Must specify namespace to resolve reference to pipeline %s", name)
 	}
 
 	pipeline, err := l.Tektonclient.TektonV1beta1().Pipelines(l.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := verifyResolvedPipeline(ctx, pipeline, l.K8sclient); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return pipeline, nil
+	return pipeline, nil, nil
 }
 
 // resolvePipeline accepts an impl of remote.Resolver and attempts to
 // fetch a pipeline with given name. An error is returned if the
 // resolution doesn't work or the returned data isn't a valid
 // v1beta1.PipelineObject.
-func resolvePipeline(ctx context.Context, resolver remote.Resolver, name string, k8s kubernetes.Interface) (v1beta1.PipelineObject, error) {
-	obj, err := resolver.Get(ctx, "pipeline", name)
+func resolvePipeline(ctx context.Context, resolver remote.Resolver, name string, k8s kubernetes.Interface) (v1beta1.PipelineObject, *v1beta1.ConfigSource, error) {
+	obj, source, err := resolver.Get(ctx, "pipeline", name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	pipelineObj, err := readRuntimeObjectAsPipeline(ctx, obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert obj %s into Pipeline", obj.GetObjectKind().GroupVersionKind().String())
+		return nil, nil, fmt.Errorf("failed to convert obj %s into Pipeline", obj.GetObjectKind().GroupVersionKind().String())
 	}
 	// TODO(#5527): Consider move this function call to GetPipelineData
 	if err := verifyResolvedPipeline(ctx, pipelineObj, k8s); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return pipelineObj, nil
+	return pipelineObj, source, nil
 }
 
 // readRuntimeObjectAsPipeline tries to convert a generic runtime.Object

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -778,7 +778,9 @@ func resolveTask(
 			spec = *taskRun.Status.TaskSpec
 			taskName = pipelineTask.TaskRef.Name
 		} else {
-			t, err = getTask(ctx, pipelineTask.TaskRef.Name)
+			// Following minimum status principle (TEP-0100), no need to propagate the source about PipelineTask up to PipelineRun status.
+			// Instead, the child TaskRun's status will be the place recording the source of individual task.
+			t, _, err = getTask(ctx, pipelineTask.TaskRef.Name)
 			switch {
 			case errors.Is(err, remote.ErrorRequestInProgress):
 				return v1beta1.TaskSpec{}, "", "", err

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -58,16 +58,21 @@ func GetTaskKind(taskrun *v1beta1.TaskRun) v1beta1.TaskKind {
 // cluster or authorize against an external repositroy. It will figure out whether it needs to look in the cluster or in
 // a remote image to fetch the  reference. It will also return the "kind" of the task being referenced.
 func GetTaskFuncFromTaskRun(ctx context.Context, k8s kubernetes.Interface, tekton clientset.Interface, requester remoteresource.Requester, taskrun *v1beta1.TaskRun) (GetTask, error) {
-	// if the spec is already in the status, do not try to fetch it again, just use it as source of truth
+	// if the spec is already in the status, do not try to fetch it again, just use it as source of truth.
+	// Same for the Source field in the Status.Provenance.
 	if taskrun.Status.TaskSpec != nil {
-		return func(_ context.Context, name string) (v1beta1.TaskObject, error) {
+		return func(_ context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
+			var configsource *v1beta1.ConfigSource
+			if taskrun.Status.Provenance != nil {
+				configsource = taskrun.Status.Provenance.ConfigSource
+			}
 			return &v1beta1.Task{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      name,
 					Namespace: taskrun.Namespace,
 				},
 				Spec: *taskrun.Status.TaskSpec,
-			}, nil
+			}, configsource, nil
 		}, nil
 	}
 	return GetTaskFunc(ctx, k8s, tekton, requester, taskrun, taskrun.Spec.TaskRef, taskrun.Name, taskrun.Namespace, taskrun.Spec.ServiceAccountName)
@@ -89,14 +94,14 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 	case cfg.FeatureFlags.EnableTektonOCIBundles && tr != nil && tr.Bundle != "":
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a TaskObject.
-		return func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
+		return func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
 			// If there is a bundle url at all, construct an OCI resolver to fetch the task.
 			kc, err := k8schain.New(ctx, k8s, k8schain.Options{
 				Namespace:          namespace,
 				ServiceAccountName: saName,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to get keychain: %w", err)
+				return nil, nil, fmt.Errorf("failed to get keychain: %w", err)
 			}
 			resolver := oci.NewResolver(tr.Bundle, kc)
 
@@ -105,7 +110,7 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 	case tr != nil && tr.Resolver != "" && requester != nil:
 		// Return an inline function that implements GetTask by calling Resolver.Get with the specified task type and
 		// casting it to a TaskObject.
-		return func(ctx context.Context, name string) (v1beta1.TaskObject, error) {
+		return func(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
 			var replacedParams []v1beta1.Param
 			if ownerAsTR, ok := owner.(*v1beta1.TaskRun); ok {
 				stringReplacements, arrayReplacements := paramsFromTaskRun(ctx, ownerAsTR)
@@ -139,22 +144,22 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 // fetch a task with given name. An error is returned if the
 // remoteresource doesn't work or the returned data isn't a valid
 // v1beta1.TaskObject.
-func resolveTask(ctx context.Context, resolver remote.Resolver, name string, kind v1beta1.TaskKind, k8s kubernetes.Interface) (v1beta1.TaskObject, error) {
+func resolveTask(ctx context.Context, resolver remote.Resolver, name string, kind v1beta1.TaskKind, k8s kubernetes.Interface) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
 	// Because the resolver will only return references with the same kind (eg ClusterTask), this will ensure we
 	// don't accidentally return a Task with the same name but different kind.
-	obj, err := resolver.Get(ctx, strings.TrimSuffix(strings.ToLower(string(kind)), "s"), name)
+	obj, configSource, err := resolver.Get(ctx, strings.TrimSuffix(strings.ToLower(string(kind)), "s"), name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	taskObj, err := readRuntimeObjectAsTask(ctx, obj)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
+		return nil, nil, fmt.Errorf("failed to convert obj %s into Task", obj.GetObjectKind().GroupVersionKind().String())
 	}
 	// TODO(#5527): Consider move this function call to GetTaskData
 	if err := verifyResolvedTask(ctx, taskObj, k8s); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return taskObj, nil
+	return taskObj, configSource, nil
 }
 
 // readRuntimeObjectAsTask tries to convert a generic runtime.Object
@@ -179,27 +184,29 @@ type LocalTaskRefResolver struct {
 
 // GetTask will resolve either a Task or ClusterTask from the local cluster using a versioned Tekton client. It will
 // return an error if it can't find an appropriate Task for any reason.
-func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (v1beta1.TaskObject, error) {
+// TODO: if we want to set source for in-cluster task, set it here.
+// https://github.com/tektoncd/pipeline/issues/5522
+func (l *LocalTaskRefResolver) GetTask(ctx context.Context, name string) (v1beta1.TaskObject, *v1beta1.ConfigSource, error) {
 	if l.Kind == v1beta1.ClusterTaskKind {
 		task, err := l.Tektonclient.TektonV1beta1().ClusterTasks().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return task, nil
+		return task, nil, nil
 	}
 
 	// If we are going to resolve this reference locally, we need a namespace scope.
 	if l.Namespace == "" {
-		return nil, fmt.Errorf("must specify namespace to resolve reference to task %s", name)
+		return nil, nil, fmt.Errorf("must specify namespace to resolve reference to task %s", name)
 	}
 	task, err := l.Tektonclient.TektonV1beta1().Tasks(l.Namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := verifyResolvedTask(ctx, task, l.K8sclient); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return task, nil
+	return task, nil, nil
 }
 
 // IsGetTaskErrTransient returns true if an error returned by GetTask is retryable.

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -37,6 +37,7 @@ import (
 	resourcelisters "github.com/tektoncd/pipeline/pkg/client/resource/listers/resource/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/internal/affinityassistant"
 	"github.com/tektoncd/pipeline/pkg/internal/computeresources"
+	resolutionutil "github.com/tektoncd/pipeline/pkg/internal/resolution"
 	podconvert "github.com/tektoncd/pipeline/pkg/pod"
 	tknreconciler "github.com/tektoncd/pipeline/pkg/reconciler"
 	"github.com/tektoncd/pipeline/pkg/reconciler/events"
@@ -347,7 +348,7 @@ func (c *Reconciler) prepare(ctx context.Context, tr *v1beta1.TaskRun) (*v1beta1
 		return nil, nil, controller.NewPermanentError(err)
 	default:
 		// Store the fetched TaskSpec on the TaskRun for auditing
-		if err := storeTaskSpecAndMergeMeta(tr, taskSpec, taskMeta); err != nil {
+		if err := storeTaskSpecAndMergeMeta(ctx, tr, taskSpec, taskMeta); err != nil {
 			logger.Errorf("Failed to store TaskSpec on TaskRun.Statusfor taskrun %s: %v", tr.Name, err)
 		}
 	}
@@ -914,10 +915,14 @@ func applyVolumeClaimTemplates(workspaceBindings []v1beta1.WorkspaceBinding, own
 	return taskRunWorkspaceBindings
 }
 
-func storeTaskSpecAndMergeMeta(tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec, meta *metav1.ObjectMeta) error {
+func storeTaskSpecAndMergeMeta(ctx context.Context, tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec, meta *resolutionutil.ResolvedObjectMeta) error {
 	// Only store the TaskSpec once, if it has never been set before.
 	if tr.Status.TaskSpec == nil {
 		tr.Status.TaskSpec = ts
+		if meta == nil {
+			return nil
+		}
+
 		// Propagate annotations from Task to TaskRun. TaskRun annotations take precedences over Task.
 		tr.ObjectMeta.Annotations = kmap.Union(meta.Annotations, tr.ObjectMeta.Annotations)
 		// Propagate labels from Task to TaskRun. TaskRun labels take precedences over Task.
@@ -928,6 +933,18 @@ func storeTaskSpecAndMergeMeta(tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec, meta *
 			} else {
 				tr.ObjectMeta.Labels[pipeline.TaskLabelKey] = meta.Name
 			}
+		}
+	}
+
+	// Propagate ConfigSource from remote resolution to TaskRun Status
+	// This lives outside of the status.spec check to avoid the case where only the spec is available in the first reconcile and source comes in next reconcile.
+	cfg := config.FromContextOrDefaults(ctx)
+	if cfg.FeatureFlags.EnableProvenanceInStatus && meta != nil && meta.ConfigSource != nil {
+		if tr.Status.Provenance == nil {
+			tr.Status.Provenance = &v1beta1.Provenance{}
+		}
+		if tr.Status.Provenance.ConfigSource == nil {
+			tr.Status.Provenance.ConfigSource = meta.ConfigSource
 		}
 	}
 	return nil

--- a/pkg/reconciler/testing/configmap.go
+++ b/pkg/reconciler/testing/configmap.go
@@ -17,10 +17,12 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"testing"
 
+	"github.com/tektoncd/pipeline/pkg/apis/config"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -44,4 +46,20 @@ func ConfigMapFromTestFile(t *testing.T, name string) *corev1.ConfigMap {
 	}
 
 	return &cm
+}
+
+// EnableFeatureFlagField enables a boolean feature flag in an existing context (for use in testing).
+func EnableFeatureFlagField(ctx context.Context, t *testing.T, flagName string) context.Context {
+	featureFlags, err := config.NewFeatureFlagsFromMap(map[string]string{
+		flagName: "true",
+	})
+
+	if err != nil {
+		t.Fatalf("Fail to create a feature config: %v", err)
+	}
+
+	cfg := &config.Config{
+		FeatureFlags: featureFlags,
+	}
+	return config.ToContext(ctx, cfg)
 }

--- a/pkg/remote/oci/resolver_test.go
+++ b/pkg/remote/oci/resolver_test.go
@@ -203,13 +203,17 @@ func TestOCIResolver(t *testing.T) {
 			}
 
 			for _, obj := range tc.objs {
-				actual, err := resolver.Get(context.Background(), strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), test.GetObjectName(obj))
+				actual, source, err := resolver.Get(context.Background(), strings.ToLower(obj.GetObjectKind().GroupVersionKind().Kind), test.GetObjectName(obj))
 				if err != nil {
 					t.Fatalf("could not retrieve object from image: %#v", err)
 				}
 
 				if d := cmp.Diff(actual, obj); d != "" {
 					t.Error(diff.PrintWantGot(d))
+				}
+
+				if source != nil {
+					t.Errorf("expected source is nil, but received %v", source)
 				}
 			}
 		})

--- a/pkg/remote/resolution/resolver_test.go
+++ b/pkg/remote/resolution/resolver_test.go
@@ -69,7 +69,7 @@ func TestGet_Successful(t *testing.T) {
 			ResolvedResource: resolved,
 		}
 		resolver := NewResolver(requester, owner, "git", "", "", nil)
-		if _, err := resolver.Get(ctx, "foo", "bar"); err != nil {
+		if _, _, err := resolver.Get(ctx, "foo", "bar"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
@@ -123,9 +123,12 @@ func TestGet_Errors(t *testing.T) {
 			ResolvedResource: tc.resolvedResource,
 		}
 		resolver := NewResolver(requester, owner, "git", "", "", nil)
-		obj, err := resolver.Get(ctx, "foo", "bar")
+		obj, source, err := resolver.Get(ctx, "foo", "bar")
 		if obj != nil {
 			t.Errorf("received unexpected resolved resource")
+		}
+		if source != nil {
+			t.Errorf("expected source is nil, but received %v", source)
 		}
 		if !errors.Is(err, tc.expectedGetErr) {
 			t.Fatalf("expected %v received %v", tc.expectedGetErr, err)

--- a/pkg/remote/resolver.go
+++ b/pkg/remote/resolver.go
@@ -16,6 +16,7 @@ package remote
 import (
 	"context"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,8 +29,8 @@ type ResolvedObject struct {
 
 // Resolver defines a generic API to retrieve Tekton resources from remote locations. It allows 2 principle operations:
 //   - List:     retrieve a flat set of Tekton objects in this remote location
-//   - Get:      retrieves a specific object with the given Kind and name.
+//   - Get:      retrieves a specific object with the given Kind and name, and the source identifying where the resource came from.
 type Resolver interface {
 	List(ctx context.Context) ([]ResolvedObject, error)
-	Get(ctx context.Context, kind, name string) (runtime.Object, error)
+	Get(ctx context.Context, kind, name string) (runtime.Object, *v1beta1.ConfigSource, error)
 }

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -57,7 +57,7 @@ function set_feature_gate() {
   kubectl patch configmap feature-flags -n tekton-pipelines -p "$jsonpatch"
   if [ "$gate" == "alpha" ]; then
     printf "enabling resolvers\n"
-    jsonpatch=$(printf "{\"data\": {\"enable-git-resolver\": \"true\", \"enable-hub-resolver\": \"true\", \"enable-bundles-resolver\": \"true\", \"enable-cluster-resolver\": \"true\"}}")
+    jsonpatch=$(printf "{\"data\": {\"enable-git-resolver\": \"true\", \"enable-hub-resolver\": \"true\", \"enable-bundles-resolver\": \"true\", \"enable-cluster-resolver\": \"true\", \"enable-provenance-in-status\": \"true\"}}")
     echo "resolvers-feature-flags ConfigMap patch: ${jsonpatch}"
     kubectl patch configmap resolvers-feature-flags -n tekton-pipelines-resolvers -p "$jsonpatch"
   fi

--- a/test/resolution.go
+++ b/test/resolution.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinev1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
 	"github.com/tektoncd/pipeline/test/diff"
@@ -27,10 +28,11 @@ func NewRequester(resource resolution.ResolvedResource, err error) *Requester {
 // NewResolvedResource creates a mock resolved resource that is
 // populated with the given data and annotations or returns the given
 // error from its Data() method.
-func NewResolvedResource(data []byte, annotations map[string]string, dataErr error) *ResolvedResource {
+func NewResolvedResource(data []byte, annotations map[string]string, source *v1beta1.ConfigSource, dataErr error) *ResolvedResource {
 	return &ResolvedResource{
 		ResolvedData:        data,
 		ResolvedAnnotations: annotations,
+		ResolvedSource:      source,
 		DataErr:             dataErr,
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

***Before:*** 
Prior, remote `ResolutionRequest` CRD supports **recording** the source information
in its Status that identifies where the remote resource came from.
Similarly, `TaskRun/PipelineRun` CRD supports **receiving** the source information
via a field in its status from remote ResolutionRequest. Specifically,
this field named `ConfigSource` is a subfield of the `Provenance` field in status.

***Now:*** 
In this PR, we are trying to pass the data from `ResolutionRequest` to pipeline
reconciler so that the data can be captured in TaskRun/PipelineRun's `Status.Provenance.ConfigSource`.
The implication of this change is that many functions' interface has been
changed because we are passing this extra source data alongside the remote resoure.

***Note:***
- The `provenance` field in Run.status is behind a feature flag named `enable-provenance-in-status`
, which was introduced in https://github.com/tektoncd/pipeline/pull/5670. The field will be populated iff
the flag is set to `true`.
- If a pipeline yaml is from remote place A, and the individual tasks
are from other remote places, pipelinerun status will only record the source
for the pipeline, and the individual taskrun status will record the
source for the corresponding task.

***Related PRs/Issues:***
- https://github.com/tektoncd/pipeline/pull/5580
- https://github.com/tektoncd/pipeline/pull/5551
- https://github.com/tektoncd/pipeline/pull/5670
- https://github.com/tektoncd/pipeline/issues/5522

Signed-off-by: Chuang Wang <chuangw@google.com>




<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Populate the TaskRun/PipelineRun's Status.Provenance.ConfigSource field with the value from the remote ResolutionRequest Status. 

Note: the feature flag `enable-provenance-in-status` needs to be set to "true" to enable this provenance field to be populated & available in *Run.Status.
```
