### PR TITLE
Fix v1 PipelineRun CRD conversionReviewVersions and conversion typo

### DIFF
--- a/config/300-pipelinerun.yaml
+++ b/config/300-pipelinerun.yaml
@@ -101,7 +101,7 @@ spec:
   conversion:
     strategy: Webhook
     webhook:
-      conversionReviewVersions: ["v1beta1"]
+      conversionReviewVersions: ["v1beta1", "v1"]
       clientConfig:
         service:
           name: tekton-pipelines-webhook

--- a/pkg/apis/pipeline/v1/pipelinerun_conversion.go
+++ b/pkg/apis/pipeline/v1/pipelinerun_conversion.go
@@ -30,7 +30,7 @@ func (pr *PipelineRun) ConvertTo(ctx context.Context, sink apis.Convertible) err
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", sink)
+	return fmt.Errorf("v1 is the highest known version, got: %T", sink)
 }
 
 // ConvertFrom implements apis.Convertible
@@ -38,5 +38,5 @@ func (pr *PipelineRun) ConvertFrom(ctx context.Context, source apis.Convertible)
 	if apis.IsInDelete(ctx) {
 		return nil
 	}
-	return fmt.Errorf("v1beta1 is the highest known version, got: %T", source)
+	return fmt.Errorf("v1 is the highest known version, got: %T", source)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This change adds the v1 conversionReviewVersion for v1 for pipelineRun CRD
and fixes the typo for pipelineRun conversion.

/kind bug
cc @lbernick 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [n/a] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [n/a] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [n/a] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [n/a] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
