### PR TITLE
Refactor ensureConfigurationConfigMapsExist to reduce duplicate code

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -123,57 +123,6 @@ type PipelineRunTest struct {
 	Cancel     func()
 }
 
-func ensureConfigurationConfigMapsExist(d *test.Data) {
-	var defaultsExists, featureFlagsExists, artifactBucketExists, artifactPVCExists, metricsExists bool
-	for _, cm := range d.ConfigMaps {
-		if cm.Name == config.GetDefaultsConfigName() {
-			defaultsExists = true
-		}
-		if cm.Name == config.GetFeatureFlagsConfigName() {
-			featureFlagsExists = true
-		}
-		if cm.Name == config.GetArtifactBucketConfigName() {
-			artifactBucketExists = true
-		}
-		if cm.Name == config.GetArtifactPVCConfigName() {
-			artifactPVCExists = true
-		}
-		if cm.Name == config.GetMetricsConfigName() {
-			metricsExists = true
-		}
-	}
-	if !defaultsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !featureFlagsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !artifactBucketExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactBucketConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !artifactPVCExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactPVCConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !metricsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetMetricsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-}
-
 // getPipelineRunController returns an instance of the PipelineRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
@@ -185,7 +134,7 @@ func getPipelineRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 func initializePipelineRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
-	ensureConfigurationConfigMapsExist(&d)
+	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 	ctl := NewController(&opts, testClock)(ctx, configMapWatcher)
@@ -4885,7 +4834,7 @@ spec:
     script: |
       #!/usr/bin/env bash
       echo "Hello from bash!"
-  
+
 `),
 	}
 
@@ -4912,7 +4861,7 @@ spec:
   pipelineRef:
     name: test-pipeline
 status:
-  pipelineSpec: 
+  pipelineSpec:
     results:
     - description: pipeline result
       name: result
@@ -4934,7 +4883,7 @@ status:
       taskRef:
         apiVersion: example.dev/v0
         kind: Example
-        name: b-task  
+        name: b-task
   conditions:
   - status: "True"
     type: Succeeded
@@ -4984,7 +4933,7 @@ spec:
   pipelineRef:
     name: test-pipeline
 status:
-  pipelineSpec: 
+  pipelineSpec:
     results:
     - description: pipeline result
       name: result
@@ -5003,7 +4952,7 @@ status:
         name: a-task
         kind: Task
     - name: b-task
-      taskRef: 
+      taskRef:
         name: b-task
         apiVersion: example.dev/v0
         kind: Example
@@ -5070,7 +5019,7 @@ spec:
     name: test-pipeline
 status:
   runs: {}
-  pipelineSpec: 
+  pipelineSpec:
     results:
     - description: pipeline result
       name: result
@@ -5089,7 +5038,7 @@ status:
         name: a-task
         kind: Task
     - name: b-task
-      taskRef: 
+      taskRef:
         name: b-task
         apiVersion: example.dev/v0
         kind: Example
@@ -5239,7 +5188,7 @@ spec:
   pipelineRef:
     name: test-pipeline
 status:
-  pipelineSpec: 
+  pipelineSpec:
     results:
     - description: pipeline result
       name: result
@@ -5300,7 +5249,7 @@ spec:
   pipelineRef:
     name: test-pipeline
 status:
-  pipelineSpec: 
+  pipelineSpec:
     results:
     - description: pipeline result
       name: result
@@ -5371,7 +5320,7 @@ spec:
     name: test-pipeline
 status:
   runs: {}
-  pipelineSpec: 
+  pipelineSpec:
     results:
     - description: pipeline result
       name: result
@@ -9519,7 +9468,7 @@ metadata:
   labels:
     tekton.dev/pipeline: p
 spec:
-  serviceAccountName: test-sa 
+  serviceAccountName: test-sa
   pipelineRef:
     name: p
 status:
@@ -9565,7 +9514,7 @@ metadata:
   labels:
     tekton.dev/pipeline: p
 spec:
-  serviceAccountName: test-sa 
+  serviceAccountName: test-sa
   pipelineRef:
     name: p
 status:
@@ -9701,7 +9650,7 @@ metadata:
   labels:
     tekton.dev/pipeline: p
 spec:
-  serviceAccountName: test-sa 
+  serviceAccountName: test-sa
   pipelineRef:
     name: p
 status:
@@ -9747,7 +9696,7 @@ metadata:
   labels:
     tekton.dev/pipeline: p
 spec:
-  serviceAccountName: test-sa 
+  serviceAccountName: test-sa
   pipelineRef:
     name: p
 status:
@@ -10573,11 +10522,11 @@ spec:
       steps:
       - name: 1st-step
         image: foo-image
-        command: 
+        command:
         - /foo-cmd
       - name: 2nd-step
         image: foo-image
-        command: 
+        command:
         - /foo-cmd
 `)
 

