### PR TITLE
Emit warning for deprecated fields in v1beta1

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -22,8 +22,11 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logtesting "knative.dev/pkg/logging/testing"
 )
 
 const (
@@ -208,4 +211,18 @@ func EnableAlphaAPIFields(ctx context.Context) context.Context {
 		FeatureFlags: featureFlags,
 	}
 	return ToContext(ctx, cfg)
+}
+
+// EnableTektonOCIBundles enables OCI Bundles feature in an existing context (for use in testing)
+func EnableTektonOCIBundles(t *testing.T) func(context.Context) context.Context {
+	return func(ctx context.Context) context.Context {
+		s := NewStore(logtesting.TestLogger(t))
+		s.OnConfigChanged(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: GetFeatureFlagsConfigName()},
+			Data: map[string]string{
+				"enable-tekton-oci-bundles": "true",
+			},
+		})
+		return s.ToContext(ctx)
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -529,3 +529,19 @@ func validateResultsFromMatrixedPipelineTasksNotConsumed(tasks []PipelineTask, f
 	}
 	return errs
 }
+
+func warnPipelineFieldsDeprecation(ctx context.Context, ps *PipelineSpec) (errs *apis.FieldError) {
+	if ps.Resources != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Resources field is deprecated in v1 Pipeline",
+			Paths:   []string{"Resources"},
+		})
+	}
+	// if ps. != nil {
+	// 	errs = errs.Also(&apis.FieldError{
+	// 		Message: "Bundle field is deprecated in v1 Pipeline",
+	// 		Paths:   []string{"Bundle"},
+	// 	})
+	// }
+	return errs.At(apis.WarningLevel)
+}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -540,15 +540,17 @@ func warnPipelineFieldsDeprecation(ctx context.Context, ps *PipelineSpec) (errs 
 		errs = errs.Also(&apis.FieldError{
 			Message: "Resources field is deprecated in v1 Pipeline",
 			Paths:   []string{"Resources"},
-		})
+		}).At(apis.WarningLevel)
 	}
 	for _, pt := range ps.Tasks {
-		if pt.TaskRef.Bundle != "" {
-			errs = errs.Also(&apis.FieldError{
-				Message: "Bundle field is deprecated in v1 Pipeline",
-				Paths:   []string{"Bundle"},
-			})
-			break
+		if pt.TaskRef != nil {
+			if pt.TaskRef.Bundle != "" {
+				errs = errs.Also(&apis.FieldError{
+					Message: "Bundle field is deprecated in v1 Pipeline",
+					Paths:   []string{"Bundle"},
+				}).At(apis.WarningLevel)
+				break
+			}
 		}
 	}
 	return errs.At(apis.WarningLevel)

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3580,5 +3581,51 @@ func enableFeatures(t *testing.T, features []string) func(context.Context) conte
 			Data:       data,
 		})
 		return s.ToContext(ctx)
