### PR TITLE
Clarify API policy for CustomRuns

### DIFF
--- a/api_compatibility_policy.md
+++ b/api_compatibility_policy.md
@@ -77,6 +77,9 @@ These changes must be approved by at least 2 [OWNERS](OWNERS).
 Backwards incompatible changes change the API, e.g. by removing fields from a CRD
 spec. These changes will mean that folks using a previous version of the API will need
 to adjust their usage in order to use the new version.
+Adding a new field to the CustomRun API that all CustomRun controllers are expected to support
+is also a backwards incompatible change, as CustomRun controllers that were valid before the change
+would be invalid after the change.
 
 These changes must be approved by [more than half of the project OWNERS](OWNERS)
 (i.e. 50% + 1).


### PR DESCRIPTION
# Changes
This commit updates the API compatibility policy to clarify the definition of backwards compatibility in the context of custom runs.

/kind documentation

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
