### PR TITLE
Update docs for testing and enabling alpha features

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -371,7 +371,8 @@ file lists the keys you can customize along with their default values.
 
 ### Customizing the Pipelines Controller behavior
 
-To customize the behavior of the Pipelines Controller, modify the ConfigMap `feature-flags` as follows:
+To customize the behavior of the Pipelines Controller, modify the ConfigMap `feature-flags` via
+`kubectl edit configmap feature-flags -n tekton-pipelines`. The flags in this ConfigMap are as follows:
 
 - `disable-affinity-assistant` - set this flag to `true` to disable the [Affinity Assistant](./workspaces.md#specifying-workspace-order-in-a-pipeline-and-affinity-assistants)
   that is used to provide Node Affinity for `TaskRun` pods that share workspace volume.
@@ -451,7 +452,7 @@ data:
 Alpha features are still in development and their syntax is subject to change.
 To enable these, set the `enable-api-fields` feature flag to `"alpha"` in
 the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via
-`kubectl edit configmap feature-flags -n tekton-pipelines`.
+`kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"alpha"}}'`.
 
 Features currently in "alpha" are:
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,17 +2,24 @@
 
 To run tests:
 
-```shell
-# Land the latest codes
-ko apply -R -f ./config/
-
+[Unit tests](#unit-tests) and build tests (those run by [presubmits](#presubmit-tests)) run against your Pipelines clone:
+```sh
 # Unit tests
 go test ./...
+# Build tests
+./test/presubmit-tests.sh --build-tests
+```
 
-# Integration tests (against your current kube cluster)
+[E2E tests](#end-to-end-tests) run test cases in your local Pipelines clone
+against the Pipelines installation on your current kube cluster.
+To ensure your local changes are reflected on your cluster, you must first build
+and install them with `ko apply -R -f ./config/`.
+
+```shell
+# Integration tests
 go test -v -count=1 -tags=e2e -timeout=20m ./test
 
-# Conformance tests  (against your current kube cluster)
+# Conformance tests
 go test -v -count=1 -tags=conformance -timeout=10m ./test
 ```
 


### PR DESCRIPTION
# Changes

This commit simplifies the instructions for enabling alpha features,
adds instructions for editing the "feature-flags" configMap in general,
and clarifies docs on running tests.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