+	}
+}
+
+func TestPipelineDeprecationWarning(t *testing.T) {
+	tests := []struct {
+		name          string
+		taskSpec      *v1beta1.TaskSpec
+		expectedError *apis.FieldError
+	}{{
+		name: "Resources",
+		taskSpec: &v1beta1.TaskSpec{
+			Steps: validSteps,
+			Resources: TaskResources{
+				Inputs: []v1beta1.TaskResource{validResource},
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: "Resources field is deprecated in v1 Task",
+			Paths:   []string{"Resources"},
+		},
+	}, {
+		name: "StepTemplate",
+		taskSpec: &v1beta1.TaskSpec{
+			Steps: validSteps,
+			StepTemplate: &v1beta1.StepTemplate{
+				Env:  []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+				Args: []string{"template", "args"},
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: "StepTemplate field is deprecated in v1 Task",
+			Paths:   []string{"StepTemplate"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := tt.taskSpec
+			ctx := context.Background()
+			err := ts.Validate(ctx)
+			if err == nil && tt.expectedError.Error() != "" {
+				t.Fatalf("Expected an error, got nothing for %v", ts)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3629,7 +3629,7 @@ func TestPipelineDeprecationWarning(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := tt.pipelineSpec
 			ctx := context.Background()
-			err := ts.Validate(enableTektonOCIBundles(t)(ctx))
+			err := ts.Validate(config.EnableTektonOCIBundles(t)(ctx))
 			if err == nil && tt.expectedError.Error() != "" {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}
@@ -3637,19 +3637,5 @@ func TestPipelineDeprecationWarning(t *testing.T) {
 				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
 			}
 		})
-	}
-}
-
-// TODO refactor in #5111
-func enableTektonOCIBundles(t *testing.T) func(context.Context) context.Context {
-	return func(ctx context.Context) context.Context {
-		s := config.NewStore(logtesting.TestLogger(t))
-		s.OnConfigChanged(&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-			Data: map[string]string{
-				"enable-tekton-oci-bundles": "true",
-			},
-		})
-		return s.ToContext(ctx)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation_test.go
@@ -3606,7 +3606,7 @@ func TestPipelineDeprecationWarning(t *testing.T) {
 			}},
 		},
 		expectedError: &apis.FieldError{
-			Message: "Resources field is deprecated in v1 Pipeline",
+			Message: "Resources field is deprecated",
 			Paths:   []string{"Resources"},
 		},
 	}, {
@@ -3621,7 +3621,7 @@ func TestPipelineDeprecationWarning(t *testing.T) {
 			}},
 		},
 		expectedError: &apis.FieldError{
-			Message: "Bundle field is deprecated in v1 Pipeline",
+			Message: "Bundle field is deprecated",
 			Paths:   []string{"Bundle"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_validation_test.go
@@ -24,10 +24,7 @@ import (
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/test/diff"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-	logtesting "knative.dev/pkg/logging/testing"
 )
 
 func TestPipelineRef_Invalid(t *testing.T) {
@@ -49,7 +46,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			Bundle: "docker.io/foo",
 		},
 		wantErr:     apis.ErrMissingField("name"),
-		withContext: enableTektonOCIBundles(t),
+		withContext: config.EnableTektonOCIBundles(t),
 	}, {
 		name: "invalid bundle reference",
 		ref: &v1beta1.PipelineRef{
@@ -57,7 +54,7 @@ func TestPipelineRef_Invalid(t *testing.T) {
 			Bundle: "not a valid reference",
 		},
 		wantErr:     apis.ErrInvalidValue("invalid bundle reference", "bundle", "could not parse reference: not a valid reference"),
-		withContext: enableTektonOCIBundles(t),
+		withContext: config.EnableTektonOCIBundles(t),
 	}, {
 		name:    "pipelineRef without Pipeline Name",
 		ref:     &v1beta1.PipelineRef{},
@@ -230,18 +227,5 @@ func TestPipelineRef_Valid(t *testing.T) {
 				t.Error(err)
 			}
 		})
-	}
-}
-
-func enableTektonOCIBundles(t *testing.T) func(context.Context) context.Context {
-	return func(ctx context.Context) context.Context {
-		s := config.NewStore(logtesting.TestLogger(t))
-		s.OnConfigChanged(&corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName()},
-			Data: map[string]string{
-				"enable-tekton-oci-bundles": "true",
-			},
-		})
-		return s.ToContext(ctx)
 	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -118,6 +118,8 @@ func (ps *PipelineRunSpec) Validate(ctx context.Context) (errs *apis.FieldError)
 		errs = errs.Also(validateTaskRunSpec(ctx, trs).ViaIndex(idx).ViaField("taskRunSpecs"))
 	}
 
+	errs = errs.Also(warnPipelineRunFieldsDeprecation(ctx, ps))
+
 	return errs
 }
 
@@ -305,7 +307,7 @@ func validateTaskRunSpec(ctx context.Context, trs PipelineTaskRunSpec) (errs *ap
 // Instead of rejecting the deprecated field entirely, warnPipelineRunFieldsDeprecation
 // emits a WarningLevel FieldError to notify users that the CRD created contains one
 // or more fields that are deprecated.
-func warnPipelineRunFieldsDeprecation(ctx context.Context, prs PipelineRunSpec) (errs *apis.FieldError) {
+func warnPipelineRunFieldsDeprecation(ctx context.Context, prs *PipelineRunSpec) (errs *apis.FieldError) {
 	if prs.Resources != nil {
 		errs = errs.Also(&apis.FieldError{
 			Message: "Resources field is deprecated in v1 PipelineRun",
@@ -318,11 +320,13 @@ func warnPipelineRunFieldsDeprecation(ctx context.Context, prs PipelineRunSpec) 
 			Paths:   []string{"Timeout"},
 		})
 	}
-	if prs.PipelineRef.Bundle != "" {
-		errs = errs.Also(&apis.FieldError{
-			Message: "Bundle field is deprecated in v1 PipelineRun",
-			Paths:   []string{"Bundle"},
-		})
+	if prs.PipelineRef != nil {
+		if prs.PipelineRef.Bundle != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "Bundle field is deprecated in v1 PipelineRun",
+				Paths:   []string{"Bundle"},
+			})
+		}
 	}
 	return errs.At(apis.WarningLevel)
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -301,3 +301,28 @@ func validateTaskRunSpec(ctx context.Context, trs PipelineTaskRunSpec) (errs *ap
 	}
 	return errs
 }
