### PR TITLE
Add extra display columns for resource resolution

### DIFF
--- a/config/300-resolutionrequest.yaml
+++ b/config/300-resolutionrequest.yaml
@@ -73,9 +73,21 @@ spec:
           # See issue: https://github.com/knative/serving/issues/912
           x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
+        - name: OwnerKind
+          type: string
+          jsonPath: ".metadata.ownerReferences[0].kind"
+        - name: Owner
+          type: string
+          jsonPath: ".metadata.ownerReferences[0].name"
         - name: Succeeded
           type: string
           jsonPath: ".status.conditions[?(@.type=='Succeeded')].status"
         - name: Reason
           type: string
           jsonPath: ".status.conditions[?(@.type=='Succeeded')].reason"
+        - name: StartTime
+          type: string
+          jsonPath: .metadata.creationTimestamp
+        - name: EndTime
+          type: string
+          jsonPath: .status.conditions[?(@.type=='Succeeded')].lastTransitionTime


### PR DESCRIPTION
# Changes

Add start and end time, as well as details about the owner
resource to to the resource requests. Example:

```shell
 NAME                                   OWNERKIND   OWNER                SUCCEEDED   REASON             STARTTIME              ENDTIME
 git-40e5840171b418bcbd0bfa73defec338   TaskRun     git-resolver-p75s8   True                           2022-10-05T09:16:08Z   2022-10-05T09:16:10Z
 git-6ecf81c8e0b418bcbd0c05c1bc3cd0c5   TaskRun     git-resolver-tmvqd   True                           2022-10-05T09:11:20Z   2022-10-05T09:11:22Z
 git-e97b40047eb418bcbd0be5341ed71802   TaskRun     git-resolver-xdq55   False       ResolutionFailed   2022-10-05T09:19:51Z   2022-10-05T09:19:52Z
```

Signed-off-by: Andrea Frittoli <andrea.frittoli@uk.ibm.com>

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Add more details (start time, end time, owner) in the default view of resource resolutions
```

/kind feature
