### PR TITLE
Replace `$(context...)` values in resolver parameters

### DIFF
--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -140,16 +140,19 @@ func paramsFromPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) (map[st
 	return stringReplacements, arrayReplacements, objectReplacements
 }
 
-// ApplyContexts applies the substitution from $(context.(pipelineRun|pipeline).*) with the specified values.
-// Currently supports only name substitution. Uses "" as a default if name is not specified.
-func ApplyContexts(ctx context.Context, spec *v1beta1.PipelineSpec, pipelineName string, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
-	replacements := map[string]string{
+func getContextReplacements(pipelineName string, pr *v1beta1.PipelineRun) map[string]string {
+	return map[string]string{
 		"context.pipelineRun.name":      pr.Name,
 		"context.pipeline.name":         pipelineName,
 		"context.pipelineRun.namespace": pr.Namespace,
 		"context.pipelineRun.uid":       string(pr.ObjectMeta.UID),
 	}
-	return ApplyReplacements(ctx, spec, replacements, map[string][]string{}, map[string]map[string]string{})
+}
+
+// ApplyContexts applies the substitution from $(context.(pipelineRun|pipeline).*) with the specified values.
+// Currently supports only name substitution. Uses "" as a default if name is not specified.
+func ApplyContexts(ctx context.Context, spec *v1beta1.PipelineSpec, pipelineName string, pr *v1beta1.PipelineRun) *v1beta1.PipelineSpec {
+	return ApplyReplacements(ctx, spec, getContextReplacements(pipelineName, pr), map[string][]string{}, map[string]map[string]string{})
 }
 
 // ApplyPipelineTaskContexts applies the substitution from $(context.pipelineTask.*) with the specified values.

--- a/pkg/reconciler/pipelinerun/resources/pipelineref.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelineref.go
@@ -74,6 +74,9 @@ func GetPipelineFunc(ctx context.Context, k8s kubernetes.Interface, tekton clien
 		return func(ctx context.Context, name string) (v1beta1.PipelineObject, error) {
 			params := map[string]string{}
 			stringReplacements, arrayReplacements, objectReplacements := paramsFromPipelineRun(ctx, pipelineRun)
+			for k, v := range getContextReplacements("", pipelineRun) {
+				stringReplacements[k] = v
+			}
 			replacedParams := replaceParamValues(pr.Params, stringReplacements, arrayReplacements, objectReplacements)
 			for _, p := range replacedParams {
 				params[p.Name] = p.Value.StringVal

--- a/pkg/reconciler/taskrun/resources/apply.go
+++ b/pkg/reconciler/taskrun/resources/apply.go
@@ -159,17 +159,20 @@ func ApplyResources(spec *v1beta1.TaskSpec, resolvedResources map[string]v1beta1
 	return ApplyReplacements(spec, replacements, map[string][]string{})
 }
 
-// ApplyContexts applies the substitution from $(context.(taskRun|task).*) with the specified values.
-// Uses "" as a default if a value is not available.
-func ApplyContexts(spec *v1beta1.TaskSpec, taskName string, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
-	replacements := map[string]string{
+func getContextReplacements(taskName string, tr *v1beta1.TaskRun) map[string]string {
+	return map[string]string{
 		"context.taskRun.name":      tr.Name,
 		"context.task.name":         taskName,
 		"context.taskRun.namespace": tr.Namespace,
 		"context.taskRun.uid":       string(tr.ObjectMeta.UID),
 		"context.task.retry-count":  strconv.Itoa(len(tr.Status.RetriesStatus)),
 	}
-	return ApplyReplacements(spec, replacements, map[string][]string{})
+}
+
+// ApplyContexts applies the substitution from $(context.(taskRun|task).*) with the specified values.
+// Uses "" as a default if a value is not available.
+func ApplyContexts(spec *v1beta1.TaskSpec, taskName string, tr *v1beta1.TaskRun) *v1beta1.TaskSpec {
+	return ApplyReplacements(spec, getContextReplacements(taskName, tr), map[string][]string{})
 }
 
 // ApplyWorkspaces applies the substitution from paths that the workspaces in declarations mounted to, the

--- a/pkg/reconciler/taskrun/resources/taskref.go
+++ b/pkg/reconciler/taskrun/resources/taskref.go
@@ -108,6 +108,9 @@ func GetTaskFunc(ctx context.Context, k8s kubernetes.Interface, tekton clientset
 			var replacedParams []v1beta1.Param
 			if ownerAsTR, ok := owner.(*v1beta1.TaskRun); ok {
 				stringReplacements, arrayReplacements := paramsFromTaskRun(ctx, ownerAsTR)
+				for k, v := range getContextReplacements("", ownerAsTR) {
+					stringReplacements[k] = v
+				}
 				for _, p := range tr.Params {
 					p.Value.ApplyReplacements(stringReplacements, arrayReplacements, nil)
 					replacedParams = append(replacedParams, p)

--- a/pkg/reconciler/taskrun/resources/taskref_test.go
+++ b/pkg/reconciler/taskrun/resources/taskref_test.go
@@ -553,7 +553,10 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			Resolver: "git",
 			Params: []v1beta1.Param{{
 				Name:  "foo",
-				Value: *v1beta1.NewArrayOrString("$(params.resolver-param)"),
+				Value: *v1beta1.NewStructuredValues("$(params.resolver-param)"),
+			}, {
+				Name:  "bar",
+				Value: *v1beta1.NewStructuredValues("$(context.taskRun.name)"),
 			}},
 		},
 	}
@@ -565,16 +568,22 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 	resolved := test.NewResolvedResource([]byte(taskYAML), nil, nil)
 	requester := &test.Requester{
 		ResolvedResource: resolved,
-		Params:           map[string]string{"foo": "bar"},
+		Params: map[string]string{
+			"foo": "bar",
+			"bar": "test-task",
+		},
 	}
 	tr := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef:            taskRef,
 			ServiceAccountName: "default",
 			Params: []v1beta1.Param{{
 				Name:  "resolver-param",
-				Value: *v1beta1.NewArrayOrString("bar"),
+				Value: *v1beta1.NewStructuredValues("bar"),
 			}},
 		},
 	}
@@ -597,19 +606,25 @@ func TestGetTaskFunc_RemoteResolution_ReplacedParams(t *testing.T) {
 			Resolver: "git",
 			Params: []v1beta1.Param{{
 				Name:  "foo",
-				Value: *v1beta1.NewArrayOrString("$(params.resolver-param)"),
+				Value: *v1beta1.NewStructuredValues("$(params.resolver-param)"),
+			}, {
+				Name:  "bar",
+				Value: *v1beta1.NewStructuredValues("$(context.taskRun.name)"),
 			}},
 		},
 	}
 
 	trNotMatching := &v1beta1.TaskRun{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-task",
+			Namespace: "default",
+		},
 		Spec: v1beta1.TaskRunSpec{
 			TaskRef:            taskRefNotMatching,
 			ServiceAccountName: "default",
 			Params: []v1beta1.Param{{
 				Name:  "resolver-param",
-				Value: *v1beta1.NewArrayOrString("banana"),
+				Value: *v1beta1.NewStructuredValues("banana"),
 			}},
 		},
 	}

--- a/test/resolution.go
+++ b/test/resolution.go
@@ -2,7 +2,9 @@ package test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	resolution "github.com/tektoncd/pipeline/pkg/resolution/resource"
 )
@@ -54,10 +56,14 @@ func (r *Requester) Submit(ctx context.Context, resolverName resolution.Resolver
 		reqParams[k] = v
 	}
 
+	var wrongParams []string
 	for k, v := range r.Params {
 		if reqValue, ok := reqParams[k]; !ok || reqValue != v {
-			return nil, fmt.Errorf("expected %s param to be %s, but was %s", k, v, reqValue)
+			wrongParams = append(wrongParams, fmt.Sprintf("expected %s param to be %s, but was %s", k, v, reqValue))
 		}
+	}
+	if len(wrongParams) > 0 {
+		return nil, errors.New(strings.Join(wrongParams, "; "))
 	}
 
 	return r.ResolvedResource, r.SubmitErr


### PR DESCRIPTION
# Changes

fixes #5475

I did not think of this previously, but now it works.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
