### PR TITLE
TEP-0111 - Propagating workspaces in pipelinerun

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/propagating-workspaces.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating-workspaces.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sensitive-recipe-storage
+data:
+  brownies: |
+    1. Heat oven to 325 degrees F
+    2. Melt 1/2 cup butter w/ 1/2 cup cocoa, stirring smooth.
+    3. Remove from heat, allow to cool for a few minutes.
+    4. Transfer to bowl.
+    5. Whisk in 2 eggs, one at a time.
+    6. Stir in vanilla.
+    7. Separately combine 1 cup sugar, 1/4 cup flour, 1 cup chopped
+       walnuts and pinch of salt
+    8. Combine mixtures.
+    9. Bake in greased pan for 30 minutes. Watch carefully for
+       appropriate level of gooeyness.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-password
+type: Opaque
+data:
+  password: aHVudGVyMg==
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: recipe-time-
+spec:
+  params:
+  - name: filename
+    value: recipe.txt
+  workspaces:
+    - name: shared-data
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 16Mi
+          volumeMode: Filesystem
+    - name: recipe-store
+      configMap:
+        name: sensitive-recipe-storage
+        items:
+        - key: brownies
+          path: recipe.txt
+    - name: password-vault
+      secret:
+        secretName: secret-password
+  pipelineSpec:
+    tasks:
+    - name: fetch-secure-data
+      taskSpec:
+        steps:
+        - name: fetch-and-write-secure
+          image: ubuntu
+          script: |
+            if [ "hunter2" = "$(cat $(workspaces.password-vault.path)/password)" ]; then
+              cp $(workspaces.recipe-store.path)/recipe.txt $(workspaces.shared-data.path)
+              echo "success!!!"
+            else
+              echo "wrong password!"
+              exit 1
+            fi
+    - name: print-the-recipe
+      runAfter:
+        - fetch-secure-data
+      taskSpec:
+        steps:
+        - name: print-secrets
+          image: ubuntu
+          script: cat $(workspaces.shared-data.path)/$(params.filename)

--- a/examples/v1beta1/pipelineruns/alpha/propagating_workspaces_with_referenced_resources.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_workspaces_with_referenced_resources.yaml
@@ -1,0 +1,44 @@
+# PipelineRun attempting to propagate Workspaces to referenced Tasks
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: fetch-secure-data
+spec:
+  workspaces: # If Referenced, Workspaces need to be explicitly declared
+  - name: shared-data
+  steps:
+  - name: fetch-and-write
+    image: ubuntu
+    script: |
+      echo hi >> $(workspaces.shared-data.path)/recipe.txt
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: recipe-time-
+spec:
+  workspaces:
+  - name: shared-data
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 16Mi
+        volumeMode: Filesystem
+  pipelineSpec:
+    tasks:
+    - name: fetch-the-recipe
+      workspaces: # If referencing resources, Workspaces need to be explicitly declared
+      - name: shared-data
+      taskRef: # Referencing a resource
+        name: fetch-secure-data
+    - name: print-the-recipe
+      taskSpec:
+        steps:
+        - name: print-secrets
+          image: ubuntu
+          script: cat $(workspaces.shared-data.path)/recipe.txt
+      runAfter:
+        - fetch-the-recipe

--- a/pkg/apis/pipeline/v1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation.go
@@ -62,8 +62,8 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateExecutionStatusVariables(ps.Tasks, ps.Finally))
 	// Validate the pipeline's workspaces.
 	errs = errs.Also(validatePipelineWorkspacesDeclarations(ps.Workspaces))
-	errs = errs.Also(validatePipelineWorkspacesUsage(ps.Workspaces, ps.Tasks).ViaField("tasks"))
-	errs = errs.Also(validatePipelineWorkspacesUsage(ps.Workspaces, ps.Finally).ViaField("finally"))
+	errs = errs.Also(validatePipelineWorkspacesUsage(ctx, ps.Workspaces, ps.Tasks).ViaField("tasks"))
+	errs = errs.Also(validatePipelineWorkspacesUsage(ctx, ps.Workspaces, ps.Finally).ViaField("finally"))
 	// Validate the pipeline's results
 	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
