### PR TITLE
Fix versions referencing in conversion tests

### DIFF
--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -152,14 +152,14 @@ func TestPipelineConversion(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.Pipeline))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 					return
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.Pipeline{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
@@ -221,13 +221,13 @@ func TestPipelineConversionFromDeprecated(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.Pipeline))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.Pipeline{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -150,14 +150,14 @@ func TestPipelineRunConversion(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.PipelineRun))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 					return
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.PipelineRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
@@ -238,13 +238,13 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.PipelineRun))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.PipelineRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)

--- a/pkg/apis/pipeline/v1beta1/task_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/task_conversion_test.go
@@ -167,14 +167,14 @@ func TestTaskConversion(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.Task))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 					return
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.Task{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)
@@ -246,13 +246,13 @@ func TestTaskConversionFromDeprecated(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.Task))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.Task{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)

--- a/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_conversion_test.go
@@ -175,14 +175,14 @@ func TestTaskrunConversion(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.TaskRun))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 					return
 				}
 				t.Logf("ConvertTo() =%v", ver)
 				got := &v1beta1.TaskRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() =%v", got)
@@ -284,13 +284,13 @@ func TestTaskRunConversionFromDeprecated(t *testing.T) {
 	for _, test := range tests {
 		for _, version := range versions {
 			t.Run(test.name, func(t *testing.T) {
-				ver := version
-				if err := test.in.ConvertTo(context.Background(), ver); err != nil {
+				ver := *(version.(*v1.TaskRun))
+				if err := test.in.ConvertTo(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertTo() = %v", err)
 				}
 				t.Logf("ConvertTo() = %#v", ver)
 				got := &v1beta1.TaskRun{}
-				if err := got.ConvertFrom(context.Background(), ver); err != nil {
+				if err := got.ConvertFrom(context.Background(), &ver); err != nil {
 					t.Errorf("ConvertFrom() = %v", err)
 				}
 				t.Logf("ConvertFrom() = %#v", got)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit fixes the pointer referencing issue which causes improper
test versions values to be used. Previously the var ver is pointing to the
address of the empty CRD struct and now updated to dereferenced in 
each test case.

/kind bug
# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
