### PR TITLE
Ensure resource defaulting is always done regardless of ref type.

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec.go
@@ -43,7 +43,6 @@ func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getP
 		}
 		pipelineMeta = t.PipelineMetadata()
 		pipelineSpec = t.PipelineSpec()
-		pipelineSpec.SetDefaults(ctx)
 	case pipelineRun.Spec.PipelineSpec != nil:
 		pipelineMeta = pipelineRun.ObjectMeta
 		pipelineSpec = *pipelineRun.Spec.PipelineSpec
@@ -61,5 +60,7 @@ func GetPipelineData(ctx context.Context, pipelineRun *v1beta1.PipelineRun, getP
 	default:
 		return nil, nil, fmt.Errorf("pipelineRun %s not providing PipelineRef or PipelineSpec", pipelineRun.Name)
 	}
+
+	pipelineSpec.SetDefaults(ctx)
 	return &pipelineMeta, &pipelineSpec, nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinespec/pipelinespec_test.go
@@ -143,6 +143,7 @@ func TestGetPipelineData_ResolutionSuccess(t *testing.T) {
 		Tasks: []v1beta1.PipelineTask{{
 			Name: "pt1",
 			TaskRef: &v1beta1.TaskRef{
+				Kind: "Task",
 				Name: "tref",
 			},
 		}},

--- a/pkg/reconciler/taskrun/resources/taskspec.go
+++ b/pkg/reconciler/taskrun/resources/taskspec.go
@@ -49,7 +49,6 @@ func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask)
 		}
 		taskMeta = t.TaskMetadata()
 		taskSpec = t.TaskSpec()
-		taskSpec.SetDefaults(ctx)
 	case taskRun.Spec.TaskSpec != nil:
 		taskMeta = taskRun.ObjectMeta
 		taskSpec = *taskRun.Spec.TaskSpec
@@ -67,5 +66,7 @@ func GetTaskData(ctx context.Context, taskRun *v1beta1.TaskRun, getTask GetTask)
 	default:
 		return nil, nil, fmt.Errorf("taskRun %s not providing TaskRef or TaskSpec", taskRun.Name)
 	}
+
+	taskSpec.SetDefaults(ctx)
 	return &taskMeta, &taskSpec, nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

Previously we were only setting defaults for k8s API based resources. This change ensures defaulting is done after we've extracted the spec, making it agnostic to the resolver type.

This isn't a change in behavior, this just ensures that we're applying defaults consistently.

/kind cleanup

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
