### PR TITLE
Add examples for some resolvers

### DIFF
--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -61,7 +61,7 @@ spec:
     - name: catalog # optional
       value: Tekton
     - name: kind
-      value: pipeline
+      value: task
     - name: name
       value: git-clone
     - name: version

--- a/docs/migrating-v1beta1-to-v1.md
+++ b/docs/migrating-v1beta1-to-v1.md
@@ -64,7 +64,28 @@ spec:
 ```
 
 ## Replacing ClusterTask with Remote Resolution
-`ClusterTask` is deprecated. Please use the `cluster` resolver instead, for example: .... 
-# TODO add example after #5404 is merged
+`ClusterTask` is deprecated. Please use the `cluster` resolver instead.
+
+The [`enable-cluster-resolver`](https://github.com/tektoncd/pipeline/blob/main/docs/install.md#customizing-the-pipelines-controller-behavior) feature flag must be enabled to use this feature.
+
+The `cluster` resolver allows `Pipeline`s, `PipelineRun`s, and `TaskRun`s to refer
+to `Pipeline`s and `Task`s defined in other namespaces in the cluster.
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: cluster-task-reference
+spec:
+  taskRef:
+    resolver: cluster
+    params:
+    - name: kind
+      value: task
+    - name: name
+      value: example-task
+    - name: namespace
+      value: example-namespace
+```
 
 For more information, see [Remote resolution](https://github.com/tektoncd/community/blob/main/teps/0060-remote-resource-resolution.md).

--- a/examples/v1beta1/pipelineruns/no-ci/cluster-resolver.yaml
+++ b/examples/v1beta1/pipelineruns/no-ci/cluster-resolver.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: remote-pipeline-reference
+spec:
+  pipelineRef:
+    resolver: cluster
+    params:
+      - name: kind
+        value: pipeline
+      - name: name
+        value: some-pipeline
+      - name: namespace
+        value: namespace-containing-pipeline

--- a/examples/v1beta1/pipelineruns/no-ci/git-resolver.yaml
+++ b/examples/v1beta1/pipelineruns/no-ci/git-resolver.yaml
@@ -1,0 +1,48 @@
+# NOTE: The referenced Pipeline requires that the git-clone, buildpacks, and buildpacks-phase tasks from the Hub
+# are available in the namespace.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: git-resovler-buildpacks-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: git-resolver-
+spec:
+  pipelineRef:
+    resolver: bundles
+    params:
+      - name: url
+        value: https://github.com/tektoncd/catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipeline/buildpacks/0.2/buildpacks.yaml
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "false"
+    - name: APP_IMAGE
+      value: localhost:5000/buildpacks-app
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps/ruby-bundler
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: git-resolver-buildpacks-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: git-resolver-buildpacks-ws-pvc

--- a/examples/v1beta1/pipelineruns/no-ci/hub-resolver.yaml
+++ b/examples/v1beta1/pipelineruns/no-ci/hub-resolver.yaml
@@ -1,0 +1,50 @@
+# NOTE: The referenced Pipeline requires that the git-clone, buildpacks, and buildpacks-phase tasks from the Hub
+# are available in the namespace.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hub-resovler-buildpacks-ws-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: hub-resolver-
+spec:
+  pipelineRef:
+    resolver: hub
+    params:
+      - name: catalog # optional
+        value: Tekton
+      - name: kind
+        value: pipeline
+      - name: name
+        value: buildpacks
+      - name: version
+        value: "0.2"
+  params:
+    - name: BUILDER_IMAGE
+      value: docker.io/cnbs/sample-builder:bionic@sha256:6c03dd604503b59820fd15adbc65c0a077a47e31d404a3dcad190f3179e920b5
+    - name: TRUST_BUILDER
+      value: "false"
+    - name: APP_IMAGE
+      value: localhost:5000/buildpacks-app
+    - name: SOURCE_URL
+      value: https://github.com/buildpacks/samples
+    - name: SOURCE_SUBPATH
+      value: apps/ruby-bundler
+  workspaces:
+    - name: source-ws
+      subPath: source
+      persistentVolumeClaim:
+        claimName: hub-resolver-buildpacks-ws-pvc
+    - name: cache-ws
+      subPath: cache
+      persistentVolumeClaim:
+        claimName: hub-resolver-buildpacks-ws-pvc

--- a/examples/v1beta1/taskruns/alpha/bundles-resolver.yaml
+++ b/examples/v1beta1/taskruns/alpha/bundles-resolver.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: bundles-resolver-
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  taskRef:
+    resolver: bundles
+    params:
+      - name: bundle
+        value: gcr.io/tekton-releases/catalog/upstream/git-clone@sha256:8e2c3fb0f719d6463e950f3e44965aa314e69b800833e29e68ba2616bb82deeb
+      - name: name
+        value: git-clone
+      - name: kind
+        value: task
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: revision
+      value: master

--- a/examples/v1beta1/taskruns/alpha/git-resolver.yaml
+++ b/examples/v1beta1/taskruns/alpha/git-resolver.yaml
@@ -1,0 +1,25 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: git-resolver-
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  params:
+    - name: url
+      value: https://github.com/kelseyhightower/nocode
+    - name: revision
+      value: master
+  taskRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/tektoncd/catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: task/git-clone/0.8/git-clone.yaml

--- a/examples/v1beta1/taskruns/alpha/hub-resolver.yaml
+++ b/examples/v1beta1/taskruns/alpha/hub-resolver.yaml
@@ -1,0 +1,27 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: hub-resolver
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  params:
+    - name: url
+      value: https://github.com/tektoncd/pipeline.git
+    - name: revision
+      value: main
+  taskRef:
+    resolver: hub
+    params:
+      - name: catalog # optional
+        value: Tekton
+      - name: kind
+        value: task
+      - name: name
+        value: git-clone
+      - name: version
+        value: "0.6"

--- a/examples/v1beta1/taskruns/no-ci/cluster-resolver.yaml
+++ b/examples/v1beta1/taskruns/no-ci/cluster-resolver.yaml
@@ -1,0 +1,14 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: remote-cluster-reference
+spec:
+  taskRef:
+    resolver: cluster
+    params:
+      - name: kind
+        value: task
+      - name: name
+        value: some-task
+      - name: namespace
+        value: namespace-containing-task

--- a/test/resolvers_yaml/pipeline-in-git.yaml
+++ b/test/resolvers_yaml/pipeline-in-git.yaml
@@ -1,0 +1,18 @@
+# This Pipeline is intended to be referenced in an example PipelineRun under ../examples/v1beta1/pipelineruns.
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: simple-example-pipeline
+spec:
+  tasks:
+    - name: echo-good-morning
+      taskSpec:
+        metadata:
+          labels:
+            app: "example"
+        steps:
+          - name: echo
+            image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              echo "Good Morning!"


### PR DESCRIPTION
# Changes

Note that there's no bundles resolver example at all for Pipeline, because I can't find a publicly available bundle containing a Pipeline. Also, the cluster resolvers for both Pipeline and Task are in `no-ci`, since they require an existing `Pipeline`/`Task` in another namespace in the cluster, and I didn't feel comfortable adding a new namespace to those examples. The hub resolver example for `Pipeline` is in `no-ci` because it's using https://github.com/tektoncd/catalog/blob/main/pipeline/buildpacks/0.2/buildpacks.yaml, which requires various tasks already be present.

For the moment, the git resolver example for `Pipeline` is also in `no-ci`, but the new file ./test/resolvers_yaml/pipeline-in-git.yaml is intended to be used in an updated git resolver example once this is merged and can be referenced in the example.

Also fixes a mistake I made in `docs/hub-resolver.md`.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
