### PR TITLE
OWNERS: move dlorenc to alumni

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,6 @@ aliases:
   - afrittoli
   - bobcatfish
   - dibyom
-  - dlorenc
   - ImJasonH
   - vdemeester
   - pritidesai
@@ -15,7 +14,6 @@ aliases:
   - afrittoli
   - bobcatfish
   - dibyom
-  - dlorenc
   - ImJasonH
   - vdemeester
   - pritidesai
@@ -38,3 +36,4 @@ aliases:
 # shashwathi
 # aaron-prindle
 # sbwsg
+# dlorenc


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Following the Contributor ladder[1], I am moving dlorenc to alumni because of being inactive for a longer period.

[1]: https://github.com/tektoncd/community/blob/main/process.md#inactivity

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

/cc @dlorenc 
Thank you for everything you did for Tekton 👼🏼 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
