### PR TITLE
Restore results dependencies in v1 Pipeline

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -472,6 +472,7 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 func (pt PipelineTask) Deps() []string {
 	deps := []string{}
 
+	deps = append(deps, pt.resultDeps()...)
 	deps = append(deps, pt.orderingDeps()...)
 
 	uniqueDeps := sets.NewString()
@@ -483,6 +484,17 @@ func (pt PipelineTask) Deps() []string {
 	}
 
 	return uniqueDeps.List()
+}
+
+func (pt PipelineTask) resultDeps() []string {
+	resultDeps := []string{}
+
+	// Add any dependents from result references.
+	for _, ref := range PipelineTaskResultRefs(&pt) {
+		resultDeps = append(resultDeps, ref.PipelineTask)
+	}
+
+	return resultDeps
 }
 
 func (pt PipelineTask) orderingDeps() []string {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit restores the results dependencies deleted earlier due to the deprecation of `resources`.

Thanks to @afrittoli for https://github.com/tektoncd/pipeline/pull/5219#discussion_r961786371.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
