### PR TITLE
Increase timeout for entrypoint waiter tests

### DIFF
--- a/cmd/entrypoint/waiter_test.go
+++ b/cmd/entrypoint/waiter_test.go
@@ -24,7 +24,7 @@ import (
 	"time"
 )
 
-const testWaitPollingInterval = 10 * time.Millisecond
+const testWaitPollingInterval = 50 * time.Millisecond
 
 func TestRealWaiterWaitMissingFile(t *testing.T) {
 	// Create a temp file and then immediately delete it to get


### PR DESCRIPTION
# Changes
This commit increases the timeout for entrypoint waiter tests to mitigate the frequency of CI flakes. This doesn't fix the underlying problem (which is likely that it takes longer than the timeout to create and write to a tempfile during CI). However, we don't have a way to reproduce this flake right now, and this change is the easiest way to reduce this test's flake rate.

Alternatively, we could rewrite these tests to use filesystem mocks, likely using a library like afero.

/kind flake
Closes #5254
(Doesn't actually fix the underlying problem, but if it happens again this issue can be reopened and it'll be a good signal that this increased timeout doesn't address the problem)

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- n/a Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- n/a Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- n/a Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- n/a Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
