### PR TITLE
Change image refs: distroless.dev -> cgr.dev/chainguard

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,5 +1,5 @@
-defaultBaseImage: distroless.dev/static
+defaultBaseImage: cgr.dev/chainguard/static
 baseImageOverrides:
   # git-init uses a base image that includes Git, and supports running either
   # as root or as user nonroot with UID 65532.
-  github.com/tektoncd/pipeline/cmd/git-init: distroless.dev/git
+  github.com/tektoncd/pipeline/cmd/git-init: cgr.dev/chainguard/git

--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -77,9 +77,9 @@ spec:
           "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
 
           # The shell image must allow root in order to create directories and copy files to PVCs.
-          # distroless.dev/busybox as of April 14 2022
+          # cgr.dev/chainguard/busybox as of April 14 2022
           # image shall not contains tag, so it will be supported on a runtime like cri-o
-          "-shell-image", "distroless.dev/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791",
+          "-shell-image", "cgr.dev/chainguard/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791",
 
           # for script mode to work with windows we need a powershell image
           # pinning to nanoserver tag as of July 15 2021
@@ -123,7 +123,7 @@ spec:
           capabilities:
             drop:
             - all
-          # User 65532 is the distroless nonroot user ID
+          # User 65532 is the nonroot user ID
           runAsUser: 65532
           runAsGroup: 65532
         ports:

--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -98,7 +98,7 @@ spec:
 
       # Combine Distroless with a Windows base image, used for the entrypoint image.
       COMBINED_BASE_IMAGE=$(go run ./vendor/github.com/tektoncd/plumbing/cmd/combine/main.go \
-        distroless.dev/static \
+        cgr.dev/chainguard/static \
         mcr.microsoft.com/windows/nanoserver:ltsc2019 \
         mcr.microsoft.com/windows/nanoserver:ltsc2022 \
         ${CONTAINER_REGISTRY}/$(params.package)/combined-base-image:latest)
@@ -106,7 +106,7 @@ spec:
       # NOTE: Make sure this list of images to use the combined base image is in sync with what's in test/presubmit-tests.sh's 'ko_resolve' function.
       cat <<EOF > ${PROJECT_ROOT}/.ko.yaml
       # This matches the value configured in .ko.yaml
-      defaultBaseImage: distroless.dev/static
+      defaultBaseImage: cgr.dev/chainguard/static
       baseImageOverrides:
         # Use the combined base image for images that should include Windows support.
         $(params.package)/cmd/entrypoint: ${COMBINED_BASE_IMAGE}
@@ -114,7 +114,7 @@ spec:
         $(params.package)/cmd/workingdirinit: ${COMBINED_BASE_IMAGE}
 
         # This matches values configured in .ko.yaml
-        $(params.package)/cmd/git-init: distroless.dev/git
+        $(params.package)/cmd/git-init: cgr.dev/chainguard/git
       EOF
 
       cat ${PROJECT_ROOT}/.ko.yaml

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -61,7 +61,7 @@ function ko_resolve() {
   header "Running `ko resolve`"
 
   cat <<EOF > .ko.yaml
-    defaultBaseImage: distroless.dev/static
+    defaultBaseImage: cgr.dev/chainguard/static
     baseImageOverrides:
       # Use the combined base image for images that should include Windows support.
       # NOTE: Make sure this list of images to use the combined base image is in sync with what's in tekton/publish.yaml's 'create-ko-yaml' Task.
@@ -69,7 +69,7 @@ function ko_resolve() {
       github.com/tektoncd/pipeline/cmd/nop: gcr.io/tekton-releases/github.com/tektoncd/pipeline/combined-base-image:latest
       github.com/tektoncd/pipeline/cmd/workingdirinit: gcr.io/tekton-releases/github.com/tektoncd/pipeline/combined-base-image:latest
 
-      github.com/tektoncd/pipeline/cmd/git-init: distroless.dev/git
+      github.com/tektoncd/pipeline/cmd/git-init: cgr.dev/chainguard/git
 EOF
 
   KO_DOCKER_REPO=example.com ko resolve -l 'app.kubernetes.io/component!=resolvers' --platform=all --push=false -R -f config 1>/dev/null


### PR DESCRIPTION
These images are equivalent, and both redirect to exactly the same backend location, but we're trying to move away from the distroless "brand" in favor of the "Chainguard Images" brand.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Images are based on cgr.dev/chainguard/* instead of the exactly equivalent distroless.dev/* image references.
```

edit: I will never not forget to remove the ` ` in the `release-note` block 🤬 