### PR TITLE
[release-v0.39.x] de-dupe order and resource dependencies

### DIFF
--- a/pkg/apis/pipeline/v1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1/pipeline_types.go
@@ -468,29 +468,22 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return
 }
 
-// Deps returns all other PipelineTask dependencies of this PipelineTask, based on ordering
+// Deps returns all other PipelineTask dependencies of this PipelineTask, based on resource usage or ordering
 func (pt PipelineTask) Deps() []string {
-	deps := []string{}
+	// hold the list of dependencies in a set to avoid duplicates
+	deps := sets.NewString()
 
-	deps = append(deps, pt.orderingDeps()...)
-
-	uniqueDeps := sets.NewString()
-	for _, w := range deps {
-		if uniqueDeps.Has(w) {
-			continue
-		}
-		uniqueDeps.Insert(w)
+	// add any new dependents from result references - resource dependency
+	for _, ref := range PipelineTaskResultRefs(&pt) {
+		deps.Insert(ref.PipelineTask)
 	}
 
-	return uniqueDeps.List()
-}
-
-func (pt PipelineTask) orderingDeps() []string {
-	orderingDeps := []string{}
+	// add any new dependents from runAfter - order dependency
 	for _, runAfter := range pt.RunAfter {
-		orderingDeps = append(orderingDeps, runAfter)
+		deps.Insert(runAfter)
 	}
-	return orderingDeps
+
+	return deps.List()
 }
 
 // PipelineTaskList is a list of PipelineTasks

--- a/pkg/apis/pipeline/v1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1/pipeline_types_test.go
@@ -366,6 +366,205 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 		expectedDeps: map[string][]string{
 			"task-2": {"task-1"},
 		},
+	}, {
+		name: "valid pipeline with Task Results deps",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2",
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-1.results.result)",
+				}},
+			}},
+		},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+		},
+	}, {
+		name: "valid pipeline with Task Results in Matrix deps",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2",
+			Matrix: []Param{{
+				Value: ParamValue{
+					Type: ParamTypeArray,
+					ArrayVal: []string{
+						"$(tasks.task-1.results.result)",
+					},
+				}},
+			}},
+		},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+		},
+	}, {
+		name: "valid pipeline with When Expressions deps",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2",
+			When: WhenExpressions{{
+				Input:    "$(tasks.task-1.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+		},
+	}, {
+		name: "valid pipeline with ordering deps and resource deps",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2", RunAfter: []string{"task-1"},
+		}, {
+			Name:     "task-3",
+			RunAfter: []string{"task-1"},
+		}, {
+			Name:     "task-4",
+			RunAfter: []string{"task-1"},
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-3.results.result)",
+				}},
+			},
+		}, {
+			Name:     "task-5",
+			RunAfter: []string{"task-1"},
+			When: WhenExpressions{{
+				Input:    "$(tasks.task-4.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}, {
+			Name:     "task-6",
+			RunAfter: []string{"task-1"},
+			Matrix: []Param{{
+				Value: ParamValue{
+					Type: ParamTypeArray,
+					ArrayVal: []string{
+						"$(tasks.task-2.results.result)",
+						"$(tasks.task-5.results.result)",
+					},
+				}},
+			},
+		}},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+			"task-3": {"task-1"},
+			"task-4": {"task-1", "task-3"},
+			"task-5": {"task-1", "task-4"},
+			"task-6": {"task-1", "task-2", "task-5"},
+		},
+	}, {
+		name: "valid pipeline with ordering deps and resource deps - verify unique dependencies",
+		tasks: []PipelineTask{{
+			Name: "task-1",
+		}, {
+			Name: "task-2", RunAfter: []string{"task-1"},
+		}, {
+			Name:     "task-3",
+			RunAfter: []string{"task-1"},
+		}, {
+			Name:     "task-4",
+			RunAfter: []string{"task-1", "task-3"},
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-2.results.result)",
+				}}, {
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-3.results.result)",
+				}},
+			},
+		}, {
+			Name:     "task-5",
+			RunAfter: []string{"task-1", "task-2", "task-3", "task-4"},
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result)",
+				}},
+			},
+			When: WhenExpressions{{
+				Input:    "$(tasks.task-3.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}, {
+				Input:    "$(tasks.task-4.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}, {
+			Name:     "task-6",
+			RunAfter: []string{"task-1", "task-2", "task-3", "task-4", "task-5"},
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result)",
+				}},
+			},
+			When: WhenExpressions{{
+				Input:    "$(tasks.task-3.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}, {
+				Input:    "$(tasks.task-4.results.result)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+			Matrix: []Param{{
+				Value: ParamValue{
+					Type: ParamTypeArray,
+					ArrayVal: []string{
+						"$(tasks.task-2.results.result)",
+						"$(tasks.task-5.results.result)",
+					},
+				}},
+			},
+		}, {
+			Name: "task-7",
+			When: WhenExpressions{{
+				Input:    "$(tasks.task-3.results.result1)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}, {
+				Input:    "$(tasks.task-3.results.result2)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}, {
+			Name: "task-8",
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result1)",
+				}}, {
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result2)",
+				}},
+			},
+		}, {
+			Name:     "task-9",
+			RunAfter: []string{"task-1", "task-1", "task-1", "task-1"},
+		}},
+		expectedDeps: map[string][]string{
+			"task-2": {"task-1"},
+			"task-3": {"task-1"},
+			"task-4": {"task-1", "task-2", "task-3"},
+			"task-5": {"task-1", "task-2", "task-3", "task-4"},
+			"task-6": {"task-1", "task-2", "task-3", "task-4", "task-5"},
+			"task-7": {"task-3"},
+			"task-8": {"task-4"},
+			"task-9": {"task-1"},
+		},
 	}}
 	for _, tc := range pipelines {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/apis/pipeline/v1beta1/pipeline_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types.go
@@ -512,44 +512,29 @@ func (pt PipelineTask) Validate(ctx context.Context) (errs *apis.FieldError) {
 
 // Deps returns all other PipelineTask dependencies of this PipelineTask, based on resource usage or ordering
 func (pt PipelineTask) Deps() []string {
-	deps := []string{}
+	// hold the list of dependencies in a set to avoid duplicates
+	deps := sets.NewString()
 
-	deps = append(deps, pt.resourceDeps()...)
-	deps = append(deps, pt.orderingDeps()...)
-
-	uniqueDeps := sets.NewString()
-	for _, w := range deps {
-		if uniqueDeps.Has(w) {
-			continue
-		}
-		uniqueDeps.Insert(w)
-	}
-
-	return uniqueDeps.List()
-}
-
-func (pt PipelineTask) resourceDeps() []string {
-	resourceDeps := []string{}
+	// add any new dependents from a resource/workspace
 	if pt.Resources != nil {
 		for _, rd := range pt.Resources.Inputs {
-			resourceDeps = append(resourceDeps, rd.From...)
+			for _, f := range rd.From {
+				deps.Insert(f)
+			}
 		}
 	}
 
-	// Add any dependents from result references.
+	// add any new dependents from result references - resource dependency
 	for _, ref := range PipelineTaskResultRefs(&pt) {
-		resourceDeps = append(resourceDeps, ref.PipelineTask)
+		deps.Insert(ref.PipelineTask)
 	}
 
-	return resourceDeps
-}
-
-func (pt PipelineTask) orderingDeps() []string {
-	orderingDeps := []string{}
+	// add any new dependents from runAfter - order dependency
 	for _, runAfter := range pt.RunAfter {
-		orderingDeps = append(orderingDeps, runAfter)
+		deps.Insert(runAfter)
 	}
-	return orderingDeps
+
+	return deps.List()
 }
 
 // PipelineTaskList is a list of PipelineTasks

--- a/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_types_test.go
@@ -643,13 +643,50 @@ func TestPipelineTaskList_Deps(t *testing.T) {
 					},
 				}},
 			},
