### PR TITLE
TEP-0114: Implements Retries in The Testing Wait Custom Task

### DIFF
--- a/test/custom-task-ctrls/wait-task/README.md
+++ b/test/custom-task-ctrls/wait-task/README.md
@@ -7,4 +7,4 @@ wait custom task removed.
 It provides a [Tekton Custom
 Task](https://tekton.dev/docs/pipelines/runs/) that, when run, simply waits a
 given amount of time before succeeding, specified by an input parameter named
-`duration`.
+`duration`. It also supports `timeout` and `retries`.


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR implements `retries` in the testing Wait custom task,
enabling e2e test to cover test cases of Custom Task `retries`
in the future.

/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
