### PR TITLE
Feature flag for provenance field in status

### DIFF
--- a/config/config-feature-flags.yaml
+++ b/config/config-feature-flags.yaml
@@ -85,3 +85,8 @@ data:
   # will fail the taskrun/pipelinerun. "warn" will only log the err message and "skip"
   # will skip the whole verification
   resource-verification-mode: "skip"
+  # Setting this flag to "true" enables populating the "provenance" field in TaskRun
+  # and PipelineRun status. This field contains metadata about resources used
+  # in the TaskRun/PipelineRun such as the source from where a remote Task/Pipeline
+  # definition was fetched.
+  enable-provenance-in-status: "false"

--- a/docs/install.md
+++ b/docs/install.md
@@ -422,6 +422,11 @@ features](#alpha-features) to be used.
 
 - `resource-verification-mode`: Setting this flag to "enforce" will enforce verification of tasks/pipeline. Failing to verify will fail the taskrun/pipelinerun. "warn" will only log the err message and "skip" will skip the whole verification.
 
+- `enable-provenance-in-status`: set this flag to "true" to enable recording 
+  the `provenance` field in `TaskRun` and `PipelineRun` status. The `provenance` 
+  field contains metadata about resources used in the TaskRun/PipelineRun such as the 
+  source from where a remote Task/Pipeline definition was fetched.
+
 For example:
 
 ```yaml
@@ -435,15 +440,16 @@ data:
 
 ### Alpha Features
 
-Alpha features are still in development and their syntax is subject to change.
-To enable these, set the `enable-api-fields` feature flag to `"alpha"` in
-the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via
-`kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"alpha"}}'`.
-Setting `enable-api-fields` to "alpha" also enables [beta features](#beta-features).
+Alpha features in the following table are still in development and their syntax is subject to change.
+- To enable the features ***without*** an individual flag:
+  set the `enable-api-fields` feature flag to `"alpha"` in the `feature-flags` ConfigMap alongside your Tekton Pipelines deployment via `kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"enable-api-fields":"alpha"}}'`.
+- To enable the features ***with*** an individual flag:
+  set the individual flag accordingly in the `feature-flag` ConfigMap alongside your Tekton Pipelines deployment. Example: `kubectl patch cm feature-flags -n tekton-pipelines -p '{"data":{"<FLAG-NAME>":"<FLAG-VALUE>"}}'`.
+
 
 Features currently in "alpha" are:
 
-| Feature                                                                                               | TEP                                                                                                                        | Release                                                              | Individual Flag             |
+| Feature                                                                                               | Proposal                                                                                                                        | Release                                                              | Individual Flag             |
 |:------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|:----------------------------|
 | [Bundles ](./pipelineruns.md#tekton-bundles)                                                          | [TEP-0005](https://github.com/tektoncd/community/blob/main/teps/0005-tekton-oci-bundles.md)                                | [v0.18.0](https://github.com/tektoncd/pipeline/releases/tag/v0.18.0) | `enable-tekton-oci-bundles` |
 | [`Runs` and `Custom Tasks`](./runs.md)                                                                | [TEP-0002](https://github.com/tektoncd/community/blob/main/teps/0002-custom-tasks.md)                                      | [v0.19.0](https://github.com/tektoncd/pipeline/releases/tag/v0.19.0) | `enable-custom-tasks`       |
@@ -455,11 +461,12 @@ Features currently in "alpha" are:
 | [Debug](./debug.md)                                                                                   | [TEP-0042](https://github.com/tektoncd/community/blob/main/teps/0042-taskrun-breakpoint-on-failure.md)                     | [v0.26.0](https://github.com/tektoncd/pipeline/releases/tag/v0.26.0) |                             |
 | [Step and Sidecar Overrides](./taskruns.md#overriding-task-steps-and-sidecars)                        | [TEP-0094](https://github.com/tektoncd/community/blob/main/teps/0094-specifying-resource-requirements-at-runtime.md)       |   [v0.34.0](https://github.com/tektoncd/pipeline/releases/tag/v0.34.0)                                                                   |                             |
 | [Matrix](./matrix.md)                                                                                 | [TEP-0090](https://github.com/tektoncd/community/blob/main/teps/0090-matrix.md)                                            | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
-| [Embedded Statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses)           | [TEP-0100](https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) |   [v0.35.0](https://github.com/tektoncd/pipeline/releases/tag/v0.35.0)     |     embedded-status                 |
+| [Embedded Statuses](pipelineruns.md#configuring-usage-of-taskrun-and-run-embedded-statuses)           | [TEP-0100](https://github.com/tektoncd/community/blob/main/teps/0100-embedded-taskruns-and-runs-status-in-pipelineruns.md) |   [v0.35.0](https://github.com/tektoncd/pipeline/releases/tag/v0.35.0)     |     `embedded-status`                 |
 | [Task-level Resource Requirements](compute-resources.md#task-level-compute-resources-configuration)   | [TEP-0104](https://github.com/tektoncd/community/blob/main/teps/0104-tasklevel-resource-requirements.md)                   | [v0.39.0](https://github.com/tektoncd/pipeline/releases/tag/v0.39.0)  |                             |
 | [Object Params and Results](pipelineruns.md#specifying-parameters)                                    | [TEP-0075](https://github.com/tektoncd/community/blob/main/teps/0075-object-param-and-result-types.md)                     | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
 | [Array Results](pipelineruns.md#specifying-parameters)                                                | [TEP-0076](https://github.com/tektoncd/community/blob/main/teps/0076-array-result-types.md)                                | [v0.38.0](https://github.com/tektoncd/pipeline/releases/tag/v0.38.0) |                             |
-| [Trusted Resources](./trusted-resources.md)                                                | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                | N/A |     resource-verification-mode                        |
+| [Trusted Resources](./trusted-resources.md)                                                | [TEP-0091](https://github.com/tektoncd/community/blob/main/teps/0091-trusted-resources.md)                                | N/A |     `resource-verification-mode`                        |
+|[`Provenance` field in Status](pipeline-api.md#provenance) |[issue#5550](https://github.com/tektoncd/pipeline/issues/5550)|N/A|`enable-provenance-in-status`|
 
 ### Beta Features
 

--- a/docs/pipelineruns.md
+++ b/docs/pipelineruns.md
@@ -1386,6 +1386,7 @@ Your `PipelineRun`'s `status` field can contain the following fields:
     - [`kind`][kubernetes-overview] - Generally either `TaskRun` or `Run`.
     - [`apiVersion`][kubernetes-overview] - The API version for the underlying `TaskRun` or `Run`.
     - [`whenExpressions`](pipelines.md#guard-task-execution-using-when-expressions) - The list of when expressions guarding the execution of this task.
+  - `provenance` - Metadata about resources used in the PipelineRun such as the source from where a remote pipeline definition was fetched.
 
 ### Configuring usage of `TaskRun` and `Run` embedded statuses
 

--- a/pkg/apis/config/feature_flags.go
+++ b/pkg/apis/config/feature_flags.go
@@ -74,6 +74,8 @@ const (
 	DefaultEnableSpire = false
 	// DefaultResourceVerificationMode is the default value for "resource-verification-mode".
 	DefaultResourceVerificationMode = SkipResourceVerificationMode
+	// DefaultEnableProvenanceInStatus is the default value for "enable-provenance-status".
+	DefaultEnableProvenanceInStatus = false
 
 	disableAffinityAssistantKey         = "disable-affinity-assistant"
 	disableCredsInitKey                 = "disable-creds-init"
@@ -87,6 +89,7 @@ const (
 	embeddedStatus                      = "embedded-status"
 	enableSpire                         = "enable-spire"
 	verificationMode                    = "resource-verification-mode"
+	enableProvenanceInStatus            = "enable-provenance-in-status"
 )
 
 // FeatureFlags holds the features configurations
@@ -105,6 +108,7 @@ type FeatureFlags struct {
 	EmbeddedStatus                   string
 	EnableSpire                      bool
 	ResourceVerificationMode         string
+	EnableProvenanceInStatus         bool
 }
 
 // GetFeatureFlagsConfigName returns the name of the configmap containing all
@@ -157,6 +161,9 @@ func NewFeatureFlagsFromMap(cfgMap map[string]string) (*FeatureFlags, error) {
 		return nil, err
 	}
 	if err := setResourceVerificationMode(cfgMap, DefaultResourceVerificationMode, &tc.ResourceVerificationMode); err != nil {
+		return nil, err
+	}
+	if err := setFeature(enableProvenanceInStatus, DefaultEnableProvenanceInStatus, &tc.EnableProvenanceInStatus); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apis/config/feature_flags_test.go
+++ b/pkg/apis/config/feature_flags_test.go
@@ -46,6 +46,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				SendCloudEventsForRuns:   config.DefaultSendCloudEventsForRuns,
 				EmbeddedStatus:           config.DefaultEmbeddedStatus,
 				ResourceVerificationMode: config.DefaultResourceVerificationMode,
+				EnableProvenanceInStatus: config.DefaultEnableProvenanceInStatus,
 			},
 			fileName: config.GetFeatureFlagsConfigName(),
 		},
@@ -62,6 +63,7 @@ func TestNewFeatureFlagsFromConfigMap(t *testing.T) {
 				EmbeddedStatus:                   "both",
 				EnableSpire:                      true,
 				ResourceVerificationMode:         "enforce",
+				EnableProvenanceInStatus:         true,
 			},
 			fileName: "feature-flags-all-flags-set",
 		},
@@ -156,6 +158,7 @@ func TestNewFeatureFlagsFromEmptyConfigMap(t *testing.T) {
 		EmbeddedStatus:                   config.DefaultEmbeddedStatus,
 		EnableSpire:                      config.DefaultEnableSpire,
 		ResourceVerificationMode:         config.DefaultResourceVerificationMode,
+		EnableProvenanceInStatus:         config.DefaultEnableProvenanceInStatus,
 	}
 	verifyConfigFileWithExpectedFeatureFlagsConfig(t, FeatureFlagsConfigEmptyName, expectedConfig)
 }

--- a/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
+++ b/pkg/apis/config/testdata/feature-flags-all-flags-set.yaml
@@ -29,3 +29,4 @@ data:
   embedded-status: "both"
   enable-spire: "true"
   resource-verification-mode: "enforce"
+  enable-provenance-in-status: "true"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

/kind feature 

(*This is [an additive change](https://github.com/tektoncd/pipeline/blob/main/api_compatibility_policy.md#additive-changes)*)

Introduced a dedicated feature flag of boolean type named "enable-provenance-in-status"
in feature-flags configmap to enable the provenance field in status. The `provenance` field 
was introducted to *run status in https://github.com/tektoncd/pipeline/pull/5580 to record authenticated metadata about how a 
software artifact was built i.e. the source where remote resource came from.

By default, this feature flag is false.

Signed-off-by: Chuang Wang <chuangw@google.com>

***Related PRs***:
- #5580 
- #5397 

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Added a new boolean feature flag named "enable-provenance-in-status" in feature-flags configmap to enable the provenance field in status to be populated. This field in status aims to record authenticated metadata about how a software artifact was built i.e. the source where remote resource came from.
```
