### PR TITLE
V1: add conversion for PipelineRunSpec.PipelineRef.Bundle

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -43,8 +43,6 @@ func TestPipelineConversionBadType(t *testing.T) {
 }
 
 func TestPipelineConversion(t *testing.T) {
-	versions := []apis.Convertible{&v1.Pipeline{}}
-
 	tests := []struct {
 		name string
 		in   *v1beta1.Pipeline
@@ -150,6 +148,7 @@ func TestPipelineConversion(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.Pipeline{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
@@ -172,7 +171,6 @@ func TestPipelineConversion(t *testing.T) {
 }
 
 func TestPipelineConversionFromDeprecated(t *testing.T) {
-	versions := []apis.Convertible{&v1.Pipeline{}}
 	tests := []struct {
 		name string
 		in   *v1beta1.Pipeline
@@ -219,6 +217,7 @@ func TestPipelineConversionFromDeprecated(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.Pipeline{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version

--- a/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/pipelineref_conversion.go
@@ -9,17 +9,37 @@ import (
 func (pr PipelineRef) convertTo(ctx context.Context, sink *v1.PipelineRef) {
 	sink.Name = pr.Name
 	sink.APIVersion = pr.APIVersion
-	// TODO: handle bundle in #4546
 	new := v1.ResolverRef{}
 	pr.ResolverRef.convertTo(ctx, &new)
 	sink.ResolverRef = new
+	pr.convertBundleToResolver(sink)
 }
 
 func (pr *PipelineRef) convertFrom(ctx context.Context, source v1.PipelineRef) {
 	pr.Name = source.Name
 	pr.APIVersion = source.APIVersion
-	// TODO: handle bundle in #4546
 	new := ResolverRef{}
 	new.convertFrom(ctx, source.ResolverRef)
 	pr.ResolverRef = new
+}
+
+// convertBundleToResolver converts v1beta1 bundle string to a remote reference with the bundle resolver in v1.
+// The conversion from Resolver to Bundle is not being supported since remote resolution would be turned on by
+// default and it will be in beta before the stored version of CRD getting swapped to v1.
+func (pr PipelineRef) convertBundleToResolver(sink *v1.PipelineRef) {
+	if pr.Bundle != "" {
+		sink.ResolverRef = v1.ResolverRef{
+			Resolver: "bundles",
+			Params: []v1.Param{{
+				Name:  "bundle",
+				Value: v1.ParamValue{StringVal: pr.Bundle},
+			}, {
+				Name:  "name",
+				Value: v1.ParamValue{StringVal: pr.Name},
+			}, {
+				Name:  "kind",
+				Value: v1.ParamValue{StringVal: "Task"},
+			}},
+		}
+	}
 }

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -46,8 +46,6 @@ func TestPipelineRunConversionBadType(t *testing.T) {
 }
 
 func TestPipelineRunConversion(t *testing.T) {
-	versions := []apis.Convertible{&v1.PipelineRun{}}
-
 	tests := []struct {
 		name string
 		in   *v1beta1.PipelineRun
@@ -148,6 +146,7 @@ func TestPipelineRunConversion(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.PipelineRun{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
@@ -170,7 +169,6 @@ func TestPipelineRunConversion(t *testing.T) {
 }
 
 func TestPipelineRunConversionFromDeprecated(t *testing.T) {
-	versions := []apis.Convertible{&v1.PipelineRun{}}
 	tests := []struct {
 		name string
 		in   *v1beta1.PipelineRun
@@ -233,9 +231,42 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "bundle",
+		in: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name:   "test-bundle-name",
+					Bundle: "test-bundle",
+				},
+			},
+		},
+		want: &v1beta1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: v1beta1.PipelineRunSpec{
+				PipelineRef: &v1beta1.PipelineRef{
+					Name: "test-bundle-name",
+					ResolverRef: v1beta1.ResolverRef{
+						Resolver: "bundles",
+						Params: []v1beta1.Param{
+							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle"}},
+							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name"}},
+							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task"}},
+						},
+					},
+				},
+			},
+		},
 	}}
-	// TODO add the cases for bundles #4546
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.PipelineRun{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -43,8 +43,6 @@ func TestTaskConversionBadType(t *testing.T) {
 }
 
 func TestTaskConversion(t *testing.T) {
-	versions := []apis.Convertible{&v1.Task{}}
-
 	tests := []struct {
 		name string
 		in   *v1beta1.Task
@@ -165,6 +163,7 @@ func TestTaskConversion(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.Task{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
@@ -187,7 +186,6 @@ func TestTaskConversion(t *testing.T) {
 }
 
 func TestTaskConversionFromDeprecated(t *testing.T) {
-	versions := []apis.Convertible{&v1.Task{}}
 	tests := []struct {
 		name string
 		in   *v1beta1.Task
@@ -244,6 +242,7 @@ func TestTaskConversionFromDeprecated(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.Task{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -49,8 +49,6 @@ func TestTaskRunConversionBadType(t *testing.T) {
 }
 
 func TestTaskrunConversion(t *testing.T) {
-	versions := []apis.Convertible{&v1.TaskRun{}}
-
 	tests := []struct {
 		name string
 		in   *v1beta1.TaskRun
@@ -173,6 +171,7 @@ func TestTaskrunConversion(t *testing.T) {
 	}}
 
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.TaskRun{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version
@@ -195,7 +194,6 @@ func TestTaskrunConversion(t *testing.T) {
 }
 
 func TestTaskRunConversionFromDeprecated(t *testing.T) {
-	versions := []apis.Convertible{&v1.TaskRun{}}
 	tests := []struct {
 		name string
 		in   *v1beta1.TaskRun
@@ -282,6 +280,7 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 		},
 	}}
 	for _, test := range tests {
+		versions := []apis.Convertible{&v1.TaskRun{}}
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
 				ver := version


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit adds support for PipelineRef.Bundle when converting between
v1beta1 and v1 versions of PipelineRef. This allows us to release v1
PipelineRuns in a backwards compatible way by ensuring that v1beta1
PipelineRuns with Bundle converted to v1 pipelineRuns.

part of #4987 
/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
