### PR TITLE
fix cloud event flacky unit tests by adding waitgroup

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -104,9 +105,9 @@ func main() {
 
 	ctx = filteredinformerfactory.WithSelectors(ctx, v1beta1.ManagedByLabelKey)
 	sharedmain.MainWithConfig(ctx, ControllerLogKey, cfg,
-		taskrun.NewController(opts, clock.RealClock{}),
-		pipelinerun.NewController(opts, clock.RealClock{}),
-		run.NewController(),
+		taskrun.NewController(opts, clock.RealClock{}, &sync.WaitGroup{}),
+		pipelinerun.NewController(opts, clock.RealClock{}, &sync.WaitGroup{}),
+		run.NewController(&sync.WaitGroup{}),
 		resolutionrequest.NewController(clock.RealClock{}),
 	)
 }

--- a/pkg/reconciler/events/cloudevent/cloud_event_controller.go
+++ b/pkg/reconciler/events/cloudevent/cloud_event_controller.go
@@ -19,6 +19,7 @@ package cloudevent
 import (
 	"context"
 	"errors"
+	"sync"
 	"time"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -122,7 +123,7 @@ func SendCloudEvents(tr *v1beta1.TaskRun, ceclient CEClient, logger *zap.Sugared
 // sdk-go capabilities.
 // It accepts a runtime.Object to avoid making objectWithCondition public since
 // it's only used within the events/cloudevents packages.
-func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error {
+func SendCloudEventWithRetries(ctx context.Context, wg *sync.WaitGroup, object runtime.Object) error {
 	var (
 		o  objectWithCondition
 		ok bool
@@ -144,7 +145,9 @@ func SendCloudEventWithRetries(ctx context.Context, object runtime.Object) error
 	_, isRun := object.(*v1alpha1.Run)
 
 	wasIn := make(chan error)
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		wasIn <- nil
 		logger.Debugf("Sending cloudevent of type %q", event.Type())
 		// In case of Run event, check cache if cloudevent is already sent

--- a/pkg/reconciler/events/event_test.go
+++ b/pkg/reconciler/events/event_test.go
@@ -18,6 +18,7 @@ package events
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -235,7 +236,9 @@ func TestEmit(t *testing.T) {
 		ctx = config.ToContext(ctx, cfg)
 
 		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
-		Emit(ctx, nil, after, object)
+		var wg sync.WaitGroup
+		Emit(ctx, nil, after, object, &wg)
+		wg.Wait()
 		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -291,7 +294,9 @@ func TestEmitCloudEvents(t *testing.T) {
 		ctx = config.ToContext(ctx, cfg)
 
 		recorder := controller.GetEventRecorder(ctx).(*record.FakeRecorder)
-		EmitCloudEvents(ctx, object)
+		var wg sync.WaitGroup
+		EmitCloudEvents(ctx, object, &wg)
+		wg.Wait()
 		if err := eventstest.CheckEventsOrdered(t, recorder.Events, tc.name, tc.wantEvents); err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -18,6 +18,7 @@ package pipelinerun
 
 import (
 	"context"
+	"sync"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -43,7 +44,7 @@ import (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(opts *pipeline.Options, clock clock.PassiveClock, wg *sync.WaitGroup) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -61,6 +62,7 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 			PipelineClientSet:   pipelineclientset,
 			Images:              opts.Images,
 			Clock:               clock,
+			waitGroup:           wg,
 			pipelineRunLister:   pipelineRunInformer.Lister(),
 			taskRunLister:       taskRunInformer.Lister(),
 			runLister:           runInformer.Lister(),

--- a/pkg/reconciler/run/controller.go
+++ b/pkg/reconciler/run/controller.go
@@ -18,6 +18,7 @@ package run
 
 import (
 	"context"
+	"sync"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -32,7 +33,7 @@ import (
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
 // This is a read-only controller, hence the SkipStatusUpdates set to true
-func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(wg *sync.WaitGroup) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		runInformer := runinformer.Get(ctx)
@@ -43,6 +44,7 @@ func NewController() func(context.Context, configmap.Watcher) *controller.Impl {
 		c := &Reconciler{
 			cloudEventClient: cloudeventclient.Get(ctx),
 			cacheClient:      cacheclient.Get(ctx),
+			waitGroup:        wg,
 		}
 		impl := runreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 			return controller.Options{

--- a/pkg/reconciler/run/run.go
+++ b/pkg/reconciler/run/run.go
@@ -18,6 +18,7 @@ package run
 
 import (
 	"context"
+	"sync"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -36,6 +37,7 @@ import (
 type Reconciler struct {
 	cloudEventClient cloudevent.CEClient
 	cacheClient      *lru.Cache
+	waitGroup        *sync.WaitGroup
 }
 
 // Check that our Reconciler implements runreconciler.Interface
@@ -66,7 +68,7 @@ func (c *Reconciler) ReconcileKind(ctx context.Context, run *v1alpha1.Run) pkgre
 		condition := runEvents.Status.GetCondition(apis.ConditionSucceeded)
 		logger.Debugf("Emitting cloudevent for %s, condition: %s", runEvents.Name, condition)
 
-		events.EmitCloudEvents(ctx, &runEvents)
+		events.EmitCloudEvents(ctx, &runEvents, c.waitGroup)
 	}
 
 	return nil

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -18,6 +18,7 @@ package taskrun
 
 import (
 	"context"
+	"sync"
 
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
@@ -44,7 +45,7 @@ import (
 )
 
 // NewController instantiates a new controller.Impl from knative.dev/pkg/controller
-func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(context.Context, configmap.Watcher) *controller.Impl {
+func NewController(opts *pipeline.Options, clock clock.PassiveClock, wg *sync.WaitGroup) func(context.Context, configmap.Watcher) *controller.Impl {
 	return func(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
 		logger := logging.FromContext(ctx)
 		kubeclientset := kubeclient.Get(ctx)
@@ -73,6 +74,7 @@ func NewController(opts *pipeline.Options, clock clock.PassiveClock) func(contex
 			cloudEventClient:    cloudeventclient.Get(ctx),
 			metrics:             taskrunmetrics.Get(ctx),
 			entrypointCache:     entrypointCache,
+			waitGroup:           wg,
 			podLister:           podInformer.Lister(),
 			pvcHandler:          volumeclaim.NewPVCHandler(kubeclientset, logger),
 			resolutionRequester: resolution.NewCRDRequester(resolutionclient.Get(ctx), resolutionInformer.Lister()),

--- a/test/controller.go
+++ b/test/controller.go
@@ -19,6 +19,7 @@ package test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -116,6 +117,7 @@ type Assets struct {
 	Controller *controller.Impl
 	Clients    Clients
 	Informers  Informers
+	WaitGroup  *sync.WaitGroup
 	Recorder   *record.FakeRecorder
 	Ctx        context.Context
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This commit adds waitgroup to reconciler, so can be used when creating goroutines to send cloud events. waitgroup.Wait() can be called during unit tests to make sure all goroutines are completed and avoid the case that some events are not written into channel before checking. This change shouldn't have influence on current hebaviour since we don't call Wait to block the code. This should be able to fix flacky cloud event tests and we don't have to add time.sleep() before collecting events.

Signed-off-by: Yongxuan Zhang yongxuanzhang@google.com

/kind flake

related issues:
https://github.com/tektoncd/pipeline/issues/5160
to reproduce this issue, adding time.Sleep() to https://github.com/tektoncd/pipeline/blob/b648a5b2eaebf0ece7199dcf2bd89c65137973d5/pkg/reconciler/events/cloudevent/cloudeventsfakeclient.go#L53  
related PR:
https://github.com/tektoncd/pipeline/pull/5313
Recent failing tests:

- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5666/pull-tekton-pipeline-unit-tests/1582795530906374144
- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5662/pull-tekton-pipeline-unit-tests/1583441668340715520
- https://prow.tekton.dev/view/gs/tekton-prow/pr-logs/pull/tektoncd_pipeline/5647/pull-tekton-pipeline-unit-tests/1583130831700889600

<!-- Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! -->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [x] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings)
- [ ] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Fix cloud event flacky unit tests by adding waitgroup
```
