### PR TITLE
[release-v0.37.x] Fix TestYamls for change in `ko create`

### DIFF
--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -77,8 +77,7 @@ func substituteEnv(input []byte, namespace string) ([]byte, error) {
 	}
 	output := defaultKoDockerRepoRE.ReplaceAll(input, []byte(val))
 
-	// Strip any "namespace: default"s, all resources will be created in
-	// the test namespace using `ko create -n`
+	// Replace any "namespace: default"s with the test namespace.
 	output = defaultNamespaceRE.ReplaceAll(output, []byte("namespace: "+namespace))
 
 	// Replace image names to arch specific ones, where it's necessary
@@ -91,7 +90,7 @@ func substituteEnv(input []byte, namespace string) ([]byte, error) {
 // koCreate wraps the ko binary and invokes `ko create` for input within
 // namespace
 func koCreate(input []byte, namespace string) ([]byte, error) {
-	cmd := exec.Command("ko", "create", "--platform", "linux/"+getTestArch(), "-n", namespace, "-f", "-")
+	cmd := exec.Command("ko", "create", "--platform", "linux/"+getTestArch(), "-f", "-", "--", "--namespace", namespace)
 	cmd.Stdin = bytes.NewReader(input)
 	return cmd.CombinedOutput()
 }


### PR DESCRIPTION
# Changes

Cherry-picked from #5396

Unblocks #5430

With https://github.com/google/ko/pull/750, which we picked up when we bumped `ko` to `v0.12.0` in the test-runner image, `-n (namespace)` is no longer an argument for `ko create`. So we need to ensure that the namespace for the `TestYamls` CRDs is actually set properly, and get rid of the `-n (namespace)` from our invocation of `ko create`.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
