### PR TITLE
Fix taskrun not working with workspace having volumeClaimTemplate

### DIFF
--- a/examples/v1beta1/taskruns/workspace-with-volumeClaimTemplate.yaml
+++ b/examples/v1beta1/taskruns/workspace-with-volumeClaimTemplate.yaml
@@ -1,0 +1,24 @@
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: task-with-workspace-run-
+spec:
+  taskSpec:
+    steps:
+      - name: list-files
+        image: ubuntu
+        script: ls $(workspaces.read-allowed.path)
+    workspaces:
+      - name: read-allowed
+  workspaces:
+    - name: read-allowed
+      volumeClaimTemplate:
+        metadata:
+          name: pvc
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+          volumeMode: Filesystem

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -448,16 +448,6 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 	recorder := controller.GetEventRecorder(ctx)
 	var err error
 
-	// Get the randomized volume names assigned to workspace bindings
-	workspaceVolumes := workspace.CreateVolumes(tr.Spec.Workspaces)
-
-	ts, err := applyParamsContextsResultsAndWorkspaces(ctx, tr, rtr, workspaceVolumes)
-	if err != nil {
-		logger.Errorf("Error updating task spec parameters, contexts, results and workspaces: %s", err)
-		return err
-	}
-	tr.Status.TaskSpec = ts
-
 	// Get the TaskRun's Pod if it should have one. Otherwise, create the Pod.
 	var pod *corev1.Pod
 
@@ -505,6 +495,17 @@ func (c *Reconciler) reconcile(ctx context.Context, tr *v1beta1.TaskRun, rtr *re
 			// This is used by createPod below. Changes to the Spec are not updated.
 			tr.Spec.Workspaces = taskRunWorkspaces
 		}
+
+		// Get the randomized volume names assigned to workspace bindings
+		workspaceVolumes := workspace.CreateVolumes(tr.Spec.Workspaces)
+
+		ts, err := applyParamsContextsResultsAndWorkspaces(ctx, tr, rtr, workspaceVolumes)
+		if err != nil {
+			logger.Errorf("Error updating task spec parameters, contexts, results and workspaces: %s", err)
+			return err
+		}
+		tr.Status.TaskSpec = ts
+
 		pod, err = c.createPod(ctx, ts, tr, rtr, workspaceVolumes)
 		if err != nil {
 			newErr := c.handlePodCreationError(tr, err)


### PR DESCRIPTION
Fix taskrun not working with workspace having volumeClaimTemplate
    
This will move the auto name generation of workspace to happen after
the pvc is created for volumeClaimTemplate and then name will be generated for
workspace of volumeClaimTemplate type
    
Added an example
    
Fix #5537

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix taskrun not working with workspace having volumeClaimTemplate
```