+
+// Instead of rejecting the deprecated field entirely, warnPipelineRunFieldsDeprecation
+// emits a WarningLevel FieldError to notify users that the CRD created contains one
+// or more fields that are deprecated.
+func warnPipelineRunFieldsDeprecation(ctx context.Context, prs PipelineRunSpec) (errs *apis.FieldError) {
+	if prs.Resources != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Resources field is deprecated in v1 PipelineRun",
+			Paths:   []string{"Resources"},
+		})
+	}
+	if prs.Timeout != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Timeout field is deprecated in v1 PipelineRun",
+			Paths:   []string{"Timeout"},
+		})
+	}
+	if prs.PipelineRef.Bundle != "" {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Bundle field is deprecated in v1 PipelineRun",
+			Paths:   []string{"Bundle"},
+		})
+	}
+	return errs.At(apis.WarningLevel)
+}

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -305,9 +305,6 @@ func validateTaskRunSpec(ctx context.Context, trs PipelineTaskRunSpec) (errs *ap
 	return errs
 }
 
-// Instead of rejecting the deprecated field entirely, validate*Deprecation functions
-// emits a WarningLevel FieldError to notify users that the CRD created contains the
-// field that has been deprecated.
 func validatePipelineRunResourcesDeprecation(ctx context.Context, prs *PipelineRunSpec) (errs *apis.FieldError) {
 	if prs.Resources != nil {
 		return version.DeprecationError(ctx, "Resources")
@@ -325,7 +322,7 @@ func validateTimeoutDeprecation(ctx context.Context, prs *PipelineRunSpec) (errs
 func validatePipelineRefDeprecation(ctx context.Context, prs *PipelineRunSpec) (errs *apis.FieldError) {
 	if prs.PipelineRef != nil {
 		if prs.PipelineRef.Bundle != "" {
-			return version.DeprecationError(ctx, "PipelineRef")
+			return version.DeprecationError(ctx, "Bundle")
 		}
 	}
 	return nil

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1076,42 +1076,43 @@ func TestPipelineRunDeprecationWarning(t *testing.T) {
 		pipelineRunSpec *v1beta1.PipelineRunSpec
 		expectedError   *apis.FieldError
 	}{{
-		name: "Resources",
-		pipelineRunSpec: &v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
-			Resources: []v1beta1.PipelineResourceBinding{{
-				ResourceRef: &v1beta1.PipelineResourceRef{
-					Name: "the-git-with-branch",
-				},
-				Name: "gitspace",
-			}},
-		},
-		expectedError: &apis.FieldError{
-			Message: "Resources field is deprecated in v1 PipelineRun",
-			Paths:   []string{"Resources"},
-		},
-	}, {
+		// 	name: "Resources",
+		// 	pipelineRunSpec: &v1beta1.PipelineRunSpec{
+		// 		PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
+		// 		Resources: []v1beta1.PipelineResourceBinding{{
+		// 			ResourceRef: &v1beta1.PipelineResourceRef{
+		// 				Name: "the-git-with-branch",
+		// 			},
+		// 			Name: "gitspace",
+		// 		}},
+		// 	},
+		// 	expectedError: &apis.FieldError{
+		// 		Message: "Resources field is deprecated",
+		// 		Paths:   []string{"Resources"},
+		// 	},
+		// }, {
 		name: "Timeout",
 		pipelineRunSpec: &v1beta1.PipelineRunSpec{
 			PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
 			Timeout:     &metav1.Duration{Duration: 5 * time.Minute},
 		},
 		expectedError: &apis.FieldError{
-			Message: "Timeout field is deprecated in v1 PipelineRun",
+			Message: "Timeout field is deprecated",
 			Paths:   []string{"Timeout"},
+			Level:   apis.WarningLevel,
 		},
-	}, {
-		name: "Bundle",
-		pipelineRunSpec: &v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{
-				Name:   "foo",
-				Bundle: "test-bundle",
-			},
-		},
-		expectedError: &apis.FieldError{
-			Message: "Bundle field is deprecated in v1 PipelineRun",
-			Paths:   []string{"Bundle"},
-		},
+		// }, {
+		// 	name: "Bundle",
+		// 	pipelineRunSpec: &v1beta1.PipelineRunSpec{
+		// 		PipelineRef: &v1beta1.PipelineRef{
+		// 			Name:   "foo",
+		// 			Bundle: "test-bundle",
+		// 		},
+		// 	},
+		// 	expectedError: &apis.FieldError{
+		// 		Message: "Bundle field is deprecated",
+		// 		Paths:   []string{"Bundle"},
+		// 	},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1076,21 +1076,21 @@ func TestPipelineRunDeprecationWarning(t *testing.T) {
 		pipelineRunSpec *v1beta1.PipelineRunSpec
 		expectedError   *apis.FieldError
 	}{{
-		// 	name: "Resources",
-		// 	pipelineRunSpec: &v1beta1.PipelineRunSpec{
-		// 		PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
-		// 		Resources: []v1beta1.PipelineResourceBinding{{
-		// 			ResourceRef: &v1beta1.PipelineResourceRef{
-		// 				Name: "the-git-with-branch",
-		// 			},
-		// 			Name: "gitspace",
-		// 		}},
-		// 	},
-		// 	expectedError: &apis.FieldError{
-		// 		Message: "Resources field is deprecated",
-		// 		Paths:   []string{"Resources"},
-		// 	},
-		// }, {
+		name: "Resources",
+		pipelineRunSpec: &v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
+			Resources: []v1beta1.PipelineResourceBinding{{
+				ResourceRef: &v1beta1.PipelineResourceRef{
+					Name: "the-git-with-branch",
+				},
+				Name: "gitspace",
+			}},
+		},
+		expectedError: &apis.FieldError{
+			Message: "Resources field is deprecated",
+			Paths:   []string{"Resources"},
+		},
+	}, {
 		name: "Timeout",
 		pipelineRunSpec: &v1beta1.PipelineRunSpec{
 			PipelineRef: &v1beta1.PipelineRef{Name: "foo"},
@@ -1101,24 +1101,24 @@ func TestPipelineRunDeprecationWarning(t *testing.T) {
 			Paths:   []string{"Timeout"},
 			Level:   apis.WarningLevel,
 		},
-		// }, {
-		// 	name: "Bundle",
-		// 	pipelineRunSpec: &v1beta1.PipelineRunSpec{
-		// 		PipelineRef: &v1beta1.PipelineRef{
-		// 			Name:   "foo",
-		// 			Bundle: "test-bundle",
-		// 		},
-		// 	},
-		// 	expectedError: &apis.FieldError{
-		// 		Message: "Bundle field is deprecated",
-		// 		Paths:   []string{"Bundle"},
-		// 	},
+	}, {
+		name: "Bundle",
+		pipelineRunSpec: &v1beta1.PipelineRunSpec{
+			PipelineRef: &v1beta1.PipelineRef{
+				Name:   "foo",
+				Bundle: "test-bundle",
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: "Bundle field is deprecated",
+			Paths:   []string{"Bundle"},
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := tt.pipelineRunSpec
 			ctx := context.Background()
-			err := ts.Validate(enableTektonOCIBundles(t)(ctx))
+			err := ts.Validate(config.EnableTektonOCIBundles(t)(ctx))
 			if err == nil && tt.expectedError.Error() != "" {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -94,6 +94,9 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(ValidateResourcesVariables(ctx, ts.Steps, ts.Resources))
 	errs = errs.Also(validateTaskContextVariables(ctx, ts.Steps))
 	errs = errs.Also(validateResults(ctx, ts.Results).ViaField("results"))
+	// Emit warnings for deprecated fields
+	errs = errs.Also(validateTaskResourcesDeprecation(ctx, ts))
+	errs = errs.Also(validateStepTemplateDeprecation(ctx, ts))
 	return errs
 }
 
@@ -643,4 +646,21 @@ func warnTaskFieldsDeprecation(ctx context.Context, ts *TaskSpec) (errs *apis.Fi
 		})
 	}
 	return errs.At(apis.WarningLevel)
+}
+
+// Instead of rejecting the deprecated field entirely, validate*Deprecation functions
+// emits a WarningLevel FieldError to notify users that the CRD created contains the
+// field that has been deprecated.
+func validateTaskResourcesDeprecation(ctx context.Context, ts *TaskSpec) (errs *apis.FieldError) {
+	if ts.Resources != nil {
+		return version.DeprecationError(ctx, "Resources")
+	}
+	return nil
+}
+
+func validateStepTemplateDeprecation(ctx context.Context, ts *TaskSpec) (errs *apis.FieldError) {
+	if ts.StepTemplate != nil {
+		return version.DeprecationError(ctx, "StepTemplate")
+	}
+	return nil
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation.go
@@ -86,6 +86,7 @@ func (ts *TaskSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 		})
 	}
 
+	errs = errs.Also(warnTaskFieldsDeprecation(ctx, ts))
 	errs = errs.Also(validateSteps(ctx, mergedSteps).ViaField("steps"))
 	errs = errs.Also(ts.Resources.Validate(ctx).ViaField("resources"))
 	errs = errs.Also(ValidateParameterTypes(ctx, ts.Params).ViaField("params"))
@@ -626,4 +627,20 @@ func validateTaskArraysIsolated(value, prefix string, arrayNames sets.String) *a
 // This is useful to make sure the specified value looks like a Parameter Reference before performing any strict validation
 func isParamRefs(s string) bool {
 	return strings.HasPrefix(s, "$("+ParamsPrefix)
+}
+
+func warnTaskFieldsDeprecation(ctx context.Context, ts *TaskSpec) (errs *apis.FieldError) {
+	if ts.Resources != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Resources field is deprecated in v1 Task",
+			Paths:   []string{"Resources"},
+		})
+	}
+	if ts.StepTemplate != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "StepTemplate field is deprecated in v1 Task",
+			Paths:   []string{"StepTemplate"},
+		})
+	}
+	return errs.At(apis.WarningLevel)
 }

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1788,7 +1788,7 @@ func TestTaskDeprecationWarning(t *testing.T) {
 			},
 		},
 		expectedError: &apis.FieldError{
-			Message: "Resources field is deprecated in v1 Task",
+			Message: "Resources field is deprecated",
 			Paths:   []string{"Resources"},
 		},
 	}, {
@@ -1801,7 +1801,7 @@ func TestTaskDeprecationWarning(t *testing.T) {
 			},
 		},
 		expectedError: &apis.FieldError{
-			Message: "StepTemplate field is deprecated in v1 Task",
+			Message: "StepTemplate field is deprecated",
 			Paths:   []string{"StepTemplate"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/task_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_validation_test.go
@@ -1773,3 +1773,49 @@ func TestSubstitutedContext(t *testing.T) {
 		})
 	}
 }
