### PR TITLE
tekton: do not fail on `git status -s`

### DIFF
--- a/tekton/publish.yaml
+++ b/tekton/publish.yaml
@@ -159,10 +159,9 @@ spec:
       # Publish images and create release.yaml
       mkdir -p $OUTPUT_RELEASE_DIR
 
-      if [[ -n $(git status -s) ]]; then
-        echo "The git repository is dirty, bailing out of the release"
-        exit 1
-      fi
+      # Make a local git tag to make git status happy :)
+      # The real "tagging" will happen with the "create-release" pipeline.
+      git tag $(params.versionTag)
 
       ko resolve --platform=$(params.platforms) --preserve-import-paths -t $(params.versionTag) -l 'app.kubernetes.io/component!=resolvers' -R -f ${PROJECT_ROOT}/config/ > $OUTPUT_RELEASE_DIR/release.yaml
       ko resolve --platform=$(params.platforms) --preserve-import-paths -t $(params.versionTag) -f ${PROJECT_ROOT}/config/resolvers > $OUTPUT_RELEASE_DIR/resolvers.yaml


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes
It turns out, `git status -s` fails if the working directory is a "detached" head, which is what happens in our case. This removes that checks as it renders `pipeline` not releasable at all.

It also "locally" tag it to the specified version so that it will appear in the go build metadata.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
/kind misc
/cc @afrittoli @abayer @imjasonh 

Note: I used this to release 0.40.2 already 🙃 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
