### PR TITLE
Validate git resolver URL

### DIFF
--- a/pkg/resolution/resolver/git/resolver.go
+++ b/pkg/resolution/resolver/git/resolver.go
@@ -465,7 +465,17 @@ func populateDefaultParams(ctx context.Context, params []pipelinev1beta1.Param) 
 		return nil, fmt.Errorf("missing required git resolver params: %s", strings.Join(missingParams, ", "))
 	}
 
-	// TODO(sbwsg): validate repo url is well-formed, git:// or https://
+	if paramsMap[urlParam] != "" {
+		if !strings.HasPrefix(paramsMap[urlParam], "git://") &&
+			!strings.HasPrefix(paramsMap[urlParam], "https://") &&
+			!strings.HasPrefix(paramsMap[urlParam], "ssh://") &&
+			!strings.HasPrefix(paramsMap[urlParam], "file://") &&
+			!strings.HasPrefix(paramsMap[urlParam], "git+ssh://") &&
+			!strings.HasPrefix(paramsMap[urlParam], "/") { // We need to allow absolute paths without a protocol for testing purposes, but don't advertise support for such paths.
+			return nil, fmt.Errorf("%s must start with either git://, ssh://, https://, file://, or git+ssh://, but is %s", urlParam, paramsMap[urlParam])
+		}
+	}
+
 	// TODO(sbwsg): validate pathInRepo is valid relative pathInRepo
 	return paramsMap, nil
 }


### PR DESCRIPTION
# Changes

We will reject anything that doesn't start with `git://`, `ssh://`, `https://`, or `/`. The last is for use in our own tests, and is not included in the validation error.

/kind misc

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