@@ -106,7 +106,10 @@ func validatePipelineWorkspacesDeclarations(wss []PipelineWorkspaceDeclaration) 
 
 // validatePipelineWorkspacesUsage validates that all the referenced workspaces (by pipeline tasks) are specified in
 // the pipeline
-func validatePipelineWorkspacesUsage(wss []PipelineWorkspaceDeclaration, pts []PipelineTask) (errs *apis.FieldError) {
+func validatePipelineWorkspacesUsage(ctx context.Context, wss []PipelineWorkspaceDeclaration, pts []PipelineTask) (errs *apis.FieldError) {
+	if config.ValidateParameterVariablesAndWorkspaces(ctx) == false {
+		return nil
+	}
 	workspaceNames := sets.NewString()
 	for _, ws := range wss {
 		workspaceNames.Insert(ws.Name)

--- a/pkg/apis/pipeline/v1/pipeline_validation_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_validation_test.go
@@ -1593,7 +1593,7 @@ func TestValidatePipelineWorkspacesUsage_Success(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validatePipelineWorkspacesUsage(tt.workspaces, tt.tasks).ViaField("tasks")
+			errs := validatePipelineWorkspacesUsage(context.Background(), tt.workspaces, tt.tasks).ViaField("tasks")
 			if errs != nil {
 				t.Errorf("Pipeline.validatePipelineWorkspacesUsage() returned error for valid pipeline workspaces: %v", errs)
 			}
@@ -1688,7 +1688,8 @@ func TestValidatePipelineWorkspacesUsage_Failure(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := validatePipelineWorkspacesUsage(tt.workspaces, tt.tasks).ViaField("tasks")
+			ctx := config.SkipValidationDueToPropagatedParametersAndWorkspaces(context.Background(), false)
+			errs := validatePipelineWorkspacesUsage(ctx, tt.workspaces, tt.tasks).ViaField("tasks")
 			if errs == nil {
 				t.Errorf("Pipeline.validatePipelineWorkspacesUsage() did not return error for invalid pipeline workspaces")
 			}

--- a/pkg/apis/pipeline/v1beta1/pipeline_validation.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_validation.go
@@ -68,8 +68,8 @@ func (ps *PipelineSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	errs = errs.Also(validateExecutionStatusVariables(ps.Tasks, ps.Finally))
 	// Validate the pipeline's workspaces.
 	errs = errs.Also(validatePipelineWorkspacesDeclarations(ps.Workspaces))
-	errs = errs.Also(validatePipelineWorkspacesUsage(ps.Workspaces, ps.Tasks).ViaField("tasks"))
-	errs = errs.Also(validatePipelineWorkspacesUsage(ps.Workspaces, ps.Finally).ViaField("finally"))
+	errs = errs.Also(validatePipelineWorkspacesUsage(ctx, ps.Workspaces, ps.Tasks).ViaField("tasks"))
+	errs = errs.Also(validatePipelineWorkspacesUsage(ctx, ps.Workspaces, ps.Finally).ViaField("finally"))
 	// Validate the pipeline's results
 	errs = errs.Also(validatePipelineResults(ps.Results, ps.Tasks, ps.Finally))
 	errs = errs.Also(validateTasksAndFinallySection(ps))
@@ -112,7 +112,10 @@ func validatePipelineWorkspacesDeclarations(wss []PipelineWorkspaceDeclaration) 
 
 // validatePipelineWorkspacesUsage validates that all the referenced workspaces (by pipeline tasks) are specified in
 // the pipeline
-func validatePipelineWorkspacesUsage(wss []PipelineWorkspaceDeclaration, pts []PipelineTask) (errs *apis.FieldError) {
+func validatePipelineWorkspacesUsage(ctx context.Context, wss []PipelineWorkspaceDeclaration, pts []PipelineTask) (errs *apis.FieldError) {
+	if config.ValidateParameterVariablesAndWorkspaces(ctx) == false {
+		return nil
+	}
 	workspaceNames := sets.NewString()
 	for _, ws := range wss {
 		workspaceNames.Insert(ws.Name)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_validation_test.go
@@ -722,6 +722,140 @@ func TestPipelineRun_Validate(t *testing.T) {
 		},
 		wc: config.EnableAlphaAPIFields,
 	}, {
+		name: "propagating workspaces",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				Workspaces: []v1beta1.WorkspaceBinding{{
+					Name:     "ws",
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}},
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Tasks: []v1beta1.PipelineTask{{
+						Name: "echoit",
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{
+								Name:    "echo",
+								Image:   "ubuntu",
+								Command: []string{"echo"},
+								Args:    []string{"$(workspaces.ws.path)"},
+							}},
+						}},
+					}},
+					Finally: []v1beta1.PipelineTask{{
+						Name: "echoitifinally",
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{
+								Name:    "echo",
+								Image:   "ubuntu",
+								Command: []string{"echo"},
+								Args:    []string{"$(workspaces.ws.path)"},
+							}},
+						}},
+					}},
+				},
+			},
+		},
+		wc: config.EnableAlphaAPIFields,
+	}, {
+		name: "propagating workspaces partially defined",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				Workspaces: []v1beta1.WorkspaceBinding{{
+					Name:     "ws",
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}},
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Workspaces: []v1beta1.PipelineWorkspaceDeclaration{{
+						Name: "ws",
+					}},
+					Tasks: []v1beta1.PipelineTask{{
+						Name: "echoit",
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{
+								Name:    "echo",
+								Image:   "ubuntu",
+								Command: []string{"echo"},
+								Args:    []string{"$(workspaces.ws.path)"},
+							}},
+						}},
+					}},
+					Finally: []v1beta1.PipelineTask{{
+						Name: "echoitfinally",
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Steps: []v1beta1.Step{{
+								Name:    "echo",
+								Image:   "ubuntu",
+								Command: []string{"echo"},
+								Args:    []string{"$(workspaces.ws.path)"},
+							}},
+						}},
+					}},
+				},
+			},
+		},
+		wc: config.EnableAlphaAPIFields,
+	}, {
+		name: "propagating workspaces fully defined",
+		pr: v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pipelinelinename",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				Workspaces: []v1beta1.WorkspaceBinding{{
+					Name:     "ws",
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}},
+				PipelineSpec: &v1beta1.PipelineSpec{
+					Workspaces: []v1beta1.PipelineWorkspaceDeclaration{{
+						Name: "ws",
+					}},
+					Tasks: []v1beta1.PipelineTask{{
+						Name: "echoit",
+						Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+							Name:    "ws",
+							SubPath: "/foo",
+						}},
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Workspaces: []v1beta1.WorkspaceDeclaration{{
+								Name: "ws",
+							}},
+							Steps: []v1beta1.Step{{
+								Name:    "echo",
+								Image:   "ubuntu",
+								Command: []string{"echo"},
+								Args:    []string{"$(workspaces.ws.path)"},
+							}},
+						}},
+					}},
+					Finally: []v1beta1.PipelineTask{{
+						Name: "echoitfinally",
+						Workspaces: []v1beta1.WorkspacePipelineTaskBinding{{
+							Name:    "ws",
+							SubPath: "/foo",
+						}},
+						TaskSpec: &v1beta1.EmbeddedTask{TaskSpec: v1beta1.TaskSpec{
+							Workspaces: []v1beta1.WorkspaceDeclaration{{
+								Name: "ws",
+							}},
+							Steps: []v1beta1.Step{{
+								Name:    "echo",
+								Image:   "ubuntu",
+								Command: []string{"echo"},
+								Args:    []string{"$(workspaces.ws.path)"},
+							}},
+						}},
+					}},
+				},
+			},
+		},
+		wc: config.EnableAlphaAPIFields,
+	}, {
 		name: "pipelinerun pending",
 		pr: v1beta1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
The verbosity of writing specifications in Tekton Pipelines is a common pain point that creates difficulties in getting-started scenarios. In addition, the verbosity leads to long specifications that are error-prone, harder to maintain, and reach the etcd size limits for CRDs. Automatically propagating Workspaces will lead to better user experience. This addresses features proposed in [TEP-0111](https://github.com/tektoncd/community/blob/main/teps/0111-propagating-workspaces.md). This is a follow up PR that addresses propagating workspaces in `PipelineRuns`. Propagating workspaces in Taskruns is being addressed by https://github.com/tektoncd/pipeline/pull/5081 and should be merged first.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Workspaces are propagated in embedded specifications of pipelinerun without mutations.
```
