### PR TITLE
More places to use kmap.Union to merge maps

### DIFF
--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -1258,30 +1258,12 @@ func storePipelineSpecAndMergeMeta(pr *v1beta1.PipelineRun, ps *v1beta1.Pipeline
 	if pr.Status.PipelineSpec == nil {
 		pr.Status.PipelineSpec = ps
 
-		// Propagate labels from Pipeline to PipelineRun.
-		if pr.ObjectMeta.Labels == nil {
-			pr.ObjectMeta.Labels = make(map[string]string, len(meta.Labels)+1)
-		}
-		for key, value := range meta.Labels {
-			// Do not override duplicates between PipelineRun and Pipeline
-			// PipelineRun labels take precedences over Pipeline
-			if _, ok := pr.ObjectMeta.Labels[key]; !ok {
-				pr.ObjectMeta.Labels[key] = value
-			}
-		}
+		// Propagate labels from Pipeline to PipelineRun. PipelineRun labels take precedences over Pipeline.
+		pr.ObjectMeta.Labels = kmap.Union(meta.Labels, pr.ObjectMeta.Labels)
 		pr.ObjectMeta.Labels[pipeline.PipelineLabelKey] = meta.Name
 
-		// Propagate annotations from Pipeline to PipelineRun.
-		if pr.ObjectMeta.Annotations == nil {
-			pr.ObjectMeta.Annotations = make(map[string]string, len(meta.Annotations))
-		}
-		for key, value := range meta.Annotations {
-			// Do not override duplicates between PipelineRun and Pipeline
-			// PipelineRun labels take precedences over Pipeline
-			if _, ok := pr.ObjectMeta.Annotations[key]; !ok {
-				pr.ObjectMeta.Annotations[key] = value
-			}
-		}
+		// Propagate annotations from Pipeline to PipelineRun. PipelineRun annotations take precedences over Pipeline.
+		pr.ObjectMeta.Annotations = kmap.Union(meta.Annotations, pr.ObjectMeta.Annotations)
 
 	}
 	return nil

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -913,28 +913,10 @@ func storeTaskSpecAndMergeMeta(tr *v1beta1.TaskRun, ts *v1beta1.TaskSpec, meta *
 	// Only store the TaskSpec once, if it has never been set before.
 	if tr.Status.TaskSpec == nil {
 		tr.Status.TaskSpec = ts
-		// Propagate annotations from Task to TaskRun.
-		if tr.ObjectMeta.Annotations == nil {
-			tr.ObjectMeta.Annotations = make(map[string]string, len(meta.Annotations))
-		}
-		for key, value := range meta.Annotations {
-			// Do not override duplicates between TaskRun and Task
-			// TaskRun labels take precedences over Task
-			if _, ok := tr.ObjectMeta.Annotations[key]; !ok {
-				tr.ObjectMeta.Annotations[key] = value
-			}
-		}
-		// Propagate labels from Task to TaskRun.
-		if tr.ObjectMeta.Labels == nil {
-			tr.ObjectMeta.Labels = make(map[string]string, len(meta.Labels)+1)
-		}
-		for key, value := range meta.Labels {
-			// Do not override duplicates between TaskRun and Task
-			// TaskRun labels take precedences over Task
-			if _, ok := tr.ObjectMeta.Labels[key]; !ok {
-				tr.ObjectMeta.Labels[key] = value
-			}
-		}
+		// Propagate annotations from Task to TaskRun. TaskRun annotations take precedences over Task.
+		tr.ObjectMeta.Annotations = kmap.Union(meta.Annotations, tr.ObjectMeta.Annotations)
+		// Propagate labels from Task to TaskRun. TaskRun labels take precedences over Task.
+		tr.ObjectMeta.Labels = kmap.Union(meta.Labels, tr.ObjectMeta.Labels)
 		if tr.Spec.TaskRef != nil {
 			if tr.Spec.TaskRef.Kind == "ClusterTask" {
 				tr.ObjectMeta.Labels[pipeline.ClusterTaskLabelKey] = meta.Name


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind cleanup 

Add on to https://github.com/tektoncd/pipeline/pull/5660.

Previously, we use too much self-invented code to merge two maps. 

Now we use the existing [kmap.Union](https://pkg.go.dev/knative.dev/pkg@v0.0.0-20221014164553-b812affa3893/kmap#Union) to merge maps.

Signed-off-by: Chuang Wang <chuangw@google.com>

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [ ] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [ ] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
NONE
```
