### PR TITLE
Describe Runtime Envs of E2E Tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -16,6 +16,15 @@ go test -v -count=1 -tags=e2e -timeout=20m ./test
 go test -v -count=1 -tags=conformance -timeout=10m ./test
 ```
 
+By running the commands above, you start the tests on the cluster of `current-context`
+in local kubeconfig file (~/.kube/config by default) in you local machine.
+
+> Sometimes local tests pass but presubmit tests fail, one possible reason
+is the difference of running environments. The envs that our presubmit test
+uses are stored in ./*.env files. Specifically,
+> - e2e-tests-kind-prow-alpha.env for [`pull-tekton-pipeline-alpha-integration-tests`](https://github.com/tektoncd/plumbing/blob/d2c8ccb63d02c6e72c62def788af32d63ff1981a/prow/config.yaml#L1304)
+> - e2e-tests-kind-prow.env for [`pull-tekton-pipeline-integration-tests`](https://github.com/tektoncd/plumbing/blob/d2c8ccb63d02c6e72c62def788af32d63ff1981a/prow/config.yaml#L1249)
+
 ## Unit tests
 
 Unit tests live side by side with the code they are testing and can be run with:


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
# Changes

Prior to this PR, it is unclear that where the local tests run and the difference between local tests and presubmit/CI tests. It can be hard for people to understand/debug test failures, especially for people who start to contribute to Tekton.

This PR enriches the test doc to clarify the difference mentioned above.

/kind documentation

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
