### PR TITLE
Update API spec doc to reflect the new fields introduced from TEP75&76

### DIFF
--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -244,7 +244,8 @@ List responses have the following fields (based on [`meta.v1/ListMeta`](https://
 |---------------|------------|-------------|
 | `name`        | string     | REQUIRED    |
 | `description` | string     | REQUIRED    |
-| `type`        | Enum: <br>- `"string"` (default) <br>- `"array"` | REQUIRED |
+| `type`      | Enum:<br>- `"string"` (default)<br>- `"array"` <br>- `"object"` | REQUIRED (The values `string` and `array` for this field are REQUIRED, and the value `object` is RECOMMENDED.) |
+| `properties`  | map<string,PropertySpec> |RECOMMENDED <br><br>note: `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1beta1/taskruns/alpha/object-param-result.yaml).|
 | `default`     | `ParamValue` | REQUIRED |
 
 ### `Step`
@@ -279,13 +280,16 @@ List responses have the following fields (based on [`meta.v1/ListMeta`](https://
 |--------------|------------|-------------|
 | `name`        | string    | REQUIRED    |
 | `description` | string    | REQUIRED    |
+| `type`      | Enum:<br>- `"string"` (default)<br>- `"array"` <br>- `"object"` | RECOMMENDED (Each of the values is RECOMMENDED.)|
+| `properties`  | map<string,PropertySpec> | RECOMMENDED <br><br>note: `PropertySpec` is a type that defines the spec of an individual key. See how to define the `properties` section in the [example](../examples/v1beta1/taskruns/alpha/object-param-result.yaml).|
 
 ### `TaskRunResult`
 
 | Field Name | Field Type | Requirement |
 |------------|------------|-------------|
 | `name`     | string     | REQUIRED    |
-| `value`    | string     | REQUIRED    |
+| `type`      | Enum:<br>- `"string"` (default)<br>- `"array"` <br>- `"object"` | RECOMMENDED (Each of the values is RECOMMENDED.) |
+| `value`    | `ParamValue`     | REQUIRED    |
 
 ### `TaskSpec`
 


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Implementation of TEP75&76 supported object type param, object type result and array type result, which introduced some changes to the API spec i.e. `ParamSpec`, `TaskResult` and `TaskRunResult`.

This PR updates the doc to reflect the changes.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
