### PR TITLE
readable error message - double quote an invalid value in `step.onError`

### DIFF
--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -246,9 +246,9 @@ func validateStep(ctx context.Context, s Step, names sets.String) (errs *apis.Fi
 	if s.OnError != "" {
 		if !isParamRefs(string(s.OnError)) && s.OnError != Continue && s.OnError != StopAndFail {
 			errs = errs.Also(&apis.FieldError{
-				Message: fmt.Sprintf("invalid value: %v", s.OnError),
+				Message: fmt.Sprintf("invalid value: \"%v\"", s.OnError),
 				Paths:   []string{"onError"},
-				Details: "Task step onError must be either continue or stopAndFail",
+				Details: "Task step onError must be either \"continue\" or \"stopAndFail\"",
 			})
 		}
 	}

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1553,9 +1553,9 @@ func TestStepOnError(t *testing.T) {
 			Args:    []string{"arg"},
 		}},
 		expectedError: &apis.FieldError{
-			Message: fmt.Sprintf("invalid value: onError"),
+			Message: fmt.Sprintf("invalid value: \"onError\""),
 			Paths:   []string{"steps[0].onError"},
-			Details: "Task step onError must be either continue or stopAndFail",
+			Details: "Task step onError must be either \"continue\" or \"stopAndFail\"",
 		},
 	}, {
 		name: "invalid step - invalid onError usage - set to a parameter which does not exist in the task",

--- a/pkg/pod/entrypoint.go
+++ b/pkg/pod/entrypoint.go
@@ -138,7 +138,7 @@ func orderContainers(commonExtraEntrypointArgs []string, steps []corev1.Containe
 			if taskSpec.Steps != nil && len(taskSpec.Steps) >= i+1 {
 				if taskSpec.Steps[i].OnError != "" {
 					if taskSpec.Steps[i].OnError != v1beta1.Continue && taskSpec.Steps[i].OnError != v1beta1.StopAndFail {
-						return nil, fmt.Errorf("task step onError must be either %s or %s but it is set to an invalid value %s",
+						return nil, fmt.Errorf("task step onError must be either \"%s\" or \"%s\" but it is set to an invalid value \"%s\"",
 							v1beta1.Continue, v1beta1.StopAndFail, taskSpec.Steps[i].OnError)
 					}
 					argsForEntrypoint = append(argsForEntrypoint, "-on_error", string(taskSpec.Steps[i].OnError))

--- a/pkg/pod/entrypoint_test.go
+++ b/pkg/pod/entrypoint_test.go
@@ -397,7 +397,7 @@ func TestEntryPointOnError(t *testing.T) {
 				OnError: "invalid-on-error",
 			}},
 		},
-		err: errors.New("task step onError must be either continue or stopAndFail but it is set to an invalid value invalid-on-error"),
+		err: errors.New("task step onError must be either \"continue\" or \"stopAndFail\" but it is set to an invalid value \"invalid-on-error\""),
 	}} {
 		t.Run(tc.desc, func(t *testing.T) {
 			got, err := orderContainers([]string{}, steps, &tc.taskSpec, nil, true)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

step.onError accepts two values - continue and stopAndError

The pipeline validation returns failure if it is set to any value other than these two constants. This change is quoting the value to make it easy for the users to know that what was the specified invalid value.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Updating error message - when step.onError is set to an invalid value, the error message now double quotes that value to easily spot it. 
```
