### PR TITLE
Fix Hub Resolver doc typo

### DIFF
--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -37,7 +37,7 @@ for the name, namespace and defaults that the resolver ships with.
 By default this resolver will hit the public hub api at https://hub.tekton.dev/
 but you can configure your own (for example to use a private hub
 instance) by setting the `HUB_API` environment variable in
-`../config/resolvers/hubresolver-deployment.yaml`. Example:
+[`../config/resolvers/resolvers-deployment.yaml`](../config/resolvers/resolvers-deployment.yaml). Example:
 
 ```yaml
 env


### PR DESCRIPTION
This commit fixes the Hub API endpoints configuration to `../config/resolvers/resolvers-deployment.yaml`

/kind documentation

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [ ] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [ ] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