+
+func TestTaskDeprecationWarning(t *testing.T) {
+	tests := []struct {
+		name          string
+		taskSpec      *v1beta1.TaskSpec
+		expectedError *apis.FieldError
+	}{{
+		name: "Resources",
+		taskSpec: &v1beta1.TaskSpec{
+			Steps: validSteps,
+			Resources: &v1beta1.TaskResources{
+				Inputs: []v1beta1.TaskResource{validResource},
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: "Resources field is deprecated in v1 Task",
+			Paths:   []string{"Resources"},
+		},
+	}, {
+		name: "StepTemplate",
+		taskSpec: &v1beta1.TaskSpec{
+			Steps: validSteps,
+			StepTemplate: &v1beta1.StepTemplate{
+				Env:  []corev1.EnvVar{{Name: "FOO", Value: "bar"}},
+				Args: []string{"template", "args"},
+			},
+		},
+		expectedError: &apis.FieldError{
+			Message: "StepTemplate field is deprecated in v1 Task",
+			Paths:   []string{"StepTemplate"},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := tt.taskSpec
+			ctx := context.Background()
+			err := ts.Validate(ctx)
+			if err == nil && tt.expectedError.Error() != "" {
+				t.Fatalf("Expected an error, got nothing for %v", ts)
+			}
+			if d := cmp.Diff(tt.expectedError.Error(), err.Error(), cmpopts.IgnoreUnexported(apis.FieldError{})); d != "" {
+				t.Errorf("TaskSpec.Validate() errors diff %s", diff.PrintWantGot(d))
+			}
+		})
+	}
+}

--- a/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_validation_test.go
@@ -100,7 +100,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 			Bundle: "docker.io/foo",
 		},
 		wantErr: apis.ErrMissingField("name"),