--- a/pkg/reconciler/run/run_test.go
+++ b/pkg/reconciler/run/run_test.go
@@ -48,61 +48,10 @@ import (
 	_ "knative.dev/pkg/system/testing" // Setup system.Namespace()
 )
 
-func ensureConfigurationConfigMapsExist(d *test.Data) {
-	var defaultsExists, featureFlagsExists, artifactBucketExists, artifactPVCExists, metricsExists bool
-	for _, cm := range d.ConfigMaps {
-		if cm.Name == config.GetDefaultsConfigName() {
-			defaultsExists = true
-		}
-		if cm.Name == config.GetFeatureFlagsConfigName() {
-			featureFlagsExists = true
-		}
-		if cm.Name == config.GetArtifactBucketConfigName() {
-			artifactBucketExists = true
-		}
-		if cm.Name == config.GetArtifactPVCConfigName() {
-			artifactPVCExists = true
-		}
-		if cm.Name == config.GetMetricsConfigName() {
-			metricsExists = true
-		}
-	}
-	if !defaultsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !featureFlagsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !artifactBucketExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactBucketConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !artifactPVCExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactPVCConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !metricsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetMetricsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-}
-
 func initializeRunControllerAssets(t *testing.T, d test.Data) (test.Assets, func()) {
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
-	ensureConfigurationConfigMapsExist(&d)
+	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 	ctl := NewController()(ctx, configMapWatcher)

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -467,57 +467,6 @@ func getRunName(tr *v1beta1.TaskRun) string {
 	return strings.Join([]string{tr.Namespace, tr.Name}, "/")
 }
 
-func ensureConfigurationConfigMapsExist(d *test.Data) {
-	var defaultsExists, featureFlagsExists, artifactBucketExists, artifactPVCExists, metricsExists bool
-	for _, cm := range d.ConfigMaps {
-		if cm.Name == config.GetDefaultsConfigName() {
-			defaultsExists = true
-		}
-		if cm.Name == config.GetFeatureFlagsConfigName() {
-			featureFlagsExists = true
-		}
-		if cm.Name == config.GetArtifactBucketConfigName() {
-			artifactBucketExists = true
-		}
-		if cm.Name == config.GetArtifactPVCConfigName() {
-			artifactPVCExists = true
-		}
-		if cm.Name == config.GetMetricsConfigName() {
-			metricsExists = true
-		}
-	}
-	if !defaultsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetDefaultsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !featureFlagsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetFeatureFlagsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !artifactBucketExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactBucketConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !artifactPVCExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetArtifactPVCConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-	if !metricsExists {
-		d.ConfigMaps = append(d.ConfigMaps, &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: config.GetMetricsConfigName(), Namespace: system.Namespace()},
-			Data:       map[string]string{},
-		})
-	}
-}
-
 // getTaskRunController returns an instance of the TaskRun controller/reconciler that has been seeded with
 // d, where d represents the state of the system (existing resources) needed for the test.
 func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
@@ -529,7 +478,7 @@ func getTaskRunController(t *testing.T, d test.Data) (test.Assets, func()) {
 func initializeTaskRunControllerAssets(t *testing.T, d test.Data, opts pipeline.Options) (test.Assets, func()) {
 	ctx, _ := ttesting.SetupFakeContext(t)
 	ctx, cancel := context.WithCancel(ctx)
-	ensureConfigurationConfigMapsExist(&d)
+	test.EnsureConfigurationConfigMapsExist(&d)
 	c, informers := test.SeedTestData(t, ctx, d)
 	configMapWatcher := cminformer.NewInformedWatcher(c.Kube, system.Namespace())
 	ctl := NewController(&opts, testClock)(ctx, configMapWatcher)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

ensureConfigurationConfigMapsExist is used in pipelinerun, taskrun, run test files to ensure the test data contains needed configmap and they all share the same code. This commit move this function to a test package and can be used accross different files.


<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
