### PR TITLE
Fix the value for `APISecretNamespaceKey`

### DIFF
--- a/pkg/resolution/resolver/git/config.go
+++ b/pkg/resolution/resolver/git/config.go
@@ -41,5 +41,5 @@ const (
 	// APISecretKeyKey is the config map key for the containing the token within the token secret
 	APISecretKeyKey = "api-token-secret-key"
 	// APISecretNamespaceKey is the config map key for the token secret's namespace
-	APISecretNamespaceKey = "api-token-namespace"
+	APISecretNamespaceKey = "api-token-secret-namespace"
 )


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Related to https://github.com/tektoncd/pipeline/pull/5450.

The key for APISecretNamespace in the configmap is named `api-token-secret-namespace`, but the value of `APISecretNamespaceKey` in `pkg/resolution/resolver/git/config.go` is `api-token-namespace`. This will cause resolver to fail to get API token.

In this PR, we use the correct key name `api-token-secret-namespace`.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
