### PR TITLE
Add instructions for enabling alpha features

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -416,7 +416,8 @@ data:
 
 Alpha features are still in development and their syntax is subject to change.
 To enable these, set the `enable-api-fields` feature flag to `"alpha"` in
-the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment.
+the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via
+`kubectl edit configmap feature-flags -n tekton-pipelines`.
 
 Features currently in "alpha" are:
 


### PR DESCRIPTION
# Changes
This commit adds an example kubectl command for enabling alpha features.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
