### PR TITLE
migrate PipelineRun to use YAMLParser  Reconciler_TestReconcileTaskResolutionError

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -2178,34 +2178,29 @@ func TestReconcileTaskResolutionError(t *testing.T) {
 	}
 	ptName := "hello-world-1"
 	prName := "test-pipeline-fails-task-resolution"
-	prs := []*v1beta1.PipelineRun{{
-		ObjectMeta: baseObjectMeta(prName, "foo"),
-		Spec: v1beta1.PipelineRunSpec{
-			PipelineRef: &v1beta1.PipelineRef{Name: "test-pipeline"},
-			Status:      v1beta1.PipelineRunSpecStatusCancelledRunFinally,
-		},
-		Status: v1beta1.PipelineRunStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{
-					apis.Condition{
-						Type:    apis.ConditionSucceeded,
-						Status:  corev1.ConditionUnknown,
-						Reason:  v1beta1.PipelineRunReasonRunning.String(),
-						Message: "running...",
-					},
-				},
-			},
-			PipelineRunStatusFields: v1beta1.PipelineRunStatusFields{
-				TaskRuns: map[string]*v1beta1.PipelineRunTaskRunStatus{
-					prName + ptName: {
-						PipelineTaskName: ptName,
-						Status:           &v1beta1.TaskRunStatus{},
-					},
-				},
-				StartTime: &metav1.Time{Time: now},
-			},
-		},
-	}}
+	prs := []*v1beta1.PipelineRun{
+		parse.MustParsePipelineRun(t, fmt.Sprintf(`
+metadata:
+  name: %s
+  namespace: foo
+spec:
+  pipelineRef:
+    name: test-pipeline
+  status: %s
+status:
+  conditions:
+  - type: Succeeded
+    status: Unknown
+    reason: Running
+    message: "running..."
+  taskRuns:
+    %s%s:
+      pipelineTaskName: %s
+      status: {}
+      startTime: %s
+`, prName, v1beta1.PipelineRunSpecStatusCancelledRunFinally, ptName, prName, ptName, now.Format(time.RFC3339))),
+	}
+
 	trs := []*v1beta1.TaskRun{
 		getTaskRun(
 			t,


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->
Migrate PipelineRun to use YAMLParser  for Reconciler_TestReconcileTaskResolutionError

part of issue: https://github.com/tektoncd/pipeline/issues/4610

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

``` release-note
NONE
```
