### PR TITLE
TEP-0075: More flexible ways to provide values for object param keys

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -532,6 +532,7 @@ Each declared parameter has a `type` field, which can be set to `string`, `array
   > NOTE: 
   > - `object` param is an `alpha` feature and gated by the `alpha` feature flag.
   > - `object` param must specify the `properties` section to define the schema i.e. what keys are available for this object param. See how to define `properties` section in the following example and the [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md#defaulting-to-string-types-for-values).
+  > - When providing value for an `object` param, one may provide values for just a subset of keys in spec's `default`, and provide values for the rest of keys at runtime ([example](../examples/v1beta1/taskruns/alpha/object-param-result.yaml)).
   > - When using object in variable replacement, users can only access its individual key ("child" member) of the object by its name i.e. `$(params.gitrepo.url)`. Using an entire object as a value is only allowed when the value is also an object like [this example](https://github.com/tektoncd/pipeline/blob/55665765e4de35b3a4fb541549ae8cdef0996641/examples/v1beta1/pipelineruns/alpha/pipeline-object-param-and-result.yaml#L64-L65). See more details about using object param from the [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md#using-objects-in-variable-replacement).
 
 - `array` type 

--- a/examples/v1beta1/taskruns/alpha/object-param-result.yaml
+++ b/examples/v1beta1/taskruns/alpha/object-param-result.yaml
@@ -6,7 +6,6 @@ spec:
   params:
     - name: gitrepo
       value:
-        url: "xyz.com"
         commit: "sha123"
   taskSpec:
     params:
@@ -15,6 +14,8 @@ spec:
         properties:
           url: {type: string}
           commit: {type: string}
+        default:
+          url: "github.example.com"
     results:
       - name: object-results
         type: object

--- a/pkg/apis/pipeline/v1/task_validation.go
+++ b/pkg/apis/pipeline/v1/task_validation.go
@@ -27,7 +27,6 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/validate"
 	"github.com/tektoncd/pipeline/pkg/apis/version"
-	"github.com/tektoncd/pipeline/pkg/list"
 	"github.com/tektoncd/pipeline/pkg/substitution"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -366,7 +365,6 @@ func ValidateParameterVariables(ctx context.Context, steps []Step, params []Para
 		errs = errs.Also(validateVariables(ctx, steps, "params", allParameterNames))
 	}
 	errs = errs.Also(validateArrayUsage(steps, "params", arrayParameterNames))
-	errs = errs.Also(validateObjectDefault(objectParamSpecs))
 	return errs.Also(validateObjectUsage(ctx, steps, objectParamSpecs))
 }
 
@@ -402,45 +400,6 @@ func validateObjectUsage(ctx context.Context, steps []Step, params []ParamSpec) 
 	}
 
 	return errs.Also(validateObjectUsageAsWhole(steps, "params", objectParameterNames))
-}
-
-// validateObjectDefault validates the keys of all the object params within a
-// slice of ParamSpecs are provided in default iff the default section is provided.
-func validateObjectDefault(objectParams []ParamSpec) (errs *apis.FieldError) {
-	for _, p := range objectParams {
-		errs = errs.Also(ValidateObjectKeys(p.Properties, p.Default).ViaField(p.Name))
-	}
-	return errs
-}
-
-// ValidateObjectKeys validates if object keys defined in properties are all provided in its value provider iff the provider is not nil.
-func ValidateObjectKeys(properties map[string]PropertySpec, propertiesProvider *ParamValue) (errs *apis.FieldError) {
-	if propertiesProvider == nil || propertiesProvider.ObjectVal == nil {
-		return nil
-	}
-
-	neededKeys := []string{}
-	providedKeys := []string{}
-
-	// collect all needed keys
-	for key := range properties {
-		neededKeys = append(neededKeys, key)
-	}
-
-	// collect all provided keys
-	for key := range propertiesProvider.ObjectVal {
-		providedKeys = append(providedKeys, key)
-	}
-
-	missings := list.DiffLeft(neededKeys, providedKeys)
-	if len(missings) != 0 {
-		return &apis.FieldError{
-			Message: fmt.Sprintf("Required key(s) %s are missing in the value provider.", missings),
-			Paths:   []string{"properties", "default"},
-		}
-	}
-
-	return nil
 }
 
 // validateObjectUsageAsWhole makes sure the object params are not used as whole when providing values for strings

--- a/pkg/apis/pipeline/v1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1/task_validation_test.go
@@ -189,6 +189,17 @@ func TestTaskSpecValidate(t *testing.T) {
 					"key1": {},
 					"key2": {},
 				},
+			}, {
+				Name:        "myobjWithDefaultPartialKeys",
+				Type:        v1.ParamTypeObject,
+				Description: "param",
+				Properties: map[string]v1.PropertySpec{
+					"key1": {},
+					"key2": {},
+				},
+				Default: v1.NewObject(map[string]string{
+					"key1": "default",
+				}),
 			}},
 			Steps: validSteps,
 		},
@@ -685,27 +696,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: fmt.Sprintf("The value type specified for these keys %v is invalid", []string{"key1"}),
 			Paths:   []string{"params.task.properties"},
-		},
-	}, {
-		name: "keys defined in properties are missed in default",
-		fields: fields{
-			Params: []v1.ParamSpec{{
-				Name:        "myobjectParam",
-				Description: "param",
-				Properties: map[string]v1.PropertySpec{
-					"key1": {},
-					"key2": {},
-				},
-				Default: v1.NewObject(map[string]string{
-					"key1": "var1",
-					"key3": "var1",
-				}),
-			}},
-			Steps: validSteps,
-		},
-		expectedError: apis.FieldError{
-			Message: fmt.Sprintf("Required key(s) %s are missing in the value provider.", []string{"key2"}),
-			Paths:   []string{"myobjectParam.properties", "myobjectParam.default"},
 		},
 	}, {
 		name: "invalid step",

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -225,6 +225,17 @@ func TestTaskSpecValidate(t *testing.T) {
 					"key1": {},
 					"key2": {},
 				},
+			}, {
+				Name:        "myobjWithDefaultPartialKeys",
+				Type:        v1beta1.ParamTypeObject,
+				Description: "param",
+				Properties: map[string]v1beta1.PropertySpec{
+					"key1": {},
+					"key2": {},
+				},
+				Default: v1beta1.NewObject(map[string]string{
+					"key1": "default",
+				}),
 			}},
 			Steps: validSteps,
 		},
@@ -797,27 +808,6 @@ func TestTaskSpecValidateError(t *testing.T) {
 		expectedError: apis.FieldError{
 			Message: fmt.Sprintf("The value type specified for these keys %v is invalid", []string{"key1"}),
 			Paths:   []string{"params.task.properties"},
-		},
-	}, {
-		name: "keys defined in properties are missed in default",
-		fields: fields{
-			Params: []v1beta1.ParamSpec{{
-				Name:        "myobjectParam",
-				Description: "param",
-				Properties: map[string]v1beta1.PropertySpec{
-					"key1": {},
-					"key2": {},
-				},
-				Default: v1beta1.NewObject(map[string]string{
-					"key1": "var1",
-					"key3": "var1",
-				}),
-			}},
-			Steps: validSteps,
-		},
-		expectedError: apis.FieldError{
-			Message: fmt.Sprintf("Required key(s) %s are missing in the value provider.", []string{"key2"}),
-			Paths:   []string{"myobjectParam.properties", "myobjectParam.default"},
 		},
 	}, {
 		name: "invalid step",

--- a/pkg/reconciler/pipelinerun/resources/validate_params_test.go
+++ b/pkg/reconciler/pipelinerun/resources/validate_params_test.go
@@ -253,6 +253,31 @@ func TestValidateObjectParamRequiredKeys_Valid(t *testing.T) {
 		pp   []v1beta1.ParamSpec
 		prp  []v1beta1.Param
 	}{{
+		name: "some keys are provided by default, and the rest are provided in value",
+		pp: []v1beta1.ParamSpec{
+			{
+				Name: "an-object-param",
+				Type: v1beta1.ParamTypeObject,
+				Properties: map[string]v1beta1.PropertySpec{
+					"key1": {Type: "string"},
+					"key2": {Type: "string"},
+				},
+				Default: &v1beta1.ParamValue{
+					Type: v1beta1.ParamTypeObject,
+					ObjectVal: map[string]string{
+						"key1": "val1",
+					},
+				},
+			},
+		},
+		prp: []v1beta1.Param{
+			{
+				Name: "an-object-param",
+				Value: *v1beta1.NewObject(map[string]string{
+					"key2": "val2",
+				})},
+		},
+	}, {
 		name: "all keys are provided with a value",
 		pp: []v1beta1.ParamSpec{
 			{

--- a/pkg/reconciler/taskrun/validate_resources_test.go
+++ b/pkg/reconciler/taskrun/validate_resources_test.go
@@ -149,11 +149,27 @@ func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
 					Name: "arrayResultRef",
 					Type: v1beta1.ParamTypeArray,
 				}, {
-					Name: "myobj",
+					Name: "myObjWithoutDefault",
 					Type: v1beta1.ParamTypeObject,
 					Properties: map[string]v1beta1.PropertySpec{
 						"key1": {},
 						"key2": {},
+					},
+				}, {
+					Name: "myObjWithDefault",
+					Type: v1beta1.ParamTypeObject,
+					Properties: map[string]v1beta1.PropertySpec{
+						"key1": {},
+						"key2": {},
+						"key3": {},
+					},
+					Default: &v1beta1.ParamValue{
+						Type: v1beta1.ParamTypeObject,
+						ObjectVal: map[string]string{
+							"key1": "val1-default",
+							"key2": "val2-default", // key2 is also provided and will be overridden by taskrun
+							// key3 will be provided by taskrun
+						},
 					},
 				},
 			},
@@ -172,11 +188,17 @@ func TestValidateResolvedTaskResources_ValidParams(t *testing.T) {
 		Name:  "arrayResultRef",
 		Value: *v1beta1.NewStructuredValues("$(results.resultname[*])"),
 	}, {
-		Name: "myobj",
+		Name: "myObjWithoutDefault",
 		Value: *v1beta1.NewObject(map[string]string{
 			"key1":      "val1",
 			"key2":      "val2",
 			"extra_key": "val3",
+		}),
+	}, {
+		Name: "myObjWithDefault",
+		Value: *v1beta1.NewObject(map[string]string{
+			"key2": "val2",
+			"key3": "val3",
 		}),
 	}}
 	m := []v1beta1.Param{{
@@ -221,11 +243,27 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 					Type: v1beta1.ParamTypeArray,
 				},
 				{
-					Name: "myobj",
+					Name: "myObjWithoutDefault",
 					Type: v1beta1.ParamTypeObject,
 					Properties: map[string]v1beta1.PropertySpec{
 						"key1": {},
 						"key2": {},
+					},
+				}, {
+					Name: "myObjWithDefault",
+					Type: v1beta1.ParamTypeObject,
+					Properties: map[string]v1beta1.PropertySpec{
+						"key1": {},
+						"key2": {},
+						"key3": {},
+					},
+					Default: &v1beta1.ParamValue{
+						Type: v1beta1.ParamTypeObject,
+						ObjectVal: map[string]string{
+							"key1": "default",
+							// key2 is not provided by default nor taskrun, which is why error is epected.
+							// key3 is provided by taskrun
+						},
 					},
 				},
 			},
@@ -273,10 +311,21 @@ func TestValidateResolvedTaskResources_InvalidParams(t *testing.T) {
 			TaskSpec: &task.Spec,
 		},
 		params: []v1beta1.Param{{
-			Name: "myobj",
+			Name:  "foo",
+			Value: *v1beta1.NewStructuredValues("test"),
+		}, {
+			Name:  "bar",
+			Value: *v1beta1.NewStructuredValues("a", "b"),
+		}, {
+			Name: "myObjWithoutDefault",
 			Value: *v1beta1.NewObject(map[string]string{
 				"key1":    "val1",
 				"misskey": "val2",
+			}),
+		}, {
+			Name: "myObjWithDefault",
+			Value: *v1beta1.NewObject(map[string]string{
+				"key3": "val3",
 			}),
 		}},
 	},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Related to https://github.com/tektoncd/pipeline/issues/5270.

Prior to this change, if users want to provide default value for an
object param, they have to provide values for ALL keys, but can't provide
values for a subset of required keys that are declared in `properties`
section. Same restriction applies to the `value` provided from run level.

In this PR, we relax the validation for object param keys to allow users
to provide values for an object param in a more flexible way i.e. a subset
of keys are provided in the spec's default, and the rest of the keys are
provided in run level's value.



<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
More flexible ways to provide values for object param keys: a subset of keys can be provided from default, and the rest is provided at runtime.
```
