### PR TITLE
Add conversion for v1 PipelineRun

### DIFF
--- a/pkg/apis/pipeline/v1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_conversion.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"knative.dev/pkg/apis"
+)
+
+var _ apis.Convertible = (*PipelineRun)(nil)
+
+// ConvertTo implements apis.Convertible
+func (pr *PipelineRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+}
+
+// ConvertFrom implements apis.Convertible
+func (pr *PipelineRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
+	if apis.IsInDelete(ctx) {
+		return nil
+	}
+	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+}

--- a/pkg/apis/pipeline/v1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_conversion_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Tetkon Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1_test
+
+import (
+	"context"
+	"testing"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func TestPipelineRunConversionBadType(t *testing.T) {
+	good, bad := &v1.PipelineRun{}, &v1.Pipeline{}
+
+	if err := good.ConvertTo(context.Background(), bad); err == nil {
+		t.Errorf("ConvertTo() = %#v, wanted error", bad)
+	}
+
+	if err := good.ConvertFrom(context.Background(), bad); err == nil {
+		t.Errorf("ConvertFrom() = %#v, wanted error", good)
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion.go
@@ -279,6 +279,16 @@ func (pr *PipelineResult) convertFrom(ctx context.Context, source v1.PipelineRes
 	pr.Value = newValue
 }
 
+func (ptm PipelineTaskMetadata) convertTo(ctx context.Context, sink *v1.PipelineTaskMetadata) {
+	sink.Labels = ptm.Labels
+	sink.Annotations = ptm.Annotations
+}
+
+func (ptm *PipelineTaskMetadata) convertFrom(ctx context.Context, source v1.PipelineTaskMetadata) {
+	ptm.Labels = source.Labels
+	ptm.Annotations = source.Labels
+}
+
 func serializePipelineResources(meta *metav1.ObjectMeta, spec *PipelineSpec) error {
 	if spec.Resources == nil {
 		return nil

--- a/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
@@ -1,0 +1,25 @@
+package v1beta1
+
+import (
+	"context"
+
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func (pr PipelineRef) convertTo(ctx context.Context, sink *v1.PipelineRef) {
+	sink.Name = pr.Name
+	sink.APIVersion = pr.APIVersion
+	// TODO: handle bundle in #4546
+	new := v1.ResolverRef{}
+	pr.ResolverRef.convertTo(ctx, &new)
+	sink.ResolverRef = new
+}
+
+func (pr *PipelineRef) convertFrom(ctx context.Context, source v1.PipelineRef) {
+	pr.Name = source.Name
+	pr.APIVersion = source.APIVersion
+	// TODO: handle bundle in #4546
+	new := ResolverRef{}
+	new.convertFrom(ctx, source.ResolverRef)
+	pr.ResolverRef = new
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion.go
@@ -20,23 +20,208 @@ import (
 	"context"
 	"fmt"
 
+	v1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tektoncd/pipeline/pkg/apis/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
 var _ apis.Convertible = (*PipelineRun)(nil)
 
 // ConvertTo implements apis.Convertible
-func (pr *PipelineRun) ConvertTo(ctx context.Context, sink apis.Convertible) error {
+func (pr *PipelineRun) ConvertTo(ctx context.Context, to apis.Convertible) error {
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+	switch sink := to.(type) {
+	case *v1.PipelineRun:
+		sink.ObjectMeta = pr.ObjectMeta
+		if err := serializePipelineRunResources(&sink.ObjectMeta, &pr.Spec); err != nil {
+			return err
+		}
+		return pr.Spec.ConvertTo(ctx, &sink.Spec)
+	default:
+		return fmt.Errorf("unknown version, got: %T", sink)
+	}
+}
+
+// ConvertTo implements apis.Convertible
+func (prs PipelineRunSpec) ConvertTo(ctx context.Context, sink *v1.PipelineRunSpec) error {
+	if prs.PipelineRef != nil {
+		sink.PipelineRef = &v1.PipelineRef{}
+		prs.PipelineRef.convertTo(ctx, sink.PipelineRef)
+	}
+	if prs.PipelineSpec != nil {
+		sink.PipelineSpec = &v1.PipelineSpec{}
+		err := prs.PipelineSpec.ConvertTo(ctx, sink.PipelineSpec)
+		if err != nil {
+			return err
+		}
+	}
+	sink.Params = nil
+	for _, p := range prs.Params {
+		new := v1.Param{}
+		p.convertTo(ctx, &new)
+		sink.Params = append(sink.Params, new)
+	}
+	sink.ServiceAccountName = prs.ServiceAccountName
+	sink.Status = v1.PipelineRunSpecStatus(prs.Status)
+	if prs.Timeouts != nil {
+		sink.Timeouts = &v1.TimeoutFields{}
+		prs.Timeouts.convertTo(ctx, sink.Timeouts)
+	}
+	if prs.Timeout != nil {
+		sink.Timeouts = &v1.TimeoutFields{}
+		sink.Timeouts.Pipeline = prs.Timeout
+	}
+	sink.PodTemplate = prs.PodTemplate
+	sink.Workspaces = nil
+	for _, w := range prs.Workspaces {
+		new := v1.WorkspaceBinding{}
+		w.convertTo(ctx, &new)
+		sink.Workspaces = append(sink.Workspaces, new)
+	}
+	sink.TaskRunSpecs = nil
+	for _, ptrs := range prs.TaskRunSpecs {
+		new := v1.PipelineTaskRunSpec{}
+		ptrs.convertTo(ctx, &new)
+		sink.TaskRunSpecs = append(sink.TaskRunSpecs, new)
+	}
+	return nil
 }
 
 // ConvertFrom implements apis.Convertible
-func (pr *PipelineRun) ConvertFrom(ctx context.Context, source apis.Convertible) error {
-	if apis.IsInDelete(ctx) {
+func (pr *PipelineRun) ConvertFrom(ctx context.Context, from apis.Convertible) error {
+	switch source := from.(type) {
+	case *v1.PipelineRun:
+		pr.ObjectMeta = source.ObjectMeta
+		if err := deserializePipelineRunResources(&pr.ObjectMeta, &pr.Spec); err != nil {
+			return err
+		}
+		return pr.Spec.ConvertFrom(ctx, &source.Spec)
+	default:
+		return fmt.Errorf("unknown version, got: %T", pr)
+	}
+}
+
+// ConvertFrom implements apis.Convertible
+func (prs *PipelineRunSpec) ConvertFrom(ctx context.Context, source *v1.PipelineRunSpec) error {
+	if source.PipelineRef != nil {
+		newPipelineRef := PipelineRef{}
+		newPipelineRef.convertFrom(ctx, *source.PipelineRef)
+		prs.PipelineRef = &newPipelineRef
+	}
+	if source.PipelineSpec != nil {
+		newPipelineSpec := PipelineSpec{}
+		err := newPipelineSpec.ConvertFrom(ctx, source.PipelineSpec)
+		if err != nil {
+			return err
+		}
+		prs.PipelineSpec = &newPipelineSpec
+	}
+	prs.Params = nil
+	for _, p := range source.Params {
+		new := Param{}
+		new.convertFrom(ctx, p)
+		prs.Params = append(prs.Params, new)
+	}
+	prs.ServiceAccountName = source.ServiceAccountName
+	prs.Status = PipelineRunSpecStatus(source.Status)
+	if source.Timeouts != nil {
+		newTimeouts := &TimeoutFields{}
+		newTimeouts.convertFrom(ctx, *source.Timeouts)
+		prs.Timeouts = newTimeouts
+	}
+	prs.PodTemplate = source.PodTemplate
+	prs.Workspaces = nil
+	for _, w := range source.Workspaces {
+		new := WorkspaceBinding{}
+		new.convertFrom(ctx, w)
+		prs.Workspaces = append(prs.Workspaces, new)
+	}
+	prs.TaskRunSpecs = nil
+	for _, trs := range source.TaskRunSpecs {
+		new := PipelineTaskRunSpec{}
+		new.convertFrom(ctx, trs)
+		prs.TaskRunSpecs = append(prs.TaskRunSpecs, new)
+	}
+	return nil
+}
+
+func (tf TimeoutFields) convertTo(ctx context.Context, sink *v1.TimeoutFields) {
+	sink.Pipeline = tf.Pipeline
+	sink.Tasks = tf.Tasks
+	sink.Finally = tf.Finally
+}
+
+func (tf *TimeoutFields) convertFrom(ctx context.Context, source v1.TimeoutFields) {
+	tf.Pipeline = source.Pipeline
+	tf.Tasks = source.Tasks
+	tf.Finally = source.Finally
+}
+
+func (ptrs PipelineTaskRunSpec) convertTo(ctx context.Context, sink *v1.PipelineTaskRunSpec) {
+	sink.PipelineTaskName = ptrs.PipelineTaskName
+	sink.ServiceAccountName = ptrs.TaskServiceAccountName
+	sink.PodTemplate = ptrs.TaskPodTemplate
+	sink.StepOverrides = nil
+	for _, so := range ptrs.StepOverrides {
+		new := v1.TaskRunStepOverride{}
+		so.convertTo(ctx, &new)
+		sink.StepOverrides = append(sink.StepOverrides, new)
+	}
+	sink.SidecarOverrides = nil
+	for _, so := range ptrs.SidecarOverrides {
+		new := v1.TaskRunSidecarOverride{}
+		so.convertTo(ctx, &new)
+		sink.SidecarOverrides = append(sink.SidecarOverrides, new)
+	}
+	if ptrs.Metadata != nil {
+		sink.Metadata = &v1.PipelineTaskMetadata{}
+		ptrs.Metadata.convertTo(ctx, sink.Metadata)
+	}
+	sink.ComputeResources = ptrs.ComputeResources
+}
+
+func (ptrs *PipelineTaskRunSpec) convertFrom(ctx context.Context, source v1.PipelineTaskRunSpec) {
+	ptrs.PipelineTaskName = source.PipelineTaskName
+	ptrs.TaskServiceAccountName = source.ServiceAccountName
+	ptrs.TaskPodTemplate = source.PodTemplate
+	ptrs.StepOverrides = nil
+	for _, so := range source.StepOverrides {
+		new := TaskRunStepOverride{}
+		new.convertFrom(ctx, so)
+		ptrs.StepOverrides = append(ptrs.StepOverrides, new)
+	}
+	ptrs.SidecarOverrides = nil
+	for _, so := range source.SidecarOverrides {
+		new := TaskRunSidecarOverride{}
+		new.convertFrom(ctx, so)
+		ptrs.SidecarOverrides = append(ptrs.SidecarOverrides, new)
+	}
+	if source.Metadata != nil {
+		newMetadata := PipelineTaskMetadata{}
+		newMetadata.convertFrom(ctx, *source.Metadata)
+		ptrs.Metadata = &newMetadata
+	}
+	ptrs.ComputeResources = source.ComputeResources
+}
+
+func serializePipelineRunResources(meta *metav1.ObjectMeta, spec *PipelineRunSpec) error {
+	if spec.Resources == nil {
 		return nil
 	}
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+	return version.SerializeToMetadata(meta, spec.Resources, resourcesAnnotationKey)
+}
+
+func deserializePipelineRunResources(meta *metav1.ObjectMeta, spec *PipelineRunSpec) error {
+	resources := []PipelineResourceBinding{}
+	err := version.DeserializeFromMetadata(meta, &resources, resourcesAnnotationKey)
+	if err != nil {
+		return err
+	}
+	if len(resources) != 0 {
+		spec.Resources = resources
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit adds conversion functions between v1beta1 and v1 PipelineRun. 
It implements ConvertTo and ConvertFrom for v1beta1 PipelineRun, and leaves
these functions unimplemented for v1 PipelineRun, since it is the highest known version.
It hasn't handled the deprecated `bundle` field but has handled the `resources` deprecation.

/kind misc
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
