### PR TITLE
Add Beta feature gate for v1 Projected Workspace

### DIFF
--- a/pkg/apis/pipeline/v1/workspace_validation.go
+++ b/pkg/apis/pipeline/v1/workspace_validation.go
@@ -68,9 +68,16 @@ func (b *WorkspaceBinding) Validate(ctx context.Context) (errs *apis.FieldError)
 		return apis.ErrMissingField("secret.secretName")
 	}
 
+	// The projected workspace is only supported when the beta feature gate is enabled.
 	// For a Projected volume to work, you must provide at least one source.
 	if b.Projected != nil && len(b.Projected.Sources) == 0 {
-		return apis.ErrMissingField("projected.sources")
+		errs := version.ValidateEnabledAPIFields(ctx, "projected workspace type", config.BetaAPIFields).ViaField("workspaces")
+		if errs != nil {
+			return errs
+		}
+		if len(b.Projected.Sources) == 0 {
+			return apis.ErrMissingField("projected.sources")
+		}
 	}
 
 	// The csi workspace is only supported when the alpha feature gate is enabled.

--- a/pkg/apis/pipeline/v1/workspace_validation_test.go
+++ b/pkg/apis/pipeline/v1/workspace_validation_test.go
@@ -102,6 +102,7 @@ func TestWorkspaceBindingValidateValid(t *testing.T) {
 				}},
 			},
 		},
+		wc: config.EnableBetaAPIFields,
 	}, {
 		name: "Valid csi",
 		binding: &v1.WorkspaceBinding{
@@ -166,11 +167,18 @@ func TestWorkspaceBindingValidateInvalid(t *testing.T) {
 			Secret: &corev1.SecretVolumeSource{},
 		},
 	}, {
+		name: "projected workspace should be disallowed without beta feature gate",
+		binding: &v1.WorkspaceBinding{
+			Name:      "beth",
+			Projected: &corev1.ProjectedVolumeSource{},
+		},
+	}, {
 		name: "Provide projected without sources",
 		binding: &v1.WorkspaceBinding{
 			Name:      "beth",
 			Projected: &corev1.ProjectedVolumeSource{},
 		},
+		wc: config.EnableBetaAPIFields,
 	}, {
 		name: "csi workspace should be disallowed without alpha feature gate",
 		binding: &v1.WorkspaceBinding{


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
This commit adds the Beta feature gate for projected workspace in v1.

/kind bug

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
