### PR TITLE
Add the `enable-*-resolver` flags to the Pipeline controller customization docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -429,6 +429,12 @@ features](#alpha-features) to be used.
   name, kind, and API version information for each `TaskRun` and `Run` in the `PipelineRun` instead. Set it to "both" to
   do both. For more information, see [Configuring usage of `TaskRun` and `Run` embedded statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses).
 
+- `enable-bundles-resolver`: set this flag to `"true"` to enable the use of [the `bundles` remote resolver](./bundle-resolver.md). This requires that `enable-api-fields` be set to "alpha".
+
+- `enable-git-resolver`: set this flag to `"true"` to enable the use of [the `git` remote resolver](./git-resolver.md). This requires that `enable-api-fields` be set to "alpha".
+
+- `enable-hub-resolver`: set this flag to `"true"` to enable the use of [the `hub` remote resolver](./hub-resolver.md). This requires that `enable-api-fields` be set to "alpha".
+
 For example:
 
 ```yaml


### PR DESCRIPTION
# Changes

Prompted by https://github.com/tektoncd/pipeline/pull/5415#discussion_r961027785

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
