### PR TITLE
test: use `T.Setenv` to set env vars in tests

### DIFF
--- a/pkg/apis/config/artifact_bucket_test.go
+++ b/pkg/apis/config/artifact_bucket_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -79,12 +78,8 @@ func TestGetArtifactBucketConfigName(t *testing.T) {
 		expected:                "config-artifact-bucket-test",
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			original := os.Getenv("CONFIG_ARTIFACT_BUCKET_NAME")
-			defer t.Cleanup(func() {
-				os.Setenv("CONFIG_ARTIFACT_BUCKET_NAME", original)
-			})
 			if tc.artifactsBucketEnvValue != "" {
-				os.Setenv("CONFIG_ARTIFACT_BUCKET_NAME", tc.artifactsBucketEnvValue)
+				t.Setenv("CONFIG_ARTIFACT_BUCKET_NAME", tc.artifactsBucketEnvValue)
 			}
 			got := config.GetArtifactBucketConfigName()
 			want := tc.expected

--- a/pkg/apis/config/artifact_pvc_test.go
+++ b/pkg/apis/config/artifact_pvc_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -77,12 +76,8 @@ func TestGetArtifactPVCConfigName(t *testing.T) {
 		expected:             "config-artifact-pvc-test",
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			original := os.Getenv("CONFIG_ARTIFACT_PVC_NAME")
-			defer t.Cleanup(func() {
-				os.Setenv("CONFIG_ARTIFACT_PVC_NAME", original)
-			})
 			if tc.artifactsPVCEnvValue != "" {
-				os.Setenv("CONFIG_ARTIFACT_PVC_NAME", tc.artifactsPVCEnvValue)
+				t.Setenv("CONFIG_ARTIFACT_PVC_NAME", tc.artifactsPVCEnvValue)
 			}
 			got := config.GetArtifactPVCConfigName()
 			want := tc.expected

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -142,12 +141,8 @@ func TestGetFeatureFlagsConfigName(t *testing.T) {
 		expected:            "feature-flags-test",
 	}} {
 		t.Run(tc.description, func(t *testing.T) {
-			original := os.Getenv("CONFIG_FEATURE_FLAGS_NAME")
-			defer t.Cleanup(func() {
-				os.Setenv("CONFIG_FEATURE_FLAGS_NAME", original)
-			})
 			if tc.featureFlagEnvValue != "" {
-				os.Setenv("CONFIG_FEATURE_FLAGS_NAME", tc.featureFlagEnvValue)
+				t.Setenv("CONFIG_FEATURE_FLAGS_NAME", tc.featureFlagEnvValue)
 			}
 			got := config.GetFeatureFlagsConfigName()
 			want := tc.expected

--- a/pkg/credentials/dockercreds/creds_test.go
+++ b/pkg/credentials/dockercreds/creds_test.go
@@ -53,7 +53,7 @@ func TestFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -103,7 +103,7 @@ func TestFlagHandlingTwice(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -281,7 +281,7 @@ func TestMultipleFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -313,7 +313,7 @@ func TestNoAuthProvided(t *testing.T) {
 	if err != nil {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}

--- a/pkg/credentials/gitcreds/creds_test.go
+++ b/pkg/credentials/gitcreds/creds_test.go
@@ -53,7 +53,7 @@ func TestBasicFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -117,7 +117,7 @@ func TestBasicFlagHandlingTwice(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -209,7 +209,7 @@ func TestSSHFlagHandling(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -294,7 +294,7 @@ func TestSSHFlagHandlingThrice(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}
@@ -472,7 +472,7 @@ func TestBasicBackslashInUsername(t *testing.T) {
 		t.Fatalf("flag.CommandLine.Parse() = %v", err)
 	}
 
-	os.Setenv("HOME", credentials.VolumePath)
+	t.Setenv("HOME", credentials.VolumePath)
 	if err := NewBuilder().Write(credentials.VolumePath); err != nil {
 		t.Fatalf("Write() = %v", err)
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,27 +29,10 @@ import (
 
 const fileMode = 0755 // rwxr-xr-x
 
-func withTemporaryGitConfig(t *testing.T) func() {
+func withTemporaryGitConfig(t *testing.T) {
 	gitConfigDir := t.TempDir()
 	key := "GIT_CONFIG_GLOBAL"
-	t.Helper()
-	oldValue, envVarExists := os.LookupEnv(key)
-	if err := os.Setenv(key, filepath.Join(gitConfigDir, "config")); err != nil {
-		t.Fatal(err)
-	}
-	clean := func() {
-		t.Helper()
-		if !envVarExists {
-			if err := os.Unsetenv(key); err != nil {
-				t.Fatal(err)
-			}
-			return
-		}
-		if err := os.Setenv(key, oldValue); err != nil {
-			t.Fatal(err)
-		}
-	}
-	return clean
+	t.Setenv(key, filepath.Join(gitConfigDir, "config"))
 }
 
 func TestValidateGitSSHURLFormat(t *testing.T) {
@@ -264,8 +247,7 @@ func TestEnsureHomeEnv(t *testing.T) {
 				homeenv = t.TempDir()
 			}
 			if tt.homeenvSet {
-				cleanup := setEnv("HOME", homeenv, t)
-				defer cleanup()
+				t.Setenv("HOME", homeenv)
 			}
 			// Create SSH creds directory in directory specified by HOME envvar
 			if err := os.MkdirAll(filepath.Join(homeenv, ".ssh"), fileMode); err != nil {
@@ -430,14 +412,6 @@ func createTempGit(t *testing.T, logger *zap.SugaredLogger, gitDir string, submo
 			t.Fatal(err.Error())
 		}
 	}
-}
-
-func setEnv(key, value string, t *testing.T) func() {
-	previous := os.Getenv(key)
-	if err := os.Setenv(key, value); err != nil {
-		t.Errorf("Error setting env var %s to %s: %v", key, value, err)
-	}
-	return func() { os.Setenv(key, previous) }
 }
 
 func checkLogMessage(logMessage string, log *observer.ObservedLogs, logLine int, t *testing.T) {

--- a/pkg/resolution/resolver/git/resolver_test.go
+++ b/pkg/resolution/resolver/git/resolver_test.go
@@ -627,27 +627,10 @@ func writeAndCommitToTestRepo(t *testing.T, worktree *git.Worktree, repoDir stri
 }
 
 // withTemporaryGitConfig resets the .gitconfig for the duration of the test.
-func withTemporaryGitConfig(t *testing.T) func() {
+func withTemporaryGitConfig(t *testing.T) {
 	gitConfigDir := t.TempDir()
 	key := "GIT_CONFIG_GLOBAL"
-	t.Helper()
-	oldValue, envVarExists := os.LookupEnv(key)
-	if err := os.Setenv(key, filepath.Join(gitConfigDir, "config")); err != nil {
-		t.Fatal(err)
-	}
-	clean := func() {
-		t.Helper()
-		if !envVarExists {
-			if err := os.Unsetenv(key); err != nil {
-				t.Fatal(err)
-			}
-			return
-		}
-		if err := os.Setenv(key, oldValue); err != nil {
-			t.Fatal(err)
-		}
-	}
-	return clean
+	t.Setenv(key, filepath.Join(gitConfigDir, "config"))
 }
 
 func createRequest(repoURL, pathInRepo, revision, specificCommit string, useNthCommit int, commitsByBranch map[string][]string) *v1alpha1.ResolutionRequest {

--- a/test/pullrequest/e2e_test.go
+++ b/test/pullrequest/e2e_test.go
@@ -84,8 +84,7 @@ func TestPullRequest(t *testing.T) {
 			// If provided, set the AUTH_TOKEN environment variable that the
 			// pullrequest binary expects.
 			if tc.token != "" {
-				os.Setenv("AUTH_TOKEN", tc.token)
-				defer os.Unsetenv("AUTH_TOKEN")
+				t.Setenv("AUTH_TOKEN", tc.token)
 			}
 
 			if *proxy {
@@ -138,7 +137,7 @@ func startProxy(t *testing.T, dataPath string, header http.Header) {
 			fmt.Println("http.Serve:", err)
 		}
 	}()
-	os.Setenv("http_proxy", l.Addr().String())
+	t.Setenv("http_proxy", l.Addr().String())
 }
 
 // updateDeps makes sure command is installed locally to resolve any


### PR DESCRIPTION
# Changes

/kind cleanup

This PR replaces `os.Setenv` with `t.Setenv`. Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

This saves us at least 2 lines (error check, and unsetting the env var) on every instance.

```go
func TestFoo(t *testing.T) {
	// before
	key := "ENV"
	originalEnv := os.Getenv(key)
	
	if err := os.Setenv(key, "new value"); err != nil {
		t.Fatal(err)
	}
	defer func() {
		if err := os.Setenv(key, originalEnv); err != nil {
			t.Logf("failed to set env %s back to original value: %v", key, err)
		}
	}()
	
	// after
	t.Setenv(key, "new value")
}
```

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
