### PR TITLE
Allow user to specify only tasks or finally timeout

### DIFF
--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -866,7 +866,7 @@ timeouts:
 All three sub-fields are optional, and will be automatically processed according to the following constraint:
 * `timeouts.pipeline >= timeouts.tasks + timeouts.finally`
 
-You may combine the timeouts as follow:
+Example timeouts usages are as follows:
 
 Combination 1: Set the timeout for the entire `pipeline` and reserve a portion of it for `tasks`.
 
@@ -885,6 +885,26 @@ kind: PipelineRun
 spec:
   timeouts:
     pipeline: "0h4m0s"
+    finally: "0h3m0s"
+```
+
+Combination 3: Set only a `tasks` timeout, with no timeout for the entire `pipeline`.
+
+```yaml
+kind: PipelineRun
+spec:
+  timeouts:
+    pipeline: "0"  # No timeout
+    tasks: "0h3m0s"
+```
+
+Combination : Set only a `finally` timeout, with no timeout for the entire `pipeline`.
+
+```yaml
+kind: PipelineRun
+spec:
+  timeouts:
+    pipeline: "0"  # No timeout
     finally: "0h3m0s"
 ```
 

--- a/pkg/apis/pipeline/v1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation.go
@@ -238,7 +238,7 @@ func (ps *PipelineRunSpec) validatePipelineTimeout(timeout time.Duration, errorM
 	if ps.Timeouts.Tasks != nil {
 		tasksTimeoutErr := false
 		tasksTimeoutStr := ps.Timeouts.Tasks.Duration.String()
-		if ps.Timeouts.Tasks.Duration > timeout {
+		if ps.Timeouts.Tasks.Duration > timeout && timeout != config.NoTimeoutDuration {
 			tasksTimeoutErr = true
 		}
 		if ps.Timeouts.Tasks.Duration == config.NoTimeoutDuration && timeout != config.NoTimeoutDuration {
@@ -253,7 +253,7 @@ func (ps *PipelineRunSpec) validatePipelineTimeout(timeout time.Duration, errorM
 	if ps.Timeouts.Finally != nil {
 		finallyTimeoutErr := false
 		finallyTimeoutStr := ps.Timeouts.Finally.Duration.String()
-		if ps.Timeouts.Finally.Duration > timeout {
+		if ps.Timeouts.Finally.Duration > timeout && timeout != config.NoTimeoutDuration {
 			finallyTimeoutErr = true
 		}
 		if ps.Timeouts.Finally.Duration == config.NoTimeoutDuration && timeout != config.NoTimeoutDuration {

--- a/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_validation_test.go
@@ -793,6 +793,38 @@ func TestPipelineRunWithTimeout_Validate(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "timeouts.tasks only",
+		pr: v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "prname",
+				},
+				Timeouts: &v1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 0 * time.Hour},
+					Tasks:    &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+		},
+	}, {
+		name: "timeouts.finally only",
+		pr: v1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1.PipelineRunSpec{
+				PipelineRef: &v1.PipelineRef{
+					Name: "prname",
+				},
+				Timeouts: &v1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 0 * time.Hour},
+					Finally:  &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+		},
 	}}
 
 	for _, ts := range tests {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation.go
@@ -250,7 +250,7 @@ func (ps *PipelineRunSpec) validatePipelineTimeout(timeout time.Duration, errorM
 	if ps.Timeouts.Tasks != nil {
 		tasksTimeoutErr := false
 		tasksTimeoutStr := ps.Timeouts.Tasks.Duration.String()
-		if ps.Timeouts.Tasks.Duration > timeout {
+		if ps.Timeouts.Tasks.Duration > timeout && timeout != config.NoTimeoutDuration {
 			tasksTimeoutErr = true
 		}
 		if ps.Timeouts.Tasks.Duration == config.NoTimeoutDuration && timeout != config.NoTimeoutDuration {
@@ -265,7 +265,7 @@ func (ps *PipelineRunSpec) validatePipelineTimeout(timeout time.Duration, errorM
 	if ps.Timeouts.Finally != nil {
 		finallyTimeoutErr := false
 		finallyTimeoutStr := ps.Timeouts.Finally.Duration.String()
-		if ps.Timeouts.Finally.Duration > timeout {
+		if ps.Timeouts.Finally.Duration > timeout && timeout != config.NoTimeoutDuration {
 			finallyTimeoutErr = true
 		}
 		if ps.Timeouts.Finally.Duration == config.NoTimeoutDuration && timeout != config.NoTimeoutDuration {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -1054,6 +1054,38 @@ func TestPipelineRunWithTimeout_Validate(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "timeouts.tasks only",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "prname",
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 0 * time.Hour},
+					Tasks:    &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+		},
+	}, {
+		name: "timeouts.finally only",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "prname",
+				},
+				Timeouts: &v1beta1.TimeoutFields{
+					Pipeline: &metav1.Duration{Duration: 0 * time.Hour},
+					Finally:  &metav1.Duration{Duration: 30 * time.Minute},
+				},
+			},
+		},
 	}}
 
 	for _, ts := range tests {


### PR DESCRIPTION
# Changes
This commit updates PipelineRun validation to allow a user to specify only a tasks timeout or only a finally timeout.
Prior to this commit, if a user wanted to specify no Pipeline timeout (i.e. timeouts.pipeline = 0), they would not be able to specify values for the other timeouts fields.
Closes #5459.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Bug fix: allow specifying only timeouts.tasks or timeouts.finally
```