-		wc:      enableTektonOCIBundles(t),
+		wc:      config.EnableTektonOCIBundles(t),
 	}, {
 		name: "invalid bundle reference",
 		taskRef: &v1beta1.TaskRef{
@@ -108,7 +108,7 @@ func TestTaskRef_Invalid(t *testing.T) {
 			Bundle: "invalid reference",
 		},
 		wantErr: apis.ErrInvalidValue("invalid bundle reference", "bundle", "could not parse reference: invalid reference"),
-		wc:      enableTektonOCIBundles(t),
+		wc:      config.EnableTektonOCIBundles(t),
 	}, {
 		name: "taskref resolver disallowed without alpha feature gate",
 		taskRef: &v1beta1.TaskRef{

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -245,11 +245,13 @@ func warnTaskRunFieldsDeprecation(ctx context.Context, trs *TaskRunSpec) (errs *
 			Paths:   []string{"Resources"},
 		})
 	}
-	if trs.TaskRef.Bundle != "" {
-		errs = errs.Also(&apis.FieldError{
-			Message: "Bundle field is deprecated in v1 TaskRun",
-			Paths:   []string{"Bundle"},
-		})
+	if trs.TaskRef != nil {
+		if trs.TaskRef.Bundle != "" {
+			errs = errs.Also(&apis.FieldError{
+				Message: "Bundle field is deprecated in v1 TaskRun",
+				Paths:   []string{"Bundle"},
+			})
+		}
 	}
 	return errs.At(apis.WarningLevel)
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation.go
@@ -101,6 +101,8 @@ func (ts *TaskRunSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	}
 
+	errs = errs.Also(warnTaskRunFieldsDeprecation(ctx, ts))
+
 	return errs
 }
 
@@ -234,4 +236,20 @@ func validateNoDuplicateNames(names []string, byIndex bool) (errs *apis.FieldErr
 		seen.Insert(strings.ToLower(n))
 	}
 	return errs
+}
+
+func warnTaskRunFieldsDeprecation(ctx context.Context, trs *TaskRunSpec) (errs *apis.FieldError) {
+	if trs.Resources != nil {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Resources field is deprecated in v1 TaskRun",
+			Paths:   []string{"Resources"},
+		})
+	}
+	if trs.TaskRef.Bundle != "" {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Bundle field is deprecated in v1 TaskRun",
+			Paths:   []string{"Bundle"},
+		})
+	}
+	return errs.At(apis.WarningLevel)
 }

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -910,7 +910,7 @@ func TestTaskRunDeprecationWarning(t *testing.T) {
 				}},
 			}},
 		expectedError: &apis.FieldError{
-			Message: "Resources field is deprecated in v1 TaskRun",
+			Message: "Resources field is deprecated",
 			Paths:   []string{"Resources"},
 		},
 	}, {
@@ -923,7 +923,7 @@ func TestTaskRunDeprecationWarning(t *testing.T) {
 			},
 		},
 		expectedError: &apis.FieldError{
-			Message: "Bundle field is deprecated in v1 TaskRun",
+			Message: "Bundle field is deprecated",
 			Paths:   []string{"Bundle"},
 		},
 	}}

