### PR TITLE
Fix gcloud config syntax for e2e test setup

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -161,7 +161,7 @@ EMAIL=$(gcloud iam service-accounts list | grep $ACCOUNT_NAME | awk '{print $2}'
 gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$EMAIL --role roles/storage.admin
 
 # create the JSON key
-gcloud iam service-accounts keys create config.json --iam-account $EMAIL
+gcloud iam service-accounts keys create config.json --iam-account=$EMAIL
 
 export GCP_SERVICE_ACCOUNT_KEY_PATH="$PWD/config.json"
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

This commit fixes the argument passed in the gcloud key creation command.

Thanks @XinruZhang for spotting this.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:
/kind bug

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
