### PR TITLE
Fix kind value type in bundle-resolver docs

### DIFF
--- a/docs/bundle-resolver.md
+++ b/docs/bundle-resolver.md
@@ -51,7 +51,7 @@ spec:
     - name: name
       value: hello-world
     - name: kind
-      value: pipeline
+      value: task
 ```
 
 ### Pipeline Resolution


### PR DESCRIPTION
# Changes

When creating a `TaskRun`, the `taskRef` should use the kind `task`, not `pipeline`.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