--- a/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_validation_test.go
@@ -931,7 +931,7 @@ func TestTaskRunDeprecationWarning(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ts := tt.taskRunSpec
 			ctx := context.Background()
-			err := ts.Validate(enableTektonOCIBundles(t)(ctx))
+			err := ts.Validate(config.EnableTektonOCIBundles(t)(ctx))
 			if err == nil && tt.expectedError.Error() != "" {
 				t.Fatalf("Expected an error, got nothing for %v", ts)
 			}

--- a/pkg/apis/version/version_validation.go
+++ b/pkg/apis/version/version_validation.go
@@ -36,3 +36,13 @@ func ValidateEnabledAPIFields(ctx context.Context, featureName, wantVersion stri
 	}
 	return nil
 }
+
+// DeprecationError emits a WarningLevel FieldError to notify users that the CRD
+// created contains a field that is deprecated.
+func DeprecationError(ctx context.Context, fieldName string) *apis.FieldError {
+	return &apis.FieldError{
+		Message: fmt.Sprintf("%v field is deprecated", fieldName),
+		Paths:   []string{fieldName},
+		Level:   apis.WarningLevel,
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
[WIP]This commit adds warnings when a user creates a CRD with a deprecated field.

Needs: https://github.com/knative/pkg/issues/2514
Fixes: #5373 
/kind feature

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
