### PR TITLE
Fix empty paramValueType conversion

### DIFF
--- a/pkg/apis/pipeline/v1beta1/param_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/param_conversion.go
@@ -8,7 +8,11 @@ import (
 
 func (p ParamSpec) convertTo(ctx context.Context, sink *v1.ParamSpec) {
 	sink.Name = p.Name
-	sink.Type = v1.ParamType(p.Type)
+	if p.Type != "" {
+		sink.Type = v1.ParamType(p.Type)
+	} else {
+		sink.Type = v1.ParamType(ParamTypeString)
+	}
 	sink.Description = p.Description
 	var properties map[string]v1.PropertySpec
 	if p.Properties != nil {
@@ -28,7 +32,11 @@ func (p ParamSpec) convertTo(ctx context.Context, sink *v1.ParamSpec) {
 
 func (p *ParamSpec) convertFrom(ctx context.Context, source v1.ParamSpec) {
 	p.Name = source.Name
-	p.Type = ParamType(source.Type)
+	if source.Type != "" {
+		p.Type = ParamType(source.Type)
+	} else {
+		p.Type = ParamTypeString
+	}
 	p.Description = source.Description
 	var properties map[string]PropertySpec
 	if source.Properties != nil {
@@ -61,14 +69,22 @@ func (p *Param) convertFrom(ctx context.Context, source v1.Param) {
 }
 
 func (v ParamValue) convertTo(ctx context.Context, sink *v1.ParamValue) {
-	sink.Type = v1.ParamType(v.Type)
+	if v.Type != "" {
+		sink.Type = v1.ParamType(v.Type)
+	} else {
+		sink.Type = v1.ParamType(ParamTypeString)
+	}
 	sink.StringVal = v.StringVal
 	sink.ArrayVal = v.ArrayVal
 	sink.ObjectVal = v.ObjectVal
 }
 
 func (v *ParamValue) convertFrom(ctx context.Context, source v1.ParamValue) {
-	v.Type = ParamType(source.Type)
+	if source.Type != "" {
+		v.Type = ParamType(source.Type)
+	} else {
+		v.Type = ParamTypeString
+	}
 	v.StringVal = source.StringVal
 	v.ArrayVal = source.ArrayVal
 	v.ObjectVal = source.ObjectVal

--- a/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipeline_conversion_test.go
@@ -104,6 +104,7 @@ func TestPipelineConversion(t *testing.T) {
 						Name: "param-task-1",
 						Value: v1beta1.ParamValue{
 							ArrayVal: []string{"value-task-1"},
+							Type:     "string",
 						},
 					}},
 					Matrix: &v1beta1.Matrix{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_conversion_test.go
@@ -256,9 +256,9 @@ func TestPipelineRunConversionFromDeprecated(t *testing.T) {
 					ResolverRef: v1beta1.ResolverRef{
 						Resolver: "bundles",
 						Params: []v1beta1.Param{
-							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle"}},
-							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name"}},
-							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task"}},
+							{Name: "bundle", Value: v1beta1.ParamValue{StringVal: "test-bundle", Type: "string"}},
+							{Name: "name", Value: v1beta1.ParamValue{StringVal: "test-bundle-name", Type: "string"}},
+							{Name: "kind", Value: v1beta1.ParamValue{StringVal: "Task", Type: "string"}},
 						},
 					},
 				},

--- a/pkg/apis/pipeline/v1beta1/taskref_conversion.go
+++ b/pkg/apis/pipeline/v1beta1/taskref_conversion.go
@@ -34,13 +34,13 @@ func (tr TaskRef) convertBundleToResolver(sink *v1.TaskRef) {
 			Resolver: "bundles",
 			Params: []v1.Param{{
 				Name:  "bundle",
-				Value: v1.ParamValue{StringVal: tr.Bundle},
+				Value: v1.ParamValue{StringVal: tr.Bundle, Type: v1.ParamTypeString},
 			}, {
 				Name:  "name",
-				Value: v1.ParamValue{StringVal: tr.Name},
+				Value: v1.ParamValue{StringVal: tr.Name, Type: v1.ParamTypeString},
 			}, {
 				Name:  "kind",
-				Value: v1.ParamValue{StringVal: "Task"},
+				Value: v1.ParamValue{StringVal: "Task", Type: v1.ParamTypeString},
 			}},
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This commit fixes the paramValueType that is not handled if input is an empty string,
which could lead to issues for 'marshal' in knative.

FIx: #5500 
/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
