### PR TITLE
[TEP-0115] Support Artifact Hub in Hub Resolver

### DIFF
--- a/config/resolvers/hubresolver-config.yaml
+++ b/config/resolvers/hubresolver-config.yaml
@@ -22,7 +22,13 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 data:
-  # the default catalog from where to pull the resource.
-  default-catalog: "Tekton"
-  # The default layer kind in the hub image.
+  # the default Tekton Hub catalog from where to pull the resource.
+  default-tekton-hub-catalog: "Tekton"
+  # the default Artifact Hub Task catalog from where to pull the resource.
+  default-artifact-hub-task-catalog: "tekton-catalog-tasks"
+  # the default Artifact Hub Pipeline catalog from where to pull the resource.
+  default-artifact-hub-pipeline-catalog: "tekton-catalog-pipelines"
+  # the default layer kind in the hub image.
   default-kind: "task"
+  # the default hub source to pull the resource from.
+  default-type: "artifact"

--- a/config/resolvers/resolvers-deployment.yaml
+++ b/config/resolvers/resolvers-deployment.yaml
@@ -93,8 +93,8 @@ spec:
         - name: METRICS_DOMAIN
           value: tekton.dev/resolution
         # Override this env var to set a private hub api endpoint
-        - name: HUB_API
-          value: "https://api.hub.tekton.dev/"
+        - name: ARTIFACT_HUB_API
+          value: "https://artifacthub.io/"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/docs/hub-resolver.md
+++ b/docs/hub-resolver.md
@@ -6,10 +6,13 @@ Use resolver type `hub`.
 
 | Param Name       | Description                                                                   | Example Value                                              |
 |------------------|-------------------------------------------------------------------------------|------------------------------------------------------------|
-| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `Tekton`                                         |
-| `kind`           | Either `task` or `pipeline`                                                   | `task`                                                     |
+| `catalog`        | The catalog from where to pull the resource (Optional)                        | Default:  `tekton-catalog-tasks` (for `task` kind);  `tekton-catalog-pipelines` (for `pipeline` kind)                                        |
+| `type`           | The type of Hub from where to pull the resource (Optional). Either `artifact` or `tekton` | Default:  `artifact`                                         |
+| `kind`           | Either `task` or `pipeline` (Optional)                                        | Default: `task`                                                     |
 | `name`           | The name of the task or pipeline to fetch from the hub                        | `golang-build`                                             |
-| `version`        | Version of task or pipeline to pull in from hub. Wrap the number in quotes!   | `"0.5"`                                                    |
+| `version`        | Version of task or pipeline to pull in from hub. Wrap the number in quotes!   | `"0.5.0"`                                                    |
+
+The Catalogs in the Artifact Hub follows the semVer (i.e.` <major-version>.<minor-version>.0`) and the Catalogs in the Tekton Hub follows the simplified semVer (i.e. `<major-version>.<minor-version>`). Both full and simplified semantic versioning will be accepted by the `version` parameter. The Hub Resolver will map the version to the format expected by the target Hub `type`.
 
 ## Requirements
 
@@ -26,24 +29,43 @@ for the name, namespace and defaults that the resolver ships with.
 
 ### Options
 
-| Option Name       | Description                                          | Example Values     |
-|-------------------|------------------------------------------------------|--------------------|
-| `default-catalog` | The default catalog from where to pull the resource. | `tekton`           |
-| `default-kind`    | The default object kind for references.              | `task`, `pipeline` |
+| Option Name                 | Description                                          | Example Values         |
+|-----------------------------|------------------------------------------------------|------------------------|
+| `default-tekton-hub-catalog`| The default tekton hub catalog from where to pull the resource.| `Tekton`               |
+| `default-artifact-hub-task-catalog`| The default artifact hub catalog from where to pull the resource for task kind.| `tekton-catalog-tasks`               |
+| `default-artifact-hub-pipeline-catalog`| The default artifact hub catalog from where to pull the resource for pipeline kind.  | `tekton-catalog-pipelines`               |
+| `default-kind`              | The default object kind for references.              | `task`, `pipeline`     |
+| `default-type`              | The default hub from where to pull the resource.     | `artifact`, `tekton`   |
 
 
 ### Configuring the Hub API endpoint
 
