### PR TITLE
Propagated Parameters for Finally Tasks

### DIFF
--- a/examples/v1beta1/pipelineruns/alpha/propagating_params_implicit_parameters.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_params_implicit_parameters.yaml
@@ -16,3 +16,12 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.HELLO)"
+    finally:
+      - name: echo-hello-finally
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "And Finally ... $(params.HELLO)"

--- a/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence.yaml
@@ -19,3 +19,15 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.HELLO)"
+    finally:
+      - name: echo-hello-finally
+        params:
+          - name: HELLO
+            value: "Finally Hello World!"
+        taskSpec:
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "And finally.. $(params.HELLO)"

--- a/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence_default_only.yaml
+++ b/examples/v1beta1/pipelineruns/alpha/propagating_params_with_scope_precedence_default_only.yaml
@@ -19,3 +19,15 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 echo "$(params.HELLO)"
+    finally:
+      - name: echo-hello-finally
+        taskSpec:
+          params:
+            - name: HELLO
+              default: "Default Hello World!"
+          steps:
+            - name: echo
+              image: ubuntu
+              script: |
+                #!/usr/bin/env bash
+                echo "And finally... $(params.HELLO)"

--- a/pkg/reconciler/pipelinerun/resources/apply.go
+++ b/pkg/reconciler/pipelinerun/resources/apply.go
@@ -249,6 +249,7 @@ func ApplyReplacements(ctx context.Context, p *v1beta1.PipelineSpec, replacement
 		if p.Finally[i].TaskRef != nil && p.Finally[i].TaskRef.Params != nil {
 			p.Finally[i].TaskRef.Params = replaceParamValues(p.Finally[i].TaskRef.Params, replacements, arrayReplacements, objectReplacements)
 		}
+		p.Finally[i], replacements, arrayReplacements, objectReplacements = propagateParams(ctx, p.Finally[i], replacements, arrayReplacements, objectReplacements)
 	}
 
 	return p


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Propagated parameters was only called for regular pipeline tasks, not finally tasks. This was due to an oversight, and not a design choice. This PR extends the propagated paramsters usage to finally tasks now. It addresses issue https://github.com/tektoncd/pipeline/issues/5588 .

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Propagated Parameters extended to `Finally` tasks.
```
