### PR TITLE
Fail linting if k8s.io/apimachinery/pkg/util/clock is imported

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,11 @@ linters-settings:
         - github.com/ghodss/yaml:
             recommendations:
               - sigs.k8s.io/yaml
+  depguard:
+    list-type: denylist
+    include-go-root: false
+    packages-with-error-message:
+    - k8s.io/apimachinery/pkg/util/clock: 'use k8s.io/utils/clock or k8s.io/utils/clock/testing'
 linters:
   disable-all: true
   enable:
@@ -20,6 +25,7 @@ linters:
   - revive
   - misspell
   - unconvert
+  - depguard
 output:
   uniq-by-line: false
 issues:


### PR DESCRIPTION
# Changes

Instead, suggest using k8s.io/utils/clock or k8s.io/utils/clock/testing.

Prompted by #5448 and #5494

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
