### PR TITLE
petite DAG - introduce key to identify node instead of holding a `task`

### DIFF
--- a/pkg/reconciler/pipeline/dag/dag.go
+++ b/pkg/reconciler/pipeline/dag/dag.go
@@ -39,8 +39,8 @@ type Tasks interface {
 
 // Node represents a Task in a pipeline.
 type Node struct {
-	// Task represent the PipelineTask in Pipeline
-	Task Task
+	// Key represent a unique name of the node in a graph
+	Key string
 	// Prev represent all the Previous task Nodes for the current Task
 	Prev []*Node
 	// Next represent all the Next task Nodes for the current Task
@@ -63,7 +63,7 @@ func (g *Graph) addPipelineTask(t Task) (*Node, error) {
 		return nil, errors.New("duplicate pipeline task")
 	}
 	newNode := &Node{
-		Task: t,
+		Key: t.HashKey(),
 	}
 	g.Nodes[t.HashKey()] = newNode
 	return newNode, nil
@@ -108,8 +108,8 @@ func GetCandidateTasks(g *Graph, doneTasks ...string) (sets.String, error) {
 	visited := sets.NewString()
 	for _, root := range roots {
 		schedulable := findSchedulable(root, visited, tm)
-		for _, task := range schedulable {
-			d.Insert(task.HashKey())
+		for _, taskName := range schedulable {
+			d.Insert(taskName)
 		}
 	}
 
@@ -214,16 +214,16 @@ func getRoots(g *Graph) []*Node {
 	return n
 }
 
-func findSchedulable(n *Node, visited sets.String, doneTasks sets.String) []Task {
-	if visited.Has(n.Task.HashKey()) {
-		return []Task{}
+func findSchedulable(n *Node, visited sets.String, doneTasks sets.String) []string {
+	if visited.Has(n.Key) {
+		return []string{}
 	}
-	visited.Insert(n.Task.HashKey())
-	if doneTasks.Has(n.Task.HashKey()) {
-		schedulable := []Task{}
+	visited.Insert(n.Key)
+	if doneTasks.Has(n.Key) {
+		schedulable := []string{}
 		// This one is done! Take note of it and look at the next candidate
 		for _, next := range n.Next {
-			if _, ok := visited[next.Task.HashKey()]; !ok {
+			if _, ok := visited[next.Key]; !ok {
 				schedulable = append(schedulable, findSchedulable(next, visited, doneTasks)...)
 			}
 		}
@@ -232,10 +232,10 @@ func findSchedulable(n *Node, visited sets.String, doneTasks sets.String) []Task
 	// This one isn't done! Return it if it's schedulable
 	if isSchedulable(doneTasks, n.Prev) {
 		// FIXME(vdemeester)
-		return []Task{n.Task}
+		return []string{n.Key}
 	}
 	// This one isn't done, but it also isn't ready to schedule
-	return []Task{}
+	return []string{}
 }
 
 func isSchedulable(doneTasks sets.String, prevs []*Node) bool {
@@ -244,8 +244,8 @@ func isSchedulable(doneTasks sets.String, prevs []*Node) bool {
 	}
 	collected := []string{}
 	for _, n := range prevs {
-		if doneTasks.Has(n.Task.HashKey()) {
-			collected = append(collected, n.Task.HashKey())
+		if doneTasks.Has(n.Key) {
+			collected = append(collected, n.Key)
 		}
 	}
 	return len(collected) == len(prevs)

--- a/pkg/reconciler/pipeline/dag/dag_test.go
+++ b/pkg/reconciler/pipeline/dag/dag_test.go
@@ -140,9 +140,9 @@ func TestBuild_Parallel(t *testing.T) {
 	}
 	expectedDAG := &dag.Graph{
 		Nodes: map[string]*dag.Node{
-			"a": {Task: a},
-			"b": {Task: b},
-			"c": {Task: c},
+			"a": {Key: "a"},
+			"b": {Key: "b"},
+			"c": {Key: "c"},
 		},
 	}
 	g, err := dag.Build(v1beta1.PipelineTaskList(p.Spec.Tasks), v1beta1.PipelineTaskList(p.Spec.Tasks).Deps())
@@ -182,12 +182,12 @@ func TestBuild_JoinMultipleRoots(t *testing.T) {
 	//   |
 	//   z
 
-	nodeA := &dag.Node{Task: a}
-	nodeB := &dag.Node{Task: b}
-	nodeC := &dag.Node{Task: c}
-	nodeX := &dag.Node{Task: xDependsOnA}
-	nodeY := &dag.Node{Task: yDependsOnARunsAfterB}
-	nodeZ := &dag.Node{Task: zDependsOnX}
+	nodeA := &dag.Node{Key: "a"}
+	nodeB := &dag.Node{Key: "b"}
+	nodeC := &dag.Node{Key: "c"}
+	nodeX := &dag.Node{Key: xDependsOnA.Name}
+	nodeY := &dag.Node{Key: yDependsOnARunsAfterB.Name}
+	nodeZ := &dag.Node{Key: zDependsOnX.Name}
 
 	nodeA.Next = []*dag.Node{nodeX, nodeY}
 	nodeB.Next = []*dag.Node{nodeY}
@@ -250,11 +250,11 @@ func TestBuild_FanInFanOut(t *testing.T) {
 	//   f
 	//   |
 	//   g
-	nodeA := &dag.Node{Task: a}
-	nodeD := &dag.Node{Task: dDependsOnA}
-	nodeE := &dag.Node{Task: eRunsAfterA}
-	nodeF := &dag.Node{Task: fDependsOnDAndE}
-	nodeG := &dag.Node{Task: gRunsAfterF}
+	nodeA := &dag.Node{Key: "a"}
+	nodeD := &dag.Node{Key: dDependsOnA.Name}
+	nodeE := &dag.Node{Key: eRunsAfterA.Name}
+	nodeF := &dag.Node{Key: fDependsOnDAndE.Name}
+	nodeG := &dag.Node{Key: gRunsAfterF.Name}
 
 	nodeA.Next = []*dag.Node{nodeD, nodeE}
 	nodeD.Prev = []*dag.Node{nodeA}
@@ -327,16 +327,16 @@ func TestBuild_TaskParamsFromTaskResults(t *testing.T) {
 	//   a  b   c  d   e  f
 	//   |   \ /    \ /   |
 	//   x    y      z    w
-	nodeA := &dag.Node{Task: a}
-	nodeB := &dag.Node{Task: b}
-	nodeC := &dag.Node{Task: c}
-	nodeD := &dag.Node{Task: d}
-	nodeE := &dag.Node{Task: e}
-	nodeF := &dag.Node{Task: f}
-	nodeX := &dag.Node{Task: xDependsOnA}
-	nodeY := &dag.Node{Task: yDependsOnBRunsAfterC}
-	nodeZ := &dag.Node{Task: zDependsOnDAndE}
-	nodeW := &dag.Node{Task: wDependsOnF}
+	nodeA := &dag.Node{Key: "a"}
+	nodeB := &dag.Node{Key: "b"}
+	nodeC := &dag.Node{Key: "c"}
+	nodeD := &dag.Node{Key: "d"}
+	nodeE := &dag.Node{Key: "e"}
+	nodeF := &dag.Node{Key: "f"}
+	nodeX := &dag.Node{Key: xDependsOnA.Name}
+	nodeY := &dag.Node{Key: yDependsOnBRunsAfterC.Name}
+	nodeZ := &dag.Node{Key: zDependsOnDAndE.Name}
+	nodeW := &dag.Node{Key: wDependsOnF.Name}
 
 	nodeA.Next = []*dag.Node{nodeX}
 	nodeB.Next = []*dag.Node{nodeY}
@@ -662,10 +662,10 @@ func testGraph(t *testing.T) *dag.Graph {
 func sameNodes(l, r []*dag.Node) error {
 	lNames, rNames := []string{}, []string{}
 	for _, n := range l {
-		lNames = append(lNames, n.Task.HashKey())
+		lNames = append(lNames, n.Key)
 	}
 	for _, n := range r {
-		rNames = append(rNames, n.Task.HashKey())
+		rNames = append(rNames, n.Key)
 	}
 
 	return list.IsSame(lNames, rNames)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -377,7 +377,7 @@ func (t *ResolvedPipelineTask) checkParentsDone(facts *PipelineRunFacts) bool {
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]
 	for _, p := range node.Prev {
-		if !stateMap[p.Task.HashKey()].isDone(facts) {
+		if !stateMap[p.Key].isDone(facts) {
 			return false
 		}
 	}
@@ -453,7 +453,7 @@ func (t *ResolvedPipelineTask) skipBecauseParentTaskWasSkipped(facts *PipelineRu
 	stateMap := facts.State.ToMap()
 	node := facts.TasksGraph.Nodes[t.PipelineTask.Name]
 	for _, p := range node.Prev {
-		parentTask := stateMap[p.Task.HashKey()]
+		parentTask := stateMap[p.Key]
 		if parentSkipStatus := parentTask.Skip(facts); parentSkipStatus.IsSkipped {
 			// if the parent task was skipped due to its `when` expressions,
 			// then we should ignore that and continue evaluating if we should skip because of other parent tasks


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

A graph is built using all `pipelineTasks` from `tasks` section as `nodes`. A `node` includes a `pipelineTask` along with a list of parents (`prev`) and dependencies(`next`). The entire `pipelineTask` struct is not needed in building a graph since the list of dependencies is calculated outside of `dag.build` and passed as an additional parameter. This struct (pipelineTask) doesn't serve any purpose and not required in the `node`. The `node` now includes a key instead of `Task`.

For example, the `DAG` for [this](https://github.com/tektoncd/pipeline/blob/main/pkg/reconciler/pipeline/dag/dag_test.go#L155) unit test now shows:

```
 Nodes: (map[string]*dag.Node) (len=6) {
  (string) (len=1) "a": (*dag.Node)(0xc000467900)({
   Key: (string) (len=1) "a",
   Prev: ([]*dag.Node) <nil>,
   Next: ([]*dag.Node) (len=2 cap=2) {
    (*dag.Node)(0xc000467940)({
     Key: (string) (len=1) "x",
     Prev: ([]*dag.Node) (len=1 cap=1) {
      (*dag.Node)(0xc000467900)(<already shown>)
     },
...
```

Instead of:

```
 Nodes: (map[string]*dag.Node) (len=6) {
  (string) (len=1) "a": (*dag.Node)(0xc0005ab780)({
   Task: (v1beta1.PipelineTask) {
    Name: (string) (len=1) "a",
    TaskRef: (*v1beta1.TaskRef)(<nil>),
    TaskSpec: (*v1beta1.EmbeddedTask)(<nil>),
    WhenExpressions: (v1beta1.WhenExpressions) <nil>,
    Retries: (int) 0,
    RunAfter: ([]string) <nil>,
    Resources: (*v1beta1.PipelineTaskResources)(<nil>),
    Params: ([]v1beta1.Param) <nil>,
    Matrix: (*v1beta1.Matrix)(<nil>),
    Workspaces: ([]v1beta1.WorkspacePipelineTaskBinding) <nil>,
    Timeout: (*v1.Duration)(<nil>)
   },
   Prev: ([]*dag.Node) <nil>,
   Next: ([]*dag.Node) (len=2 cap=2) {
    (*dag.Node)(0xc0005ab7c0)({
     Task: (v1beta1.PipelineTask) {
      Name: (string) (len=1) "x",
      TaskRef: (*v1beta1.TaskRef)(<nil>),
      TaskSpec: (*v1beta1.EmbeddedTask)(<nil>),
      WhenExpressions: (v1beta1.WhenExpressions) <nil>,
      Retries: (int) 0,
      RunAfter: ([]string) <nil>,
      Resources: (*v1beta1.PipelineTaskResources)(0xc00050d560)({
       Inputs: ([]v1beta1.PipelineTaskInputResource) (len=1 cap=1) {
        (v1beta1.PipelineTaskInputResource) {
         Name: (string) "",
         Resource: (string) "",
         From: ([]string) (len=1 cap=1) {
          (string) (len=1) "a"
         }
        }
       },
       Outputs: ([]v1beta1.PipelineTaskOutputResource) <nil>
      }),
      Params: ([]v1beta1.Param) <nil>,
      Matrix: (*v1beta1.Matrix)(<nil>),
      Workspaces: ([]v1beta1.WorkspacePipelineTaskBinding) <nil>,
      Timeout: (*v1.Duration)(<nil>)
     },
     Prev: ([]*dag.Node) (len=1 cap=1) {
      (*dag.Node)(0xc0005ab780)(<already shown>)
     },
...
``` 

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Replace holding a `Task` in `dag.Node` with a unique string identifier. 
```
