### PR TITLE
Merge Labels and Annotations instead of override

### DIFF
--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -599,11 +599,24 @@ func (c *Reconciler) updateLabelsAndAnnotations(ctx context.Context, tr *v1beta1
 		// If we want to switch this to Patch, then we will need to teach the utilities in test/controller.go
 		// to deal with Patch (setting resourceVersion, and optimistic concurrency checks).
 		newTr = newTr.DeepCopy()
-		newTr.Labels = tr.Labels
-		newTr.Annotations = tr.Annotations
+		newTr.Labels = merge(newTr.Labels, tr.Labels)
+		newTr.Annotations = merge(newTr.Annotations, tr.Annotations)
 		return c.PipelineClientSet.TektonV1beta1().TaskRuns(tr.Namespace).Update(ctx, newTr, metav1.UpdateOptions{})
 	}
 	return newTr, nil
+}
+
+func merge(new, old map[string]string) map[string]string {
+	if new == nil {
+		new = map[string]string{}
+	}
+	if old == nil {
+		return new
+	}
+	for k, v := range old {
+		new[k] = v
+	}
+	return new
 }
 
 func (c *Reconciler) handlePodCreationError(tr *v1beta1.TaskRun, err error) error {


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When the `PipelineRun` controller updates labels, it does override whatever it fetched using the client. This means, if the labels where updated during the reconciliation, the controller will override them (possibly loosing some information). This can happen on "not so quick" reconciliation loop, for example, when fetching bundles.

This is also true for `TaskRun`, and this fixes it for both.

/kind bug

This affects all version of Tekton since 2020 🙃. Because this is a race, this is *very* hard to actually test 🙃.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The `PipelineRun` and `TaskRun` controller will not override label set by other tools during the reconciler loop, and will merge them instead
```