-By default this resolver will hit the public hub api at https://hub.tekton.dev/
+The Hub Resolver supports to resolve resources from the [Artifact Hub](https://artifacthub.io/) and the [Tekton Hub](https://hub.tekton.dev/),
+which can be configured by setting the `type` field of the resolver. 
+
+*(Please note that the [Tekton Hub](https://hub.tekton.dev/) will be deprecated after [migration to the Artifact Hub](https://github.com/tektoncd/hub/issues/667) is done.)*
+
+When setting the `type` field to `artifact`, the resolver will hit the public hub api at https://artifacthub.io/ by default
 but you can configure your own (for example to use a private hub
-instance) by setting the `HUB_API` environment variable in
+instance) by setting the `ARTIFACT_HUB_API` environment variable in
 [`../config/resolvers/resolvers-deployment.yaml`](../config/resolvers/resolvers-deployment.yaml). Example:
 
 ```yaml
 env
-- name: HUB_API
-  value: "https://api.hub.tekton.dev/"
+- name: ARTIFACT_HUB_API
+  value: "https://artifacthub.io/"
 ```
+
+When setting the `type` field to `tekton`, you **must** configure your own instance of the Tekton Hub by setting the `TEKTON_HUB_API` environment variable in
+[`../config/resolvers/resolvers-deployment.yaml`](../config/resolvers/resolvers-deployment.yaml). Example:
+
+```yaml
+env
+- name: TEKTON_HUB_API
+  value: "https://api.private.hub.instance.dev"
+```
+
+The Tekton Hub deployment guide can be found [here](https://github.com/tektoncd/hub/blob/main/docs/DEPLOYMENT.md).
 
 ## Usage
 
@@ -59,7 +81,9 @@ spec:
     resolver: hub
     params:
     - name: catalog # optional
-      value: Tekton
+      value: tekton-catalog-tasks
+    - name: type # optional
+      value: artifact 
     - name: kind
       value: task
     - name: name
@@ -80,7 +104,9 @@ spec:
     resolver: hub
     params:
     - name: catalog # optional
-      value: Tekton 
+      value: tekton-catalog-pipelines 
+    - name: type # optional
+      value: artifact
     - name: kind
       value: pipeline
     - name: name

--- a/examples/v1beta1/taskruns/hub-resolver.yaml
+++ b/examples/v1beta1/taskruns/hub-resolver.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: TaskRun
 metadata:
-  generateName: hub-resolver
+  generateName: hub-resolver-simple-semver-
 spec:
   workspaces:
     - name: output
@@ -17,11 +17,35 @@ spec:
   taskRef:
     resolver: hub
     params:
-      - name: catalog # optional
-        value: Tekton
-      - name: kind
+      - name: type  #optional
+        value: artifact
+      - name: kind  #optional
         value: task
       - name: name
         value: git-clone
       - name: version
         value: "0.6"
+---
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  generateName: hub-resolver-semver-required-fields-only-
+spec:
+  workspaces:
+    - name: output
+      emptyDir: {}
+  podTemplate:
+    securityContext:
+      fsGroup: 65532
+  params:
+    - name: url
+      value: https://github.com/tektoncd/pipeline.git
+    - name: revision
+      value: main
+  taskRef:
+    resolver: hub
+    params:
+      - name: name
+        value: git-clone
+      - name: version
+        value: "0.6.0"

--- a/pkg/resolution/resolver/hub/config.go
+++ b/pkg/resolution/resolver/hub/config.go
@@ -16,10 +16,22 @@ limitations under the License.
 
 package hub
 
-// ConfigCatalog is the configuration field name for controlling
-// the catalog to fetch the remote resource from.
-const ConfigCatalog = "default-catalog"
+// ConfigTektonHubCatalog is the configuration field name for controlling
+// the Tekton Hub catalog to fetch the remote resource from.
+const ConfigTektonHubCatalog = "default-tekton-hub-catalog"
+
+// ConfigArtifactHubTaskCatalog is the configuration field name for controlling
+// the Artifact Hub Task catalog to fetch the remote resource from.
+const ConfigArtifactHubTaskCatalog = "default-artifact-hub-task-catalog"
+
+// ConfigArtifactHubPipelineCatalog is the configuration field name for controlling
+// the Artifact Hub Pipeline catalog to fetch the remote resource from.
+const ConfigArtifactHubPipelineCatalog = "default-artifact-hub-pipeline-catalog"
 
 // ConfigKind is the configuration field name for controlling
 // what the layer name in the hub image is.
 const ConfigKind = "default-kind"
+
+// ConfigType is the configuration field name for controlling
+// the hub type to pull the resource from.
+const ConfigType = "default-type"

--- a/pkg/resolution/resolver/hub/params.go
+++ b/pkg/resolution/resolver/hub/params.go
@@ -13,11 +13,14 @@ limitations under the License.
 
 package hub
 
-// DefaultHubURL is de default url for the Tekton hub api
-const DefaultHubURL = "https://api.hub.tekton.dev/v1/resource/%s/%s/%s/%s/yaml"
+// DefaultArtifactHubURL is the default url for the Artifact hub api
+const DefaultArtifactHubURL = "https://artifacthub.io/api/v1/packages/tekton-%s/%s/%s/%s"
 
-// YamlEndpoint is the suffix for a private custom hub instance
-const YamlEndpoint = "v1/resource/%s/%s/%s/%s/yaml"
+// TektonHubYamlEndpoint is the suffix for a private custom Tekton hub instance
+const TektonHubYamlEndpoint = "v1/resource/%s/%s/%s/%s/yaml"
+
+// ArtifactHubYamlEndpoint is the suffix for a private custom Artifact hub instance
+const ArtifactHubYamlEndpoint = "api/v1/packages/tekton-%s/%s/%s/%s"
 
 // ParamName is the parameter defining what the layer name in the bundle
 // image is.
@@ -34,3 +37,6 @@ const ParamVersion = "version"
 // ParamCatalog is the parameter defining what the catalog in the bundle
 // image is.
 const ParamCatalog = "catalog"
+
+// ParamType is the parameter defining what the hub type to pull the resource from.
+const ParamType = "type"

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -190,7 +190,7 @@ spec:
 	if err := WaitForPipelineRunState(ctx, c, prName, timeout,
 		Chain(
 			FailedWithReason(pod.ReasonCouldntGetTask, prName),
-			FailedWithMessage("requested resource 'https://api.hub.tekton.dev/v1/resource/Tekton/task/git-clone-this-does-not-exist/0.7/yaml' not found on hub", prName),
+			FailedWithMessage("requested resource 'https://artifacthub.io/api/v1/packages/tekton-task/tekton-catalog-tasks/git-clone-this-does-not-exist/0.7.0' not found on hub", prName),
 		), "PipelineRunFailed"); err != nil {
 		t.Fatalf("Error waiting for PipelineRun to finish with expected error: %s", err)
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Part of [issues/667].
This commit adds support to resolve catalog from the [Artifact Hub] and keep current functionality of fetching catalog from the Tekton Hub.

- Change 1:

The commit adds a new field `type` to the hub resolver indicating the type of the Hub to pull the resource from. The value can be set to `tekton` or `artifact`. By default, the resolver fetches resources from `https://artifacthub.io/` when setting `type` to  `artifact`. 

- Change 2:

Prior to this change, the hub resolver only supports pulling resources from the Tekton Hub. This commit updates the default hub type to `artifact` since the [Artifact Hub][Artifact Hub] will be the main entrypoint for Tekton Catalogs in the future.

- Change 3:

Prior to this change, the default Tekton Hub URL is: `https://api.hub.tekton.dev`. This commit removes the default value of the Tekton Hub URL and enforces users to configure their own instance of Tekton Hub since the public instance `https://api.hub.tekton.dev` will be deprecated after the migration to Artifact Hub is done.

/kind feature

[Artifact Hub]: https://artifacthub.io/
[issues/667]: https://github.com/tektoncd/hub/issues/667

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
The Hub Resolver will have a new `type` field to indicate the type of Hub from where to pull the resource. The default hub type is updated from the Tekton Hub to the Artifact Hub. Please see more details in TEP-0115
```