### PR TITLE
[TEP-0089] Apis to handle SPIRE signing and verification.

### DIFF
--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -62,6 +62,8 @@ const (
 	DefaultSendCloudEventsForRuns = false
 	// DefaultEmbeddedStatus is the default value for "embedded-status".
 	DefaultEmbeddedStatus = FullEmbeddedStatus
+	// DefaultEnableSpire is the default value for "enable-spire".
+	DefaultEnableSpire = false
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -73,6 +75,7 @@ const (
 	enableAPIFields                     = "enable-api-fields"
 	sendCloudEventsForRuns              = "send-cloudevents-for-runs"
 	embeddedStatus                      = "embedded-status"
+	enableSpire                         = "enable-spire"
 )
 
 // FeatureFlags holds the features configurations
@@ -89,6 +92,7 @@ type FeatureFlags struct {
 	SendCloudEventsForRuns           bool
 	AwaitSidecarReadiness            bool
 	EmbeddedStatus                   string
+	EnableSpire                      bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -150,11 +154,15 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 	if tc.EnableAPIFields == AlphaAPIFields {
 		tc.EnableTektonOCIBundles = true
 		tc.EnableCustomTasks = true
+		tc.EnableSpire = true
 	} else {
 		if err := setFeature(enableTektonOCIBundles, DefaultEnableTektonOciBundles, &tc.EnableTektonOCIBundles); err != nil {
 			return nil, err
 		}
 		if err := setFeature(enableCustomTasks, DefaultEnableCustomTasks, &tc.EnableCustomTasks); err != nil {
+			return nil, err
+		}
+		if err := setFeature(enableSpire, DefaultEnableSpire, &tc.EnableSpire); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -59,6 +59,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EnableAPIFields:                  "alpha",
 				SendCloudEventsForRuns:           true,
 				EmbeddedStatus:                   "both",
+				EnableSpire:                      true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -69,6 +70,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				// if the submitted text value is "false".
 				EnableTektonOCIBundles: true,
 				EnableCustomTasks:      true,
+				EnableSpire:            true,
 
 				DisableAffinityAssistant:         config.DefaultDisableAffinityAssistant,
 				DisableCredsInit:                 config.DefaultDisableCredsInit,
@@ -112,6 +114,17 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 			},
 			fileName: "feature-flags-beta-api-fields",
 		},
+		{
+			expectedConfig: &config.FeatureFlags{
+				EnableAPIFields: "stable",
+				EmbeddedStatus:  "full",
+				EnableSpire:     true,
+
+				RunningInEnvWithInjectedSidecars: config.DefaultRunningInEnvWithInjectedSidecars,
+				AwaitSidecarReadiness:            config.DefaultAwaitSidecarReadiness,
+			},
+			fileName: "feature-flags-enable-spire",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -136,6 +149,7 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		EnableAPIFields:                  config.DefaultEnableAPIFields,
 		SendCloudEventsForRuns:           config.DefaultSendCloudEventsForRuns,
 		EmbeddedStatus:                   config.DefaultEmbeddedStatus,
+		EnableSpire:                      config.DefaultEnableSpire,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -27,3 +27,4 @@ data:
   enable-api-fields: "alpha"
   send-cloudevents-for-runs: "true"
   embedded-status: "both"
+  enable-spire: "true"

--- a/pkg/apis/config/testdata/feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks.yaml
+++ b/pkg/apis/config/testdata/feature-flags-enable-api-fields-overrides-bundles-and-custom-tasks.yaml
@@ -6,4 +6,5 @@ metadata:
 data:
   enable-tekton-oci-bundles: "false"
   enable-custom-tasks: "false"
+  enable-spire: "false"
   enable-api-fields: "alpha"

--- a/pkg/apis/config/testdata/feature-flags-enable-spire.yaml
+++ b/pkg/apis/config/testdata/feature-flags-enable-spire.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: feature-flags
+  namespace: tekton-pipelines
+data:
+  enable-spire: "true"

--- a/pkg/apis/pipeline/v1beta1/taskrun_types.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types.go
@@ -139,6 +139,19 @@ type TaskRunStatus struct {
 	TaskRunStatusFields `json:",inline"`
 }
 
+// TaskRunConditionType is an enum used to store TaskRun custom conditions
+// conditions such as one used in spire results verification
+type TaskRunConditionType string
+
+const (
+	// TaskRunConditionResultsVerified is a Condition Type that indicates that the results were verified by spire
+	TaskRunConditionResultsVerified TaskRunConditionType = "SignedResultsVerified"
+)
+
+func (t TaskRunConditionType) String() string {
+	return string(t)
+}
+
 // TaskRunReason is an enum used to store all TaskRun reason for
 // the Succeeded condition that are controlled by the TaskRun itself. Failure
 // reasons that emerge from underlying resources are not included here
@@ -162,6 +175,12 @@ const (
 	TaskRunReasonResolvingTaskRef = "ResolvingTaskRef"
 	// TaskRunReasonImagePullFailed is the reason set when the step of a task fails due to image not being pulled
 	TaskRunReasonImagePullFailed TaskRunReason = "TaskRunImagePullFailed"
+	// TaskRunReasonResultsVerified is the reason set when the TaskRun results are verified by spire
+	TaskRunReasonResultsVerified TaskRunReason = "TaskRunResultsVerified"
+	// TaskRunReasonsResultsVerificationFailed is the reason set when the TaskRun results are failed to verify by spire
+	TaskRunReasonsResultsVerificationFailed TaskRunReason = "TaskRunResultsVerificationFailed"
+	// AwaitingTaskRunResults is the reason set when waiting upon `TaskRun` results and signatures to verify
+	AwaitingTaskRunResults TaskRunReason = "AwaitingTaskRunResults"
 )
 
 func (t TaskRunReason) String() string {
@@ -437,6 +456,16 @@ func (tr *TaskRun) IsSuccessful() bool {
 // IsCancelled returns true if the TaskRun's spec status is set to Cancelled state
 func (tr *TaskRun) IsCancelled() bool {
 	return tr.Spec.Status == TaskRunSpecStatusCancelled
+}
+
+// IsTaskRunResultVerified returns true if the TaskRun's results have been validated by spire.
+func (tr *TaskRun) IsTaskRunResultVerified() bool {
+	return tr.Status.GetCondition(apis.ConditionType(TaskRunConditionResultsVerified.String())).IsTrue()
+}
+
+// IsTaskRunResultDone returns true if the TaskRun's results are available for verification
+func (tr *TaskRun) IsTaskRunResultDone() bool {
+	return !tr.Status.GetCondition(apis.ConditionType(TaskRunConditionResultsVerified.String())).IsUnknown()
 }
 
 // HasTimedOut returns true if the TaskRun runtime is beyond the allowed timeout

--- a/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
+++ b/pkg/apis/pipeline/v1beta1/taskrun_types_test.go
@@ -151,6 +151,70 @@ func TestTaskRunIsCancelledWithMessage(t *testing.T) {
 	}
 }
 
+func TestTaskRunIsTaskRunResultVerified(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String()),
+					Status:  corev1.ConditionTrue,
+					Reason:  v1beta1.TaskRunReasonResultsVerified.String(),
+					Message: "Successfully verified all spire signed taskrun results",
+				}},
+			},
+		},
+	}
+	if !tr.IsTaskRunResultVerified() {
+		t.Fatal("Expected pipelinerun status to be results verified")
+	}
+	if tr.Status.GetCondition(apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String())).Reason != v1beta1.TaskRunReasonResultsVerified.String() {
+		t.Fatal("Expected pipelinerun status reason to be TaskRunResultsVerified")
+	}
+}
+
+func TestTaskRunEmptyIsTaskRunResultVerified(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{},
+		},
+	}
+	if tr.IsTaskRunResultVerified() {
+		t.Fatal("Expected false as no condition exists for SignedResultsVerified")
+	}
+}
+
+func TestTaskRunIsTaskRunResultDone(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{
+				Conditions: []apis.Condition{{
+					Type:    apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String()),
+					Status:  corev1.ConditionUnknown,
+					Reason:  v1beta1.AwaitingTaskRunResults.String(),
+					Message: "Waiting upon TaskRun results and signatures to verify",
+				}},
+			},
+		},
+	}
+	if tr.IsTaskRunResultDone() {
+		t.Fatal("Expected pipelinerun status to be unknown and waiting")
+	}
+	if tr.Status.GetCondition(apis.ConditionType(v1beta1.TaskRunConditionResultsVerified.String())).Reason != v1beta1.AwaitingTaskRunResults.String() {
+		t.Fatal("Expected pipelinerun status reason to be AwaitingTaskRunResults")
+	}
+}
+
+func TestTaskRunEmptyIsTaskRunResultDone(t *testing.T) {
+	tr := &v1beta1.TaskRun{
+		Status: v1beta1.TaskRunStatus{
+			Status: duckv1beta1.Status{},
+		},
+	}
+	if tr.IsTaskRunResultDone() {
+		t.Fatal("Expected false as no condition exists for SignedResultsVerified")
+	}
+}
+
 func TestTaskRunHasVolumeClaimTemplate(t *testing.T) {
 	tr := &v1beta1.TaskRun{
 		Spec: v1beta1.TaskRunSpec{


### PR DESCRIPTION
# Changes

Breaking down PR #4759 originally proposed by @pxp928 to address TEP-0089
according @lumjjb suggestions.
Plan for breaking down PR is
PR 1.1: api
PR 1.2: entrypointer (+cmd line + test/entrypointer)
Entrypoint takes results and signs the results (termination message).
PR 1.3: reconciler + pod + cmd/controller + integration tests
Controller will verify the signed result.

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [X] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [X] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [X] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [X] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
