### PR TITLE
Minor Fix - There's An Error in The Example of Using Resources in Task

### DIFF
--- a/examples/v1beta1/taskruns/optional-resources.yaml
+++ b/examples/v1beta1/taskruns/optional-resources.yaml
@@ -33,7 +33,7 @@ spec:
         else
           echo "Git repo was not cloned at $(resources.inputs.git-repo.path)"
         fi
-        if [ "$(outputs.resources.optionalimage.url)" == "" ]; then
+        if [ "$(outputs.resources.optionalimage.url)" != "" ]; then
           echo "Image URL: $(outputs.resources.optionalimage.url)"
         else
           echo "No image URL specified."


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This PR fixes a minor error exists in the v1beta1 example: optional-resources.yaml

/kind misc

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] ~Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing~
- [x] ~Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed~
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