+		}, {
+			Name: "task-7",
+			Resources: &PipelineTaskResources{
+				Inputs: []PipelineTaskInputResource{{
+					From: []string{"task-1", "task-1"},
+				}},
+			},
+		}, {
+			Name: "task-8",
+			WhenExpressions: WhenExpressions{{
+				Input:    "$(tasks.task-3.results.result1)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}, {
+				Input:    "$(tasks.task-3.results.result2)",
+				Operator: "in",
+				Values:   []string{"foo"},
+			}},
+		}, {
+			Name: "task-9",
+			Params: []Param{{
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result1)",
+				}}, {
+				Value: ParamValue{
+					Type:      "string",
+					StringVal: "$(tasks.task-4.results.result2)",
+				}},
+			},
+		}, {
+			Name:     "task-10",
+			RunAfter: []string{"task-1", "task-1", "task-1", "task-1"},
 		}},
 		expectedDeps: map[string][]string{
-			"task-2": {"task-1"},
-			"task-3": {"task-1", "task-2"},
-			"task-4": {"task-1", "task-2", "task-3"},
-			"task-5": {"task-1", "task-2", "task-3", "task-4"},
-			"task-6": {"task-1", "task-2", "task-3", "task-4", "task-5"},
+			"task-2":  {"task-1"},
+			"task-3":  {"task-1", "task-2"},
+			"task-4":  {"task-1", "task-2", "task-3"},
+			"task-5":  {"task-1", "task-2", "task-3", "task-4"},
+			"task-6":  {"task-1", "task-2", "task-3", "task-4", "task-5"},
+			"task-7":  {"task-1"},
+			"task-8":  {"task-3"},
+			"task-9":  {"task-4"},
+			"task-10": {"task-1"},
 		},
 	}}
 	for _, tc := range pipelines {

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -1308,7 +1308,7 @@ func TestDAGExecutionQueueSequentialRuns(t *testing.T) {
 }
 
 func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
-	largePipelineState := buildPipelineStateWithLargeDepencyGraph(t)
+	largePipelineState := buildPipelineStateWithLargeDependencyGraph(t)
 	tcs := []struct {
 		name          string
 		state         PipelineRunState
@@ -1354,6 +1354,14 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 		state:         largePipelineState,
 		expectedNames: []string{},
 	}, {
+		name:          "large deps through params, not started",
+		state:         buildPipelineStateWithMultipleTaskResults(t, false),
+		expectedNames: []string{},
+	}, {
+		name:          "large deps through params and when expressions, not started",
+		state:         buildPipelineStateWithMultipleTaskResults(t, true),
+		expectedNames: []string{},
+	}, {
 		name:          "one-run-started",
 		state:         oneRunStartedState,
 		expectedNames: []string{},
@@ -1386,7 +1394,7 @@ func TestPipelineRunState_CompletedOrSkippedDAGTasks(t *testing.T) {
 	}
 }
 
-func buildPipelineStateWithLargeDepencyGraph(t *testing.T) PipelineRunState {
+func buildPipelineStateWithLargeDependencyGraph(t *testing.T) PipelineRunState {
 	t.Helper()
 	var task = &v1beta1.Task{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1434,6 +1442,74 @@ func buildPipelineStateWithLargeDepencyGraph(t *testing.T) PipelineRunState {
 				Name:    fmt.Sprintf("t%d", i),
 				Params:  params,
 				TaskRef: &v1beta1.TaskRef{Name: "task"},
+			},
+			TaskRun: nil,
+			ResolvedTaskResources: &resources.ResolvedTaskResources{
+				TaskSpec: &task.Spec,
+			},
+		},
+		)
+	}
+	return pipelineRunState
+}
+
+func buildPipelineStateWithMultipleTaskResults(t *testing.T, includeWhen bool) PipelineRunState {
+	t.Helper()
+	var task = &v1beta1.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "task",
+		},
+		Spec: v1beta1.TaskSpec{
+			Steps: []v1beta1.Step{{
+				Name: "step1",
+			}},
+		},
+	}
+	var pipelineRunState PipelineRunState
+	pipelineRunState = []*ResolvedPipelineTask{{
+		PipelineTask: &v1beta1.PipelineTask{
+			Name:    "t1",
+			TaskRef: &v1beta1.TaskRef{Name: "task"},
+		},
+		TaskRun: nil,
+		ResolvedTaskResources: &resources.ResolvedTaskResources{
+			TaskSpec: &task.Spec,
+		},
+	}}
+	for i := 2; i < 400; i++ {
+		var params []v1beta1.Param
+		whenExpressions := v1beta1.WhenExpressions{}
+		var alpha byte
+		// the task has a reference to multiple task results (a through j) from each parent task - causing a redundant references
+		// the task dependents on all predecessors in a graph through params and/or whenExpressions
+		for j := 1; j < i; j++ {
+			for alpha = 'a'; alpha <= 'j'; alpha++ {
+				// include param with task results
+				params = append(params, v1beta1.Param{
+					Name: fmt.Sprintf("%c", alpha),
+					Value: v1beta1.ParamValue{
+						Type:      v1beta1.ParamTypeString,
+						StringVal: fmt.Sprintf("$(tasks.t%d.results.%c)", j, alpha),
+					},
+				})
+			}
+			if includeWhen {
+				for alpha = 'a'; alpha <= 'j'; alpha++ {
+					// include when expressions with task results
+					whenExpressions = append(whenExpressions, v1beta1.WhenExpression{
+						Input:    fmt.Sprintf("$(tasks.t%d.results.%c)", j, alpha),
+						Operator: selection.In,
+						Values:   []string{"true"},
+					})
+				}
+			}
+		}
+		pipelineRunState = append(pipelineRunState, &ResolvedPipelineTask{
+			PipelineTask: &v1beta1.PipelineTask{
+				Name:            fmt.Sprintf("t%d", i),
+				Params:          params,
+				TaskRef:         &v1beta1.TaskRef{Name: "task"},
+				WhenExpressions: whenExpressions,
 			},
 			TaskRun: nil,
 			ResolvedTaskResources: &resources.ResolvedTaskResources{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This is a manual cherry-pick of https://github.com/tektoncd/pipeline/pull/5446.

In case of a pipeline with a huge list of redundant dependencies, the list is growing exponentially. This way of calculating the list of dependencies is causing extra delay in the validation cycle. This delay sometimes hit the webhook timeout during validation. This is one of the changes being proposed to make the validation cycle efficient and avoid unnecessary delay.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
De-dupe task dependencies - order and resource dependencies all together. It's very common to have a task with multiple when expressions referring to the same task but different results. Maintain a set of dependencies and add only a new parent.
```
